### PR TITLE
Updated video tests to be more correct.

### DIFF
--- a/conformance-suites/1.0.1/conformance/textures/tex-image-and-sub-image-2d-with-video.html
+++ b/conformance-suites/1.0.1/conformance/textures/tex-image-and-sub-image-2d-with-video.html
@@ -16,9 +16,28 @@ var wtu = WebGLTestUtils;
 var gl = null;
 var textureLoc = null;
 var successfullyParsed = false;
+var video;
+var gotPlaying = false;
+var gotTimeUpdate = false;
+var runningTest = false;
 
 if (window.initNonKhronosFramework) {
     window.initNonKhronosFramework(true);
+}
+
+function playingListener() {
+    gotPlaying = true;
+    maybeRunTest(video);
+}
+
+function timeupdateListener() {
+    // Checking to make sure the current time has advanced beyond
+    // the start time seems to be a reliable heuristic that the
+    // video element has data that can be consumed.
+    if (video.currentTime > 0.0) {
+        gotTimeUpdate = true;
+        maybeRunTest(video);
+    }
 }
 
 function init()
@@ -33,9 +52,9 @@ function init()
 
     textureLoc = gl.getUniformLocation(program, "tex");
 
-    var video = document.getElementById("vid");
-    video.addEventListener(
-        "playing", function() { runTest(video); }, true);
+    video = document.getElementById("vid");
+    video.addEventListener("playing", playingListener, true);
+    video.addEventListener("timeupdate", timeupdateListener, true);
     video.loop = true;
     video.play();
 }
@@ -96,6 +115,14 @@ function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottom
     debug("Checking upper left corner");
     wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
                         "shouldBe " + topColor, tolerance);
+}
+
+function maybeRunTest(videoElement)
+{
+    if (gotPlaying && gotTimeUpdate && !runningTest) {
+        runningTest = true;
+        runTest(videoElement);
+    }
 }
 
 function runTest(videoElement)

--- a/conformance-suites/1.0.1/conformance/textures/texture-npot-video.html
+++ b/conformance-suites/1.0.1/conformance/textures/texture-npot-video.html
@@ -14,9 +14,28 @@ var wtu = WebGLTestUtils;
 var gl = null;
 var textureLoc = null;
 var successfullyParsed = false;
+var video;
+var gotPlaying = false;
+var gotTimeUpdate = false;
+var runningTest = false;
 
 if (window.initNonKhronosFramework) {
     window.initNonKhronosFramework(true);
+}
+
+function playingListener() {
+    gotPlaying = true;
+    maybeRunTest(video);
+}
+
+function timeupdateListener() {
+    // Checking to make sure the current time has advanced beyond
+    // the start time seems to be a reliable heuristic that the
+    // video element has data that can be consumed.
+    if (video.currentTime > 0.0) {
+        gotTimeUpdate = true;
+        maybeRunTest(video);
+    }
 }
 
 function init()
@@ -32,9 +51,9 @@ function init()
 
     textureLoc = gl.getUniformLocation(program, "tex");
 
-    var video = document.getElementById("vid");
-    video.addEventListener(
-        "playing", function() { runTest(video); }, true);
+    video = document.getElementById("vid");
+    video.addEventListener("playing", playingListener, true);
+    video.addEventListener("timeupdate", timeupdateListener, true);
     video.loop = true;
     video.play();
 }
@@ -123,6 +142,14 @@ function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottom
     wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
                         "shouldBe " + topColor, tolerance);
     debug("");
+}
+
+function maybeRunTest(videoElement)
+{
+    if (gotPlaying && gotTimeUpdate && !runningTest) {
+        runningTest = true;
+        runTest(videoElement);
+    }
 }
 
 function runTest(videoElement)

