### PR TITLE
Add extended attribute to isVertexArrayOES

### DIFF
--- a/extensions/OES_vertex_array_object/extension.xml
+++ b/extensions/OES_vertex_array_object/extension.xml
@@ -13,7 +13,14 @@
     <api version="1.0"/>
   </depends>
   <overview>
-    <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_vertex_array_object.txt" name="OES_vertex_array_object" />
+    <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_vertex_array_object.txt"
+name="OES_vertex_array_object">
+      <addendum>
+        The command IsVertexArrayObjectOES returns false if the vertex
+array object's <a href="#webgl-object-invalidated-flag">invalidated
+flag</a> is set.
+      </addendum>
+    </mirrors>
   </overview>
   <idl xml:space="preserve">
 interface WebGLVertexArrayObjectOES : WebGLObject {


### PR DESCRIPTION
Based on feedback and discussion between Benoit Jacob and Kenneth
Russel on the mailing list.  isVertexArray should behave much the same
as other isX() methods such as isRenderbuffer().
