### PR TITLE
Update README's with absolute URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ WebGL repository for the WebGL specifications
 and the WebGL conformance test suite.
 
 Before adding a new test or editing an existing test
-<a href="blob/master/sdk/tests/test-guidelines.md"> please read these guidelines</a>.
+<a href="http://github.com/WebGL/blob/master/sdk/tests/test-guidelines.md"> please read these guidelines</a>.
 
 You can find live versions of the specifications at
 http://www.khronos.org/webgl/

--- a/sdk/tests/README.md
+++ b/sdk/tests/README.md
@@ -2,7 +2,7 @@ Welcome to the WebGL Conformance Test Suite
 ===========================================
 
 Note: Before adding a new test or editing an existing test
-<a href="test-guidelines.md"> please read these guidelines</a>.
+<a href="https://github.com/KhronosGroup/WebGL/blob/master/sdk/tests/test-guidelines.md"> please read these guidelines</a>.
 
 This is the initial release of the WebGL conformance test suite.
 

--- a/sdk/tests/test-guidelines.md
+++ b/sdk/tests/test-guidelines.md
@@ -133,7 +133,6 @@ These lines appears at the top of every html and js file under sdk/tests/conform
     *   All HTML files must have a `<meta charset="utf-8">`
 
     *   All JavaScript must start with "use strict";
->>>>>>> Stashed changes
 
 *   If adding a new test edit the approriate 00_test_list.txt file
 


### PR DESCRIPTION
Will fix once github adds support for repo relative links
in github-flavored-markup
