### PR TITLE
Remove uniform array truncation test 

### DIFF
--- a/sdk/tests/conformance/uniforms/00_test_list.txt
+++ b/sdk/tests/conformance/uniforms/00_test_list.txt
@@ -1,5 +1,6 @@
 gl-uniform-arrays.html
---min-version 1.0.02 gl-uniform-unused-array-elements-get-truncated.html
+# This test is no longer valid with the new packing restrictions
+#--min-version 1.0.02 gl-uniform-unused-array-elements-get-truncated.html
 gl-uniform-bool.html
 gl-uniformmatrix4fv.html
 gl-unknown-uniform.html


### PR DESCRIPTION
Remove uniform array truncation test which is no longer compatible
with new WebGL January 15, 2013 section 6.24
