### PR TITLE
Add a test which checks that an element array buffer can be created, deleted, recreated, and drawn successfully.

### DIFF
--- a/conformance-suites/1.0.1/conformance/buffers/element-array-buffer-delete-recreate.html
+++ b/conformance-suites/1.0.1/conformance/buffers/element-array-buffer-delete-recreate.html
@@ -83,6 +83,6 @@ found in the LICENSE file.
     init();
     successfullyParsed = true;
   </script>
-<script src="../../../resources/js-test-post.js"></script>
+<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This test fails in Chrome Canary 25.0.1349.1, but passed in Chrome Canary 25.0.1342.? (or Chrome stable), and passes in FireFox 16.0.2.

I've narrowed down the cause in Chromium and created a bug for the issue:
http://code.google.com/p/chromium/issues/detail?id=164445
