### PR TITLE
Account for literal constants taking up uniform storage

### DIFF
--- a/conformance-suites/1.0.2/conformance/glsl/misc/shader-with-too-many-uniforms.html
+++ b/conformance-suites/1.0.2/conformance/glsl/misc/shader-with-too-many-uniforms.html
@@ -86,10 +86,18 @@ var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
 var maxFragmentUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
 var maxVertexUniformVectors = gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS);
+
+// Up to 2 uniform vector registers may be spent for literal constants in
+// vshader-max or fshader-max code. One vector row is used for the vec4, and
+// another may be used for integer constants that are allowed to be treated
+// internally as floats and are packable to the space of one row. This is
+// according to the GLSL ES variable packing algorithm detailed in Section 7 of
+// Appendix A of the GLSL ES Specification 10.0.17.
+var maxVectorStorageUsedForLiterals = 2;
+
 var tests = [
  { desc: "using all uniforms in vertex shader should succeed",
-// 2 uniform vector registers may be spent for literal constants in the shader code
-   maxUniformVectors: maxVertexUniformVectors - 2,
+   maxUniformVectors: maxVertexUniformVectors - maxVectorStorageUsedForLiterals,
    vShader: "vshader-max",
    fShader: "fshader",
    success: true,
@@ -102,8 +110,7 @@ var tests = [
    success: false,
  },
  { desc: "using all uniforms in fragment shader should succeed",
-// 2 uniform vector registers may be spent for literal constants in the shader code
-   maxUniformVectors: maxFragmentUniformVectors - 2,
+   maxUniformVectors: maxFragmentUniformVectors - maxVectorStorageUsedForLiterals,
    vShader: "vshader",
    fShader: "fshader-max",
    success: true,

--- a/sdk/tests/conformance/glsl/misc/shader-with-too-many-uniforms.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-too-many-uniforms.html
@@ -86,10 +86,18 @@ var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
 var maxFragmentUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
 var maxVertexUniformVectors = gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS);
+
+// Up to 2 uniform vector registers may be spent for literal constants in
+// vshader-max or fshader-max code. One vector row is used for the vec4, and
+// another may be used for integer constants that are allowed to be treated
+// internally as floats and are packable to the space of one row. This is
+// according to the GLSL ES variable packing algorithm detailed in Section 7 of
+// Appendix A of the GLSL ES Specification 10.0.17.
+var maxVectorStorageUsedForLiterals = 2;
+
 var tests = [
  { desc: "using all uniforms in vertex shader should succeed",
-// 2 uniform vector registers may be spent for literal constants in the shader code
-   maxUniformVectors: maxVertexUniformVectors - 2,
+   maxUniformVectors: maxVertexUniformVectors - maxVectorStorageUsedForLiterals,
    vShader: "vshader-max",
    fShader: "fshader",
    success: true,
@@ -102,8 +110,7 @@ var tests = [
    success: false,
  },
  { desc: "using all uniforms in fragment shader should succeed",
-// 2 uniform vector registers may be spent for literal constants in the shader code
-   maxUniformVectors: maxFragmentUniformVectors - 2,
+   maxUniformVectors: maxFragmentUniformVectors - maxVectorStorageUsedForLiterals,
    vShader: "vshader",
    fShader: "fshader-max",
    success: true,


### PR DESCRIPTION
According to GLSL ES spec 10.0.17 Appendix A section 7:

"When calculating the number of uniform variables used, any literal
constants present in the shader source after preprocessing are included
when calculating the storage requirements. Multiple instances of
identical constants should count multiple times."
