### PR TITLE
Use absolute, not relative canvas position when logging errors

### DIFF
--- a/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
@@ -872,7 +872,7 @@ var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRan
         for (j = 1; j < color.length; ++j) {
           was += "," + buf[offset + j];
         }
-        logFn('at (' + (i % width) + ', ' + Math.floor(i / width) +
+        logFn('at (' + (x + (i % width)) + ', ' + (y + Math.floor(i / width)) +
               ') expected: ' + color + ' was ' + was);
         return;
       }

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1014,7 +1014,7 @@ var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRan
         for (j = 1; j < color.length; ++j) {
           was += "," + buf[offset + j];
         }
-        logFn('at (' + (i % width) + ', ' + Math.floor(i / width) +
+        logFn('at (' + (x + (i % width)) + ', ' + (y + Math.floor(i / width)) +
               ') expected: ' + color + ' was ' + was);
         return;
       }


### PR DESCRIPTION
checkCanvasRectColor used to log position relative to the corner of the
rectangle being checked. Logging absolute canvas position makes more
sense when analyzing errors, so switch to that in the new and 1.0.2
versions of the conformance suite.
