### PR TITLE
Some fixes to TexSubImage tests

### DIFF
--- a/sdk/tests/conformance/more/functions/copyTexSubImage2D.html
+++ b/sdk/tests/conformance/more/functions/copyTexSubImage2D.html
@@ -41,14 +41,18 @@ Tests.startUnit = function () {
 
 Tests.setup = function(gl) {
   var tex = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(gl.TEXTURE_2D, tex);
   var texCubeMap = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE1);
   gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap);
   return [gl]
 }
 
 Tests.teardown = function(gl,tex,texCubeMap) {
+  gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(gl.TEXTURE_2D, null);
+  gl.activeTexture(gl.TEXTURE1);
   gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
   gl.deleteTexture(tex);
   gl.deleteTexture(texCubeMap);
@@ -56,6 +60,7 @@ Tests.teardown = function(gl,tex,texCubeMap) {
 
 
 Tests.testTexImage2D = function(gl) {
+  gl.activeTexture(gl.TEXTURE0);
   gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 0,0,16,16,0);
   gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0,0, 0,0,1,1);
   gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0,0, 0,0,2,1);
@@ -64,8 +69,13 @@ Tests.testTexImage2D = function(gl) {
   gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0,0, 15,15,1,1);
   gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 1,1, 0,0,15,15);
   gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 15,15, 0,0,1,1);
+
+  assertOk(function(){
+      gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 0,0,1,1,0);
+      gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0,0,0,0,1,1);
+  });
+
   var valid_targets = [
-    gl.TEXTURE_2D,
     gl.TEXTURE_CUBE_MAP_POSITIVE_X,
     gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
     gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
@@ -73,6 +83,8 @@ Tests.testTexImage2D = function(gl) {
     gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
     gl.TEXTURE_CUBE_MAP_NEGATIVE_Z
   ];
+
+  gl.activeTexture(gl.TEXTURE1);
   valid_targets.forEach(function(t) {
     assertOk(function(){
         gl.copyTexImage2D(t, 0, gl.RGBA, 0,0,1,1,0);
@@ -90,6 +102,7 @@ Tests.testRoundtrip = function(gl) {
     // red texture
     gl.clearColor(0.0, 0.0, 0.0, 0.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.activeTexture(gl.TEXTURE0);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, document.getElementById('gl'));
     gl.clearColor(1.0, 0.0, 0.0, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT);

--- a/sdk/tests/conformance/more/functions/texSubImage2D.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2D.html
@@ -41,20 +41,25 @@ Tests.startUnit = function () {
 
 Tests.setup = function(gl) {
   var tex = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(gl.TEXTURE_2D, tex);
   var texCubeMap = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE1);
   gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap);
   return [gl]
 }
 
 Tests.teardown = function(gl,tex,texCubeMap) {
+  gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(gl.TEXTURE_2D, null);
-  gl.deleteTexture(tex);
+  gl.activeTexture(gl.TEXTURE1);
   gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
+  gl.deleteTexture(tex);
   gl.deleteTexture(texCubeMap);
 }
 
 Tests.testTexSubImage2D = function(gl) {
+  gl.activeTexture(gl.TEXTURE0);
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2,2,0,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]));
   gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
   gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 2,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0,0,0,0,0]));
