### PR TITLE
After discussion with ECMAScript committee, Uint8ClampedArray was change...

### DIFF
--- a/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
@@ -190,9 +190,6 @@ function testInheritanceHierarchy() {
   } catch (e) {
     testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
   }
-
-  // There is currently only one kind of view that inherits from another
-  shouldBe('new Uint8ClampedArray(1) instanceof Uint8Array', 'true');
 }
 
 //

--- a/sdk/tests/conformance/typedarrays/array-unit-tests.html
+++ b/sdk/tests/conformance/typedarrays/array-unit-tests.html
@@ -191,8 +191,10 @@ function testInheritanceHierarchy() {
     testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
   }
 
-  // There is currently only one kind of view that inherits from another
-  shouldBe('new Uint8ClampedArray(1) instanceof Uint8Array', 'true');
+  // Uint8ClampedArray inherited from Uint8Array in earlier versions
+  // of the typed array specification. Since this is no longer the
+  // case, assert the new behavior.
+  shouldBe('new Uint8ClampedArray(1) instanceof Uint8Array', 'false');
 }
 
 //


### PR DESCRIPTION
...d to no longer inherit from Uint8Array. Firefox never implemented this, so web compatibility impact should be minimal, and there are good arguments for keeping the types distinct because they do have differing behavior. (The original motivation was to allow Uint8ClampedArray instances coming from CanvasRenderingContext2D.getImageData to be passed to APIs taking Uint8Array, but this can be done with no copies simply by creating a new view against the same ArrayBuffer.)

Removed the invalidated test from the 1.0.2 conformance suite and updated the test (incompatibly) in the top of tree conformance suite.
