### PR TITLE
After discussion with the ECMAScript committee, the typed array editor's...

### DIFF
--- a/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
@@ -144,27 +144,51 @@ function testSlice() {
   }
 }
 
+function testArrayBufferIsViewMethod() {
+  debug('test ArrayBuffer.isView() with various values');
+
+  try {
+    if (!ArrayBuffer.isView) {
+      testFailed('ArrayBuffer.isView() method does not exist');
+    } else {
+      testPassed('ArrayBuffer.isView() method exists');
+
+      shouldBe('ArrayBuffer.isView(new Int8Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint8Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint8ClampedArray(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Int16Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint16Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Int32Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint32Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Float32Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Float64Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new DataView(new ArrayBuffer(8)))', 'true');
+
+      shouldBe('ArrayBuffer.isView(undefined)', 'false');
+      shouldBe('ArrayBuffer.isView(null)', 'false');
+      shouldBe('ArrayBuffer.isView(true)', 'false');
+      shouldBe('ArrayBuffer.isView(false)', 'false');
+      shouldBe('ArrayBuffer.isView(0)', 'false');
+      shouldBe('ArrayBuffer.isView(1)', 'false');
+      shouldBe('ArrayBuffer.isView(1.0)', 'false');
+      shouldBe('ArrayBuffer.isView("hello")', 'false');
+      shouldBe('ArrayBuffer.isView({})', 'false');
+      shouldBe('ArrayBuffer.isView(function() {})', 'false');
+      shouldBe('ArrayBuffer.isView(new Array(1))', 'false');
+    }
+  } catch (e) {
+    testFailed('Exception thrown while testing ArrayBuffer.isView method: ' + e);
+  }
+}
+
 function testInheritanceHierarchy() {
   debug('test inheritance hierarchy of typed array views');
 
   try {
     var foo = ArrayBufferView;
-    testPassed('ArrayBufferView does not have [NoInterfaceObject] extended attribute and should be defined');
-
-    shouldBe('new Int8Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint8Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint8ClampedArray(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Int16Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint16Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Int32Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint32Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Float32Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Float64Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new DataView(new ArrayBuffer(8)) instanceof ArrayBufferView', 'true');
-
-    shouldThrowTypeError(function() { new ArrayBufferView() }, "new ArrayBufferView()");
+    testFailed('ArrayBufferView has [NoInterfaceObject] extended attribute and should not be defined');
   } catch (e) {
-    testFailed('ArrayBufferView does not have [NoInterfaceObject] extended attribute but was not defined');
+    testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
   }
 
   // There is currently only one kind of view that inherits from another
@@ -1000,6 +1024,7 @@ function runTests() {
   allPassed = true;
 
   testSlice();
+  testArrayBufferIsViewMethod();
   testInheritanceHierarchy();
 
   for (var i = 0; i < testCases.length; i++) {

--- a/sdk/tests/conformance/typedarrays/array-unit-tests.html
+++ b/sdk/tests/conformance/typedarrays/array-unit-tests.html
@@ -144,27 +144,51 @@ function testSlice() {
   }
 }
 
+function testArrayBufferIsViewMethod() {
+  debug('test ArrayBuffer.isView() with various values');
+
+  try {
+    if (!ArrayBuffer.isView) {
+      testFailed('ArrayBuffer.isView() method does not exist');
+    } else {
+      testPassed('ArrayBuffer.isView() method exists');
+
+      shouldBe('ArrayBuffer.isView(new Int8Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint8Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint8ClampedArray(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Int16Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint16Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Int32Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Uint32Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Float32Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new Float64Array(1))', 'true');
+      shouldBe('ArrayBuffer.isView(new DataView(new ArrayBuffer(8)))', 'true');
+
+      shouldBe('ArrayBuffer.isView(undefined)', 'false');
+      shouldBe('ArrayBuffer.isView(null)', 'false');
+      shouldBe('ArrayBuffer.isView(true)', 'false');
+      shouldBe('ArrayBuffer.isView(false)', 'false');
+      shouldBe('ArrayBuffer.isView(0)', 'false');
+      shouldBe('ArrayBuffer.isView(1)', 'false');
+      shouldBe('ArrayBuffer.isView(1.0)', 'false');
+      shouldBe('ArrayBuffer.isView("hello")', 'false');
+      shouldBe('ArrayBuffer.isView({})', 'false');
+      shouldBe('ArrayBuffer.isView(function() {})', 'false');
+      shouldBe('ArrayBuffer.isView(new Array(1))', 'false');
+    }
+  } catch (e) {
+    testFailed('Exception thrown while testing ArrayBuffer.isView method: ' + e);
+  }
+}
+
 function testInheritanceHierarchy() {
   debug('test inheritance hierarchy of typed array views');
 
   try {
     var foo = ArrayBufferView;
-    testPassed('ArrayBufferView does not have [NoInterfaceObject] extended attribute and should be defined');
-
-    shouldBe('new Int8Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint8Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint8ClampedArray(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Int16Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint16Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Int32Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Uint32Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Float32Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new Float64Array(1) instanceof ArrayBufferView', 'true');
-    shouldBe('new DataView(new ArrayBuffer(8)) instanceof ArrayBufferView', 'true');
-
-    shouldThrowTypeError(function() { new ArrayBufferView() }, "new ArrayBufferView()");
+    testFailed('ArrayBufferView has [NoInterfaceObject] extended attribute and should not be defined');
   } catch (e) {
-    testFailed('ArrayBufferView does not have [NoInterfaceObject] extended attribute but was not defined');
+    testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
   }
 
   // There is currently only one kind of view that inherits from another
@@ -1000,6 +1024,7 @@ function runTests() {
   allPassed = true;
 
   testSlice();
+  testArrayBufferIsViewMethod();
   testInheritanceHierarchy();
 
   for (var i = 0; i < testCases.length; i++) {


### PR DESCRIPTION
... draft and ES6 draft specs have been changed so that the ArrayBufferView interface is no longer exposed, and the static method ArrayBuffer.isView is added for type tests. Updated the 1.0.2 and top of tree WebGL conformance tests to reflect these changes.
