### PR TITLE
Speed up the quickCheckAPI tests

### DIFF
--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-A.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-A.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B1.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B1.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B2.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B2.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B3.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B3.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B4.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B4.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-C.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-C.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-D_G.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-D_G.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-G_I.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-G_I.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-L_S.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-L_S.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-S_V.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-S_V.html
@@ -59,16 +59,16 @@ Tests.testValidArgs = function() {
         var ok = false;
         // if we have an validity checker, assert that the generated args are valid
         if (gen.checkArgValidity)
-          assert("Valid args: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assert("Valid args: "+name+"("+argsToString(args)+")",
                 gen.checkArgValidity.apply(gen, args));
         var rv;
         // assert that GL function works when called with valid args
-        assertOk("This should work: "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertOk("This should work: "+name+"("+argsToString(args)+")",
                 function(){rv = GL[name].apply(GL, args); ok = true;});
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup)
-          assertOk("Cleaning up return value after "+name+"("+args.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(args)+")",
                    function() { gen.returnValueCleanup(rv); });
         return ok;
       }, argGen.testCount || randomTestCount);

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI.js
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI.js
@@ -410,4 +410,21 @@ argGeneratorTestRunner = function(argGen, testFunction, numberOfTests) {
   if (argGen.teardown)
     argGen.teardown.apply(argGen, setupVars);
   if (error) throw(error);
-}
+};
+
+// TODO: Remove this
+// WebKit or at least Chrome is really slow at laying out strings with
+// unprintable characters. Without this tests can take 30-90 seconds.
+// With this they're instant.
+sanitize = function(str) {
+  var newStr = [];
+  for (var ii = 0; ii < str.length; ++ii) {
+    var c = str.charCodeAt(ii);
+    newStr.push((c > 31 && c < 128) ? str[ii] : "?");
+  }
+  return newStr.join('');
+};
+
+argsToString = function(args) {
+  return sanitize(args.map(function(a){return Object.toSource(a)}).join(","));
+};

--- a/sdk/tests/conformance/more/conformance/quickCheckAPIBadArgs.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPIBadArgs.html
@@ -75,7 +75,7 @@ Tests.testInvalidArgs = function() {
         var ok = false;
         var rv;
         // assert that GL function fails when called with invalid args
-        assertFail("This should fail: "+name+"("+mutatedArgs.map(function(a){return Object.toSource(a)}).join(",")+")",
+        assertFail("This should fail: "+name+"("+argsToString(mutatedArgs)+")",
           function(){
             GL.getError(); // clear off existing error
             rv = GL[name].apply(GL, mutatedArgs);
@@ -85,7 +85,7 @@ Tests.testInvalidArgs = function() {
         // if we need to cleanup the return value, do it here
         // e.g. calling gl.deleteBuffer(rv) after testing gl.createBuffer() above
         if (gen.returnValueCleanup && rv != null) {
-          assertOk("Cleaning up return value after "+name+"("+mutatedArgs.map(function(a){return Object.toSource(a)}).join(",")+")",
+          assertOk("Cleaning up return value after "+name+"("+argsToString(mutatedArgs)+")",
                    function() { gen.returnValueCleanup(rv); });
         }
         GL.getError();


### PR DESCRIPTION
The issue is that for some reason Chrome is EXTREMELY slow
at laying out unprintable characters. While there's no excuse
that it's slow there's also not much insentive to fix it
since few pages use unprintable characters. So, sanitize the
output so no unprintible characters are added to the DOM.
