### PR TITLE
 Add FLOAT readPixels to the features list ...

### DIFF
--- a/extensions/proposals/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/proposals/EXT_color_buffer_half_float/extension.xml
@@ -48,6 +48,14 @@
       </feature>
 
       <feature>
+        <p>The format and type combination <code>RGBA</code> and
+        <code>FLOAT</code> becomes valid for reading from a floating-point
+        rendering buffer. Note: <code>RGBA</code> and
+        <code>UNSIGNED_BYTE</code> cannot be used for reading from a
+        floating-point rendering buffer.</p>
+      </feature>
+
+      <feature>
         <p>The component types of framebuffer object attachments can be
         queried.</p>
       </feature>
@@ -63,9 +71,65 @@
   }; // interface EXT_color_buffer_half_float
 }; // module webgl</idl>
 
+  <additions>
+    <p>In section 5.13.12 <cite>Reading back pixels</cite>, change the allowed
+    format and types table to the following .</p>
+
+    <dl class="methods">
+      <dt class="idl-code">
+        <dd>
+          <table>
+            <tbody>
+              <tr>
+                <th>frame buffer type</th>
+
+                <th>
+                  <code>format</code>
+                </th>
+
+                <th>
+                  <code>type</code>
+                </th>
+              </tr>
+
+              <tr>
+                <td>normalized fixed-point</td>
+
+                <td>RGBA</td>
+
+                <td>UNSIGNED_BYTE</td>
+              </tr>
+
+              <tr>
+                <td>floating-point</td>
+
+                <td>RGBA</td>
+
+                <td>FLOAT</td>
+              </tr>
+
+              <tr/>
+            </tbody>
+          </table>
+        </dd>
+      </dt>
+    </dl>
+
+    <p>Change the paragraph beginning "If <code>pixels</code> is null ..."
+    to<blockquote>If frame buffer type is not that indicated in the table for
+    the <code>format</code> and <code>type</code> combination, an
+    INVALID_OPERATON error is generated. If pixels is null
+    ...</blockquote></p>
+  </additions>
+
   <history>
     <revision date="2012/11/08">
       <change>Initial revision.</change>
+    </revision>
+
+    <revision date="2012/11/13">
+      <change>"Add reading-pixels-as-FLOAT feature to the Overview and related
+      changes to WebGL section 5.13.12.</change>
     </revision>
   </history>
 </proposal>

--- a/extensions/proposals/EXT_color_buffer_half_float/index.html
+++ b/extensions/proposals/EXT_color_buffer_half_float/index.html
@@ -20,8 +20,8 @@
 <p>Mark Callow, HI Corporation</p>
 <p>Members of the WebGL working group</p>
 <h2 class="no-toc">Version</h2>
-<p> Last modified date: November 08, 2012<br>
-          Revision: 1</p>
+<p> Last modified date: November 13, 2012<br>
+          Revision: 2</p>
 <h2 class="no-toc">Number</h2>
 <p> WebGL extension #NN</p>
 <h2 class="no-toc">Dependencies</h2>
@@ -60,6 +60,13 @@
         to the type of color buffer in use.</p>
       </li>
 <li>
+        <p>The format and type combination <code>RGBA</code> and
+        <code>FLOAT</code> becomes valid for reading from a floating-point
+        rendering buffer. Note: <code>RGBA</code> and
+        <code>UNSIGNED_BYTE</code> cannot be used for reading from a
+        floating-point rendering buffer.</p>
+      </li>
+<li>
         <p>The component types of framebuffer object attachments can be
         queried.</p>
       </li>
@@ -73,8 +80,60 @@
     const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
   }; // interface EXT_color_buffer_half_float
 }; // module webgl</pre></p>
