### PR TITLE
Add a new test for SVG image textures.

### DIFF
--- a/sdk/tests/conformance/resources/red-green.svg
+++ b/sdk/tests/conformance/resources/red-green.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="2">
+  <rect fill="#f00" width="1" height="1"/>
+  <rect fill="#0f0" y="1" width="1" height="1"/>
+</svg>

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
@@ -1,0 +1,105 @@
+/*
+** Copyright (c) 2013 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
+    var wtu = WebGLTestUtils;
+    var gl = null;
+    var textureLoc = null;
+    var successfullyParsed = false;
+    var imgCanvas;
+    var red = [255, 0, 0];
+    var green = [0, 255, 0];
+
+    var init = function()
+    {
+        description('Verify texImage2D and texSubImage2D code paths taking SVG image elements (' + pixelFormat + '/' + pixelType + ')');
+
+        gl = wtu.create3DContext("example");
+
+        if (!prologue(gl)) {
+            finishTest();
+            return;
+        }
+
+        var program = wtu.setupTexturedQuad(gl);
+
+        gl.clearColor(0,0,0,1);
+        gl.clearDepth(1);
+
+        textureLoc = gl.getUniformLocation(program, "tex");
+
+        wtu.loadTexture(gl, pathToTestRoot + "/resources/red-green.svg", runTest);
+    }
+
+    function runOneIteration(image, useTexSubImage2D, flipY, topColor, bottomColor)
+    {
+        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
+              ' with flipY=' + flipY);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        // Disable any writes to the alpha channel
+        gl.colorMask(1, 1, 1, 0);
+        var texture = gl.createTexture();
+        // Bind the texture to texture unit 0
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        // Set up texture parameters
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        // Set up pixel store parameters
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        // Upload the image into the texture
+        if (useTexSubImage2D) {
+            // Initialize the texture to black first
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], image.width, image.height, 0,
+                          gl[pixelFormat], gl[pixelType], null);
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl[pixelFormat], gl[pixelType], image);
+        } else {
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], image);
+        }
+
+        // Point the uniform sampler to texture unit 0
+        gl.uniform1i(textureLoc, 0);
+        // Draw the triangles
+        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+        // Check a few pixels near the top and bottom and make sure they have
+        // the right color.
+        debug("Checking lower left corner");
+        wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
+                            "shouldBe " + bottomColor);
+        debug("Checking upper left corner");
+        wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
+                            "shouldBe " + topColor);
+    }
+
+    function runTest(image)
+    {
+        runOneIteration(image, false, true, red, green);
+        runOneIteration(image, false, false, green, red);
+        runOneIteration(image, true, true, red, green);
+        runOneIteration(image, true, false, green, red);
+        finishTest();
+    }
+
+    return init;
+}

--- a/sdk/tests/conformance/textures/00_test_list.txt
+++ b/sdk/tests/conformance/textures/00_test_list.txt
@@ -15,6 +15,7 @@ tex-image-and-sub-image-2d-with-image-data-rgb565.html
 tex-image-and-sub-image-2d-with-image-data-rgba4444.html
 tex-image-and-sub-image-2d-with-image-data-rgba5551.html
 tex-image-and-sub-image-2d-with-image.html
+--min-version 1.0.2 tex-image-and-sub-image-2d-with-svg-image.html
 tex-image-and-sub-image-2d-with-image-rgb565.html
 tex-image-and-sub-image-2d-with-image-rgba4444.html
 tex-image-and-sub-image-2d-with-image-rgba5551.html

--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-svg-image.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-svg-image.html
@@ -1,0 +1,49 @@
+<!--
+
+/*
+** Copyright (c) 2013 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/webgl-test.js"></script>
+<script src="../resources/webgl-test-utils.js"></script>
+<script src="../resources/tex-image-and-sub-image-2d-with-svg-image.js"></script>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+</script>
+</head>
+<body onload='generateTest("RGBA", "UNSIGNED_BYTE", "..", testPrologue)()'>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+</body>
+</html>


### PR DESCRIPTION
This patch adds a new test for SVG image textures.

The conformance test results for Chrome are listed below. I verified this test also passes in Safari (above r157647) and Firefox (27.0a1 (2013-10-17)).

WebGL Conformance Test Results
Version 1.0.3 (beta)

---

User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1678.0 Safari/537.36
WebGL VENDOR: WebKit
WebGL VERSION: WebGL 1.0 (OpenGL ES 2.0 Chromium)
WebGL RENDERER: WebKit WebGL
Unmasked VENDOR: undefined
Unmasked RENDERER: undefined
WebGL R/G/B/A/Depth/Stencil bits (default config): 8/8/8/8/24/0

---

Test Summary (9 total tests):
Tests PASSED: 9
Tests FAILED: 0
Tests TIMED OUT: 0
Tests SKIPPED: 0

---

All tests PASSED

---

Complete Test Results (total / pass / fail / timeout / skipped):

conformance/textures/tex-image-and-sub-image-2d-with-svg-image.html: 9 / 9 / 0 / 0 / 0

---

Generated on: Mon Oct 21 2013 15:57:02 GMT-0700 (PDT)
