### PR TITLE
Add missing init calls in buffer tests in 1.0.1

### DIFF
--- a/conformance-suites/1.0.1/conformance/canvas/buffer-offscreen-test.html
+++ b/conformance-suites/1.0.1/conformance/canvas/buffer-offscreen-test.html
@@ -13,6 +13,9 @@ body {
 }
 </style>
 <script type="text/javascript">
+if (window.initNonKhronosFramework) {
+    window.initNonKhronosFramework(true);
+}
 
 var iter = 0;
 var gl1;

--- a/conformance-suites/1.0.1/conformance/canvas/buffer-preserve-test.html
+++ b/conformance-suites/1.0.1/conformance/canvas/buffer-preserve-test.html
@@ -13,6 +13,9 @@ body {
 }
 </style>
 <script type="text/javascript">
+if (window.initNonKhronosFramework) {
+    window.initNonKhronosFramework(true);
+}
 
 var iter = 0;
 var gl1;


### PR DESCRIPTION
These tests are asynchronous, but didn't call waitUntilDone correctly in
1.0.1 when run under the webkit test runner. Add the missing call. In
1.0.2+, waitUntilDone is called indirectly and no changes are needed.
