### PR TITLE
Per discussion with Boris Zbarsky and Benoit Jacob from Mozilla on

### DIFF
--- a/specs/latest/index.html
+++ b/specs/latest/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
     
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 16 October 2012</h2>
+    <h2 class="no-toc">Editor's Draft 01 November 2012</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -1494,7 +1494,7 @@ for (var i = 0; i < numVertices; i++) {
     readonly attribute GLsizei drawingBufferWidth;
     readonly attribute GLsizei drawingBufferHeight;
 
-    [WebGLHandlesContextLoss] WebGLContextAttributes getContextAttributes();
+    [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
     [WebGLHandlesContextLoss] boolean isContextLost();
     
     sequence&lt;DOMString&gt;? getSupportedExtensions();
@@ -1777,9 +1777,11 @@ for (var i = 0; i < numVertices; i++) {
     <h4>Getting information about the context</h4>
 
     <dl class="methods">
-        <dt class="idl-code">[WebGLHandlesContextLoss] WebGLContextAttributes getContextAttributes()
+        <dt class="idl-code">[WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes()
         <dd>
-            Returns a copy of the <a href="#actual-context-parameters">actual context parameters</a>.
+            If the <a href="#webgl-context-lost-flag">webgl context lost flag</a> is set, returns
+            null. Otherwise, returns a copy of the <a href="#actual-context-parameters">actual
+            context parameters</a>.
     </dl>
      
 <!-- ======================================================================================================= -->

--- a/specs/latest/webgl.idl
+++ b/specs/latest/webgl.idl
@@ -489,7 +489,7 @@ interface WebGLRenderingContext {
     readonly attribute GLsizei drawingBufferWidth;
     readonly attribute GLsizei drawingBufferHeight;
 
-    [WebGLHandlesContextLoss] WebGLContextAttributes getContextAttributes();
+    [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
     [WebGLHandlesContextLoss] boolean isContextLost();
     
     sequence<DOMString>? getSupportedExtensions();


### PR DESCRIPTION
public_webgl list, and discussion with WebGL WG, made the return value
of getContextAttributes nullable, and specified that it returns null
while the context is lost.
