### PR TITLE
Use attribute locations instead of hard coded indixes

### DIFF
--- a/sdk/tests/conformance/extensions/oes-element-index-uint.html
+++ b/sdk/tests/conformance/extensions/oes-element-index-uint.html
@@ -317,11 +317,12 @@ function runCopiesIndicesTests() {
 
     gl.useProgram(program);
     var vertexObject = gl.createBuffer();
-    gl.enableVertexAttribArray(0);
+    var vertexLoc = gl.getAttribLocation(program, "a_vertex");
+    gl.enableVertexAttribArray(vertexLoc);
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
     // 4 vertices -> 2 triangles
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0,0, 0,1,0, 1,0,0, 1,1,0 ]), gl.STATIC_DRAW);
-    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+    gl.vertexAttribPointer(vertexLoc, 3, gl.FLOAT, false, 0, 0);
 
     var indexObject = gl.createBuffer();
 
@@ -336,6 +337,7 @@ function runCopiesIndicesTests() {
     shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 4)");
     shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 0)");
     shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 8)");
+    gl.disableVertexAttribArray(vertexLoc);
 }
 
 function runResizedBufferTests() {


### PR DESCRIPTION
Found this while working on the extension implementation for Firefox. The test would fail on Windows because ANGLE didn't appear to overwrite the hardcoded index 0. This passes on Chrome stable for OS X; I'll do additional testing with Chrome and Firefox on other platforms.
