### PR TITLE
Upped resolution of corruption test canvas

### DIFF
--- a/sdk/tests/conformance/rendering/multisample-corruption.html
+++ b/sdk/tests/conformance/rendering/multisample-corruption.html
@@ -36,7 +36,7 @@
     <script src="../resources/webgl-test-utils.js"> </script>
 </head>
 <body>
-<canvas id="example" width="1024" height="1024" style="width: 128px; height: 128px;"></canvas>
+<canvas id="example" width="2048" height="2048" style="width: 128px; height: 128px;"></canvas>
 <div id="description"></div>
 <div id="console"></div>
     <script id="vshader" type="x-shader/x-vertex">


### PR DESCRIPTION
increased resolution to the point where the test can provoke corruption
on certain Macbooks using AMD chipsets with an external display attached
