### PR TITLE
Remove incorrect comment about canvas size check

### DIFF
--- a/conformance-suites/1.0.1/conformance/canvas/drawingbuffer-static-canvas-test.html
+++ b/conformance-suites/1.0.1/conformance/canvas/drawingbuffer-static-canvas-test.html
@@ -112,7 +112,6 @@ if (!gl) {
   debug("");
   debug("Checking drawingBufferWidth/drawingBufferHeight");
 
-  // Check that a canvas with no width or height is 300x150 pixels
   shouldBe('gl.drawingBufferWidth', 'gl.canvas.width');
   shouldBe('gl.drawingBufferHeight', 'gl.canvas.height');
 

--- a/conformance-suites/1.0.2/conformance/canvas/drawingbuffer-static-canvas-test.html
+++ b/conformance-suites/1.0.2/conformance/canvas/drawingbuffer-static-canvas-test.html
@@ -132,7 +132,6 @@ if (!gl) {
   debug("");
   debug("Checking drawingBufferWidth/drawingBufferHeight");
 
-  // Check that a canvas with no width or height is 300x150 pixels
   shouldBe('gl.drawingBufferWidth', 'gl.canvas.width');
   shouldBe('gl.drawingBufferHeight', 'gl.canvas.height');
 

--- a/sdk/tests/conformance/canvas/drawingbuffer-static-canvas-test.html
+++ b/sdk/tests/conformance/canvas/drawingbuffer-static-canvas-test.html
@@ -132,7 +132,6 @@ if (!gl) {
   debug("");
   debug("Checking drawingBufferWidth/drawingBufferHeight");
 
-  // Check that a canvas with no width or height is 300x150 pixels
   shouldBe('gl.drawingBufferWidth', 'gl.canvas.width');
   shouldBe('gl.drawingBufferHeight', 'gl.canvas.height');
 


### PR DESCRIPTION
The canvas is in fact sized to 50_50 pixels while the comment claimed it
to be the default 300_150 pixels. The fix is applied to all versions of
the conformance test suite.
