### PR TITLE
WebGL 1.0.1 has not yet been published

### DIFF
--- a/extensions/WEBGL_compressed_texture_atc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_atc/extension.xml
@@ -10,7 +10,7 @@
   </contributors>
   <number>12</number>
   <depends>
-    <api version="1.0.1"/>
+    <api version="1.0"/>
   </depends>
   <overview>
     <p>

--- a/extensions/WEBGL_compressed_texture_atc/index.html
+++ b/extensions/WEBGL_compressed_texture_atc/index.html
@@ -24,7 +24,7 @@
 <h2 class="no-toc">Number</h2>
 <p> WebGL extension #12</p>
 <h2 class="no-toc">Dependencies</h2>
-    <p> Written against the <a href="http://www.khronos.org/registry/webgl/specs/1.0.1/">WebGL API 1.0.1</a> specification. </p>
+    <p> Written against the <a href="http://www.khronos.org/registry/webgl/specs/1.0/">WebGL API 1.0</a> specification. </p>
   <h2 class="no-toc">Overview</h2>
     <p>
       This extension exposes the compressed texture formats defined in the 

--- a/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
@@ -10,7 +10,7 @@
   </contributors>
   <number>13</number>
   <depends>
-    <api version="1.0.1"/>
+    <api version="1.0"/>
   </depends>
   <overview>
     <p>

--- a/extensions/WEBGL_compressed_texture_pvrtc/index.html
+++ b/extensions/WEBGL_compressed_texture_pvrtc/index.html
@@ -24,7 +24,7 @@
 <h2 class="no-toc">Number</h2>
 <p> WebGL extension #13</p>
 <h2 class="no-toc">Dependencies</h2>
-    <p> Written against the <a href="http://www.khronos.org/registry/webgl/specs/1.0.1/">WebGL API 1.0.1</a> specification. </p>
+    <p> Written against the <a href="http://www.khronos.org/registry/webgl/specs/1.0/">WebGL API 1.0</a> specification. </p>
   <h2 class="no-toc">Overview</h2>
     <p>
       This extension exposes the compressed texture formats defined in the 

--- a/extensions/WEBGL_compressed_texture_s3tc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_s3tc/extension.xml
@@ -10,7 +10,7 @@
   </contributors>
   <number>8</number>
   <depends>
-    <api version="1.0.1"/>
+    <api version="1.0"/>
   </depends>
   <overview>
     <p>

--- a/extensions/WEBGL_compressed_texture_s3tc/index.html
+++ b/extensions/WEBGL_compressed_texture_s3tc/index.html
@@ -24,7 +24,7 @@
 <h2 class="no-toc">Number</h2>
 <p> WebGL extension #8</p>
 <h2 class="no-toc">Dependencies</h2>
-    <p> Written against the <a href="http://www.khronos.org/registry/webgl/specs/1.0.1/">WebGL API 1.0.1</a> specification. </p>
+    <p> Written against the <a href="http://www.khronos.org/registry/webgl/specs/1.0/">WebGL API 1.0</a> specification. </p>
   <h2 class="no-toc">Overview</h2>
     <p>
       This extension exposes the compressed texture formats defined in the 


### PR DESCRIPTION
Fixing broken links that point to a non-existent WebGL 1.0.1 specification.
