### PR TITLE
Increased tolerance in oes-standard-derivatives test from 2 to 5 on

### DIFF
--- a/conformance-suites/1.0.1/conformance/extensions/oes-standard-derivatives.html
+++ b/conformance-suites/1.0.1/conformance/extensions/oes-standard-derivatives.html
@@ -248,7 +248,7 @@ function runOutputTests() {
     //    g = floor(dFdy * 255) = 3
     //    b = floor(fw * 255) = 5
 
-    var e = 2; // Amount of variance to allow in result pixels - may need to be tweaked higher
+    var e = 5; // Amount of variance to allow in result pixels - may need to be tweaked higher
 
     debug("Testing various draws for valid built-in function behavior");
 

--- a/conformance-suites/1.0.2/conformance/extensions/oes-standard-derivatives.html
+++ b/conformance-suites/1.0.2/conformance/extensions/oes-standard-derivatives.html
@@ -271,7 +271,7 @@ function runOutputTests() {
     //    g = floor(dFdy * 40.0 * 255) = 102
     //    b = floor(fw * 40.0 * 255) = 204
 
-    var e = 2; // Amount of variance to allow in result pixels - may need to be tweaked higher
+    var e = 5; // Amount of variance to allow in result pixels - may need to be tweaked higher
 
     debug("Testing various draws for valid built-in function behavior");
 

--- a/sdk/tests/conformance/extensions/oes-standard-derivatives.html
+++ b/sdk/tests/conformance/extensions/oes-standard-derivatives.html
@@ -271,7 +271,7 @@ function runOutputTests() {
     //    g = floor(dFdy * 40.0 * 255) = 102
     //    b = floor(fw * 40.0 * 255) = 204
 
-    var e = 2; // Amount of variance to allow in result pixels - may need to be tweaked higher
+    var e = 5; // Amount of variance to allow in result pixels - may need to be tweaked higher
 
     debug("Testing various draws for valid built-in function behavior");
 


### PR DESCRIPTION
request from Qualcomm.

This is essentially a bug fix and has therefore been applied to the
1.0.1, 1.0.2 and top-of-tree conformance suites.
