### PR TITLE
Added second pass to point sprite conformance test 

### DIFF
--- a/sdk/tests/conformance/rendering/point-size.html
+++ b/sdk/tests/conformance/rendering/point-size.html
@@ -65,8 +65,6 @@
 
     var gl = initWebGL('testbed', { antialias: false });
     shouldBeNonNull("gl");
-    var program = setupProgram(gl, 'vshader', 'fshader', ['pos', 'colorIn']);
-    shouldBe('gl.getError()', 'gl.NO_ERROR');
 
     gl.disable(gl.BLEND);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -81,63 +79,83 @@
 
     var colorOffset = vertices.byteLength;
 
+    var buf = new Uint8Array(2 * 2 * 4);
+    var index = 0;
+
     var vbo = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
     gl.bufferData(gl.ARRAY_BUFFER, colorOffset + colors.byteLength, gl.STATIC_DRAW);
     gl.bufferSubData(gl.ARRAY_BUFFER, 0, vertices);
     gl.bufferSubData(gl.ARRAY_BUFFER, colorOffset, colors);
 
-    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
-    gl.enableVertexAttribArray(0);
-    gl.vertexAttribPointer(1, 4, gl.UNSIGNED_BYTE, true, 0, colorOffset);
-    gl.enableVertexAttribArray(1);
+    function test(program) {
+        gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+        gl.enableVertexAttribArray(0);
+        gl.vertexAttribPointer(1, 4, gl.UNSIGNED_BYTE, true, 0, colorOffset);
+        gl.enableVertexAttribArray(1);
 
-    var locPointSize = gl.getUniformLocation(program, 'pointSize');
+        var locPointSize = gl.getUniformLocation(program, 'pointSize');
 
-    shouldBe('gl.getError()', 'gl.NO_ERROR');
+        shouldBe('gl.getError()', 'gl.NO_ERROR');
 
-    debug('Draw a point of size 1 and verify it does not touch any other pixels.');
+        debug('Draw a point of size 1 and verify it does not touch any other pixels.');
 
-    gl.uniform1f(locPointSize, 1.0);
-    gl.drawArrays(gl.POINTS, 0, vertices.length / 3);
-    var buf = new Uint8Array(2 * 2 * 4);
-    gl.readPixels(0, 0, 2, 2, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    shouldBe('gl.getError()', 'gl.NO_ERROR');
-
-    var index = 0;
-    var correctColor;
-    for (var y = 0; y < 2; ++y) {
-        for (var x = 0; x < 2; ++x) {
-            correctColor = [0, 0, 0];
-            if (x == 1 && y == 1)
-                shouldBe('buf[index]', '255');
-            else
-                shouldBe('buf[index]', '0');
-            shouldBe('buf[index + 1]', '0');
-            shouldBe('buf[index + 2]', '0');
-            index += 4;
-        }
-    }
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-
-    debug('Draw a point of size 2 and verify it fills the appropriate region.');
-
-    var pointSizeRange = gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE);
-    if (pointSizeRange[1] >= 2.0) {
-        gl.uniform1f(locPointSize, 2.0);
+        gl.uniform1f(locPointSize, 1.0);
         gl.drawArrays(gl.POINTS, 0, vertices.length / 3);
+        
         gl.readPixels(0, 0, 2, 2, gl.RGBA, gl.UNSIGNED_BYTE, buf);
         shouldBe('gl.getError()', 'gl.NO_ERROR');
-        index = 0;
+
+        index = 0
+        var correctColor;
         for (var y = 0; y < 2; ++y) {
             for (var x = 0; x < 2; ++x) {
-                shouldBe('buf[index]', '255');
+                correctColor = [0, 0, 0];
+                if (x == 1 && y == 1)
+                    shouldBe('buf[index]', '255');
+                else
+                    shouldBe('buf[index]', '0');
                 shouldBe('buf[index + 1]', '0');
                 shouldBe('buf[index + 2]', '0');
                 index += 4;
             }
         }
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+        debug('Draw a point of size 2 and verify it fills the appropriate region.');
+
+        var pointSizeRange = gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE);
+        if (pointSizeRange[1] >= 2.0) {
+            gl.uniform1f(locPointSize, 2.0);
+            gl.drawArrays(gl.POINTS, 0, vertices.length / 3);
+            gl.readPixels(0, 0, 2, 2, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+            shouldBe('gl.getError()', 'gl.NO_ERROR');
+            index = 0;
+            for (var y = 0; y < 2; ++y) {
+                for (var x = 0; x < 2; ++x) {
+                    shouldBe('buf[index]', '255');
+                    shouldBe('buf[index + 1]', '0');
+                    shouldBe('buf[index + 2]', '0');
+                    index += 4;
+                }
+            }
+        }
     }
+
+    debug('');
+    debug('Pass 1');
+    var program1 = setupProgram(gl, 'vshader', 'fshader', ['pos', 'colorIn']);
+    shouldBe('gl.getError()', 'gl.NO_ERROR');
+    test(program1);
+
+    // Under some versions of ANGLE point sprite shader programs were 
+    // incorrectly reloaded from cache. Rebuilding the shader program and
+    // repeating the test simulates the conditions that caused it to fail
+    debug('');
+    debug('Pass 2');
+    var program2 = setupProgram(gl, 'vshader', 'fshader', ['pos', 'colorIn']);
+    shouldBe('gl.getError()', 'gl.NO_ERROR');
+    test(program2);
 
     successfullyParsed = true;
 </script>


### PR DESCRIPTION
This provokes an ANGLE shader program caching error that causes point sprites to fail to render.
