### PR TITLE
Fix undefined behaviour in rendering/more-than-65536-indices conformance test

### DIFF
--- a/conformance-suites/1.0.2/conformance/rendering/more-than-65536-indices.html
+++ b/conformance-suites/1.0.2/conformance/rendering/more-than-65536-indices.html
@@ -45,6 +45,7 @@ attribute vec4 vColor;
 varying vec4 color;
 void main() {
     gl_Position = vPosition;
+    gl_PointSize = 1.0;
     color = vColor;
 }
 </script>


### PR DESCRIPTION
Not writing to gl_PointSize but using a shader for rendering point primitives results in an undefined point size.  The vertex shader in rendering/more-than-65536-indices is used to render points (among other primitive types) but never sets gl_PointSize.
