### PR TITLE
Based on feedback from Boris Zbarsky and others on public_webgl, changed...

### DIFF
--- a/specs/latest/index.html
+++ b/specs/latest/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
     
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 01 November 2012</h2>
+    <h2 class="no-toc">Editor's Draft 28 November 2012</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -649,8 +649,8 @@ typedef long long      GLsizeiptr;
 typedef octet          GLubyte;        /* 'octet' should be an unsigned 8 bit type. */
 typedef unsigned short GLushort;
 typedef unsigned long  GLuint;
-typedef float          GLfloat;
-typedef float          GLclampf;  
+typedef unrestricted float GLfloat;
+typedef unrestricted float GLclampf;  
 </pre>
 
 <!-- ======================================================================================================= -->
@@ -1671,25 +1671,25 @@ for (var i = 0; i < numVertices; i++) {
 
     void uniform1f(WebGLUniformLocation? location, GLfloat x);
     void uniform1fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform1fv(WebGLUniformLocation? location, sequence&lt;float&gt; v);
+    void uniform1fv(WebGLUniformLocation? location, sequence&lt;GLfloat&gt; v);
     void uniform1i(WebGLUniformLocation? location, GLint x);
     void uniform1iv(WebGLUniformLocation? location, Int32Array v);
     void uniform1iv(WebGLUniformLocation? location, sequence&lt;long&gt; v);
     void uniform2f(WebGLUniformLocation? location, GLfloat x, GLfloat y);
     void uniform2fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform2fv(WebGLUniformLocation? location, sequence&lt;float&gt; v);
+    void uniform2fv(WebGLUniformLocation? location, sequence&lt;GLfloat&gt; v);
     void uniform2i(WebGLUniformLocation? location, GLint x, GLint y);
     void uniform2iv(WebGLUniformLocation? location, Int32Array v);
     void uniform2iv(WebGLUniformLocation? location, sequence&lt;long&gt; v);
     void uniform3f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z);
     void uniform3fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform3fv(WebGLUniformLocation? location, sequence&lt;float&gt; v);
+    void uniform3fv(WebGLUniformLocation? location, sequence&lt;GLfloat&gt; v);
     void uniform3i(WebGLUniformLocation? location, GLint x, GLint y, GLint z);
     void uniform3iv(WebGLUniformLocation? location, Int32Array v);
     void uniform3iv(WebGLUniformLocation? location, sequence&lt;long&gt; v);
     void uniform4f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
     void uniform4fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform4fv(WebGLUniformLocation? location, sequence&lt;float&gt; v);
+    void uniform4fv(WebGLUniformLocation? location, sequence&lt;GLfloat&gt; v);
     void uniform4i(WebGLUniformLocation? location, GLint x, GLint y, GLint z, GLint w);
     void uniform4iv(WebGLUniformLocation? location, Int32Array v);
     void uniform4iv(WebGLUniformLocation? location, sequence&lt;long&gt; v);
@@ -1697,31 +1697,31 @@ for (var i = 0; i < numVertices; i++) {
     void uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, 
                           Float32Array value);
     void uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, 
-                          sequence&lt;float&gt; value);
+                          sequence&lt;GLfloat&gt; value);
     void uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, 
                           Float32Array value);
     void uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, 
-                          sequence&lt;float&gt; value);
+                          sequence&lt;GLfloat&gt; value);
     void uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, 
                           Float32Array value);
     void uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, 
-                          sequence&lt;float&gt; value);
+                          sequence&lt;GLfloat&gt; value);
 
     void useProgram(WebGLProgram? program);
     void validateProgram(WebGLProgram? program);
 
     void vertexAttrib1f(GLuint indx, GLfloat x);
     void vertexAttrib1fv(GLuint indx, Float32Array values);
-    void vertexAttrib1fv(GLuint indx, sequence&lt;float&gt; values);
+    void vertexAttrib1fv(GLuint indx, sequence&lt;GLfloat&gt; values);
     void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
     void vertexAttrib2fv(GLuint indx, Float32Array values);
-    void vertexAttrib2fv(GLuint indx, sequence&lt;float&gt; values);
+    void vertexAttrib2fv(GLuint indx, sequence&lt;GLfloat&gt; values);
     void vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
     void vertexAttrib3fv(GLuint indx, Float32Array values);
-    void vertexAttrib3fv(GLuint indx, sequence&lt;float&gt; values);
+    void vertexAttrib3fv(GLuint indx, sequence&lt;GLfloat&gt; values);
     void vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
     void vertexAttrib4fv(GLuint indx, Float32Array values);
-    void vertexAttrib4fv(GLuint indx, sequence&lt;float&gt; values);
+    void vertexAttrib4fv(GLuint indx, sequence&lt;GLfloat&gt; values);
     void vertexAttribPointer(GLuint indx, GLint size, GLenum type, 
                              GLboolean normalized, GLsizei stride, GLintptr offset);
 

