### PR TITLE
Fix in ATC proposal: use the WebGL enums, not the OpenGL enums

### DIFF
--- a/extensions/proposals/WEBGL_compressed_texture_atc/extension.xml
+++ b/extensions/proposals/WEBGL_compressed_texture_atc/extension.xml
@@ -20,9 +20,9 @@
     </p>
     <features>
       <feature>
-        Compression formats <code>ATC_RGB_AMD</code>,
-        <code>ATC_RGBA_EXPLICIT_ALPHA_AMD</code>, and
-        <code>ATC_RGBA_INTERPOLATED_ALPHA_AMD</code> may be passed to
+        Compression formats <code>COMPRESSED_RGB_ATC_WEBGL</code>,
+        <code>COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL</code>, and
+        <code>COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL</code> may be passed to
         the <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code> entry points.
 
         These formats correspond to the 3 formats defined in the AMD_compressed_ATC_texture OpenGL

--- a/extensions/proposals/WEBGL_compressed_texture_atc/index.html
+++ b/extensions/proposals/WEBGL_compressed_texture_atc/index.html
@@ -35,9 +35,9 @@
     <p> When this extension is enabled: </p>
 <ul>
 <li>
-        Compression formats <code>ATC_RGB_AMD</code>,
-        <code>ATC_RGBA_EXPLICIT_ALPHA_AMD</code>, and
-        <code>ATC_RGBA_INTERPOLATED_ALPHA_AMD</code> may be passed to
+        Compression formats <code>COMPRESSED_RGB_ATC_WEBGL</code>,
+        <code>COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL</code>, and
+        <code>COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL</code> may be passed to
         the <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code> entry points.
 
         These formats correspond to the 3 formats defined in the AMD_compressed_ATC_texture OpenGL


### PR DESCRIPTION
Just a trivial fix.
