### PR TITLE
Fix antialias setting in copy-tex-image-and-sub-image-2d.html

### DIFF
--- a/conformance-suites/1.0.1/conformance/textures/copy-tex-image-and-sub-image-2d.html
+++ b/conformance-suites/1.0.1/conformance/textures/copy-tex-image-and-sub-image-2d.html
@@ -33,7 +33,7 @@ function runTestIteration(antialias)
 {
     var canvas = document.getElementById(
         antialias ? "antialiasOn" : "antialiasOff");
-    var attribs = antialias ? { antialias: false } : undefined;
+    var attribs = antialias ? { antialias: true } : { antialias: false };
     gl = wtu.create3DContext(canvas, attribs);
     var program = wtu.setupTexturedQuad(gl);
     var textureLoc = gl.getUniformLocation(program, "tex");

--- a/conformance-suites/1.0.2/conformance/textures/copy-tex-image-and-sub-image-2d.html
+++ b/conformance-suites/1.0.2/conformance/textures/copy-tex-image-and-sub-image-2d.html
@@ -54,7 +54,7 @@ function runTestIteration(antialias)
 {
     var canvas = document.getElementById(
         antialias ? "antialiasOn" : "antialiasOff");
-    var attribs = antialias ? { antialias: false } : undefined;
+    var attribs = antialias ? { antialias: true } : { antialias: false };
     gl = wtu.create3DContext(canvas, attribs);
     var program = wtu.setupTexturedQuad(gl);
     var textureLoc = gl.getUniformLocation(program, "tex");

--- a/sdk/tests/conformance/textures/copy-tex-image-and-sub-image-2d.html
+++ b/sdk/tests/conformance/textures/copy-tex-image-and-sub-image-2d.html
@@ -52,7 +52,7 @@ function runTestIteration(antialias)
 {
     var canvas = document.getElementById(
         antialias ? "antialiasOn" : "antialiasOff");
-    var attribs = antialias ? { antialias: false } : undefined;
+    var attribs = antialias ? { antialias: true } : { antialias: false };
     gl = wtu.create3DContext(canvas, attribs);
     var program = wtu.setupTexturedQuad(gl);
     var textureLoc = gl.getUniformLocation(program, "tex");
@@ -96,12 +96,12 @@ function runTestIteration(antialias)
           case 0:
             gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, xx, yy, 2, 2, 0);
             glErrorShouldBe(gl, gl.NO_ERROR,
-                "using copyTexImage2D: x =" + xx + ", y = " + yy);
+                "using copyTexImage2D: x = " + xx + ", y = " + yy);
             break;
           case 1:
             gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, xx, yy, 2, 2);
             glErrorShouldBe(gl, gl.NO_ERROR,
-                "using copyTexSubImage2D: x =" + xx + ", y = " + yy);
+                "using copyTexSubImage2D: x = " + xx + ", y = " + yy);
             break;
           }
 


### PR DESCRIPTION
Previously, if the antialias flag was set, the test actually forced
antialiasing off. If antialias flag was not set, the test used the
default setting in WebGL test utils, which also is antialiasing off. Fix
this so that antialiasing is always explicitly specified in the test and
that having antialiasing on gets tested. This fix is backported to 1.0.1
and 1.0.2.

Also fix formatting of this test's output in 1.0.3+
