### PR TITLE
Clean up script references in 2.0 tests

### DIFF
--- a/sdk/tests/conformance2/context/constants-and-properties-2.html
+++ b/sdk/tests/conformance2/context/constants-and-properties-2.html
@@ -30,9 +30,7 @@
 <meta charset="utf-8">
 <title>WebGL2 Constants and Properties Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/context/context-type-test-2.html
+++ b/sdk/tests/conformance2/context/context-type-test-2.html
@@ -31,9 +31,7 @@
 <meta charset="utf-8">
 <title>WebGL2 Canvas Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/context/methods-2.html
+++ b/sdk/tests/conformance2/context/methods-2.html
@@ -30,9 +30,7 @@
 <meta charset="utf-8">
 <title>WebGL2 Methods Test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/core/draw-buffers.html
+++ b/sdk/tests/conformance2/core/draw-buffers.html
@@ -31,9 +31,7 @@
 <meta charset="utf-8">
 <title>WebGL Draw Buffers Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 </head>
 <body>
@@ -88,7 +86,7 @@ if (!gl) {
   runAttachmentTest();
   runDrawTests();
 
-  glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
 
 function createDrawBuffersProgram(scriptId, sub) {
@@ -108,7 +106,7 @@ function runShadersTest() {
   wtu.clearAndDrawUnitQuad(gl);
   wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green");
   gl.deleteProgram(program);
-  glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
 
 function makeArray(size, value) {
@@ -139,17 +137,17 @@ function runAttachmentTest() {
   gl.bindTexture(gl.TEXTURE_2D, tex);
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + maxColorAttachments, gl.TEXTURE_2D, tex, 0);
-  glErrorShouldBe(gl, gl.INVALID_ENUM, "should not be able to attach pass the max attachment point: gl.COLOR_ATTACHMENT0 + " + maxColorAttachments);
+  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "should not be able to attach pass the max attachment point: gl.COLOR_ATTACHMENT0 + " + maxColorAttachments);
   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + maxColorAttachments - 1, gl.TEXTURE_2D, tex, 0);
-  glErrorShouldBe(gl, gl.NO_ERROR, "should be able to attach to the max attachment point: gl.COLOR_ATTACHMENT0 + " + (maxColorAttachments - 1));
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to attach to the max attachment point: gl.COLOR_ATTACHMENT0 + " + (maxColorAttachments - 1));
   gl.drawBuffers(makeArray(maxDrawingBuffers, gl.NONE));
-  glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with array NONE of size " + maxColorAttachments);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with array NONE of size " + maxColorAttachments);
   var bufs = makeColorAttachmentArray(maxDrawingBuffers);
   gl.drawBuffers(bufs);
-  glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with array attachments of size " + maxColorAttachments);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with array attachments of size " + maxColorAttachments);
   bufs[0] = gl.NONE;
   gl.drawBuffers(bufs);
