### PR TITLE
Fix float_literal.vert.html bug in both ToT and 1.0.2 suites.

### DIFF
--- a/conformance-suites/1.0.2/conformance/glsl/literals/float_literal.vert.html
+++ b/conformance-suites/1.0.2/conformance/glsl/literals/float_literal.vert.html
@@ -59,7 +59,8 @@ void main() {
   highp float posHuge = 1E100;
   highp float negInRange = -4611686018427387903.;
   highp float negOutRange = -4611686018427387905.;
-  highp float negHuge = 1E100;
+  highp float negHuge = -1E100;
+  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
 }
 </script>
 <script>

--- a/sdk/tests/conformance/glsl/literals/float_literal.vert.html
+++ b/sdk/tests/conformance/glsl/literals/float_literal.vert.html
@@ -59,7 +59,8 @@ void main() {
   highp float posHuge = 1E100;
   highp float negInRange = -4611686018427387903.;
   highp float negOutRange = -4611686018427387905.;
-  highp float negHuge = 1E100;
+  highp float negHuge = -1E100;
+  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
 }
 </script>
 <script>


### PR DESCRIPTION
Without gl_Position in vertex shader, linking will fail.
