### PR TITLE
remove some tests on tesing absence of oes-float-linear extension

### DIFF
--- a/sdk/tests/conformance/resources/oes-texture-float-and-half-float-linear.js
+++ b/sdk/tests/conformance/resources/oes-texture-float-and-half-float-linear.js
@@ -41,7 +41,7 @@ function generateTest(extensionTypeName, extensionName, pixelType, prologue) {
 
         // Before the extension is enabled
         var extensionEnabled = false;
-        runTestSuite(extensionEnabled);
+        // runTestSuite(extensionEnabled);
 
         if (!gl.getExtension(extensionName))
             testPassed("No " + extensionName + " support -- this is legal");


### PR DESCRIPTION
This is to align with the possible change at https://codereview.chromium.org/18863007/.