--- a/conformance-suites/1.0.2/conformance/resources/tex-image-and-sub-image-2d-with-video.js
+++ b/conformance-suites/1.0.2/conformance/resources/tex-image-and-sub-image-2d-with-video.js
@@ -48,12 +48,41 @@ function generateTest(pixelFormat, pixelType, prologue) {
 
     var videoNdx = 0;
     var video;
-    var runNextVideo = function() {
+    var gotPlaying = false;
+    var gotTimeUpdate = false;
+    var runningTest = false;
+
+    function playingListener() {
+        gotPlaying = true;
+        maybeRunTest(video);
+    }
+
+    function timeupdateListener() {
+        // Checking to make sure the current time has advanced beyond
+        // the start time seems to be a reliable heuristic that the
+        // video element has data that can be consumed.
+        if (video.currentTime > 0.0) {
+            gotTimeUpdate = true;
+            maybeRunTest(video);
+        }
+    }
+
+    function runNextVideo() {
+        if (video) {
+            video.removeEventListener("playing", playingListener, true);
+            video.removeEventListener("timeupdate", timeupdateListener, true);
+            video.pause();
+        }
+
         if (videoNdx == videos.length) {
-            video.removeEventListener("playing", runTest);
             finishTest();
             return;
         }
+
+        gotPlaying = false;
+        gotTimeUpdate = false;
+        runningTest = false;
+
         var info = videos[videoNdx++];
         debug("");
         debug("testing: " + info.type);
@@ -61,7 +90,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
         var canPlay = true;
         if (!video.canPlayType) {
           testFailed("video.canPlayType required method missing");
-          runNextTest();
+          runNextVideo();
           return;
         }
 
@@ -72,8 +101,8 @@ function generateTest(pixelFormat, pixelType, prologue) {
         };
 
         document.body.appendChild(video);
-        video.addEventListener(
-            "playing", function() { runTest(video); }, true);
+        video.addEventListener("playing", playingListener, true);
+        video.addEventListener("timeupdate", timeupdateListener, true);
         video.type = info.type;
         video.src = info.src;
         video.loop = true;
@@ -150,6 +179,14 @@ function generateTest(pixelFormat, pixelType, prologue) {
         debug("Checking upper left corner");
         wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
                             "shouldBe " + topColor, tolerance);
+    }
+
+    function maybeRunTest(videoElement)
+    {
+        if (gotPlaying && gotTimeUpdate && !runningTest) {
+            runningTest = true;
+            runTest(videoElement);
+        }
     }
 
     function runTest(videoElement)

--- a/conformance-suites/1.0.2/conformance/textures/texture-npot-video.html
+++ b/conformance-suites/1.0.2/conformance/textures/texture-npot-video.html
@@ -38,8 +38,28 @@ var wtu = WebGLTestUtils;
 var gl = null;
 var textureLoc = null;
 var successfullyParsed = false;
+var video;
+var gotPlaying = false;
+var gotTimeUpdate = false;
+var runningTest = false;
 
 initTestingHarnessWaitUntilDone();
+
+
+function playingListener() {
+    gotPlaying = true;
+    maybeRunTest(video);
+}
+
+function timeupdateListener() {
+    // Checking to make sure the current time has advanced beyond
+    // the start time seems to be a reliable heuristic that the
+    // video element has data that can be consumed.
+    if (video.currentTime > 0.0) {
+        gotTimeUpdate = true;
+        maybeRunTest(video);
+    }
+}
 
 function init()
 {
@@ -54,9 +74,9 @@ function init()
 
     textureLoc = gl.getUniformLocation(program, "tex");
 
-    var video = document.getElementById("vid");
-    video.addEventListener(
-        "playing", function() { runTest(video); }, true);
+    video = document.getElementById("vid");
+    video.addEventListener("playing", playingListener, true);
+    video.addEventListener("timeupdate", timeupdateListener, true);
     video.loop = true;
     video.play();
 }
@@ -147,6 +167,14 @@ function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottom
     debug("");
 }
 
+function maybeRunTest(videoElement)
+{
+    if (gotPlaying && gotTimeUpdate && !runningTest) {
+        runningTest = true;
+        runTest(videoElement);
+    }
+}
+
 function runTest(videoElement)
 {
     var red = [255, 0, 0];
@@ -162,7 +190,8 @@ function runTest(videoElement)
     runOneIteration(videoElement, true, false, red, green, false, false, false);
 
     glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-    videoElement.removeEventListener("playing", runTest);
+    videoElement.removeEventListener("playing", playingListener, true);
+    videoElement.removeEventListener("timeupdate", timeupdateListener, true);
     finishTest();
 }
 </script>

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
@@ -48,12 +48,41 @@ function generateTest(pixelFormat, pixelType, prologue) {
 
     var videoNdx = 0;
     var video;
-    var runNextVideo = function() {
+    var gotPlaying = false;
+    var gotTimeUpdate = false;
+    var runningTest = false;
+
+    function playingListener() {
+        gotPlaying = true;
+        maybeRunTest(video);
+    }
+
+    function timeupdateListener() {
+        // Checking to make sure the current time has advanced beyond
+        // the start time seems to be a reliable heuristic that the
+        // video element has data that can be consumed.
+        if (video.currentTime > 0.0) {
+            gotTimeUpdate = true;
+            maybeRunTest(video);
+        }
+    }
+
+    function runNextVideo() {
+        if (video) {
+            video.removeEventListener("playing", playingListener, true);
+            video.removeEventListener("timeupdate", timeupdateListener, true);
+            video.pause();
+        }
+
         if (videoNdx == videos.length) {
-            video.removeEventListener("playing", runTest);
             finishTest();
             return;
         }
+
+        gotPlaying = false;
+        gotTimeUpdate = false;
+        runningTest = false;
+
         var info = videos[videoNdx++];
         debug("");
         debug("testing: " + info.type);
@@ -61,7 +90,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
         var canPlay = true;
         if (!video.canPlayType) {
           testFailed("video.canPlayType required method missing");
-          runNextTest();
+          runNextVideo();
           return;
         }
 
@@ -72,8 +101,8 @@ function generateTest(pixelFormat, pixelType, prologue) {
         };
 
         document.body.appendChild(video);
-        video.addEventListener(
-            "playing", function() { runTest(video); }, true);
+        video.addEventListener("playing", playingListener, true);
+        video.addEventListener("timeupdate", timeupdateListener, true);
         video.type = info.type;
         video.src = info.src;
         video.loop = true;
@@ -150,6 +179,14 @@ function generateTest(pixelFormat, pixelType, prologue) {
         debug("Checking upper left corner");
         wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
                             "shouldBe " + topColor, tolerance);
+    }
+
+    function maybeRunTest(videoElement)
+    {
+        if (gotPlaying && gotTimeUpdate && !runningTest) {
+            runningTest = true;
+            runTest(videoElement);
+        }
     }
 
     function runTest(videoElement)

--- a/sdk/tests/conformance/textures/texture-npot-video.html
+++ b/sdk/tests/conformance/textures/texture-npot-video.html
@@ -38,8 +38,28 @@ var wtu = WebGLTestUtils;
 var gl = null;
 var textureLoc = null;
 var successfullyParsed = false;
+var video;
+var gotPlaying = false;
+var gotTimeUpdate = false;
+var runningTest = false;
 
 initTestingHarnessWaitUntilDone();
+
+
+function playingListener() {
+    gotPlaying = true;
+    maybeRunTest(video);
+}
+
+function timeupdateListener() {
+    // Checking to make sure the current time has advanced beyond
+    // the start time seems to be a reliable heuristic that the
+    // video element has data that can be consumed.
+    if (video.currentTime > 0.0) {
+        gotTimeUpdate = true;
+        maybeRunTest(video);
+    }
+}
 
 function init()
 {
@@ -54,9 +74,9 @@ function init()
 
     textureLoc = gl.getUniformLocation(program, "tex");
 
-    var video = document.getElementById("vid");
-    video.addEventListener(
-        "playing", function() { runTest(video); }, true);
+    video = document.getElementById("vid");
+    video.addEventListener("playing", playingListener, true);
+    video.addEventListener("timeupdate", timeupdateListener, true);
     video.loop = true;
     video.play();
 }
@@ -147,6 +167,14 @@ function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottom
     debug("");
 }
 
+function maybeRunTest(videoElement)
+{
+    if (gotPlaying && gotTimeUpdate && !runningTest) {
+        runningTest = true;
+        runTest(videoElement);
+    }
+}
+
 function runTest(videoElement)
 {
     var red = [255, 0, 0];
@@ -162,7 +190,8 @@ function runTest(videoElement)
     runOneIteration(videoElement, true, false, red, green, false, false, false);
 
     glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-    videoElement.removeEventListener("playing", runTest);
+    videoElement.removeEventListener("playing", playingListener, true);
+    videoElement.removeEventListener("timeupdate", timeupdateListener, true);
     finishTest();
 }
 </script>


### PR DESCRIPTION
The video-related WebGL conformance tests
(tex-image-and-sub-image-2d-with-video.html with variants, and
texture-npot-video.html) currently start the test upon receiving the
"playing" event. After receiving feedback from the Chrome on Android
team, and studying the HTMLVideoElement spec, it seems that this is
incorrect.
http://www.w3.org/html/wg/drafts/html/master/embedded-content-0.html#mediaevents
says for the "playing" event: "Even if this event fires, the element
might still not be potentially playing".

Watching for a "timeupdate" event where the video's currentTime is
past the start time seems to be a more reliable heuristic.

There are bugs in Safari, including current WebKit nightlies, with
dynamically created video elements, and video elements with
style="display:none". This patch improves the reliability with
dynamically created video elements, but causes reliable failures with
display:none elements (used by texture-npot-video.html). This test was
already previously failing in Safari, so I believe it is warranted to
update all versions of these video tests in the same way to generally
improve their reliability, and assume that this bug will be fixed in
Safari at some point in the future.

Tested all versions of these tests with Chrome, Firefox and Safari on
Mac OS. Chrome and Firefox pass the tests completely. The current
WebKit nightly now passes the 1.0.2 and top of tree
tex-image-and-sub-image-with-video.html tests, where it was failing
them before.
