### PR TITLE
mat3 row column ordering in construction

### DIFF
--- a/sdk/tests/conformance/glsl/matrices/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/matrices/00_test_list.txt
@@ -1,2 +1,2 @@
 glsl-mat4-to-mat3.html
-glsl-mat3-construction.html
+--min-version 1.0.3 glsl-mat3-construction.html

--- a/sdk/tests/conformance/glsl/matrices/glsl-mat3-construction.html
+++ b/sdk/tests/conformance/glsl/matrices/glsl-mat3-construction.html
@@ -1,7 +1,7 @@
 <!--
 
 /*
-** Copyright (c) 2012 The Khronos Group Inc.
+** Copyright (c) 2013 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the


### PR DESCRIPTION
Check the row column ordering of mat3 construction in a shader.

Currently IE 11 produces different results to other browsers