@@ -64,8 +69,13 @@ Tests.testTexSubImage2D = function(gl) {
   gl.texSubImage2D(gl.TEXTURE_2D, 0, 1,1, 1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
   gl.texImage2D(gl.TEXTURE_2D, 1,gl.RGBA, 1,1,0,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
   gl.texSubImage2D(gl.TEXTURE_2D, 1, 0,0, 1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
+
+  assertOk(function(){
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1,1,0,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
+  });
+
   var valid_targets = [
-    gl.TEXTURE_2D,
     gl.TEXTURE_CUBE_MAP_POSITIVE_X,
     gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
     gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
@@ -73,6 +83,8 @@ Tests.testTexSubImage2D = function(gl) {
     gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
     gl.TEXTURE_CUBE_MAP_NEGATIVE_Z
   ];
+
+  gl.activeTexture(gl.TEXTURE1);
   valid_targets.forEach(function(t) {
     assertOk(function(){
         gl.texImage2D(t, 0, gl.RGBA, 1,1,0,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));

--- a/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
@@ -45,16 +45,20 @@ Tests.startUnit = function () {
 
 Tests.setup = function(gl) {
     var tex = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, tex);
     var texCubeMap = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE1);
     gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap);
     return [gl]
 }
 
 Tests.teardown = function(gl, tex, texCubeMap) {
+    gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, null);
-    gl.deleteTexture(tex);
+    gl.activeTexture(gl.TEXTURE1);
     gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
+    gl.deleteTexture(tex);
     gl.deleteTexture(texCubeMap);
 }
 
@@ -64,6 +68,7 @@ Tests.testTexImage2D = function(gl) {
     var c = document.getElementById('c');
     var ctx = c.getContext('2d');
     ctx.drawImage(img,0,0);
+    gl.activeTexture(gl.TEXTURE0);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
     gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, img);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
@@ -80,8 +85,17 @@ Tests.testTexImage2D = function(gl) {
     gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
     f.apply();
     f.destroy();
+
+    assertOk(function(){
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, c);
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
+    });
+    assertOk(function(){
+            gl.texImage2D(gl.TEXTURE_2D, 1, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, c);
+            gl.texSubImage2D(gl.TEXTURE_2D, 1, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
+    });
+
     var valid_targets = [
-        gl.TEXTURE_2D,
         gl.TEXTURE_CUBE_MAP_POSITIVE_X,
         gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
         gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
@@ -89,6 +103,8 @@ Tests.testTexImage2D = function(gl) {
         gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
         gl.TEXTURE_CUBE_MAP_NEGATIVE_Z
     ];
+
+    gl.activeTexture(gl.TEXTURE1);
     valid_targets.forEach(function(t) {
         assertOk(function(){
                 gl.texImage2D(t, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, c);
@@ -107,6 +123,7 @@ Tests.testTexImage2DNonSOP = function(gl) {
     var c = document.getElementById('c');
     var ctx = c.getContext('2d');
     ctx.drawImage(img,0,0);
+    gl.activeTexture(gl.TEXTURE0);
     assertThrowNoGLError(gl, "texImage2D with cross-origin image should throw exception.",
       function(){gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);});
     assertThrowNoGLError(gl, "texSubImage2D with cross-origin image should throw exception.",

--- a/sdk/tests/conformance/textures/texture-size.html
+++ b/sdk/tests/conformance/textures/texture-size.html
@@ -83,9 +83,9 @@ var max2DSquareSize = Math.min(max2DSize, 2048);
 var maxCubeMapSize = Math.min(maxCubeMapSize, 1024);
 
 var colors = [
-  { name: "green", rgba: [0, 0, 255, 255] },
+  { name: "green", rgba: [0, 255, 0, 255] },
   { name: "red", rgba: [255, 0, 0, 255] },
-  { name: "blue", rgba: [0, 255, 0, 255] },
+  { name: "blue", rgba: [0, 0, 255, 255] },
   { name: "yellow", rgba: [255, 255, 0, 255] },
   { name: "magenta", rgba: [255, 0, 255, 255] },
   { name: "cyan", rgba: [0, 255, 255, 255] }


### PR DESCRIPTION
According to OpenGL ES 2.0 specification it is not possible to use both texture2D and textureCubeMap in one texture unit.

conformance/more/functions/texSubImage2DHTML.html
conformance/more/functions/texSubImage2D.html
conformance/more/functions/copyTexSubImage2D.html

should all be using gl.activeTexture appropriate to switch between using the texture bound to GL_TEXTURE_2D, and the texture bound to GL_TEXTURE_CUBE_MAP.

And a nit: conformance/more/textures/texture-size.html passes fine, but green and blue are mixed up...
