### PR TITLE
LUMINANCE and ALPHA textures should not be renderable

### DIFF
--- a/conformance-suites/1.0.2/conformance/textures/copy-tex-image-2d-formats.html
+++ b/conformance-suites/1.0.2/conformance/textures/copy-tex-image-2d-formats.html
@@ -66,14 +66,6 @@ var formats = [
   'RGBA'
 ];
 
-var isRenderable = {
-  'ALPHA': false,
-  'LUMINANCE': false,
-  'LUMINANCE_ALPHA': false,
-  'RGB': true,
-  'RGBA': true
-};
-
 var gl = null;
 var wtu = WebGLTestUtils;
 
@@ -115,12 +107,8 @@ function testBackbufferFormats() {
 
     debug('');
     if (status == gl.FRAMEBUFFER_COMPLETE) {
-      if (!isRenderable[backFormat]) {
-        testFailed('Creating framebuffer from ' + backFormat + ' texture succeeded even though it is not a renderable format');
-      } else {
-        debug('test with ' + backFormat + ' fbo');
-        testFormats(backFormat);
-      }
+      debug('test with ' + backFormat + ' fbo');
+      testFormats(backFormat);
     } else {
       debug(backFormat + ' not supported as a renderbuffer attachment');
     }
@@ -143,7 +131,7 @@ function toChannels(value) {
 function testCopyTexImage2D(backFormat, texFormat) {
   var need = getChannelsFromFormat(texFormat);
   var have = getChannelsFromFormat(backFormat);
-  var shouldPass = (need & have) == need;
+  var shouldPass = (need & have) == need
 
   //debug("need: " + toChannels(need));
   //debug("have: " + toChannels(have));


### PR DESCRIPTION
Check that attaching these texture types results in an incomplete
framebuffer instead of trying to render to that framebuffer. This helps
to ensure that unspecified rendering to these texture types is not
supported in any implementation, maintaining compatibility.

For reference, see OpenGL ES 2.0 spec section 4.4.5 Framebuffer
Completeness, specifically table 4.5. "Renderbuffer image formats", which
enumerates all renderable formats. Rendering to other formats is not
specified.
