### PR TITLE
Conserve instruction space in uniform packing test

### DIFF
--- a/conformance-suites/1.0.2/conformance/glsl/misc/shader-uniform-packing-restrictions.html
+++ b/conformance-suites/1.0.2/conformance/glsl/misc/shader-uniform-packing-restrictions.html
@@ -140,7 +140,7 @@ var shaderTypes = [
     vertUniformTest: vUniformTestSource,
     fragUniformTest: fBaseSource,
     maxVectors: gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS),
-    minVectors: 126,  // GLSL ES 1.0.17 Appendix A.7 and A.8. Reserve two rows for constants in the code, hence 128 - 2.
+    minVectors: 127,  // GLSL ES 1.0.17 Appendix A.7 and A.8. Reserve one row for constants in the code, hence 128 - 1.
   },
   { type: "fragment",
     // For tests that expect failure which shader might fail.
@@ -151,7 +151,7 @@ var shaderTypes = [
     vertUniformTest: vBaseSource,
     fragUniformTest: fUniformTestSource,
     maxVectors: gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS),
-    minVectors: 14,  // GLSL ES 1.0.17 Appendix A.8 - minimum value of gl_maxFragmentUniformVectors is 16. Again, reserve two rows for constants.
+    minVectors: 15,  // GLSL ES 1.0.17 Appendix A.8 - minimum value of gl_maxFragmentUniformVectors is 16. Again, reserve a row for constants.
   },
 ];
 for (var ss = 0; ss < shaderTypes.length; ++ss) {

--- a/sdk/tests/conformance/glsl/misc/shader-uniform-packing-restrictions.html
+++ b/sdk/tests/conformance/glsl/misc/shader-uniform-packing-restrictions.html
@@ -140,7 +140,7 @@ var shaderTypes = [
     vertUniformTest: vUniformTestSource,
     fragUniformTest: fBaseSource,
     maxVectors: gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS),
-    minVectors: 126,  // GLSL ES 1.0.17 Appendix A.7 and A.8. Reserve two rows for constants in the code, hence 128 - 2.
+    minVectors: 127,  // GLSL ES 1.0.17 Appendix A.7 and A.8. Reserve one row for constants in the code, hence 128 - 1.
   },
   { type: "fragment",
     // For tests that expect failure which shader might fail.
@@ -151,7 +151,7 @@ var shaderTypes = [
     vertUniformTest: vBaseSource,
     fragUniformTest: fUniformTestSource,
     maxVectors: gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS),
-    minVectors: 14,  // GLSL ES 1.0.17 Appendix A.8 - minimum value of gl_maxFragmentUniformVectors is 16. Again, reserve two rows for constants.
+    minVectors: 15,  // GLSL ES 1.0.17 Appendix A.8 - minimum value of gl_maxFragmentUniformVectors is 16. Again, reserve a row for constants.
   },
 ];
 for (var ss = 0; ss < shaderTypes.length; ++ss) {


### PR DESCRIPTION
Shaders in variable packing tests could go past instruction register
limits on GLES2 compliant hardware. The GLSL ES 1.0.17 Appendix A.2 says
that the limit is defined by the conformance tests. This limit is inexact
since there's no shader bytecode spec in OpenGL, but instructions can
typically be conserved by doing padding from float, vec2 and vec3 types
to vec4 only once per shader instead of once per uniform as before. This
makes it possible to pass the conformance tests on a wider array of GLES2
compliant devices than before.

Also reduce the minimum number of rows for uniforms from 128 to 126 in
the vertex shader tests to make two rows available to constants.

Includes some cleanup and clarifications in the surrounding code.

This is a bugfix to the conformance suite, so it is backported also to
1.0.2.
