### PR TITLE
Fix randomImage in quickCheckAPI.js to allow choosing to generate videos

### DIFF
--- a/conformance-suites/1.0.2/conformance/more/conformance/quickCheckAPI.js
+++ b/conformance-suites/1.0.2/conformance/more/conformance/quickCheckAPI.js
@@ -353,7 +353,7 @@ randomLineWidth = function() {
 randomImage = function(w,h) {
   var img;
   var r = Math.random();
-  if (r < 0.5) {
+  if (r < 0.25) {
     img = document.createElement('canvas');
     img.width = w; img.height = h;
     img.getContext('2d').fillRect(0,0,w,h);


### PR DESCRIPTION
Allow randomImage to choose to generate a video in conformance-suites/1.0.2/conformance/more/conformance/quickCheckAPI.js .
