### PR TITLE
Per discussion on public_webgl, clarified that MAX_TEXTURE_SIZE must be ...

### DIFF
--- a/specs/latest/index.html
+++ b/specs/latest/index.html
@@ -3550,6 +3550,11 @@ extensions.
     </ul>
 </p>
 
+    <h3><a name="MAX_TEXTURE_SIZE_POT">MAX_TEXTURE_SIZE Constraints</a></h3>
+
+<p>
+    The MAX_TEXTURE_SIZE parameter must have a power-of-two value.
+</p>
 
 <!-- ======================================================================================================= -->
 


### PR DESCRIPTION
...a power of two.
