### PR TITLE
[VMC] - Teapot and Framerate counter do not appear on the WebGL+CSS test...

### DIFF
--- a/sdk/demos/webkit/WebGL+CSS.html
+++ b/sdk/demos/webkit/WebGL+CSS.html
@@ -16,21 +16,21 @@
         // the light() function in the 2.0 context.
         struct Light
         {
-            vec4 ambient;
-            vec4 diffuse;
-            vec4 specular;
-            vec4 position;
+            mediump vec4 ambient;
+            mediump vec4 diffuse;
+            mediump vec4 specular;
+            mediump vec4 position;
 
-            vec3 halfVector;
+            mediump vec3 halfVector;
         };
 
         struct Material
         {
-            vec4 emission;
-            vec4 ambient;
-            vec4 diffuse;
-            vec4 specular;
-            float shininess;
+            mediump vec4 emission;
+            mediump vec4 ambient;
+            mediump vec4 diffuse;
+            mediump vec4 specular;
+            mediump float shininess;
         };
 
         //

--- a/sdk/demos/webkit/WebGLLogo.html
+++ b/sdk/demos/webkit/WebGLLogo.html
@@ -27,7 +27,7 @@
  -->
 <html>
   <head>
-    <title>Teapot (per-pixel)</title>
+    <title>WebGL Logo</title>
     <script type="text/javascript" src="../common/webgl-utils.js"></script>
     <script type="text/javascript" src="../../debug/webgl-debug.js"></script>
     <script src="resources/J3DI.js"> </script>
@@ -42,21 +42,21 @@
         // the light() function in the 2.0 context.
         struct Light
         {
-            vec4 ambient;
-            vec4 diffuse;
-            vec4 specular;
-            vec4 position;
+            mediump vec4 ambient;
+            mediump vec4 diffuse;
+            mediump vec4 specular;
+            mediump vec4 position;
 
-            vec3 halfVector;
+            mediump vec3 halfVector;
         };
 
         struct Material
         {
-            vec4 emission;
-            vec4 ambient;
-            vec4 diffuse;
-            vec4 specular;
-            float shininess;
+            mediump vec4 emission;
+            mediump vec4 ambient;
+            mediump vec4 diffuse;
+            mediump vec4 specular;
+            mediump float shininess;
         };
 
         //


### PR DESCRIPTION
... site on Chrome dev.

https://code.google.com/p/chromium/issues/detail?id=259817

Fixed mismatched uniform precisions between vertex and fragment shaders causing demos to fail to load in Chrome on Windows. The conformance test glsl/misc/shader-with-global-variable-precision-mismatch.html (currently failing on some platforms in Chrome) already covers this case.
