### PR TITLE
Video tests loop can infinitely (thanks to Paul Adenot)

### DIFF
--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
@@ -51,6 +51,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
     var videoNdx = 0;
     var runNextVideo = function() {
         if (videoNdx == videos.length) {
+            video.removeEventListener("playing", runTest);
             finishTest();
             return;
         }

--- a/sdk/tests/conformance/textures/texture-npot-video.html
+++ b/sdk/tests/conformance/textures/texture-npot-video.html
@@ -162,6 +162,7 @@ function runTest(videoElement)
     runOneIteration(videoElement, true, false, red, green, false, false, false);
 
     glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+    videoElement.removeEventListener("playing", runTest);
     finishTest();
 }
 </script>


### PR DESCRIPTION
Because they forget to remove their event listener.
https://bugzilla.mozilla.org/show_bug.cgi?id=786331

This is causing timeouts in Firefox.