-<h2 class="no-toc">Revision History</h2>
+<h2 class="no-toc">Additions to the WebGL Specification</h2>
+    <p>In section 5.13.12 <cite>Reading back pixels</cite>, change the allowed
+    format and types table to the following .</p>
+
+    <dl class="methods">
+      <dt class="idl-code">
+        <dd>
+          <table>
+            <tbody>
+              <tr>
+                <th>frame buffer type</th>
+
+                <th>
+                  <code>format</code>
+                </th>
+
+                <th>
+                  <code>type</code>
+                </th>
+              </tr>
+
+              <tr>
+                <td>normalized fixed-point</td>
+
+                <td>RGBA</td>
+
+                <td>UNSIGNED_BYTE</td>
+              </tr>
+
+              <tr>
+                <td>floating-point</td>
+
+                <td>RGBA</td>
+
+                <td>FLOAT</td>
+              </tr>
+
+              <tr></tr>
+            </tbody>
+          </table>
+        </dd>
+      </dt>
+    </dl>
+
+    <p>Change the paragraph beginning "If <code>pixels</code> is null ..."
+    to<blockquote>If frame buffer type is not that indicated in the table for
+    the <code>format</code> and <code>type</code> combination, an
+    INVALID_OPERATON error is generated. If pixels is null
+    ...</blockquote></p>
+  <h2 class="no-toc">Revision History</h2>
 <p>Revision 1, 2012/11/08</p>
 <ul><li>Initial revision.</li></ul>
+<p>Revision 2, 2012/11/13</p>
+<ul><li>"Add reading-pixels-as-FLOAT feature to the Overview and related
+      changes to WebGL section 5.13.12.</li></ul>
 </body>
 </html>

--- a/extensions/proposals/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/proposals/WEBGL_color_buffer_float/extension.xml
@@ -16,18 +16,13 @@
   <depends>
     <api version="1.0"/>
 
+    <ext name="EXT_color_buffer_half_float"/>
+
     <ext name="OES_texture_float" require="true"/>
   </depends>
 
   <overview>
-    <mirrors href="http://www.khronos.org/registry/gles/extensions/EXT/EXT_color_buffer_half_float.txt"
-             name="EXT_color_buffer_half_float">
-      <addendum>
-        <p>All references to <code>R16F</code>, <code>RG16F</code>,
-        <code>RGB16F</code> and <code>RGBA16F</code> types are ignored. 32-bit
-        float types are supported instead.</p>
-      </addendum>
-    </mirrors>
+    <p>Adds support for rendering to 32-bit floating-point color buffers.</p>
 
     <features>
       <feature>
@@ -46,6 +41,14 @@
         <code>ClearColor()</code> will no longer clamp their parameter values
         on input. Clamping will be applied as necessary at draw time according
         to the type of color buffer in use.</p>
+      </feature>
+
+      <feature>
+        <p>The format and type combination <code>RGBA</code> and
+        <code>FLOAT</code> becomes valid for reading from a floating-point
+        rendering buffer. Note: <code>RGBA</code> and
+        <code>UNSIGNED_BYTE</code> cannot be used for reading from a
+        floating-point rendering buffer.</p>
       </feature>
 
       <feature>
@@ -73,9 +76,27 @@
     <code>renderbufferStorage()</code>.</function>
   </newtok>
 
+  <additions>
+    <p>The new tokens and the behavioral changes for floating-point color
+    buffers specified in <a
+    href="http://www.khronos.org/registry/webgl/extensions/proposals/EXT_color_buffer_half_float.txt">EXT_color_buffer_half_float</a>
+    are incorporated into WebGL except for the <code>RGB16F</code> and
+    <code>RGBA16F</code> types. All references to these are replaced by the
+    32-bit floating-point types specified above.</p>
+  </additions>
+
   <history>
     <revision date="2012/11/08">
       <change>Initial revision.</change>
+    </revision>
+
+    <revision date="2012/11/12">
+      <change>Don't mirror EXT_color_buffer_half_float. Mirror has a different
+      meaning from what is done here.</change>
+    </revision>
+
+    <revision date="2012/11/13">
+      <change>Add reading-pixels-as-FLOAT feature to the Overview.</change>
     </revision>
   </history>
 </proposal>

