### PR TITLE
Removed failure in ported ES 2.0 tests if uniform is not found.

### DIFF
--- a/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
+++ b/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
@@ -471,7 +471,6 @@ function drawWithProgram(program, programInfo, test) {
   for (var name in programInfo.uniforms) {
     var location = getUniformLocation(name);
     if (!location) {
-      testFailed("uniform not found: " + name);
       continue;
     }
     var uniform = programInfo.uniforms[name];

--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -471,7 +471,6 @@ function drawWithProgram(program, programInfo, test) {
   for (var name in programInfo.uniforms) {
     var location = getUniformLocation(name);
     if (!location) {
-      testFailed("uniform not found: " + name);
       continue;
     }
     var uniform = programInfo.uniforms[name];


### PR DESCRIPTION
Original GLES 2.0 tests do not enforce this, and their test data fails does not conform to this rule. This caused the ogles/GL/vec3/vec3_001_to_008.html test to fail, since the test data specifies a uniform called lightPosition should be defined. In the corresponding shader (ogles/GL/vec3/vec3array_frag.frag) the uniform is indeed declared, but does not contribute to the final fragment color and as such is optimized out on many platforms. This appears to be a copy/paste error on the part of the original test authors, but in the interest of maintaining our ability to automatically import their conformance tests we should not place additional restrictions on the tests that cause these types of scenarios to generate failures.

Specifically, the original test uses the following code to set uniforms: (from GTFUniDataGL.c)

```
else if(pUniDataGL->Type == GTFUNITYPEGL3FV)
                glUniform3fv(glGetUniformLocation(*pUniDataGL->Program_Object_2_0, pUniDataGL->Name.cstring), pUniDataGL->Count, pUniDataGL->Value.fv);
```

As you can see, the uniform is queried and passed to the approriate set function without any inspection whatsoever. Thus attempting to set a uniform that was not present would silently fail but allow the test to continue. This patch updates the equivalent WebGL tests to do the same.
