### PR TITLE
Clean up unnecessary script tags

### DIFF
--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL vertexAttribPointer Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/canvas/canvas-test.html
+++ b/sdk/tests/conformance/canvas/canvas-test.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Canvas Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/context/constants-and-properties.html
+++ b/sdk/tests/conformance/context/constants-and-properties.html
@@ -30,7 +30,6 @@
 <meta charset="utf-8">
 <title>WebGL Constants and Properties Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/context/context-release-upon-reload.html
+++ b/sdk/tests/conformance/context/context-release-upon-reload.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Context Release Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/context/context-release-with-workers.html
+++ b/sdk/tests/conformance/context/context-release-with-workers.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Context Release Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/context/context-type-test.html
+++ b/sdk/tests/conformance/context/context-type-test.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Canvas Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/context/methods.html
+++ b/sdk/tests/conformance/context/methods.html
@@ -30,7 +30,6 @@
 <meta charset="utf-8">
 <title>WebGL Methods Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/ext-frag-depth.html
+++ b/sdk/tests/conformance/extensions/ext-frag-depth.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL EXT_frag_depth Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/ext-texture-filter-anisotropic.html
+++ b/sdk/tests/conformance/extensions/ext-texture-filter-anisotropic.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL EXT_texture_filter_anisotropic Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/get-extension.html
+++ b/sdk/tests/conformance/extensions/get-extension.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Extension Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/oes-element-index-uint.html
+++ b/sdk/tests/conformance/extensions/oes-element-index-uint.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL OES_element_index_uint Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 

--- a/sdk/tests/conformance/extensions/oes-standard-derivatives.html
+++ b/sdk/tests/conformance/extensions/oes-standard-derivatives.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL OES_standard_derivatives Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/oes-texture-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL OES_texture_float Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL OES_texture_half_float Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/oes-vertex-array-object.html
+++ b/sdk/tests/conformance/extensions/oes-vertex-array-object.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL OES_vertex_array_object Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 <!-- comment in the script tag below to test through JS emualation of the extension. -->

--- a/sdk/tests/conformance/extensions/webgl-debug-renderer-info.html
+++ b/sdk/tests/conformance/extensions/webgl-debug-renderer-info.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL WebGL_debug_renderer_info Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/webgl-debug-shaders.html
+++ b/sdk/tests/conformance/extensions/webgl-debug-shaders.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL WebGL_debug_shaders Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL WEBGL_draw_buffers Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/extensions/webgl-shared-resources.html
+++ b/sdk/tests/conformance/extensions/webgl-shared-resources.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL WEBGL_Shared_Resources Conformance Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
+++ b/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>Driver bug - Comparing loop index against uniform in a fragment shader should work</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/glsl/bugs/conditional-discard-optimization.html
+++ b/sdk/tests/conformance/glsl/bugs/conditional-discard-optimization.html
@@ -33,7 +33,6 @@
 <meta charset="utf-8">
 <title>ANGLE WebGL Shader Conditionals Repro</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/glsl/bugs/floored-division-accuracy.html
+++ b/sdk/tests/conformance/glsl/bugs/floored-division-accuracy.html
@@ -33,7 +33,6 @@
 <meta charset="utf-8">
 <title>Floored Division Accuracy Bug</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/glsl/bugs/long-expressions-should-not-crash.html
+++ b/sdk/tests/conformance/glsl/bugs/long-expressions-should-not-crash.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>Driver Bug - long experssions should not crash</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/glsl/bugs/modulo-arithmetic-accuracy.html
+++ b/sdk/tests/conformance/glsl/bugs/modulo-arithmetic-accuracy.html
@@ -33,7 +33,6 @@
 <meta charset="utf-8">
 <title>Modulo Arithmetic Accuracy Bug</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/glsl/bugs/nested-functions-should-not-crash.html
+++ b/sdk/tests/conformance/glsl/bugs/nested-functions-should-not-crash.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>Driver Bug - nested functions should not crash</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/glsl/bugs/temp-expressions-should-not-crash.html
+++ b/sdk/tests/conformance/glsl/bugs/temp-expressions-should-not-crash.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>Driver Bug - temp experssions should not crash</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/glsl/bugs/uniforms-should-not-lose-values.html
+++ b/sdk/tests/conformance/glsl/bugs/uniforms-should-not-lose-values.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>Driver Bug - Uniforms should no lose values</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/glsl/misc/shader-precision-format-obeyed.html
+++ b/sdk/tests/conformance/glsl/misc/shader-precision-format-obeyed.html
@@ -32,7 +32,6 @@
 <title>WebGL GLSL Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/glsl/misc/shader-with-error-directive.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-error-directive.html
@@ -32,7 +32,6 @@
 <title>WebGL GLSL Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/glsl/misc/shader-with-global-variable-precision-mismatch.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-global-variable-precision-mismatch.html
@@ -32,7 +32,6 @@
 <title>WebGL GLSL Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/glsl/misc/shader-with-long-line.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-long-line.html
@@ -32,7 +32,6 @@
 <title>WebGL GLSL Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/glsl/misc/shader-with-short-circuiting-operators.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-short-circuiting-operators.html
