### PR TITLE
Conformance test for mipmap generation on rendered textures

### DIFF
--- a/sdk/tests/conformance/textures/00_test_list.txt
+++ b/sdk/tests/conformance/textures/00_test_list.txt
@@ -46,4 +46,5 @@ texture-size-cube-maps.html
 --min-version 1.0.2 texture-sub-image-cube-maps.html
 texture-transparent-pixels-initialized.html
 --min-version 1.0.2 texture-upload-cube-maps.html
+--min-version 1.0.2 mipmap-fbo.html
 

--- a/sdk/tests/conformance/textures/mipmap-fbo.html
+++ b/sdk/tests/conformance/textures/mipmap-fbo.html
@@ -1,0 +1,135 @@
+<!--
+
+/*
+** Copyright (c) 2012 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+  <head>
+<meta charset="utf-8">
+    <title>WebGL TexParameter conformance test.</title>
+    <link rel="stylesheet" href="../../resources/js-test-style.css"/>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../resources/webgl-test.js"> </script>
+</head>
+<body>
+<canvas id="example" width="24" height="24"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">
+    attribute vec2 position;
+    varying vec2 texcoord;
+    void main(){
+       texcoord = position*0.5+0.5;
+       gl_Position = vec4(position, 0.0, 1.0);
+    }
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">
+    precision highp vec2;
+    varying vec2 texcoord;
+    uniform sampler2D source;
+    void main(){
+       gl_FragColor = texture2D(source, texcoord);
+    }
+</script>
+
+<script>
+function init(){
+    if (window.initNonKhronosFramework) {
+        window.initNonKhronosFramework(false);
+    }
+
+    description("Tests if mipmap generation on a texture filled by an FBO works correctly.");
+    debug("");
+
+    var gl = initWebGL("example");
+    var program = setupProgram(gl, "vshader", "fshader", [ "position"]);
+
+    gl.disable(gl.DEPTH_TEST);
+    gl.disable(gl.BLEND);
+                
+    // setup render target texture //
+    var texture = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, 2, 2, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+                
+    // setup framebuffer //
+    var fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+                
+    // fill the framebuffer //
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.clearColor(1, 0, 1, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+                
+    // setup vertex data //
+    quad = new Float32Array([
+        -1, -1,  1, -1,  1,  1,
+        -1,  1, -1, -1,  1,  1,
+    ]);
+   
+    var buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, quad, gl.STATIC_DRAW);
+    var position_loc = gl.getAttribLocation(program, 'position');
+    gl.enableVertexAttribArray(position_loc);
+    gl.vertexAttribPointer(position_loc, 2, gl.FLOAT, false, 0, 0);
+                
+    // generate mipmap //
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.generateMipmap(gl.TEXTURE_2D);
+                
+    gl.useProgram(program);
+    gl.uniform1i(gl.getUniformLocation(program, 'source'), 0);
+    gl.drawArrays(gl.TRIANGLES, 0, 6);
+                
+    // readback //
+    var read = new Uint8Array(4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, read);
+    var r=read[0], g=read[1], b=read[2];
+    if(r==255 && g==0 && b==255){
+        testPassed("rendered as expected");
+    }
+    else{
+        testFailed("Read back color=" + r + ',' + g + ',' + b + ' expected was 255,0,255');
+    }
+}
+
+init();
+successfullyParsed = true;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+
+</body>
+</html>
+


### PR DESCRIPTION
This test verifies that mipmap generation from texture data rendered to by a framebuffer object is correct. It passes on OSX and Linux, but fails on Windows in Chrome and Firefox.
