### PR TITLE
Conformance for reserved preprocessor macro names

### DIFF
--- a/conformance-suites/1.0.1/conformance/glsl/reserved/00_test_list.txt
+++ b/conformance-suites/1.0.1/conformance/glsl/reserved/00_test_list.txt
@@ -6,3 +6,4 @@ webgl_field.vert.html
 webgl_function.vert.html
 webgl_struct.vert.html
 webgl_variable.vert.html
+webgl_preprocessor_reserved.html

--- a/conformance-suites/1.0.1/conformance/glsl/reserved/webgl_preprocessor_reserved.html
+++ b/conformance-suites/1.0.1/conformance/glsl/reserved/webgl_preprocessor_reserved.html
@@ -1,0 +1,34 @@
+<!--
+Copyright (c) 2012 Florian Boesch. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vertexShader" type="text/something-not-javascript">
+
+// use of reserved macro names should fail
+void main(){
+    #define FOO__BAR 1
+    #define FOO__blubb(a) a+1
+    gl_Position = vec4(0.0);
+}
+</script>
+<script>
+GLSLConformanceTester.runTest();
+successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
GLSL preprocessor macro names with double underscore in them should fail to parse.
