### PR TITLE
checking for bufferData null/undefined data arguments to fail

### DIFF
--- a/sdk/tests/conformance/more/functions/bufferDataBadArgs.html
+++ b/sdk/tests/conformance/more/functions/bufferDataBadArgs.html
@@ -52,6 +52,10 @@ Tests.testBufferData = function(gl) {
 //        function(){gl.bufferData(gl.ARRAY_BUFFER, [1,2,3], gl.STATIC_DRAW);});
     assertFail("bad usage",
         function(){gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1,2,3]), gl.TEXTURE_2D);});
+    assertFail("null data",
+        function(){gl.bufferData(gl.ARRAY_BUFFER, null, gl.STATIC_DRAW);});
+    assertFail("undefined data",
+        function(){gl.bufferData(gl.ARRAY_BUFFER, undefined, gl.STATIC_DRAW);});
     assertOk(function(){gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Float32Array([1,2,3]), gl.STATIC_DRAW);});
     throwError(gl, 'bufferData');
     gl.bindBuffer(gl.ARRAY_BUFFER, null);


### PR DESCRIPTION
Extended the bufferDataBadArgs test to include both null and undefined data which should fail with an invalid value.
