### PR TITLE
Promote WEBGL_security_sensitive_resources from proposal to draft

### DIFF
--- a/extensions/WEBGL_security_sensitive_resources/extension.xml
+++ b/extensions/WEBGL_security_sensitive_resources/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<proposal href="proposals/WEBGL_security_sensitive_resources/">
+<draft href="WEBGL_security_sensitive_resources/">
 
   <name>WEBGL_security_sensitive_resources</name>
 
@@ -12,7 +12,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>NN</number>
+  <number>23</number>
 
   <depends>
     <api version="1.0"/>
@@ -193,4 +193,4 @@ dictionary WebGLContextAttributes {
       <change>Initial revision.</change>
     </revision>
   </history>
-</proposal>
+</draft>


### PR DESCRIPTION
Per the discussion on the public WebGL mailing list:
https://www.khronos.org/webgl/public-mailing-list/archives/1310/msg00031.html

I chose the number 23 for the extension, right after the highest number 22 for WEBGL_shared_resources. Please let me know if this is not the right approach.
