### PR TITLE
Enforce MAX_TEXTURE_SIZE to be a power of two

### DIFF
--- a/sdk/tests/conformance/limits/gl-max-texture-dimensions.html
+++ b/sdk/tests/conformance/limits/gl-max-texture-dimensions.html
@@ -66,10 +66,20 @@ var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext("example");
 var program = wtu.setupTexturedQuad(gl);
 
+function shouldBePowerOfTwo(n, name) {
+    var power = Math.round(Math.log(n) / Math.log(2));
+    if (Math.pow(2, power) == n) {
+        testPassed(name + ' is a power of two.');
+    } else {
+        testFailed(name + ' should be a power of two, but was ' + n);
+    }
+}
+
 // Note: It seems like a reasonable assuption that a 1xN texture size should
 // work. Even 1 by 128k is only 512k
 var maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
 debug("advertised max size: " + maxSize);
+shouldBePowerOfTwo(maxSize, 'Max size');
 var testSize = Math.min(maxSize, 128 * 1024);
 var pixels = new Uint8Array(testSize * 4);
 for (var ii = 0; ii < testSize; ++ii) {


### PR DESCRIPTION
This is implied by GLES2.0 spec section 3.7.1. There, the expression
"level zero through k" strongly suggests that k is expected to be an
integer, and it follows that MAX_TEXTURE_SIZE should be a power of two.
This holds in practice for almost all current implementations. Clarify
this interpretation of the spec by explicitly testing it.
