### PR TITLE
Move three extensions to community approved.

### DIFF
--- a/extensions/ANGLE_instanced_arrays/extension.xml
+++ b/extensions/ANGLE_instanced_arrays/extension.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-
-<draft href="ANGLE_instanced_arrays/">
+<extension href="ANGLE_instanced_arrays/">
   <name>ANGLE_instanced_arrays</name>
   <contact>
     <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)
@@ -9,7 +8,7 @@
     <contributor>Contributors to ANGLE_instanced_arrays</contributor>
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
-  <number>19</number>
+  <number>20</number>
   <depends>
     <api version="1.0"/>
   </depends>
@@ -34,5 +33,8 @@ interface ANGLE_instanced_arrays {
     <revision date="2013/03/11">
       <change>Renumbered to 19 to fix misnumbering problem.</change>
     </revision>
+    <revision date="2013/08/06">
+      <change>Moved to community approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/extensions/OES_texture_float_linear/extension.xml
+++ b/extensions/OES_texture_float_linear/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="OES_texture_float_linear/">
+<extension href="OES_texture_float_linear/">
   <name>OES_texture_float_linear</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -9,7 +9,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>20</number>
+  <number>21</number>
 
   <depends>
     <api version="1.0"/>
@@ -36,5 +36,8 @@
     <revision date="2013/03/11">
       <change>Moved to draft status after discussion on public_webgl.</change>
     </revision>
+    <revision date="2013/08/06">
+      <change>Moved to community approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/extensions/OES_texture_half_float_linear/extension.xml
+++ b/extensions/OES_texture_half_float_linear/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="OES_texture_half_float_linear/">
+<extension href="OES_texture_half_float_linear/">
   <name>OES_texture_half_float_linear</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -9,7 +9,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>21</number>
+  <number>22</number>
 
   <depends>
     <api version="1.0"/>
@@ -36,5 +36,8 @@
     <revision date="2013/03/11">
       <change>Moved to draft status after discussion on public_webgl.</change>
     </revision>
+    <revision date="2013/08/06">
+      <change>Moved to community approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>


### PR DESCRIPTION
Based on consensus on the public-webgl list, the following three
extensions are advanced to community approved:
- ANGLE_instanced_arrays
- OES_texture_float_linear
- OES_texture_half_float_linear
