### PR TITLE
Tightened up constants and methods tests so that the addition of any unk...

### DIFF
--- a/sdk/tests/conformance/context/00_test_list.txt
+++ b/sdk/tests/conformance/context/00_test_list.txt
@@ -1,4 +1,4 @@
-constants.html
+constants-and-properties.html
 --min-version 1.0.2 context-attribute-preserve-drawing-buffer.html
 context-attributes-alpha-depth-stencil-antialias.html
 --min-version 1.0.2 --slow context-creation-and-destruction.html

--- a/sdk/tests/conformance/context/constants-and-properties.html
+++ b/sdk/tests/conformance/context/constants-and-properties.html
@@ -28,7 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL Constants Test</title>
+<title>WebGL Constants and Properties Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
@@ -41,7 +41,7 @@
 <canvas id="canvas" style="width: 50px; height: 50px;"> </canvas>
 <script>
 "use strict";
-description("This test ensures that the WebGL context has all the constants in the specification.");
+description("This test ensures that the WebGL context has all the constants and (non-function) properties in the specification.");
 
 var constants = {
     /* ClearBufferMask */
@@ -460,6 +460,19 @@ UNPACK_COLORSPACE_CONVERSION_WEBGL : 0x9243,
 BROWSER_DEFAULT_WEBGL              : 0x9244
 };
 
+// Other non-function properties on the WebGL object
+var otherProperties = {
+drawingBufferWidth  : "number",
+drawingBufferHeight : "number",
+canvas              : "implementation-dependent"
+};
+
+// Properties to be ignored (as a list of strings) because they were
+// added in versions of the spec that are backward-compatible with
+// this version
+var ignoredProperties = [
+];
+
 // Constants removed from the WebGL spec compared to ES 2.0
 var removedConstants = {
 NUM_COMPRESSED_TEXTURE_FORMATS : 0x86A2,
@@ -522,13 +535,24 @@ if (passed) {
 }
 var extended = false;
 for (var i in gl) {
-  if (i.match(/^[^a-z]/) && constants[i] == null) {
+  if (constants[i] !== undefined) {
+    // OK; known constant
+  } else if (ignoredProperties.indexOf(i) != -1) {
+    // OK; constant that should be ignored because it was added in a later version of the spec
+  } else if (otherProperties[i] !== undefined &&
+             (otherProperties[i] == "implementation-dependent" || typeof gl[i] == otherProperties[i])) {
+    // OK; known property of known type
+  } else if (typeof gl[i] != "function") {
     if (!extended) {
       extended = true;
-      debug("Also found the following extra constants:");
+      testFailed("Also found the following extra properties:");
     }
-    debug(i);
+    testFailed(i);
   }
+}
+
+if (!extended) {
+  testPassed("No extra properties found on WebGL context.");
 }
 
 debug("");

--- a/sdk/tests/conformance/context/methods.html
+++ b/sdk/tests/conformance/context/methods.html
@@ -44,7 +44,6 @@
 description("This test ensures that the WebGL context has all the methods in the specification.");
 
 var methods = [
-"canvas",
 "getContextAttributes",
 "activeTexture",
 "attachShader",
@@ -67,6 +66,8 @@ var methods = [
 "clearStencil",
 "colorMask",
 "compileShader",
+"compressedTexImage2D",
+"compressedTexSubImage2D",
 "copyTexImage2D",
 "copyTexSubImage2D",
 "createBuffer",
@@ -105,13 +106,16 @@ var methods = [
 "getParameter",
 "getBufferParameter",
 "getError",
+"getExtension",
 "getFramebufferAttachmentParameter",
 "getProgramParameter",
 "getProgramInfoLog",
 "getRenderbufferParameter",
 "getShaderParameter",
 "getShaderInfoLog",
+"getShaderPrecisionFormat",
 "getShaderSource",
+"getSupportedExtensions",
 "getTexParameter",
 "getUniform",
 "getUniformLocation",
@@ -119,6 +123,7 @@ var methods = [
 "getVertexAttribOffset",
 "hint",
 "isBuffer",
+"isContextLost",
 "isEnabled",
 "isFramebuffer",
 "isProgram",
@@ -175,18 +180,23 @@ var methods = [
 "vertexAttrib4fv",
 "vertexAttribPointer",
 "viewport"
-]
+];
 
-function assertProperty(v, p) {
+// Properties to be ignored because they were added in versions of the
+// spec that are backward-compatible with this version
+var ignoredMethods = [
+];
+
+function assertFunction(v, f) {
   try {
-    if (v[p] == null) {
-      testFailed("Property does not exist: " + p)
+    if (typeof v[f] != "function") {
+      testFailed("Property either does not exist or is not a function: " + f);
       return false;
     } else {
       return true;
     }
   } catch(e) {
-    testFailed("Trying to access the property '"+p+"' threw an error: "+e.toString());
+    testFailed("Trying to access the property '" + f + "' threw an error: "+e.toString());
   }
 }
 
@@ -198,7 +208,7 @@ var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
 var passed = true;
 for (var i=0; i<methods.length; i++) {
-  var r = assertProperty(gl, methods[i]);
+  var r = assertFunction(gl, methods[i]);
   passed = passed && r;
 }
 if (passed) {
@@ -206,13 +216,17 @@ if (passed) {
 }
 var extended = false;
 for (var i in gl) {
-  if (i.match(/^[a-z]/) && methods.indexOf(i) == -1) {
+  if (typeof gl[i] == "function" && methods.indexOf(i) == -1 && ignoredMethods.indexOf(i) == -1) {
     if (!extended) {
       extended = true;
-      debug("Also found the following extra methods:");
+      testFailed("Also found the following extra methods:");
     }
-    debug(i);
+    testFailed(i);
   }
+}
+
+if (!extended) {
+  testPassed("No extra methods found on WebGL context.");
 }
 
 debug("");


### PR DESCRIPTION
...nown properties or functions will cause the tests to fail. This change will require these tests to be updated if future versions of the spec are released which add new properties to the WebGLRenderingContext, but the current situation where implementations may accidentally expose properties without failing these tests is unworkable.
