### PR TITLE
Ensure that webkit test runner's notifyDone is called

### DIFF
--- a/conformance-suites/1.0.2/resources/js-test-pre.js
+++ b/conformance-suites/1.0.2/resources/js-test-pre.js
@@ -85,6 +85,9 @@ function notifyFinishedToHarness() {
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
   }
+  if (window.nonKhronosFrameworkNotifyDone) {
+    window.nonKhronosFrameworkNotifyDone();
+  }
 }
 
 function description(msg)
@@ -465,11 +468,6 @@ function gc() {
 function finishTest() {
   successfullyParsed = true;
   var epilogue = document.createElement("script");
-  epilogue.onload = function() {
-    if (window.nonKhronosFrameworkNotifyDone) {
-      window.nonKhronosFrameworkNotifyDone();
-    }
-  };
 
   var basePath = "";
   var expectedBase = "js-test-pre.js";

--- a/sdk/tests/resources/js-test-pre.js
+++ b/sdk/tests/resources/js-test-pre.js
@@ -81,6 +81,9 @@ function notifyFinishedToHarness() {
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
   }
+  if (window.nonKhronosFrameworkNotifyDone) {
+    window.nonKhronosFrameworkNotifyDone();
+  }
 }
 
 function description(msg)
@@ -461,12 +464,6 @@ function gc() {
 function finishTest() {
   successfullyParsed = true;
   var epilogue = document.createElement("script");
-  epilogue.onload = function() {
-    if (window.nonKhronosFrameworkNotifyDone) {
-      window.nonKhronosFrameworkNotifyDone();
-    }
-  };
-
   var basePath = "";
   var expectedBase = "js-test-pre.js";
   var scripts = document.getElementsByTagName('script');


### PR DESCRIPTION
Some tests include js-test-post.js directly instead of calling
finishTest. Make sure that these tests also call notifyDone in 1.0.2 and
newer versions of the test suite, since waitUntilDone is always called.
