### PR TITLE
Remove/Refactor the calls to initNonKhronosFramework

### DIFF
--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer-offsets.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer-offsets.html
@@ -62,9 +62,6 @@ There is supposed to be an example drawing here, but it's not important.
         "use strict";
         function init()
         {
-            if (window.initNonKhronosFramework) {
-                window.initNonKhronosFramework(false);
-            }
             description("test vertexattribpointer offsets work");
 
             var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/canvas/canvas-test.html
+++ b/sdk/tests/conformance/canvas/canvas-test.html
@@ -43,9 +43,7 @@
 <canvas id="canvas2d" width="40" height="40"> </canvas>
 <script>
 "use strict";
-if (window.initNonKhronosFramework) {
-  window.initNonKhronosFramework(true);
-}
+initTestingHarnessWaitUntilDone();
 
 description("This test ensures WebGL implementations interact correctly with the canvas tag.");
 

--- a/sdk/tests/conformance/canvas/framebuffer-bindings-unaffected-on-resize.html
+++ b/sdk/tests/conformance/canvas/framebuffer-bindings-unaffected-on-resize.html
@@ -43,9 +43,7 @@
 "use strict";
 description("Verifies that GL framebuffer bindings do not change when canvas is resized");
 
-if (window.initNonKhronosFramework) {
-  window.initNonKhronosFramework(true);
-}
+initTestingHarnessWaitUntilDone();
 
 var err;
 var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/canvas/texture-bindings-unaffected-on-resize.html
+++ b/sdk/tests/conformance/canvas/texture-bindings-unaffected-on-resize.html
@@ -42,9 +42,7 @@
 "use strict";
 description('Verifies that GL texture bindings do not change when canvas is resized');
 
-if (window.initNonKhronosFramework) {
-  window.initNonKhronosFramework(true);
-}
+initTestingHarnessWaitUntilDone();
 
 var err;
 var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -72,9 +72,7 @@ var fbHasStencil;
 
 function init()
 {
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(true);
-    }
+    initTestingHarnessWaitUntilDone();
 
     description('Verify WebGLContextAttributes are working as specified, including alpha, depth, stencil, antialias, but not premultipliedAlpha');
 

--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -53,9 +53,7 @@ var contextRestoredEventFired;
 
 function init()
 {
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(true);
-    }
+    initTestingHarnessWaitUntilDone();
 
     description("Tests behavior under a restored context.");
 

--- a/sdk/tests/conformance/context/context-lost.html
+++ b/sdk/tests/conformance/context/context-lost.html
@@ -71,9 +71,7 @@ function init()
 
     description("Tests behavior under a lost context");
 
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(true);
-    }
+    initTestingHarnessWaitUntilDone();
 
     // call testValidContext() before checking for the extension, because this is where we check
     // for the isContextLost() method, which we want to do regardless of the extension's presence.

--- a/sdk/tests/conformance/extensions/webgl-depth-texture.html
+++ b/sdk/tests/conformance/extensions/webgl-depth-texture.html
@@ -58,9 +58,6 @@ void main()
 <canvas id="canvas" width="8" height="8" style="width: 8px; height: 8px;"></canvas>
 <script>
 "use strict";
-if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-}
 description("This test verifies the functionality of the WEBGL_depth_texture extension, if it is available.");
 
 debug("");

--- a/sdk/tests/conformance/glsl/misc/attrib-location-length-limits.html
+++ b/sdk/tests/conformance/glsl/misc/attrib-location-length-limits.html
@@ -68,9 +68,6 @@ void main() {
 </script>
 <script>
 "use strict";
-if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-}
 description("test attrib location length limit");
 
 var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/glsl/misc/glsl-2types-of-textures-on-same-unit.html