@@ -31,7 +31,6 @@
     <meta charset="utf-8">
       <title>WebGL short-circuit evaluation</title>
       <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-      <script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
       <script src="../../../resources/js-test-pre.js"></script>
       <script src="../../resources/webgl-test-utils.js"></script>
     </head>

--- a/sdk/tests/conformance/glsl/misc/shader-with-too-many-uniforms.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-too-many-uniforms.html
@@ -32,7 +32,6 @@
 <title>WebGL GLSL Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
-<script src="../../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
 <script src="../../resources/glsl-conformance-test.js"></script>

--- a/sdk/tests/conformance/misc/functions-returning-strings.html
+++ b/sdk/tests/conformance/misc/functions-returning-strings.html
@@ -30,7 +30,6 @@
 <meta charset="utf-8">
 <title>WebGL Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 <script src="../../resources/test-eval.js"></script>

--- a/sdk/tests/conformance/programs/use-program-crash-with-discard-in-fragment-shader.html
+++ b/sdk/tests/conformance/programs/use-program-crash-with-discard-in-fragment-shader.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Program Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/rendering/gl-scissor-test.html
+++ b/sdk/tests/conformance/rendering/gl-scissor-test.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Scissor Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../debug/webgl-debug.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>

--- a/sdk/tests/conformance/rendering/gl-viewport-test.html
+++ b/sdk/tests/conformance/rendering/gl-viewport-test.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Viewport Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/state/gl-getstring.html
+++ b/sdk/tests/conformance/state/gl-getstring.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL gl.getParameter Strings Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/textures/gl-pixelstorei.html
+++ b/sdk/tests/conformance/textures/gl-pixelstorei.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"> </script>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 </head>
 <body>
 <canvas id="example" width="50" height="50"></canvas>

--- a/sdk/tests/conformance/textures/origin-clean-conformance.html
+++ b/sdk/tests/conformance/textures/origin-clean-conformance.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Origin Restrictions Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 <script>

--- a/sdk/tests/conformance/uniforms/gl-uniform-bool.html
+++ b/sdk/tests/conformance/uniforms/gl-uniform-bool.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL uniformMatrix Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/uniforms/gl-unknown-uniform.html
+++ b/sdk/tests/conformance/uniforms/gl-unknown-uniform.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Unknown Uniform Conformance Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/conformance/uniforms/uniform-default-values.html
+++ b/sdk/tests/conformance/uniforms/uniform-default-values.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL uniform default values</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
 <script src="../../resources/test-eval.js"></script>

--- a/sdk/tests/extra/big-fbos-example.html
+++ b/sdk/tests/extra/big-fbos-example.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Big FBO Test</title>
 <link rel="stylesheet" href="../resources/js-test-style.css"/>
-<script src="../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../debug/webgl-debug.js"></script>
 <script src="../resources/js-test-pre.js"></script>
 <script src="../conformance/resources/webgl-test-utils.js"></script>

--- a/sdk/tests/extra/fbo-lost-context.html
+++ b/sdk/tests/extra/fbo-lost-context.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL FBO Lost Context Test</title>
 <link rel="stylesheet" href="../resources/js-test-style.css"/>
-<script src="../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../debug/webgl-debug.js"></script>
 <script src="../resources/js-test-pre.js"></script>
 <script src="../conformance/resources/webgl-test-utils.js"></script>

--- a/sdk/tests/extra/out-of-memory.html
+++ b/sdk/tests/extra/out-of-memory.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Out Of Memory Test</title>
 <link rel="stylesheet" href="../resources/js-test-style.css"/>
-<script src="../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../resources/js-test-pre.js"></script>
 <script src="../conformance/resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/extra/out-of-resources.html
+++ b/sdk/tests/extra/out-of-resources.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Out Of Resources Test</title>
 <link rel="stylesheet" href="../resources/js-test-style.css"/>
-<script src="../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../debug/webgl-debug.js"></script>
 <script src="../resources/js-test-pre.js"></script>
 <script src="../conformance/resources/webgl-test-utils.js"></script>

--- a/sdk/tests/extra/out-of-vram.html
+++ b/sdk/tests/extra/out-of-vram.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Out Of VRAM Test</title>
 <link rel="stylesheet" href="../resources/js-test-style.css"/>
-<script src="../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../resources/js-test-pre.js"></script>
 <script src="../conformance/resources/webgl-test-utils.js"></script>
 </head>

--- a/sdk/tests/extra/readpixels-after-alert.html
+++ b/sdk/tests/extra/readpixels-after-alert.html
@@ -31,7 +31,6 @@
 <meta charset="utf-8">
 <title>WebGL Behavior After Alert and Read Pixels Test</title>
 <link rel="stylesheet" href="../resources/js-test-style.css"/>
-<script src="../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../debug/webgl-debug.js"></script>
 <script src="../resources/js-test-pre.js"></script>
 <script src="../conformance/resources/webgl-test-utils.js"></script>


### PR DESCRIPTION
Many tests loaded desktop-gl-constants.js even though they do not need it. Clean up these.
