### PR TITLE
Based on feedback from Guillaume Abadie on public_webgl, removed invalid...

### DIFF
--- a/conformance-suites/1.0.1/conformance/extensions/oes-vertex-array-object.html
+++ b/conformance-suites/1.0.1/conformance/extensions/oes-vertex-array-object.html
@@ -148,7 +148,6 @@ function runObjectTest() {
     ext.bindVertexArrayOES(null);
     shouldBeTrue("ext.isVertexArrayOES(vao)");
     
-    shouldBeFalse("ext.isVertexArrayOES()");
     shouldBeFalse("ext.isVertexArrayOES(null)");
     
     ext.deleteVertexArrayOES(vao);

--- a/conformance-suites/1.0.2/conformance/extensions/oes-vertex-array-object.html
+++ b/conformance-suites/1.0.2/conformance/extensions/oes-vertex-array-object.html
@@ -188,7 +188,6 @@ function runObjectTest() {
     ext.bindVertexArrayOES(null);
     shouldBeTrue("ext.isVertexArrayOES(vao)");
     
-    shouldBeFalse("ext.isVertexArrayOES()");
     shouldBeFalse("ext.isVertexArrayOES(null)");
     
     ext.deleteVertexArrayOES(vao);

--- a/sdk/tests/conformance/extensions/oes-vertex-array-object.html
+++ b/sdk/tests/conformance/extensions/oes-vertex-array-object.html
@@ -188,7 +188,6 @@ function runObjectTest() {
     ext.bindVertexArrayOES(null);
     shouldBeTrue("ext.isVertexArrayOES(vao)");
     
-    shouldBeFalse("ext.isVertexArrayOES()");
     shouldBeFalse("ext.isVertexArrayOES(null)");
     
     ext.deleteVertexArrayOES(vao);


### PR DESCRIPTION
... call of "isVertexArrayOES()" from oes-vertex-array-object test, as far back as version 1.0.1 of the conformance suite.
