### PR TITLE
Add a check that getUniformLocation works with array names without array brackets

### DIFF
--- a/conformance-suites/1.0.1/conformance/glsl/misc/glsl-long-variable-names.html
+++ b/conformance-suites/1.0.1/conformance/glsl/misc/glsl-long-variable-names.html
@@ -137,6 +137,8 @@
         shouldBe("gl.getError()", "gl.NO_ERROR");
         var prog = gl.getParameter(gl.CURRENT_PROGRAM);
         shouldBeNonNull("prog");
+        var arrayLoc = gl.getUniformLocation(prog, "color01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567");
+        shouldBeNonNull("arrayLoc");
         var redLoc = gl.getUniformLocation(prog, "color01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567[0]");
         shouldBeNonNull("redLoc");
         var greenLoc = gl.getUniformLocation(prog, "color01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567[1]");
@@ -147,10 +149,23 @@
         shouldBe("activeUniform.type", "gl.FLOAT");
         shouldBe("activeUniform.size", "2");
         shouldBe("activeUniform.name", "'color01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567[0]'");
+        debug("Binding each uniform array value by component location...");
         gl.uniform1f(redLoc, 1.0);
         gl.uniform1f(greenLoc, 0.0);
         drawAndCheckPixels(gl);
         shouldBe("gl.getError()", "gl.NO_ERROR");
+        gl.uniform1f(redLoc, 0.5);
+        gl.uniform1f(greenLoc, 0.5);
+        debug("Binding all uniform array values by first component location...");
+        gl.uniform1fv(redLoc, [1.0, 0.0]);
+        drawAndCheckPixels(gl);
+        shouldBe("gl.getError()", "gl.NO_ERROR");
+        gl.uniform1fv(redLoc, [0.5, 0.5]);
+        debug("Binding all uniform array values by array location...");
+        gl.uniform1fv(arrayLoc, [1.0, 0.0]);
+        drawAndCheckPixels(gl);
+        shouldBe("gl.getError()", "gl.NO_ERROR");
+        gl.uniform1fv(arrayLoc, [0.5, 0.5]);
         debug("");
 
         debug("Test long varying name");


### PR DESCRIPTION
Add a check that the following works:
gl.getUniformLocation(program, "long-array-name");

We already have tests for specific components. For example:
gl.getUniformLocation(program, "long-array-name[0]");
gl.getUniformLocation(program, "long-array-name[1](http://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetUniformLocation.xml)");

Right now, Safari with WebKit r131676 fails this test. Chrome passes.

According to the glGetUniformLocation man page [1](http://www.khronos.org/opengles/sdk/docs/man/xhtml/glGetUniformLocation.xml), using the array name without array brackets should work:
"""
Except if the last part of name indicates a uniform variable array, the location of the first element of an array can be retrieved by using the name of the array, or by using the name appended by "[0]".
"""