-  glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with mixed array attachments of size " + maxColorAttachments);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with mixed array attachments of size " + maxColorAttachments);
   if (maxDrawingBuffers > 1) {
     bufs[0] = gl.COLOR_ATTACHMENT1;
     bufs[1] = gl.COLOR_ATTACHMENT0;
@@ -161,7 +159,7 @@ function runAttachmentTest() {
 
   gl.deleteFramebuffer(fb);
   gl.deleteTexture(tex);
-  glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
 
 function makeColorByIndex(index) {

--- a/sdk/tests/conformance2/core/element-index-uint.html
+++ b/sdk/tests/conformance2/core/element-index-uint.html
@@ -31,9 +31,7 @@
 <meta charset="utf-8">
 <title>WebGL Uint element indices Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 
 <script id="vs" type="x-shader/x-vertex">
@@ -94,7 +92,7 @@ for (var ii = 0; ii < 2; ++ii) {
         runVerifiesTooManyIndicesTests(drawType);
         runCrashWithBufferSubDataTests(drawType);
 
-        glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
     }
 }
 
@@ -250,9 +248,9 @@ function runIndexValidationTests(drawType) {
     gl.vertexAttribPointer(normalLoc, 3, gl.FLOAT, false, 7 * sizeInBytes(gl.FLOAT), 4 * sizeInBytes(gl.FLOAT));
     gl.enableVertexAttribArray(normalLoc);
     shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
-    glErrorShouldBe(gl, gl.NO_ERROR);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     shouldBeUndefined('gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_INT, 0)');
-    glErrorShouldBe(gl, gl.NO_ERROR);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
     debug("Testing with out-of-range indices");
 
@@ -263,15 +261,15 @@ function runIndexValidationTests(drawType) {
     gl.enableVertexAttribArray(vertexLoc);
     gl.disableVertexAttribArray(normalLoc);
     debug("Enable vertices, valid");
-    glErrorShouldBe(gl, gl.NO_ERROR);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     shouldBeUndefined('gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_INT, 0)');
-    glErrorShouldBe(gl, gl.NO_ERROR);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     debug("Enable normals, out-of-range");
     gl.vertexAttribPointer(normalLoc, 3, gl.FLOAT, false, 7 * sizeInBytes(gl.FLOAT), 4 * sizeInBytes(gl.FLOAT));
     gl.enableVertexAttribArray(normalLoc);
-    glErrorShouldBe(gl, gl.NO_ERROR);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     shouldBeUndefined('gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_INT, 0)');
-    glErrorShouldBe(gl, gl.INVALID_OPERATION);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
 
     debug("Test with enabled attribute that does not belong to current program");
 
@@ -279,16 +277,16 @@ function runIndexValidationTests(drawType) {
     var extraLoc = Math.max(vertexLoc, normalLoc) + 1;
     gl.enableVertexAttribArray(extraLoc);
     debug("Enable an extra attribute with null");
-    glErrorShouldBe(gl, gl.NO_ERROR);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     shouldBeUndefined('gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_INT, 0)');
-    glErrorShouldBe(gl, gl.INVALID_OPERATION);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
     debug("Enable an extra attribute with insufficient data buffer");
     gl.vertexAttribPointer(extraLoc, 3, gl.FLOAT, false, 7 * sizeInBytes(gl.FLOAT), 4 * sizeInBytes(gl.FLOAT));
-    glErrorShouldBe(gl, gl.NO_ERROR);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     shouldBeUndefined('gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_INT, 0)');
     debug("Pass large negative index to vertexAttribPointer");
     gl.vertexAttribPointer(normalLoc, 3, gl.FLOAT, false, 7 * sizeInBytes(gl.FLOAT), -2000000000 * sizeInBytes(gl.FLOAT));
-    glErrorShouldBe(gl, gl.INVALID_VALUE);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
     shouldBeUndefined('gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_INT, 0)');
 }
 
@@ -310,21 +308,21 @@ function runCopiesIndicesTests(drawType) {
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexObject);
     var indices = new Uint32Array([ 10000, 0, 1, 2, 3, 10000 ]);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, drawType);
-    shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 4)");
-    shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 0)");
-    shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 8)");
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 4)");
+    wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 0)");
+    wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 8)");
     indices[0] = 2;
     indices[5] = 1;
-    shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 4)");
-    shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 0)");
-    shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 8)");
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 4)");
+    wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 0)");
+    wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 8)");
 }
 
 function runResizedBufferTests(drawType) {
     debug("Test that updating the size of a vertex buffer is properly noticed by the WebGL implementation.");
 
     var program = wtu.setupProgram(gl, ["vs", "fs"], ["vPosition", "vColor"]);
-    glErrorShouldBe(gl, gl.NO_ERROR, "after initialization");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after initialization");
 
     var vertexObject = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
@@ -333,7 +331,7 @@ function runResizedBufferTests(drawType) {
          -1,-1,0, 1,1,0, 1,-1,0]), drawType);
     gl.enableVertexAttribArray(0);
     gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
-    glErrorShouldBe(gl, gl.NO_ERROR, "after vertex setup");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after vertex setup");
 
     var texCoordObject = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, texCoordObject);
@@ -342,14 +340,14 @@ function runResizedBufferTests(drawType) {
          0,1, 1,0, 1,1]), drawType);
     gl.enableVertexAttribArray(1);
     gl.vertexAttribPointer(1, 2, gl.FLOAT, false, 0, 0);
-    glErrorShouldBe(gl, gl.NO_ERROR, "after texture coord setup");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after texture coord setup");
 
     // Now resize these buffers because we want to change what we're drawing.
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
         -1,1,0, 1,1,0, -1,-1,0, 1,-1,0,
         -1,1,0, 1,1,0, -1,-1,0, 1,-1,0]), drawType);
-    glErrorShouldBe(gl, gl.NO_ERROR, "after vertex redefinition");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after vertex redefinition");
     gl.bindBuffer(gl.ARRAY_BUFFER, texCoordObject);
     gl.bufferData(gl.ARRAY_BUFFER, new Uint8Array([
         255, 0, 0, 255,
@@ -361,7 +359,7 @@ function runResizedBufferTests(drawType) {
         0, 255, 0, 255,
         0, 255, 0, 255]), drawType);
     gl.vertexAttribPointer(1, 4, gl.UNSIGNED_BYTE, false, 0, 0);
-    glErrorShouldBe(gl, gl.NO_ERROR, "after texture coordinate / color redefinition");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after texture coordinate / color redefinition");
 
     var numQuads = 2;
     var indices = new Uint32Array(numQuads * 6);
@@ -378,9 +376,9 @@ function runResizedBufferTests(drawType) {
     var indexObject = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexObject);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, drawType);
