### PR TITLE
reduce the size of texture for out of bound test to avoid possible failure on allocation of ArrayBuffer

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-size-limit.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-size-limit.html
@@ -164,17 +164,21 @@ function testFormatType(t, test) {
 
       // out of bound test
       // width or height out of bound
-      var pixelsNegativeTest1 = new test.dataType(test.func(t.maxSize * 2, t.maxSize * 2));
-      gl.compressedTexImage2D(target, 0, test.format, t.maxSize * 2, t.maxSize * 2, 0, pixelsNegativeTest1);
-      glErrorShouldBe(gl, gl.INVALID_VALUE, "width or height out of bound: should generate INVALID_VALUE."
-          + " level is 0, size is " + (t.maxSize * 2) + "x" + (t.maxSize * 2));
+      var pixelsNegativeTest1 = new test.dataType(test.func(t.maxSize * 2, 1));
+      gl.compressedTexImage2D(target, 0, test.format, t.maxSize * 2, 1, 0, pixelsNegativeTest1);
+      glErrorShouldBe(gl, gl.INVALID_VALUE, "width out of bound: should generate INVALID_VALUE."
+          + " level is 0, size is " + (t.maxSize * 2) + "x1");
+      var pixelsNegativeTest2 = new test.dataType(test.func(1, t.maxSize * 2));
+      gl.compressedTexImage2D(target, 0, test.format, 1, t.maxSize * 2, 0, pixelsNegativeTest2);
+      glErrorShouldBe(gl, gl.INVALID_VALUE, "height out of bound: should generate INVALID_VALUE."
+          + " level is 0, size is " + "1x" + (t.maxSize * 2));
       // level out of bound
-      var pixelsNegativeTest2 = new test.dataType(test.func(256, 256));
-      gl.compressedTexImage2D(target, numLevels, test.format, 256, 256, 0, pixelsNegativeTest2);
+      var pixelsNegativeTest3 = new test.dataType(test.func(256, 256));
+      gl.compressedTexImage2D(target, numLevels, test.format, 256, 256, 0, pixelsNegativeTest3);
       glErrorShouldBe(gl, gl.INVALID_VALUE, "level out of bound: should generate INVALID_VALUE."
           + " level is " + numLevels + ", size is 256x256");
       //width or height out of bound for specified level
-      gl.compressedTexImage2D(target, numLevels - 1, test.format, 256, 256, 0, pixelsNegativeTest2);
+      gl.compressedTexImage2D(target, numLevels - 1, test.format, 256, 256, 0, pixelsNegativeTest3);
       glErrorShouldBe(gl, gl.INVALID_VALUE, "width or height out of bound for specified level: should generate INVALID_VALUE."
           + " level is " + (numLevels - 1) + ", size is 256x256");
     }

--- a/sdk/tests/conformance/textures/texture-size-limit.html
+++ b/sdk/tests/conformance/textures/texture-size-limit.html
@@ -133,20 +133,19 @@ function testFormatType(t, test) {
     var numLevels = numLevelsFromSize(t.maxSize);
     var numTestLevels = Math.min(numLevels, t.maxLevel);
 
-    // out of bound test
-    var pixelsNegativeTest = new test.dataType((t.maxSize + 1) * (t.maxSize + 1) * 4);
     // level out of bound
-    gl.texImage2D(target, numLevels, test.format, 1, 1, 0, test.format, test.type, pixelsNegativeTest);
+    var pixelsNegativeTest1 = new test.dataType(1 * 1 * 4);
+    gl.texImage2D(target, numLevels, test.format, 1, 1, 0, test.format, test.type, pixelsNegativeTest1);
     glErrorShouldBe(gl, gl.INVALID_VALUE, "level out of bound: should generate INVALID_VALUE: level is: "
         + numLevels + ", size is 1x1.");
     // width or height out of bound
-    gl.texImage2D(target, 0, test.format, t.maxSize + 1, t.maxSize + 1, 0, test.format, test.type, pixelsNegativeTest);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "width or height out of bound: should generate INVALID_VALUE: level is 0, size is "
-        + (t.maxSize + 1) + "x" + (t.maxSize + 1));
-    // width or height out of bound for specified level
-    gl.texImage2D(target, (numLevels - 1), test.format, 4, 4, 0, test.format, test.type, pixelsNegativeTest);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "width or height out of bound for specified level: should generate INVALID_VALUE: levle is "
-        + (numLevels - 1) + ", size is 4x4.");
+    var pixelsNegativeTest2 = new test.dataType((t.maxSize + 1) * 1 * 4);
+    gl.texImage2D(target, 0, test.format, t.maxSize + 1, 1, 0, test.format, test.type, pixelsNegativeTest2);
+    glErrorShouldBe(gl, gl.INVALID_VALUE, "width out of bound: should generate INVALID_VALUE: level is 0, size is "
+        + (t.maxSize + 1) + "x1");
+    gl.texImage2D(target, 0, test.format, 1, t.maxSize + 1, 0, test.format, test.type, pixelsNegativeTest2);
+    glErrorShouldBe(gl, gl.INVALID_VALUE, "height out of bound: should generate INVALID_VALUE: level is 0, size is "
+        + "1x" + (t.maxSize + 1));
 
     for (var l = 0; l < numTestLevels; ++l) {
       // Do bottom levels first;


### PR DESCRIPTION
It seems Chrome Canary in Windows(31.0.1604.2 (Official Build 218184) canary Aura SyzyASan) will crash on failure of allocation of ArrayBuffer when exercising the test on texture size limit. The crash issue soon disappeared and the browser worked well again for test texture size test when upgrading it to newer version 31.0.1605.1 (Official Build 218221) canary Aura.
Although I have not checked the differences in these two versions in detail, it seems It would be better to refine the test to  use a small size for testing the limit. This patch is verified using both the release/debug build from the latest chromium code and the Canary browser.
