### PR TITLE
Precision type of vec4

### DIFF
--- a/sdk/tests/conformance/glsl/misc/large-loop-compile.html
+++ b/sdk/tests/conformance/glsl/misc/large-loop-compile.html
@@ -46,7 +46,7 @@ void main(){
 }
 </script>
 <script id="fragmentShader" type="text/something-not-javascript">
-precision highp vec4;
+precision mediump float;
 uniform sampler2D source;
 
 mat3 front = mat3(

--- a/sdk/tests/conformance/glsl/misc/shader-with-default-precision.frag.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-default-precision.frag.html
@@ -42,6 +42,9 @@
 <script id="fragmentShader" type="text/something-not-javascript">
 // fragment shader with default precision should succeed
 precision mediump float;
+precision mediump int;
+precision lowp sampler2D;
+precision lowp samplerCube;
 void main()
 {
     gl_FragColor = vec4(1.0,0.0,0.0,1.0);

--- a/sdk/tests/conformance/glsl/misc/shader-with-default-precision.vert.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-default-precision.vert.html
@@ -42,6 +42,9 @@
 <script id="vertexShader" type="text/something-not-javascript">
 // vertex shader with default precision should succeed
 precision mediump float;
+precision mediump int;
+precision lowp sampler2D;
+precision lowp samplerCube;
 attribute vec4 vPosition;
 void main()
 {

--- a/sdk/tests/conformance/glsl/misc/shader-with-illegal-default-precision.frag.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-illegal-default-precision.frag.html
@@ -1,0 +1,273 @@
+<!--
+
+/*
+** Copyright (c) 2012 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragmentShaderVoid" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump void;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderBool" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump bool;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderVec2" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump vec2;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderVec3" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump vec3;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderVec4" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump vec4;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderBvec2" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump bvec2;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderBvec3" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump bvec3;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderBvec4" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump bvec4;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderIvec2" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump ivec2;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderIvec3" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump ivec3;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderIvec4" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump ivec4;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderMat2" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump mat2;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderMat3" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump mat3;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script id="fragmentShaderMat4" type="text/something-not-javascript">
+// fragment shader with default precision for illegal type should fail
+precision mediump mat4;
+void main()
+{
+    mediump vec4 color = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragColor = color;
+}
+</script>
+<script>
+"use strict";
+GLSLConformanceTester.runTests([
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderVoid',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for void should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderBool',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bool should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderVec2',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for vec2 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderVec3',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for vec3 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderVec4',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for vec4 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderBvec2',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bvec2 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderBvec3',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bvec3 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderBvec4',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bvec4 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderIvec2',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for ivec2 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderIvec3',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for ivec3 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderIvec4',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for ivec4 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderMat2',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for mat2 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderMat3',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for mat3 should fail'
+    },
+    { vShaderId: undefined,
+      vShaderSuccess: true,
+      fShaderId: 'fragmentShaderMat4',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for mat4 should fail'
+    }
+]);
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/glsl/misc/shader-with-illegal-default-precision.vert.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-illegal-default-precision.vert.html
@@ -1,0 +1,273 @@
+<!--
+
+/*
+** Copyright (c) 2012 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vertexShaderVoid" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump void;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderBool" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump bool;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderVec2" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump vec2;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderVec3" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump vec3;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderVec4" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump vec4;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderBvec2" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump bvec2;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderBvec3" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump bvec3;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderBvec4" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump bvec4;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderIvec2" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump ivec2;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderIvec3" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump ivec3;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderIvec4" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump ivec4;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderMat2" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump mat2;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderMat3" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump mat3;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="vertexShaderMat4" type="text/something-not-javascript">
+// vertex shader with default precision for illegal type should fail
+precision mediump mat4;
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script>
+"use strict";
+GLSLConformanceTester.runTests([
+    { vShaderId: 'vertexShaderVoid',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for void should fail'
+    },
+    { vShaderId: 'vertexShaderBool',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bool should fail'
+    },
+    { vShaderId: 'vertexShaderVec2',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for vec2 should fail'
+    },
+    { vShaderId: 'vertexShaderVec3',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for vec3 should fail'
+    },
+    { vShaderId: 'vertexShaderVec4',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for vec4 should fail'
+    },
+    { vShaderId: 'vertexShaderBvec2',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bvec2 should fail'
+    },
+    { vShaderId: 'vertexShaderBvec3',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bvec3 should fail'
+    },
+    { vShaderId: 'vertexShaderBvec4',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for bvec4 should fail'
+    },
+    { vShaderId: 'vertexShaderIvec2',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for ivec2 should fail'
+    },
+    { vShaderId: 'vertexShaderIvec3',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for ivec3 should fail'
+    },
+    { vShaderId: 'vertexShaderIvec4',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for ivec4 should fail'
+    },
+    { vShaderId: 'vertexShaderMat2',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for mat2 should fail'
+    },
+    { vShaderId: 'vertexShaderMat3',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for mat3 should fail'
+    },
+    { vShaderId: 'vertexShaderMat4',
+      vShaderSuccess: true,
+      fShaderId: undefined,
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'shader with default precision for mat4 should fail'
+    }
+]);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
http://www.khronos.org/bugzilla/show_bug.cgi?id=781

Fixed illegal default precision qualifier in large-loop-test and added tests of all valid and invalid default precision qualifiers in vertex and fragment shaders. Filed ANGLE bug 410 about the failure of the new tests.