-    glErrorShouldBe(gl, gl.NO_ERROR, "after setting up indices");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after setting up indices");
     gl.drawElements(gl.TRIANGLES, numQuads * 6, gl.UNSIGNED_INT, 0);
-    glErrorShouldBe(gl, gl.NO_ERROR, "after drawing");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after drawing");
 }
 
 function runVerifiesTooManyIndicesTests(drawType) {
@@ -402,9 +400,9 @@ function runVerifiesTooManyIndicesTests(drawType) {
     debug("Test out of range indices")
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexObject);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array([ 10000, 0, 1, 2, 3, 10000 ]), drawType);
-    shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 4)");
-    shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 0)");
-    shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 8)");
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 4)");
+    wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 0)");
+    wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawElements(gl.TRIANGLE_STRIP, 4, gl.UNSIGNED_INT, 8)");
 }
 
 function runCrashWithBufferSubDataTests(drawType) {
@@ -415,7 +413,7 @@ function runCrashWithBufferSubDataTests(drawType) {
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, 256, drawType);
     var data = new Uint32Array(127);
     gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 64, data);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "after attempting to update a buffer outside of the allocated bounds");
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "after attempting to update a buffer outside of the allocated bounds");
     testPassed("bufferSubData, when buffer object was initialized with null, did not crash");
 }
 

--- a/sdk/tests/conformance2/core/frag-depth.html
+++ b/sdk/tests/conformance2/core/frag-depth.html
@@ -31,9 +31,7 @@
 <meta charset="utf-8">
 <title>WebGL Frag Depth Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/core/instanced-arrays.html
+++ b/sdk/tests/conformance2/core/instanced-arrays.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 </head>
 <body>
@@ -77,7 +76,7 @@ if (!gl) {
 
     runDivisorTest();
     runOutputTests();
-    glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
 
 function runDivisorTest() {
@@ -98,10 +97,10 @@ function runDivisorTest() {
     }
 
     gl.vertexAttribDivisor(max_vertex_attribs, 2);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "vertexAttribDivisor index set greater than or equal to MAX_VERTEX_ATTRIBS should be an invalid value");
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "vertexAttribDivisor index set greater than or equal to MAX_VERTEX_ATTRIBS should be an invalid value");
 
     gl.vertexAttribDivisor(max_vertex_attribs-1, 2);