+++ b/sdk/tests/conformance/glsl/misc/glsl-2types-of-textures-on-same-unit.html
@@ -68,10 +68,6 @@ void main()
   "use strict";
 function init()
 {
-  if (window.initNonKhronosFramework) {
-      window.initNonKhronosFramework(false);
-  }
-
   description(
     "Tests that using 2 types of textures on the same texture unit" +
     "and referencing them both in the same program fails as per" +

--- a/sdk/tests/conformance/glsl/misc/glsl-function-nodes.html
+++ b/sdk/tests/conformance/glsl/misc/glsl-function-nodes.html
@@ -132,10 +132,6 @@ function compareRendering(buffer1, buffer2, tol)
 
 function init()
 {
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(false);
-    }
-
     description("tests function nodes");
 
     var bufFunction = new Uint8Array(width * height * 4);

--- a/sdk/tests/conformance/glsl/misc/glsl-long-variable-names.html
+++ b/sdk/tests/conformance/glsl/misc/glsl-long-variable-names.html
@@ -134,10 +134,6 @@
 
     <script>
         "use strict";
-        if (window.initNonKhronosFramework) {
-            window.initNonKhronosFramework(false);
-        }
-
         description("Verify that shader long variable names works fine if they are within 256 characters.");
 
         debug("Test same long uniform name in both vertex shader and fragment shader");

--- a/sdk/tests/conformance/glsl/misc/glsl-vertex-branch.html
+++ b/sdk/tests/conformance/glsl/misc/glsl-vertex-branch.html
@@ -126,10 +126,6 @@ function compareRendering(buffer1, buffer2, tol)
 
 function init()
 {
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(false);
-    }
-
     description("tests vertex shader with branch");
 
     var bufBranch = new Uint8Array(width * height * 4);

--- a/sdk/tests/conformance/glsl/misc/large-loop-compile.html
+++ b/sdk/tests/conformance/glsl/misc/large-loop-compile.html
@@ -67,9 +67,7 @@ void main(){
 <script>
 "use strict";
 var receivedContextLost = false;
-if (window.initNonKhronosFramework) {
-  window.initNonKhronosFramework(true);
-}
+initTestingHarnessWaitUntilDone();
 description("Ensures that compilation of a large loop completes in a reasonable period of time and does not cause the WebGL context to be lost");
 var wtu = WebGLTestUtils;
 var canvas = document.createElement('canvas');

--- a/sdk/tests/conformance/glsl/misc/uniform-location-length-limits.html
+++ b/sdk/tests/conformance/glsl/misc/uniform-location-length-limits.html
@@ -83,10 +83,6 @@ void main() {
 </script>
 <script>
 "use strict";
-if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-}
-
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext("example");
 

--- a/sdk/tests/conformance/glsl/variables/gl-fragcoord.html
+++ b/sdk/tests/conformance/glsl/variables/gl-fragcoord.html
@@ -64,10 +64,6 @@
     "use strict";
     function init()
     {
-      if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(false);
-      }
-
       description("tests gl_FragCoord");
 
       var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/glsl/variables/gl-frontfacing.html
+++ b/sdk/tests/conformance/glsl/variables/gl-frontfacing.html
@@ -64,10 +64,6 @@
     "use strict";
     function init()
     {
-      if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(false);
-      }
-
       description("tests gl_FrontFacing");
 
       var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/glsl/variables/gl-pointcoord.html
+++ b/sdk/tests/conformance/glsl/variables/gl-pointcoord.html
@@ -64,10 +64,6 @@
 
   <script>
     "use strict";
-    if (window.initNonKhronosFramework) {
-      window.initNonKhronosFramework(false);
-    }
-
     description("Checks gl_PointCoord and gl_PointSize");
     debug("");
 

--- a/sdk/tests/conformance/programs/invalid-UTF-16.html
+++ b/sdk/tests/conformance/programs/invalid-UTF-16.html
@@ -39,12 +39,6 @@
 <div id="console"></div>
 <script>
 "use strict";
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(false);
-    }
-</script>
-<script>
-"use strict";
 description('This test verifies that the internal conversion from UTF16 to UTF8 is robust to invalid inputs. Any DOM entry point which converts an incoming string to UTF8 could be used for this test.');
 
 var array = [];

--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -47,9 +47,7 @@ var wtu = WebGLTestUtils;
 var canvas = document.getElementById("example");
 var gl = wtu.create3DContext(canvas);
 
-if (window.initNonKhronosFramework) {
-   window.initNonKhronosFramework(true);
-}
+initTestingHarnessWaitUntilDone();
 
 var actual;
 var expected;

--- a/sdk/tests/conformance/rendering/gl-drawelements.html
+++ b/sdk/tests/conformance/rendering/gl-drawelements.html
@@ -59,10 +59,6 @@
         "use strict";
         function init()
         {
-            if (window.initNonKhronosFramework) {
-                window.initNonKhronosFramework(false);
-            }
-
             description(document.title);
 
             function checkDrawElements(mode, count, type, expect, msg) {

--- a/sdk/tests/conformance/rendering/multisample-corruption.html
+++ b/sdk/tests/conformance/rendering/multisample-corruption.html
@@ -58,10 +58,6 @@
         "use strict";
         function init()
         {
-            if (window.initNonKhronosFramework) {
-                window.initNonKhronosFramework(false);
-            }
-
             description(document.title);
 
             var lastContext = null;

--- a/sdk/tests/conformance/rendering/triangle.html
+++ b/sdk/tests/conformance/rendering/triangle.html
@@ -60,10 +60,6 @@ There is supposed to be an example drawing here, but it's not important.
         "use strict";
         function init()
         {
-            if (window.initNonKhronosFramework) {
-                window.initNonKhronosFramework(false);
-            }
-
             description(document.title);
 
             var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/resources/glsl-generator.js
+++ b/sdk/tests/conformance/resources/glsl-generator.js
@@ -236,10 +236,6 @@ var generateTestShader = function(
 };
 
 var runFeatureTest = function(params) {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   var wtu = WebGLTestUtils;
   var gridRes = params.gridRes;
   var vertexTolerance = params.tolerance || 0;
@@ -425,10 +421,6 @@ var runFeatureTest = function(params) {
 };
 
 var runBasicTest = function(params) {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   var wtu = WebGLTestUtils;
   var gridRes = params.gridRes;
   var vertexTolerance = params.tolerance || 0;
@@ -613,10 +605,6 @@ var runBasicTest = function(params) {
 };
 
 var runReferenceImageTest = function(params) {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   var wtu = WebGLTestUtils;
   var gridRes = params.gridRes;
   var vertexTolerance = params.tolerance || 0;

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
@@ -28,9 +28,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
 
     var init = function()
     {
-        if (window.initNonKhronosFramework) {
-            window.initNonKhronosFramework(true);
-        }
+        initTestingHarnessWaitUntilDone();
 
         description('Verify texImage2D and texSubImage2D code paths taking canvas elements (' + pixelFormat + '/' + pixelType + ')');
 

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image-data.js
@@ -30,9 +30,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
 
     var init = function()
     {
-        if (window.initNonKhronosFramework) {
-            window.initNonKhronosFramework(true);
-        }
+        initTestingHarnessWaitUntilDone();
 
         description('Verify texImage2D and texSubImage2D code paths taking ImageData (' + pixelFormat + '/' + pixelType + ')');
 

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
@@ -32,9 +32,7 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
 
     var init = function()
     {
-        if (window.initNonKhronosFramework) {
-            window.initNonKhronosFramework(true);
-        }
+        initTestingHarnessWaitUntilDone();
 
         description('Verify texImage2D and texSubImage2D code paths taking image elements (' + pixelFormat + '/' + pixelType + ')');
 

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
@@ -24,9 +24,7 @@
 // This block needs to be outside the onload handler in order for this
 // test to run reliably in WebKit's test harness (at least the
 // Chromium port). https://bugs.webkit.org/show_bug.cgi?id=87448
-if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(true);
-}
+initTestingHarnessWaitUntilDone();
 
 var old = debug;
 var debug = function(msg) {

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -971,6 +971,9 @@ var hasAttributeCaseInsensitive = function(obj, attr) {
  * @return {!WebGLContext} The created context.
  */
 var create3DContext = function(opt_canvas, opt_attributes) {
+  if (window.initTestingHarness) {
+    window.initTestingHarness();
+  }
   var attributes = shallowCopyObject(opt_attributes || {});
   if (!hasAttributeCaseInsensitive(attributes, "antialias")) {
     attributes.antialias = false;

--- a/sdk/tests/conformance/textures/copy-tex-image-and-sub-image-2d.html
+++ b/sdk/tests/conformance/textures/copy-tex-image-and-sub-image-2d.html
@@ -40,9 +40,7 @@ var successfullyParsed = false;
 
 function init()
 {
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(true);
-    }
+    initTestingHarnessWaitUntilDone();
 
     description('Verify copyTexImage2D and copyTexSubImage2D');
 

--- a/sdk/tests/conformance/textures/mipmap-fbo.html
+++ b/sdk/tests/conformance/textures/mipmap-fbo.html
@@ -43,10 +43,6 @@
 "use strict";
 function init(){
     var wtu = WebGLTestUtils;
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(false);
-    }
-
     description();
 
     var gl = wtu.create3DContext("example");

--- a/sdk/tests/conformance/textures/tex-image-with-format-and-type.html
+++ b/sdk/tests/conformance/textures/tex-image-with-format-and-type.html
@@ -61,9 +61,7 @@ var DataMode = {
 
 function init()
 {
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(true);
-    }
+    initTestingHarnessWaitUntilDone();
 
     description('Verify texImage2D and texSubImage2D code paths taking both HTML and user-specified data with all format/type combinations');
 

--- a/sdk/tests/conformance/textures/texparameter-test.html
+++ b/sdk/tests/conformance/textures/texparameter-test.html
@@ -67,10 +67,6 @@ void main()
 "use strict";
 function init()
 {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   description("Tests TexParameter works as expected");
   debug("");
 

--- a/sdk/tests/conformance/textures/texture-active-bind-2.html
+++ b/sdk/tests/conformance/textures/texture-active-bind-2.html
@@ -75,10 +75,6 @@ void main()
 "use strict";
 function init()
 {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   description(
       "Tests that binding both TEXTURE_2D and TEXTURE_CUBE_MAP to the same" +
       "active texture unit works as long as they are not used" +

--- a/sdk/tests/conformance/textures/texture-active-bind.html
+++ b/sdk/tests/conformance/textures/texture-active-bind.html
@@ -57,10 +57,6 @@ var gl;
 
 function init()
 {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   description(
       "Tests that glActiveTexture and glBindTexture work as expected" +
       "Specifically texture targets are per active texture unit.");

--- a/sdk/tests/conformance/textures/texture-complete.html
+++ b/sdk/tests/conformance/textures/texture-complete.html
@@ -44,10 +44,6 @@
 "use strict";
 function init()
 {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   description(
       "Checks that a texture that is not -texture-complete- does not draw if"+
       " filtering needs mips");

--- a/sdk/tests/conformance/textures/texture-mips.html
+++ b/sdk/tests/conformance/textures/texture-mips.html
@@ -66,10 +66,6 @@ var canvas;
 var wtu = WebGLTestUtils;
 function init()
 {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   description("Checks mip issues");
 
   canvas = document.getElementById("example");

--- a/sdk/tests/conformance/textures/texture-npot-video.html
+++ b/sdk/tests/conformance/textures/texture-npot-video.html
@@ -39,9 +39,7 @@ var gl = null;
 var textureLoc = null;
 var successfullyParsed = false;
 
-if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(true);
-}
+initTestingHarnessWaitUntilDone();
 
 function init()
 {

--- a/sdk/tests/conformance/textures/texture-transparent-pixels-initialized.html
+++ b/sdk/tests/conformance/textures/texture-transparent-pixels-initialized.html
@@ -40,9 +40,7 @@ var successfullyParsed = false;
 
 function init()
 {
-    if (window.initNonKhronosFramework) {
-        window.initNonKhronosFramework(true);
-    }
+    initTestingHarnessWaitUntilDone();
 
     description('Tests there is no garbage in transparent regions of images uploaded as textures');
 

--- a/sdk/tests/conformance/uniforms/uniform-samplers-test.html
+++ b/sdk/tests/conformance/uniforms/uniform-samplers-test.html
@@ -44,10 +44,6 @@
 "use strict";
 function init()
 {
-  if (window.initNonKhronosFramework) {
-    window.initNonKhronosFramework(false);
-  }
-
   description(
       "Tests that only Uniform1i and Uniform1iv can be used to set" +
       "sampler uniforms.");

--- a/sdk/tests/extra/canvas-compositing-test.html
+++ b/sdk/tests/extra/canvas-compositing-test.html
@@ -88,10 +88,6 @@ img tag<br/>
             ctx2d.fill();
 
 
-            if (window.initNonKhronosFramework) {
-                window.initNonKhronosFramework(false);
-            }
-
             var gl = wtu.create3DContext("example");
             var program = wtu.setupProgram(["vshader", "fshader"], ["vPosition"]);
 

--- a/sdk/tests/resources/js-test-pre.js
+++ b/sdk/tests/resources/js-test-pre.js
@@ -21,18 +21,36 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-// WebKit Specfic code.  Add your own here.
-function initNonKhronosFramework(waitUntilDone) {
-  if (window.layoutTestController) {
-    layoutTestController.overridePreference("WebKitWebGLEnabled", "1");
-    layoutTestController.dumpAsText();
-    if (waitUntilDone) {
-      layoutTestController.waitUntilDone();
+(function() {
+  var testHarnessInitialized = false;
+
+  var initNonKhronosFramework = function(waitUntilDone) {
+    if (testHarnessInitialized) {
+      return;
+    }
+    testHarnessInitialized = true;
+
+    // WebKit Specific code. Add your code here.
+    if (window.layoutTestController) {
+      layoutTestController.overridePreference("WebKitWebGLEnabled", "1");
+      layoutTestController.dumpAsText();
+      if (waitUntilDone) {
+        layoutTestController.waitUntilDone();
+      }
     }
   }
-}
+
+  this.initTestingHarnessWaitUntilDone = function() {
+    initNonKhronosFramework(true);
+  }
+
+  this.initTestingHarness = function() {
+    initNonKhronosFramework(false);
+  }
+}());
 
 function nonKhronosFrameworkNotifyDone() {
+  // WebKit Specific code. Add your code here.
   if (window.layoutTestController) {
     layoutTestController.notifyDone();
   }
@@ -52,6 +70,7 @@ function notifyFinishedToHarness() {
 
 function description(msg)
 {
+    initTestingHarness();
     if (msg === undefined) {
       msg = document.title;
     }


### PR DESCRIPTION
In many samples the code would do this

```
if (window.initNonKhronosFramework) {
  window.initNonKhronosFramework(true);
}
```

Problems with that approach
1.  When is it needed?
   
   Apparently it's needed for any test run in as a WebKit layout test.
   That doesn't seem like it should be bleeding into every test.
   
   Solution: Move it to `WebGLTestUtils.create3DContext` and from
   `description`.
   
   It's now called for almost all tests automatically. A flag
   makes sure it will only be called once.
2.  What does the 'true' mean? Other places call it with 'false'.
   
   It turns out 'true' appearently tells WebKit's testing harness not
   to timeout the test.
   
   Solution: Change the 'true' calls to `initTestingHarnessWaitUntilDone`
