### PR TITLE
Fixing mismatch of uniform precision between vertex and fragment shaders...

### DIFF
--- a/sdk/demos/webkit/TeapotPerPixel.html
+++ b/sdk/demos/webkit/TeapotPerPixel.html
@@ -42,21 +42,21 @@
         // the light() function in the 2.0 context.
         struct Light
         {
-            vec4 ambient;
-            vec4 diffuse;
-            vec4 specular;
-            vec4 position;
+            mediump vec4 ambient;
+            mediump vec4 diffuse;
+            mediump vec4 specular;
+            mediump vec4 position;
 
-            vec3 halfVector;
+            mediump vec3 halfVector;
         };
 
         struct Material
         {
-            vec4 emission;
-            vec4 ambient;
-            vec4 diffuse;
-            vec4 specular;
-            float shininess;
+            mediump vec4 emission;
+            mediump vec4 ambient;
+            mediump vec4 diffuse;
+            mediump vec4 specular;
+            mediump float shininess;
         };
 
         //


### PR DESCRIPTION
ESSL 1.00.17 states:
"Shared globals are variables that can be accessed by multiple compilation units. In GLSL ES the only
shared globals are uniforms. Varyings are not considered to be shared globals since they must pass
through the rasterization stage before they can be read by the fragment shader."
"Shared globals must have the same name, storage and precision qualifiers."

The TeapotPerPixel demo breaks this rule since it shares uniforms between the vertex and fragment shader, but uses the default precision (highp) in the vertex shader and mediump in the fragment shader.

(It possibly works on many (desktop) implementations since the precision qualifiers may just be ignored there.)

Proposed patch attached. Adding matching precision qualifiers.
