### PR TITLE
Fix rendering/point-size conformance test

### DIFF
--- a/conformance-suites/1.0.2/conformance/rendering/point-size.html
+++ b/conformance-suites/1.0.2/conformance/rendering/point-size.html
@@ -70,7 +70,6 @@
     shouldBeNonNull("gl");
 
     gl.disable(gl.BLEND);
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     // The choice of (0.4, 0.4) ensures that the centers of the surrounding
     // pixels are not contained within the point when it is of size 1, but
@@ -92,6 +91,8 @@
     gl.bufferSubData(gl.ARRAY_BUFFER, colorOffset, colors);
 
     function test(program) {
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
         gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(0);
         gl.vertexAttribPointer(1, 4, gl.UNSIGNED_BYTE, true, 0, colorOffset);


### PR DESCRIPTION
Add a missing gl.clear in rendering/point-size that makes this test passable.

Currently the test always fails, because it does not clear the frame buffer between rendering passes. It clears, draws a point of size 1, clears, draws a point of size 2, then immediately will draw a point of size 1 without clearing, then finish with a clear and a point of size 2. Thus the second point of size 1 is detected as a point of size 2.

This pull request relocates the clear so it gets called on every iteration of test().
