### PR TITLE
Make floating point texture tests test filtering

### DIFF
--- a/sdk/tests/conformance/extensions/oes-texture-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float.html
@@ -117,9 +117,6 @@ if (!gl) {
   }
 }
 
-// Needs to be global for shouldBe to see it.
-var pixels;
-
 function allocateTexture()
 {
     var texture = gl.createTexture();
@@ -164,10 +161,14 @@ function runTextureCreationTest(testProgram, extensionEnabled, opt_format, opt_n
         glErrorShouldBe(gl, gl.NO_ERROR, "floating-point texture allocation should succeed if OES_texture_float is enabled");
     }
     // Verify that the texture actually works for sampling and contains the expected data.
-    gl.uniform1i(gl.getUniformLocation(testProgram, "tex"), 0);
     gl.uniform4fv(gl.getUniformLocation(testProgram, "subtractor"), subtractor);
     wtu.clearAndDrawUnitQuad(gl);
     checkRenderingResults();
+
+    // Check that linear fails.
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.checkCanvas(gl, [255, 0, 0, 255], "should be red");
 }
 
 function runRenderTargetTest(testProgram)

--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -39,6 +39,7 @@
 <body>
 <div id="description"></div>
 <canvas id="canvas" style="width: 50px; height: 50px;"> </canvas>
+<canvas id="canvas2d" style="width: 50px; height: 50px;"> </canvas>
 <div id="console"></div>
 <script id="testFragmentShader" type="x-shader/x-fragment">
 precision mediump float;
@@ -79,6 +80,12 @@ description("This test verifies the functionality of OES_texture_half_float with
 debug("");
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
+var colorCanvas = document.getElementById("canvas2d");
+colorCanvas.width = 2;
+colorCanvas.height = 2;
+var ctx = colorCanvas.getContext("2d");
+ctx.fillStyle = "rgb(255,0,0)";
+ctx.fillRect(0, 0, 2, 2);
 var gl = wtu.create3DContext(canvas);
 // This constant must be defined in order to run the texture creation test without the extension enabled.
 var halfFloatOESEnum = 0x8D61;
@@ -91,44 +98,53 @@ if (!gl) {
 
     // Verify that allocation of texture fails if extension is not enabled
     runTextureCreationTest(false);
-
-    if (!(ext = gl.getExtension("OES_texture_half_float"))) {
+    ext = gl.getExtension("OES_texture_half_float")
+    if (!ext) {
         testPassed("No OES_texture_half_float support. This is legal");
     } else {
         testPassed("Successfully enabled OES_texture_half_float extension");
 
+        var program = wtu.setupTexturedQuad(gl);
+
         // Check if creation of texture succeed's with various formats and null ArrayBufferView
-        var formats = [gl.RGBA, gl.RGB, gl.LUMINANCE, gl.ALPHA, gl.LUMINANCE_ALPHA];
-        for (var i = 0; i < formats.length; i++) {
-            runTextureCreationTest(true, formats[i], null);
-        }
+        var formats = [
+          { format: gl.RGBA,            expected: [255,   0,   0, 255], },
+          { format: gl.RGB,             expected: [255,   0,   0, 255], },
+          { format: gl.LUMINANCE,       expected: [255, 255, 255, 255], },
+          { format: gl.ALPHA,           expected: [  0,   0,   0, 255], },
+          { format: gl.LUMINANCE_ALPHA, expected: [255, 255, 255, 255], },
+        ];
+        formats.forEach(function(f) {
+            runTextureCreationTest(true, f.format, null, f.expected);
+        });
         
         // Texture creation should fail when passed with non-null ArrayBufferView
-        for (var i = 0; i < formats.length; i++) {
+        formats.forEach(function(f) {
             var width = 2;
             var height = 2;
+            var format = f.format;
             
             // Float32Array
-            var float32Data = new Float32Array(width * height * getNumberOfChannels(formats[i]));
+            var float32Data = new Float32Array(width * height * getNumberOfChannels(format));
             for (var ii = 0; ii < float32Data.length; ii++) {
                 float32Data[ii] = 1000;
             }
-            runTextureCreationTest(true, formats[i], float32Data);
+            runTextureCreationTest(true, format, float32Data);
 
             // Int16Array
-            var int16Data = new Int16Array(width * height * getNumberOfChannels(formats[i]));
+            var int16Data = new Int16Array(width * height * getNumberOfChannels(format));
             for (var ii = 0; ii <  int16Data.length; ii++) {
                 int16Data[ii] = 1000;
             }
-            runTextureCreationTest(true, formats[i], int16Data);
+            runTextureCreationTest(true, format, int16Data);
 
             // Uint16Array
-            var uint16Data = new Uint16Array(width * height * getNumberOfChannels(formats[i]));
+            var uint16Data = new Uint16Array(width * height * getNumberOfChannels(format));
             for (var ii = 0; ii <  uint16Data.length; ii++) {
                 uint16Data[ii] = 1000;
             }
-            runTextureCreationTest(true, formats[i], uint16Data);            
-        }
+            runTextureCreationTest(true, format, uint16Data);
+        });
 
         // Check if attaching texture as FBO target succeeds (Not mandatory)
         runRenderTargetTest();
@@ -175,7 +191,7 @@ function allocateTexture()
     return texture;
 }
 
-function runTextureCreationTest(extensionEnabled, opt_format, opt_data)
+function runTextureCreationTest(extensionEnabled, opt_format, opt_data, opt_expected)
 {
     var format = opt_format || gl.RGBA;
     var data = opt_data || null;
@@ -199,7 +215,16 @@ function runTextureCreationTest(extensionEnabled, opt_format, opt_data)
         return;
     } else {
         glErrorShouldBe(gl, gl.NO_ERROR, "Half floating point texture allocation should succeed if OES_texture_half_float is enabled");
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, format, format, halfFloatOESEnum, colorCanvas);
+        wtu.clearAndDrawUnitQuad(gl);
+        wtu.checkCanvas(gl, opt_expected);
+        // Check that linear fails.
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        wtu.clearAndDrawUnitQuad(gl);
+        wtu.checkCanvas(gl, [0, 0, 0, 255], "should be black");
     }
+
 }
 
 function checkRenderingResults()
@@ -254,7 +279,7 @@ function runRenderTargetTest(testProgram)
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.useProgram(testProgram);
-    gl.uniform1i(gl.getUniformLocation(testProgram, "tex"), 0);
+    gl.uniform4fv(gl.getUniformLocation(testProgram, "subtractor"), [10000, 10000, 10000, 10000]);
     wtu.drawUnitQuad(gl);
     glErrorShouldBe(gl, gl.NO_ERROR, "rendering from half floating point texture should succeed");
     checkRenderingResults();


### PR DESCRIPTION
linear filtering is not supposed to be enabled by OES_texture_float nor OES_texture_half_float. Updated test to reflect that.