--- a/specs/latest/webgl.idl
+++ b/specs/latest/webgl.idl
@@ -19,8 +19,8 @@ typedef long long      GLsizeiptr;
 typedef octet          GLubyte;        /* 'octet' should be an unsigned 8 bit type. */
 typedef unsigned short GLushort;
 typedef unsigned long  GLuint;
-typedef float          GLfloat;
-typedef float          GLclampf;  
+typedef unrestricted float GLfloat;
+typedef unrestricted float GLclampf;  
 
 
 dictionary WebGLContextAttributes {
@@ -666,25 +666,25 @@ interface WebGLRenderingContext {
 
     void uniform1f(WebGLUniformLocation? location, GLfloat x);
     void uniform1fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform1fv(WebGLUniformLocation? location, sequence<float> v);
+    void uniform1fv(WebGLUniformLocation? location, sequence<GLfloat> v);
     void uniform1i(WebGLUniformLocation? location, GLint x);
     void uniform1iv(WebGLUniformLocation? location, Int32Array v);
     void uniform1iv(WebGLUniformLocation? location, sequence<long> v);
     void uniform2f(WebGLUniformLocation? location, GLfloat x, GLfloat y);
     void uniform2fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform2fv(WebGLUniformLocation? location, sequence<float> v);
+    void uniform2fv(WebGLUniformLocation? location, sequence<GLfloat> v);
     void uniform2i(WebGLUniformLocation? location, GLint x, GLint y);
     void uniform2iv(WebGLUniformLocation? location, Int32Array v);
     void uniform2iv(WebGLUniformLocation? location, sequence<long> v);
     void uniform3f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z);
     void uniform3fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform3fv(WebGLUniformLocation? location, sequence<float> v);
+    void uniform3fv(WebGLUniformLocation? location, sequence<GLfloat> v);
     void uniform3i(WebGLUniformLocation? location, GLint x, GLint y, GLint z);
     void uniform3iv(WebGLUniformLocation? location, Int32Array v);
     void uniform3iv(WebGLUniformLocation? location, sequence<long> v);
     void uniform4f(WebGLUniformLocation? location, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
     void uniform4fv(WebGLUniformLocation? location, Float32Array v);
-    void uniform4fv(WebGLUniformLocation? location, sequence<float> v);
+    void uniform4fv(WebGLUniformLocation? location, sequence<GLfloat> v);
     void uniform4i(WebGLUniformLocation? location, GLint x, GLint y, GLint z, GLint w);
     void uniform4iv(WebGLUniformLocation? location, Int32Array v);
     void uniform4iv(WebGLUniformLocation? location, sequence<long> v);
@@ -692,31 +692,31 @@ interface WebGLRenderingContext {
     void uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, 
                           Float32Array value);
     void uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, 
-                          sequence<float> value);
+                          sequence<GLfloat> value);
     void uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, 
                           Float32Array value);
     void uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, 
-                          sequence<float> value);
+                          sequence<GLfloat> value);
     void uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, 
                           Float32Array value);
     void uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, 
-                          sequence<float> value);
+                          sequence<GLfloat> value);
 
     void useProgram(WebGLProgram? program);
     void validateProgram(WebGLProgram? program);
 
     void vertexAttrib1f(GLuint indx, GLfloat x);
     void vertexAttrib1fv(GLuint indx, Float32Array values);
-    void vertexAttrib1fv(GLuint indx, sequence<float> values);
+    void vertexAttrib1fv(GLuint indx, sequence<GLfloat> values);
     void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
     void vertexAttrib2fv(GLuint indx, Float32Array values);
-    void vertexAttrib2fv(GLuint indx, sequence<float> values);
+    void vertexAttrib2fv(GLuint indx, sequence<GLfloat> values);
     void vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
     void vertexAttrib3fv(GLuint indx, Float32Array values);
-    void vertexAttrib3fv(GLuint indx, sequence<float> values);
+    void vertexAttrib3fv(GLuint indx, sequence<GLfloat> values);
     void vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
     void vertexAttrib4fv(GLuint indx, Float32Array values);
-    void vertexAttrib4fv(GLuint indx, sequence<float> values);
+    void vertexAttrib4fv(GLuint indx, sequence<GLfloat> values);
     void vertexAttribPointer(GLuint indx, GLint size, GLenum type, 
                              GLboolean normalized, GLsizei stride, GLintptr offset);
 


### PR DESCRIPTION
... typedefs for GLfloat and GLclampf from "float" to "unrestricted float". Changed sequence<float> references in uniform*fv and other APIs to sequence<GLfloat> to implicitly pick up this change.
