### PR TITLE
Add test to ensure optimized-out struct members don't cause problems.

### DIFF
--- a/sdk/tests/conformance/uniforms/gl-uniform-struct-unused.html
+++ b/sdk/tests/conformance/uniforms/gl-uniform-struct-unused.html
@@ -1,0 +1,104 @@
+<!--
+
+/*
+** Copyright (c) 2012 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL uniform struct Conformance Test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/webgl-test.js"></script>
+<script src="../resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="example" width="2" height="2"> </canvas>
+
+<script id="vshader" type="x-shader/x-vertex">
+attribute vec4 vPosition;
+uniform vec4 u0;
+struct MyStruct {
+  vec4 var1;
+  vec4 var2;
+  vec4 var3;
+  vec4 var4;
+};
+uniform MyStruct u1;
+uniform vec4 u2;
+varying vec4 v_color;
+void main()
+{
+  gl_Position = vPosition;
+  v_color = (u0 + u2 + u1.var1) - vec4(2.0);
+}
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">
+precision mediump float;
+varying vec4 v_color;
+void main()
+{
+  gl_FragColor = v_color;
+}
+</script>
+
+<script>
+description("This test ensures WebGL implementations handle unused members at the end of structs correctly.");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext();
+var c = document.getElementById("console");
+program = setupProgram(gl, "vshader", "fshader", [ "vPosition"]);
+
+wtu.setupUnitQuad(gl, [0, 1]);
+var white = [1.0, 1.0, 1.0, 1.0];
+var black = [0.0, 0.0, 0.0, 0.0];
+gl.uniform4fv(gl.getUniformLocation(program, "u0"), white);
+gl.uniform4fv(gl.getUniformLocation(program, "u1.var1"), white);
+gl.uniform4fv(gl.getUniformLocation(program, "u1.var2"), black);
+gl.uniform4fv(gl.getUniformLocation(program, "u1.var3"), black);
+gl.uniform4fv(gl.getUniformLocation(program, "u1.var4"), black);
+gl.uniform4fv(gl.getUniformLocation(program, "u2"), white);
+wtu.drawQuad(gl);
+wtu.checkCanvas(gl, [255, 255, 255, 255], "should be white", 0);
+gl.uniform4fv(gl.getUniformLocation(program, "u1.var2"), black);
+gl.uniform4fv(gl.getUniformLocation(program, "u1.var3"), black);
+gl.uniform4fv(gl.getUniformLocation(program, "u1.var4"), black);
+wtu.drawQuad(gl, [0, 0, 0, 0]);
+wtu.checkCanvas(gl, [255, 255, 255, 255], "should still be white", 0);
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no GL errors");
+debug("");
+successfullyParsed = true;
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
As seen in http://code.google.com/p/chromium/issues/detail?id=155258 ANGLE had a bug where setting the values for uniforms at the end of a struct that were optimized out could cause other uniforms to be modified.
