### PR TITLE
reserved preprocessor macro names should fail to parse

### DIFF
--- a/sdk/tests/conformance/glsl/reserved/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/reserved/00_test_list.txt
@@ -6,3 +6,4 @@ webgl_field.vert.html
 webgl_function.vert.html
 webgl_struct.vert.html
 webgl_variable.vert.html
+--min-version 1.0.2 webgl_preprocessor_reserved.html

--- a/sdk/tests/conformance/glsl/reserved/webgl_preprocessor_reserved.html
+++ b/sdk/tests/conformance/glsl/reserved/webgl_preprocessor_reserved.html
@@ -1,0 +1,56 @@
+<!--
+
+/*
+** Copyright (c) 2012 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vertexShader" type="text/something-not-javascript">
+
+// use of reserved macro names should fail
+void main(){
+    #define FOO__BAR 1
+    #define FOO__blubb(a) a+1
+    gl_Position = vec4(0.0);
+}
+</script>
+<script>
+GLSLConformanceTester.runTest();
+successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Preprocessor macros with double underscores which are reserved as per specification should fail to parse.