--- a/extensions/proposals/WEBGL_color_buffer_float/index.html
+++ b/extensions/proposals/WEBGL_color_buffer_float/index.html
@@ -20,27 +20,18 @@
 <p>Mark Callow, HI Corporation</p>
 <p>Members of the WebGL working group</p>
 <h2 class="no-toc">Version</h2>
-<p> Last modified date: November 08, 2012<br>
-          Revision: 1</p>
+<p> Last modified date: November 13, 2012<br>
+          Revision: 3</p>
 <h2 class="no-toc">Number</h2>
 <p> WebGL extension #NN</p>
 <h2 class="no-toc">Dependencies</h2>
     <p> Written against the <a href="http://www.khronos.org/registry/webgl/specs/1.0/">WebGL API 1.0</a> specification. </p>
 
+    <p> Written against the <a href="http://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/">EXT_color_buffer_half_float</a> specification. </p>
+
     <p> Implementations must also support the <a href="http://www.khronos.org/registry/webgl/extensions/OES_texture_float/">OES_texture_float</a> extension. </p>
   <h2 class="no-toc">Overview</h2>
-    <p> This extension exposes the
-  <a href="http://www.khronos.org/registry/gles/extensions/EXT/EXT_color_buffer_half_float.txt">EXT_color_buffer_half_float</a> functionality to
-  
-      WebGL. The following WebGL-specific behavioral changes apply:
-    <ul><li>
-        <p>All references to <code>R16F</code>, <code>RG16F</code>,
-        <code>RGB16F</code> and <code>RGBA16F</code> types are ignored. 32-bit
-        float types are supported instead.</p>
-      </li></ul></p>
-<p>
-        Consult the above extension for documentation, issues and new functions and enumerants.
-      </p>
+    <p>Adds support for rendering to 32-bit floating-point color buffers.</p>
 
     <p> When this extension is enabled: </p>
 <ul>
@@ -59,6 +50,13 @@
         <code>ClearColor()</code> will no longer clamp their parameter values
         on input. Clamping will be applied as necessary at draw time according
         to the type of color buffer in use.</p>
+      </li>
+<li>
+        <p>The format and type combination <code>RGBA</code> and
+        <code>FLOAT</code> becomes valid for reading from a floating-point
+        rendering buffer. Note: <code>RGBA</code> and
+        <code>UNSIGNED_BYTE</code> cannot be used for reading from a
+        floating-point rendering buffer.</p>
       </li>
 <li>
         <p>The component types of framebuffer object attachments can be
@@ -82,8 +80,19 @@
     accepted as the <code>internalformat</code> parameter of
     <code>renderbufferStorage()</code>.</dd>
 </dl>
-<h2 class="no-toc">Revision History</h2>
+<h2 class="no-toc">Additions to the WebGL Specification</h2>
+    <p>The new tokens and the behavioral changes for floating-point color
+    buffers specified in <a href="http://www.khronos.org/registry/webgl/extensions/proposals/EXT_color_buffer_half_float.txt">EXT_color_buffer_half_float</a>
+    are incorporated into WebGL except for the <code>RGB16F</code> and
+    <code>RGBA16F</code> types. All references to these are replaced by the
+    32-bit floating-point types specified above.</p>
+  <h2 class="no-toc">Revision History</h2>
 <p>Revision 1, 2012/11/08</p>
 <ul><li>Initial revision.</li></ul>
+<p>Revision 2, 2012/11/12</p>
+<ul><li>Don't mirror EXT_color_buffer_half_float. Mirror has a different
+      meaning from what is done here.</li></ul>
+<p>Revision 3, 2012/11/13</p>
+<ul><li>Add reading-pixels-as-FLOAT feature to the Overview.</li></ul>
 </body>
 </html>


### PR DESCRIPTION
and apply necessary changes to the WebGL spec. The feature itself is not new. It was incorporated in previous versions of the extensions by way of EXT_color_buffer_half_float. This change just calls it out clearly and edits the section of the WebGL spec that details readPixels behavior.
