### PR TITLE
glsl-function-smoothstep-float should use high precision for OpenGL ES

### DIFF
--- a/sdk/tests/conformance/glsl/functions/glsl-function-smoothstep-float.html
+++ b/sdk/tests/conformance/glsl/functions/glsl-function-smoothstep-float.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-  <title>GLSL smoothstep-gentype function test</title>
+  <title>GLSL smoothstep-float function test</title>
   <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
   <link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
   <script src="../../../resources/js-test-pre.js"></script>
@@ -42,31 +42,73 @@
 <div id="console"></div>
 <script>
 
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(value, max));
+}
 
-GLSLGenerator.runFeatureTest({
+function smoothstep(edge0, edge1, value) {
+  var t = clamp((value - edge0) / (edge1 - edge0), 0, 1);
+  return t * t * (3 - 2 * t);
+}
+
+GLSLGenerator.runReferenceImageTest({
   feature: "smoothstep",
   args: "float edge0, float edge1, $(type) value",
-  baseArgs: "edge0, edge1, value$(field)",
   testFunc: "$(func)(float, float, $(type))",
-  emuFunc: ["float $(func)_base(float edge0, float edge1, float value) {",
-            "  float t = clamp((value - edge0) / (edge1 - edge0), 0.0, 1.0);",
-            "  return t * t * (3.0 - 2.0 * t);",
-            "}"].join("\n"),
   gridRes: 8,
+  tolerance: 4,
   tests: [
-    ["$(output) = vec4(",
-     "    $(func)(0.3, 0.7, $(input).x),",
-     "    $(func)(0.2, 0.8, $(input).y),",
-     "    0,",
-     "    1);"].join("\n"),
-    ["$(output) = vec4(",
-     "    $(func)(0.4, 0.8, $(input).xy),",
-     "    0, 1);"].join("\n"),
-    ["$(output) = vec4(",
-     "    $(func)(0.3, 0.7, $(input).xyz),",
-     "    1);"].join("\n"),
-    ["$(output) = ",
-     "    $(func)(0.3, 0.9, $(input));"].join("\n")
+    {
+      source: ["$(output) = vec4(",
+              "    $(func)(0.3, 0.7, $(input).x),",
+              "    $(func)(0.2, 0.8, $(input).y),",
+              "    0,",
+              "    1);"].join("\n"),
+      generator: function(x, y, z, w) {
+        return [ smoothstep(0.3, 0.7, x),
+                 smoothstep(0.2, 0.8, y),
+                 0,
+                 1 ];
+      },
+    },
+    {
+      source: [ "$(output) = vec4(",
+                "    $(func)(0.4, 0.8, $(input).xy),",
+                "    0, 1);"].join("\n"),
+      generator: function(x, y, z, w) {
+        return [ smoothstep(0.4, 0.8, x),
+                 smoothstep(0.4, 0.8, y),
+                 0,
+                 1 ];
+      },
+    },
+    {
+      // FIXME: this test seems to need a higher tolerance when run in a vertex shader.
+      source: [ "$(output) = vec4(",
+                "    $(func)(0.3, 0.7, $(input).xyz),",
+                "    1);"].join("\n"),
+      generator: function(x, y, z, w) {
+        return [ smoothstep(0.3, 0.7, x),
+                 smoothstep(0.3, 0.7, y),
+                 smoothstep(0.3, 0.7, z),
+                 1 ];
+      },
+      tolerance: 12,
+      fragmentTolerance: 3,
+    },
+    {
+      // FIXME: this test seems to need a higher tolerance when run in a vertex shader.
+      source: ["$(output) = ",
+               "    $(func)(0.3, 0.9, $(input));"].join("\n"),
+      generator: function(x, y, z, w) {
+        return [ smoothstep(0.3, 0.9, x),
+                 smoothstep(0.3, 0.9, y),
+                 smoothstep(0.3, 0.9, z),
+                 smoothstep(0.3, 0.9, w) ];
+      },
+      tolerance: 7,
+      fragmentTolerance: 3,
+    },
   ]
 });
 successfullyParsed = true;


### PR DESCRIPTION
http://www.khronos.org/bugzilla/show_bug.cgi?id=728

Converted test to use JavaScript-based reference image generation in
order to avoid needing to add highp to the reference shaders.
