### PR TITLE
Fix variable packing tests

### DIFF
--- a/conformance-suites/1.0.2/conformance/glsl/misc/shader-uniform-packing-restrictions.html
+++ b/conformance-suites/1.0.2/conformance/glsl/misc/shader-uniform-packing-restrictions.html
@@ -164,7 +164,7 @@ for (var ss = 0; ss < shaderTypes.length; ++ss) {
     var minVars = Math.floor(shaderType.minVectors / info.rows);
     // Compute the maximum allowed as single elements
     var numPerRow = Math.floor(4 / info.componentsPerRow);
-    var numMax = Math.floor(shaderType.maxVectors * numPerRow);
+    var numMax = Math.floor(shaderType.maxVectors * numPerRow / info.rows);
     // Test array[1] of the type
     var code = wtu.replaceParams(info.code, {id: "", index: "[0]"});
     tests.push({

--- a/conformance-suites/1.0.2/conformance/glsl/misc/shader-varying-packing-restrictions.html
+++ b/conformance-suites/1.0.2/conformance/glsl/misc/shader-varying-packing-restrictions.html
@@ -110,7 +110,8 @@ for (var ii = 0; ii < varyingTypes.length; ++ii) {
   var minVars = Math.floor(minVaryingVectors / info.rows);
   // Compute the maximum allowed as single elements
   var numPerRow = Math.floor(4 / info.componentsPerRow);
-  var numMax = Math.floor(shaderType.maxVectors * numPerRow);
+  var numMax = Math.floor(maxVaryingVectors * numPerRow / info.rows);
+
   // Test array[1] of the type
   var vcode = wtu.replaceParams(info.vcode, {id: "", index: "[0]"});
   var fcode = wtu.replaceParams(info.fcode, {id: "", index: "[0]"});

--- a/sdk/tests/conformance/glsl/misc/shader-uniform-packing-restrictions.html
+++ b/sdk/tests/conformance/glsl/misc/shader-uniform-packing-restrictions.html
@@ -164,7 +164,7 @@ for (var ss = 0; ss < shaderTypes.length; ++ss) {
     var minVars = Math.floor(shaderType.minVectors / info.rows);
     // Compute the maximum allowed as single elements
     var numPerRow = Math.floor(4 / info.componentsPerRow);
-    var numMax = Math.floor(shaderType.maxVectors * numPerRow);
+    var numMax = Math.floor(shaderType.maxVectors * numPerRow / info.rows);
     // Test array[1] of the type
     var code = wtu.replaceParams(info.code, {id: "", index: "[0]"});
     tests.push({

--- a/sdk/tests/conformance/glsl/misc/shader-varying-packing-restrictions.html
+++ b/sdk/tests/conformance/glsl/misc/shader-varying-packing-restrictions.html
@@ -110,7 +110,8 @@ for (var ii = 0; ii < varyingTypes.length; ++ii) {
   var minVars = Math.floor(minVaryingVectors / info.rows);
   // Compute the maximum allowed as single elements
   var numPerRow = Math.floor(4 / info.componentsPerRow);
-  var numMax = Math.floor(shaderType.maxVectors * numPerRow);
+  var numMax = Math.floor(maxVaryingVectors * numPerRow / info.rows);
+
   // Test array[1] of the type
   var vcode = wtu.replaceParams(info.vcode, {id: "", index: "[0]"});
   var fcode = wtu.replaceParams(info.fcode, {id: "", index: "[0]"});


### PR DESCRIPTION
When computing the maximum uniforms forgot to divide by
number of rows per uniform so the maximum for mat2, mat3 and mat4
was vastly too big
