### PR TITLE
Fix an error which may cause wrong test result, and a typo.

### DIFF
--- a/sdk/tests/conformance/glsl/literals/float_literal.vert.html
+++ b/sdk/tests/conformance/glsl/literals/float_literal.vert.html
@@ -59,7 +59,8 @@ void main() {
   highp float posHuge = 1E100;
   highp float negInRange = -4611686018427387903.;
   highp float negOutRange = -4611686018427387905.;
-  highp float negHuge = 1E100;
+  highp float negHuge = -1E100;
+  gl_Position = vec4(0,0,0,0);
 }
 </script>
 <script>


### PR DESCRIPTION
If the vertex shader doesn't write anything to gl_Position, the browser will generate a diagnostic message and the test will regard that as a fail.
And there is a typo in the variable negHuge fixed.
