### PR TITLE
conformance/glsl/variables/gl-pointcoord.html assumes max point size is ...

### DIFF
--- a/conformance-suites/1.0.1/conformance/glsl/variables/gl-pointcoord.html
+++ b/conformance-suites/1.0.1/conformance/glsl/variables/gl-pointcoord.html
@@ -62,6 +62,9 @@ found in the LICENSE file.
 
     var maxPointSize = gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE)[1];
     shouldBeTrue("maxPointSize >= 1");
+    // The minimum and maximum point sizes may be floating-point numbers.
+    shouldBeTrue("Math.floor(maxPointSize) >= 1");
+    maxPointSize = Math.floor(maxPointSize);
     shouldBeTrue("maxPointSize % 1 == 0");
 
     maxPointSize = Math.min(maxPointSize, 64);

--- a/sdk/tests/conformance/glsl/variables/gl-pointcoord.html
+++ b/sdk/tests/conformance/glsl/variables/gl-pointcoord.html
@@ -85,6 +85,9 @@
 
     var maxPointSize = gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE)[1];
     shouldBeTrue("maxPointSize >= 1");
+    // The minimum and maximum point sizes may be floating-point numbers.
+    shouldBeTrue("Math.floor(maxPointSize) >= 1");
+    maxPointSize = Math.floor(maxPointSize);
     shouldBeTrue("maxPointSize % 1 == 0");
 
     maxPointSize = Math.min(maxPointSize, 64);


### PR DESCRIPTION
...integer

http://www.khronos.org/bugzilla/show_bug.cgi?id=750

Improved test (both top of tree and 1.0.1 version) to support a
maximum point size which is a floating-point number.
