### PR TITLE
Specifically ignore stdio for browser sub-process to prevent hangs from ...

### DIFF
--- a/other/test-runner/index.js
+++ b/other/test-runner/index.js
@@ -389,7 +389,7 @@ function run_tests_internal(app, config, callback, browser_id, browser, platform
 
   var browser_path = platform.command ? platform.command : platform.path;
 
-  var browser_proc = child_process.spawn(browser_path, all_args);
+  var browser_proc = child_process.spawn(browser_path, all_args, { stdio: 'ignore' });
   app.browser_proc = browser_proc;
   app.browser_name = browser.name.replace(' ', '-');
   app.finished_tests = false;


### PR DESCRIPTION
...filling the stdout buffer. Fixes problem seen with node.js v0.10.18 on Mac OS X.
