### PR TITLE
Fix "antialiased" context attribute typo

### DIFF
--- a/conformance-suites/1.0.2/conformance/context/resources/context-release-child-with-worker.html
+++ b/conformance-suites/1.0.2/conformance/context/resources/context-release-child-with-worker.html
@@ -56,7 +56,7 @@
         var wtu = WebGLTestUtils;
         var myWorker = new Worker("context-release-worker.js");
 
-        var gl = wtu.create3DContext("c", {"antialiased": false});
+        var gl = wtu.create3DContext("c", { antialias: false });
         var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
 
         var vertexObject = gl.createBuffer();

--- a/conformance-suites/1.0.2/conformance/context/resources/context-release-upon-reload-child.html
+++ b/conformance-suites/1.0.2/conformance/context/resources/context-release-upon-reload-child.html
@@ -55,7 +55,7 @@
         "use strict";
         var wtu = WebGLTestUtils;
 
-        var gl = wtu.create3DContext("c", {"antialiased": false});
+        var gl = wtu.create3DContext("c", { antialias: false });
         var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
 
         var vertexObject = gl.createBuffer();

--- a/sdk/tests/conformance/context/resources/context-release-child-with-worker.html
+++ b/sdk/tests/conformance/context/resources/context-release-child-with-worker.html
@@ -56,7 +56,7 @@
         var wtu = WebGLTestUtils;
         var myWorker = new Worker("context-release-worker.js");
 
-        var gl = wtu.create3DContext("c", {"antialiased": false});
+        var gl = wtu.create3DContext("c", { antialias: false });
         var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
 
         var vertexObject = gl.createBuffer();

--- a/sdk/tests/conformance/context/resources/context-release-upon-reload-child.html
+++ b/sdk/tests/conformance/context/resources/context-release-upon-reload-child.html
@@ -55,7 +55,7 @@
         "use strict";
         var wtu = WebGLTestUtils;
 
-        var gl = wtu.create3DContext("c", {"antialiased": false});
+        var gl = wtu.create3DContext("c", { antialias: false });
         var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
 
         var vertexObject = gl.createBuffer();


### PR DESCRIPTION
The intent in these tests was to set the context to not use antialiasing.
Fix in 1.0.2 and later, 1.0.1 doesn't have these tests.
