### PR TITLE
Make negHuge actually negative in float_literal.vert.html test

### DIFF
--- a/sdk/tests/conformance/glsl/literals/float_literal.vert.html
+++ b/sdk/tests/conformance/glsl/literals/float_literal.vert.html
@@ -59,7 +59,7 @@ void main() {
   highp float posHuge = 1E100;
   highp float negInRange = -4611686018427387903.;
   highp float negOutRange = -4611686018427387905.;
-  highp float negHuge = 1E100;
+  highp float negHuge = -1E100;
 }
 </script>
 <script>


### PR DESCRIPTION
Just a simple typo fix. This is not a critical bug, and technically the
fix increases test coverage, so it's not backported to earlier releases.
