### PR TITLE
Update webgl-depth-texture.html in ToT and 1.0.2 suites.

### DIFF
--- a/conformance-suites/1.0.2/conformance/extensions/webgl-depth-texture.html
+++ b/conformance-suites/1.0.2/conformance/extensions/webgl-depth-texture.html
@@ -274,7 +274,7 @@ function runTestExtension() {
         dumpIt(gl, res, "--depth--");
 
         // Check that each pixel's R value is less than that of the previous pixel
-        // in either direction. Basically verify we have a radient.
+        // in either direction. Basically verify we have a gradient.
         var success = true;
         for (var yy = 0; yy < res; ++yy) {
           for (var xx = 0; xx < res; ++xx) {

--- a/sdk/tests/conformance/extensions/webgl-depth-texture.html
+++ b/sdk/tests/conformance/extensions/webgl-depth-texture.html
@@ -274,7 +274,7 @@ function runTestExtension() {
         dumpIt(gl, res, "--depth--");
 
         // Check that each pixel's R value is less than that of the previous pixel
-        // in either direction. Basically verify we have a radient.
+        // in either direction. Basically verify we have a gradient.
         var success = true;
         for (var yy = 0; yy < res; ++yy) {
           for (var xx = 0; xx < res; ++xx) {


### PR DESCRIPTION
We no longer ask for RGBA to match.  The updated extension spec only guarantees the R channel.
