### PR TITLE
Fixed issue pointed out by Mark Callow where the location in the text of...

### DIFF
--- a/specs/latest/index.html
+++ b/specs/latest/index.html
@@ -674,9 +674,9 @@ typedef unrestricted float GLclampf;
 
     <p>
         The following list describes each attribute in the WebGLContextAttributes object and its
-        use. For each attribute the default value is shown. The default value is used either if no
-        second parameter is passed to <code>getContext</code>, or if a user object is passed which
-        has no attribute of the given name.
+        use. The default value for each attribute is shown above. The default value is used either
+        if no second parameter is passed to <code>getContext</code>, or if a user object is passed
+        which has no attribute of the given name.
     </p>
     <dl>
         <dt><span class=prop-value>alpha</span></dt>


### PR DESCRIPTION
... the default context creation attributes changed.
