### PR TITLE
After objections on public_webgl, removed recently-added "differences" s...

### DIFF
--- a/sdk/tests/conformance/limits/gl-max-texture-dimensions.html
+++ b/sdk/tests/conformance/limits/gl-max-texture-dimensions.html
@@ -79,6 +79,7 @@ function shouldBePowerOfTwo(n, name) {
 // work. Even 1 by 128k is only 512k
 var maxSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
 debug("advertised max size: " + maxSize);
+debug("verifying max size is power-of-two (implied by GLES 2.0 section 3.7.1)");
 shouldBePowerOfTwo(maxSize, 'Max size');
 var testSize = Math.min(maxSize, 128 * 1024);
 var pixels = new Uint8Array(testSize * 4);

--- a/specs/latest/index.html
+++ b/specs/latest/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
     
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 26 July 2013</h2>
+    <h2 class="no-toc">Editor's Draft 30 July 2013</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -3548,12 +3548,6 @@ extensions.
     <li> when counting uniform variables in a fragment shader: <code>getParameter(MAX_FRAGMENT_UNIFORM_VECTORS)</code>
     <li> when counting varying variables: <code>getParameter(MAX_VARYING_VECTORS)</code>
     </ul>
-</p>
-
-    <h3><a name="MAX_TEXTURE_SIZE_POT">MAX_TEXTURE_SIZE Constraints</a></h3>
-
-<p>
-    The MAX_TEXTURE_SIZE parameter must have a power-of-two value.
 </p>
 
 <!-- ======================================================================================================= -->


### PR DESCRIPTION
...ection regarding MAX_TEXTURE_SIZE parameter, and clarified in test conformance/limits/gl-max-texture-dimensions.html where the power-of-two restriction comes from.
