### PR TITLE
EXT_frag_depth extension proposal

### DIFF
--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -17,7 +17,8 @@ EXTS := OES_standard_derivatives \
 	WEBGL_compressed_texture_atc \
 	proposals/WEBGL_multiple_render_targets \
 	proposals/EXT_color_buffer_half_float \
-	proposals/WEBGL_color_buffer_float
+	proposals/WEBGL_color_buffer_float \
+	proposals/EXT_frag_depth
 
 EXTS := $(strip $(EXTS))
 

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -314,6 +314,11 @@
               function.
             </li>
           </xsl:for-each>
+          <xsl:for-each select="output">
+            <li>
+                <code><xsl:call-template name="shader_output"/></code> is a built-in output.
+            </li>
+          </xsl:for-each>
         </ul>
       </li>
       <li>
@@ -380,6 +385,11 @@
     <xsl:if test="not(position()=last())">, </xsl:if>
   </xsl:for-each>
   <xsl:text>)</xsl:text>
+</xsl:template>
+
+<xsl:template name="shader_output">
+  <xsl:value-of select="@type"/><xsl:text> </xsl:text>
+  <xsl:value-of select="@name"/>
 </xsl:template>
 
 <xsl:template match="revision">

--- a/extensions/proposals/EXT_frag_depth/extension.xml
+++ b/extensions/proposals/EXT_frag_depth/extension.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proposal href="proposals/EXT_frag_depth">
+  <name>EXT_frag_depth</name>
+  <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
+  working group</a> (public_webgl 'at' khronos.org) </contact>
+
+  <contributors>
+    <contributor>Florian Boesch (pyalot 'at' gmail.com)</contributor>
+    <contributor>Members of the WebGL working group</contributor>
+  </contributors>
+
+  <number>NN</number>
+
+  <depends>
+    <api version="1.0"/>
+  </depends>
+
+  <overview>
+    <mirrors href="http://www.khronos.org/registry/gles/extensions/EXT/EXT_frag_depth.txt"
+             name="EXT_frag_depth">
+    </mirrors>
+
+    <features>
+      <feature>
+            Adds the ability to set the depth value of a fragment from
+            within the fragment shader with the built-in output variable gl_FragDepthEXT.
+      </feature>
+      <glsl extname="GL_EXT_frag_depth">
+        <stage type="fragment"/>
+        <output name="gl_FragDepthEXT" type="float" />
+      </glsl>
+    </features>
+  </overview>
+  
+  <idl xml:space="preserve">
+    interface EXT_frag_depth {
+    };
+  </idl>
+
+  <samplecode xml:space="preserve">
+    <pre>
+    void main(){
+        gl_FragColor = vec4(1.0, 0.0, 1.0, 1.0);
+        gl_FragDepthEXT = 0.5;
+    }
+    </pre>
+  </samplecode>
+
+  <history>
+    <revision date="2012/11/22">
+      <change>Initial revision.</change>
+    </revision>
+  </history>
+</proposal>


### PR DESCRIPTION
This change adds the specification of the EXT_frag_depth extension which mirrors the ES extension to the proposals directory.

It also introduces an xsl template in extensions.xsl to produce a built-in output description.
