### PR TITLE
Update context-lost-restored test to check that

### DIFF
--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -38,7 +38,8 @@ var wtu = WebGLTestUtils;
 var canvas;
 var gl;
 var shouldGenerateGLError;
-var extension;
+var WEBGL_lose_context;
+var new_WEBGL_lose_context;
 var bufferObjects;
 var program;
 var texture;
@@ -47,6 +48,7 @@ var allowRestore;
 var contextLostEventFired;
 var contextRestoredEventFired;
 var OES_vertex_array_object;
+var old_OES_vertex_array_object;
 var vertexArrayObject;
 var OES_texture_float;
 var newExtension;
@@ -67,8 +69,8 @@ function setupTest()
     canvas.width = 1;
     canvas.height = 1;
     gl = wtu.create3DContext(canvas);
-    extension = wtu.getExtensionWithKnownPrefixes(gl, "WEBGL_lose_context");
-    if (!extension) {
+    WEBGL_lose_context = getExtensionAndAddProperty(gl, "WEBGL_lose_context");
+    if (!WEBGL_lose_context) {
         debug("Could not find WEBGL_lose_context extension");
         return false;
     }
@@ -88,7 +90,7 @@ function getExtensionAndAddProperty(gl, name) {
   return ext;
 }
 
-function reGetExtensionAndTestForProperty(gl, name) {
+function reGetExtensionAndTestForProperty(gl, name, expectProperty) {
   newExtension = wtu.getExtensionWithKnownPrefixes(gl, name);
   // NOTE: while getting a extension after context lost/restored is allowed to fail
   // for the purpose the conformance tests it is not.
@@ -100,8 +102,12 @@ function reGetExtensionAndTestForProperty(gl, name) {
   // But, for the purpose of the conformance tests the context is expected to restore
   // on the same GPU and therefore the extensions that succeeded previously should
   // succeed on restore.
-  shouldBeTrie("newExtension != null");
-  shouldBeTrue("newExtension.webglTestProperty");
+  shouldBeTrue("newExtension != null");
+  if (expectProperty) {
+    shouldBeTrue("newExtension.webglTestProperty === true");
+  } else {
+    shouldBeTrue("newExtension.webglTestProperty === undefined");
+  }
   return newExtension;
 }
 
@@ -119,7 +125,7 @@ function testLosingContext()
        // restore the context after this event has exited.
        setTimeout(function() {
          // we didn't call prevent default so we should not be able to restore the context
-         shouldGenerateGLError(gl, gl.INVALID_OPERATION, "extension.restoreContext()");
+         shouldGenerateGLError(gl, gl.INVALID_OPERATION, "WEBGL_lose_context.restoreContext()");
          testLosingAndRestoringContext();
        }, 0);
     });
@@ -129,7 +135,7 @@ function testLosingContext()
     contextRestoredEventFired = false;
 
     testOriginalContext();
-    extension.loseContext();
+    WEBGL_lose_context.loseContext();
     // The context should be lost immediately.
     shouldBeTrue("gl.isContextLost()");
     shouldBe("gl.getError()", "gl.CONTEXT_LOST_WEBGL");
@@ -152,7 +158,7 @@ function testLosingAndRestoringContext()
       testLostContext(e);
       // restore the context after this event has exited.
       setTimeout(function() {
-        shouldGenerateGLError(gl, gl.NO_ERROR, "extension.restoreContext()");
+        shouldGenerateGLError(gl, gl.NO_ERROR, "WEBGL_lose_context.restoreContext()");
         // The context should still be lost. It will not get restored until the 
         // webglrestorecontext event is fired.
         shouldBeTrue("gl.isContextLost()");
@@ -170,7 +176,7 @@ function testLosingAndRestoringContext()
     contextRestoredEventFired = false;
 
     testOriginalContext();
-    extension.loseContext();
+    WEBGL_lose_context.loseContext();
     // The context should be lost immediately.
     shouldBeTrue("gl.isContextLost()");
     shouldBe("gl.getError()", "gl.CONTEXT_LOST_WEBGL");
@@ -246,7 +252,7 @@ function testOESTextureFloat() {
     gl.bindTexture(gl.TEXTURE_2D, tex);
     shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.FLOAT, null)");
     // Try re-enabling extension
-    OES_texture_float = reGetExtensionAndTestForProperty(gl, "OES_texture_float");
+    OES_texture_float = reGetExtensionAndTestForProperty(gl, "OES_texture_float", false);
     shouldGenerateGLError(gl, gl.NO_ERROR, "gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.FLOAT, null)");
   }
 }
@@ -256,14 +262,19 @@ function testOESVertexArrayObject() {
     // Extension must still be lost.
     shouldBeNull("OES_vertex_array_object.createVertexArrayOES()");
     // Try re-enabling extension
-    OES_vertex_array_object = reGetExtensionAndTestForProperty(gl, "OES_vertex_array_object");
+
+    old_OES_vertex_array_object = OES_vertex_array_object;
+    OES_vertex_array_object = reGetExtensionAndTestForProperty(gl, "OES_vertex_array_object", false);
     shouldBeTrue("OES_vertex_array_object.createVertexArrayOES() != null");
+    shouldBeTrue("old_OES_vertex_array_object.createVertexArrayOES() == null");
   }
 }
 
 function testExtensions() {
   testOESTextureFloat();
   testOESVertexArrayObject();
+  // Only the WEBGL_lose_context extension should be the same object after context lost.
+  new_WEBGL_lose_context = reGetExtensionAndTestForProperty(gl, "WEBGL_lose_context", true);
 }
 
 function testRestoredContext()


### PR DESCRIPTION
extensions are lost and not restorable. New extensions
must be enable after context restored
