### PR TITLE
Removed unnecessary highp from glsl/misc/shader-with-for-loop.html

### DIFF
--- a/conformance-suites/1.0.1/conformance/glsl/misc/shader-with-for-loop.html
+++ b/conformance-suites/1.0.1/conformance/glsl/misc/shader-with-for-loop.html
@@ -21,7 +21,7 @@ found in the LICENSE file.
 // fragment shader with for loop should succeed
 
 // TODO(gman): trim to min size to test bug.
-precision highp float;
+precision mediump float;
 uniform float time;
 uniform vec2 resolution;
 

--- a/conformance-suites/1.0.2/conformance/glsl/misc/shader-with-for-loop.html
+++ b/conformance-suites/1.0.2/conformance/glsl/misc/shader-with-for-loop.html
@@ -43,7 +43,7 @@
 // fragment shader with for loop should succeed
 
 // TODO(gman): trim to min size to test bug.
-precision highp float;
+precision mediump float;
 uniform float time;
 uniform vec2 resolution;
 

--- a/sdk/tests/conformance/glsl/misc/shader-with-for-loop.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-for-loop.html
@@ -43,7 +43,7 @@
 // fragment shader with for loop should succeed
 
 // TODO(gman): trim to min size to test bug.
-precision highp float;
+precision mediump float;
 uniform float time;
 uniform vec2 resolution;
 


### PR DESCRIPTION
This is in response to [3DWeb bug #890](https://www.khronos.org/bugzilla/show_bug.cgi?id=890)
