### PR TITLE
Added regression test for WebKit bug 106308 (Chromium-specific) to typed...

### DIFF
--- a/sdk/tests/conformance/typedarrays/array-unit-tests.html
+++ b/sdk/tests/conformance/typedarrays/array-unit-tests.html
@@ -574,6 +574,16 @@ function testConstructionWithNullBuffer(type, name) {
     }
 }
 
+function testConstructionWithExceptionThrowingObject(type, name) {
+    var o = {};
+    Object.defineProperty(o, "length", { get: function() { throw "bail;" }});
+    try {
+        var array = new type(o);
+    } catch (e) {
+    }
+    testPassed("Construction of " + name + " with exception-throwing array-like object didn't crash unexpectedly");
+}
+
 function shouldThrowIndexSizeErr(func, text) {
     var errorText = text + " should throw an exception";
     try {
@@ -1093,6 +1103,7 @@ function runTests() {
                                        testCase.testValues,
                                        testCase.expectedValues);
     testConstructionWithNullBuffer(type, name);
+    testConstructionWithExceptionThrowingObject(type, name);
     testConstructionWithOutOfRangeValues(type, name);
     testConstructionWithNegativeOutOfRangeValues(type, name);
     testConstructionWithUnalignedOffset(type, name, testCase.elementSizeInBytes);


### PR DESCRIPTION
... array tests. Works fine in Firefox and Safari.
