### PR TITLE
Test non-vendor prefixed WEBGL_lose_context extension string.

### DIFF
--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -39,6 +39,7 @@ var canvas;
 var gl;
 var shouldGenerateGLError;
 var extensionNames = [
+    "WEBGL_lose_context",
     "WEBKIT_WEBGL_lose_context",
     "MOZ_WEBGL_lose_context",
 ];

--- a/sdk/tests/conformance/context/context-lost.html
+++ b/sdk/tests/conformance/context/context-lost.html
@@ -39,6 +39,7 @@ var canvas;
 var gl;
 var shouldGenerateGLError;
 var extensionNames = [
+    "WEBGL_lose_context",
     "WEBKIT_WEBGL_lose_context",
     "MOZ_WEBGL_lose_context",
 ];


### PR DESCRIPTION
Since WEBGL_lose_context extension is official now, modify the conformance tests to test querying this extension. Remove vendor prefix after certain grace period.