-    glErrorShouldBe(gl, gl.NO_ERROR, "vertexAttribDivisor index set less than MAX_VERTEX_ATTRIBS should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "vertexAttribDivisor index set less than MAX_VERTEX_ATTRIBS should succeed");
 
     var queried_value = gl.getVertexAttrib(max_vertex_attribs-1, gl.VERTEX_ATTRIB_ARRAY_DIVISOR);
     if(queried_value == 2){
@@ -166,31 +165,31 @@ function runOutputTests() {
     wtu.checkCanvasRect(gl, canvas.width/2, 0, canvas.width/2, canvas.height/2, [255, 255, 0, 255]);
 
     gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, -1);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "drawArraysInstanced cannot have a primcount less than 0");
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "drawArraysInstanced cannot have a primcount less than 0");
 
     gl.drawArraysInstanced(gl.TRIANGLES, 0, -1, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "drawArraysInstanced cannot have a count less than 0");
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "drawArraysInstanced cannot have a count less than 0");
 
     gl.vertexAttribDivisor(positionLoc, 1);
     gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawArraysInstanced");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawArraysInstanced");
     gl.vertexAttribDivisor(positionLoc, 0);
 
     gl.drawArraysInstanced(gl.POINTS, 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with POINTS should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with POINTS should succeed");
     gl.drawArraysInstanced(gl.LINES, 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with LINES should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with LINES should succeed");
     gl.drawArraysInstanced(gl.LINE_LIST, 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with LINE_LIST should return succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with LINE_LIST should return succeed");
     gl.drawArraysInstanced(gl.TRI_LIST, 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with TRI_LIST should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with TRI_LIST should succeed");
 
     gl.drawArraysInstanced(desktopGL['QUAD_STRIP'], 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with QUAD_STRIP should return INVALID_ENUM");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with QUAD_STRIP should return INVALID_ENUM");
     gl.drawArraysInstanced(desktopGL['QUADS'], 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with QUADS should return INVALID_ENUM");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with QUADS should return INVALID_ENUM");
     gl.drawArraysInstanced(desktopGL['POLYGON'], 0, 6, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with POLYGON should return INVALID_ENUM");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with POLYGON should return INVALID_ENUM");
 
     // Draw 2: Draw indexed instances
     debug("Testing drawElementsInstanced");
@@ -204,34 +203,34 @@ function runOutputTests() {
 
     // Test drawElementsInstanced error conditions
     gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0, -1);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "drawElementsInstanced cannot have a primcount less than 0");
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "drawElementsInstanced cannot have a primcount less than 0");
 
     gl.drawElementsInstanced(gl.TRIANGLES, -1, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_VALUE, "drawElementsInstanced cannot have a count less than 0");
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "drawElementsInstanced cannot have a count less than 0");
 
     gl.vertexAttribDivisor(positionLoc, 1);
     gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawElementsInstanced");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawElementsInstanced");
     gl.vertexAttribDivisor(positionLoc, 0);
 
     gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with UNSIGNED_BYTE should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with UNSIGNED_BYTE should succeed");
 
     gl.drawElementsInstanced(gl.POINTS, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with POINTS should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with POINTS should succeed");
     gl.drawElementsInstanced(gl.LINES, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with LINES should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with LINES should succeed");
     gl.drawElementsInstanced(gl.LINE_LIST, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with LINE_LIST should return succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with LINE_LIST should return succeed");
     gl.drawElementsInstanced(gl.TRI_LIST, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with TRI_LIST should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with TRI_LIST should succeed");
 
     gl.drawElementsInstanced(desktopGL['QUAD_STRIP'], 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstanced with QUAD_STRIP should return INVALID_ENUM");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstanced with QUAD_STRIP should return INVALID_ENUM");
     gl.drawElementsInstanced(desktopGL['QUADS'], 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstanced with QUADS should return INVALID_ENUM");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstanced with QUADS should return INVALID_ENUM");
     gl.drawElementsInstanced(desktopGL['POLYGON'], 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstanced with POLYGON should return INVALID_ENUM");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstanced with POLYGON should return INVALID_ENUM");
 }
 
 debug("");

--- a/sdk/tests/conformance2/core/vertex-array-object.html
+++ b/sdk/tests/conformance2/core/vertex-array-object.html
@@ -31,9 +31,7 @@
 <meta charset="utf-8">
 <title>WebGL vertex_array_object Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
 <script src="../../resources/js-test-pre.js"></script>
-<script src="../../conformance/resources/webgl-test.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
 </head>
 <body>
@@ -79,7 +77,7 @@ if (!gl) {
     runDrawTests();
     runDeleteTests();
     runArrayBufferBindTests();
-    glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
 
 function runBindingTest() {
@@ -88,7 +86,7 @@ function runBindingTest() {
     shouldBe("gl.VERTEX_ARRAY_BINDING", "0x85B5");
     
     gl.getParameter(gl.VERTEX_ARRAY_BINDING);
-    glErrorShouldBe(gl, gl.NO_ERROR, "VERTEX_ARRAY_BINDING query should succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "VERTEX_ARRAY_BINDING query should succeed");
     
     // Default value is null
     if (gl.getParameter(gl.VERTEX_ARRAY_BINDING) === null) {
@@ -116,7 +114,7 @@ function runBindingTest() {
     gl.deleteVertexArray(vao1);
     shouldBeNull("gl.getParameter(gl.VERTEX_ARRAY_BINDING)");
     gl.bindVertexArray(vao1);
-    glErrorShouldBe(gl, gl.INVALID_OPERATION, "binding a deleted vertex array object");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "binding a deleted vertex array object");
     gl.bindVertexArray(null);
     shouldBeNull("gl.getParameter(gl.VERTEX_ARRAY_BINDING)");
     gl.deleteVertexArray(vao1);
@@ -126,7 +124,7 @@ function runObjectTest() {
     debug("Testing object creation");
     
     vao = gl.createVertexArray();
-    glErrorShouldBe(gl, gl.NO_ERROR, "createVertexArray should not set an error");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "createVertexArray should not set an error");
     shouldBeNonNull("vao");
     
     // Expect false if never bound


### PR DESCRIPTION
Remove references to webgl-test.js, which has been removed, and to
desktop-gl-constants.js where it is not being used. Calls to
glErrorShouldBe and shouldGenerateGLError go through wtu.
