### PR TITLE
Fix interpolation problems in GLSL fragment shader tests

### DIFF
--- a/conformance-suites/1.0.1/conformance/resources/glsl-generator.js
+++ b/conformance-suites/1.0.1/conformance/resources/glsl-generator.js
@@ -25,13 +25,17 @@ var fragmentShaderTemplate = [
   "precision mediump float;",
   "#endif",
   "",
-  "varying vec4 vColor;",
+  "varying vec2 vTexcoord;",
   "",
   "$(extra)",
   "$(emu)",
   "",
   "void main()",
   "{",
+  "   vec4 color = vec4(",
+  "       vTexcoord,",
+  "       vTexcoord.x * vTexcoord.y,",
+  "       (1.0 - vTexcoord.x) * vTexcoord.y * 0.5 + 0.5);",
   "   $(test)",
   "}"
 ].join("\n");
@@ -39,16 +43,12 @@ var fragmentShaderTemplate = [
 var baseVertexShader = [
   "attribute vec4 aPosition;",
   "",
-  "varying vec4 vColor;",
+  "varying vec2 vTexcoord;",
   "",
   "void main()",
   "{",
   "   gl_Position = aPosition;",
-  "   vec2 texcoord = vec2(aPosition.xy * 0.5 + vec2(0.5, 0.5));",
-  "   vColor = vec4(",
-  "       texcoord,",
-  "       texcoord.x * texcoord.y,",
-  "       (1.0 - texcoord.x) * texcoord.y * 0.5 + 0.5);",
+  "   vTexcoord = vec2(aPosition.xy * 0.5 + vec2(0.5, 0.5));",
   "}"
 ].join("\n");
 
@@ -269,7 +269,7 @@ var runFeatureTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,
@@ -458,7 +458,7 @@ var runBasicTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,
@@ -658,7 +658,7 @@ var runReferenceImageTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,

--- a/conformance-suites/1.0.2/conformance/resources/glsl-generator.js
+++ b/conformance-suites/1.0.2/conformance/resources/glsl-generator.js
@@ -47,13 +47,17 @@ var fragmentShaderTemplate = [
   "precision mediump float;",
   "#endif",
   "",
-  "varying vec4 vColor;",
+  "varying vec2 vTexcoord;",
   "",
   "$(extra)",
   "$(emu)",
   "",
   "void main()",
   "{",
+  "   vec4 color = vec4(",
+  "       vTexcoord,",
+  "       vTexcoord.x * vTexcoord.y,",
+  "       (1.0 - vTexcoord.x) * vTexcoord.y * 0.5 + 0.5);",
   "   $(test)",
   "}"
 ].join("\n");
@@ -61,16 +65,12 @@ var fragmentShaderTemplate = [
 var baseVertexShader = [
   "attribute vec4 aPosition;",
   "",
-  "varying vec4 vColor;",
+  "varying vec2 vTexcoord;",
   "",
   "void main()",
   "{",
   "   gl_Position = aPosition;",
-  "   vec2 texcoord = vec2(aPosition.xy * 0.5 + vec2(0.5, 0.5));",
-  "   vColor = vec4(",
-  "       texcoord,",
-  "       texcoord.x * texcoord.y,",
-  "       (1.0 - texcoord.x) * texcoord.y * 0.5 + 0.5);",
+  "   vTexcoord = vec2(aPosition.xy * 0.5 + vec2(0.5, 0.5));",
   "}"
 ].join("\n");
 
@@ -287,7 +287,7 @@ var runFeatureTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,
@@ -470,7 +470,7 @@ var runBasicTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,
@@ -664,7 +664,7 @@ var runReferenceImageTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,

--- a/sdk/tests/conformance/resources/glsl-generator.js
+++ b/sdk/tests/conformance/resources/glsl-generator.js
@@ -47,13 +47,17 @@ var fragmentShaderTemplate = [
   "precision mediump float;",
   "#endif",
   "",
-  "varying vec4 vColor;",
+  "varying vec2 vTexcoord;",
   "",
   "$(extra)",
   "$(emu)",
   "",
   "void main()",
   "{",
+  "   vec4 color = vec4(",
+  "       vTexcoord,",
+  "       vTexcoord.x * vTexcoord.y,",
+  "       (1.0 - vTexcoord.x) * vTexcoord.y * 0.5 + 0.5);",
   "   $(test)",
   "}"
 ].join("\n");
@@ -61,16 +65,12 @@ var fragmentShaderTemplate = [
 var baseVertexShader = [
   "attribute vec4 aPosition;",
   "",
-  "varying vec4 vColor;",
+  "varying vec2 vTexcoord;",
   "",
   "void main()",
   "{",
   "   gl_Position = aPosition;",
-  "   vec2 texcoord = vec2(aPosition.xy * 0.5 + vec2(0.5, 0.5));",
-  "   vColor = vec4(",
-  "       texcoord,",
-  "       texcoord.x * texcoord.y,",
-  "       (1.0 - texcoord.x) * texcoord.y * 0.5 + 0.5);",
+  "   vTexcoord = vec2(aPosition.xy * 0.5 + vec2(0.5, 0.5));",
   "}"
 ].join("\n");
 
@@ -287,7 +287,7 @@ var runFeatureTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,
@@ -470,7 +470,7 @@ var runBasicTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,
@@ -664,7 +664,7 @@ var runReferenceImageTest = function(params) {
       tolerance: vertexTolerance
     },
     { type: "fragment",
-      input: "vColor",
+      input: "color",
       output: "gl_FragColor",
       vertexShaderTemplate: baseVertexShader,
       fragmentShaderTemplate: fragmentShaderTemplate,


### PR DESCRIPTION
In the test rendering, the color varying value was being interpolated by
the GPU within each triangle by using barycentric coordinates (as per
GLES2 spec section 3.5.1) prior to being operated on in the test fragment
shaders. This did not match up with the reference rendering, where this
color value is calculated per fragment using the bilinearly interpolated
"texcoord" value.

Make the reference and test shaders agree by calculating the color value
per-fragment also in the test shaders. This can be done by setting the
texcoord into a varying. Since the texcoord is simply a multiple of the
vertex position, interpolating it by using a varying agrees with bilinear
interpolation.

This is a bug fix to the conformance suite, so the fix has been
backported as far back as version 1.0.1.
