### PR TITLE
Remove incorrect uniform location check

### DIFF
--- a/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
+++ b/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
@@ -470,10 +470,7 @@ function drawWithProgram(program, programInfo, test) {
   // Set test specific uniforms
   for (var name in programInfo.uniforms) {
     var location = getUniformLocation(name);
-    if (!location) {
-      testFailed("uniform not found: " + name);
-      continue;
-    }
+    // Note that in some tests, uniforms are allowed to be inactive
     var uniform = programInfo.uniforms[name];
     var type = uniform.type;
     var value = uniform.value;

--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -470,10 +470,7 @@ function drawWithProgram(program, programInfo, test) {
   // Set test specific uniforms
   for (var name in programInfo.uniforms) {
     var location = getUniformLocation(name);
-    if (!location) {
-      testFailed("uniform not found: " + name);
-      continue;
-    }
+    // Note that in some tests, uniforms are allowed to be inactive
     var uniform = programInfo.uniforms[name];
     var type = uniform.type;
     var value = uniform.value;


### PR DESCRIPTION
An optimized implementation is allowed to set uniforms that don't in fact affect the end result of the shader as inactive, so that they have null location. This kind of uniforms manifest in the vec3/vec3_001_to_008.html tests. Based on OpenGL ES 2.0.25 section "Uniform variables".
