### PR TITLE
Use smaller textures in compressed texture size limit test

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-size-limit.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-size-limit.html
@@ -107,19 +107,34 @@ var targets = [
   }
 ];
 
-// Share an ArrayBuffer among tests to avoid too many large allocations
-var sharedArrayBufferSize = 0;
-for (var tt = 0; tt < tests.length; ++tt) {
-  var test = tests[tt];
-  for (var trg = 0; trg < targets.length; ++trg) {
-    var t = targets[trg];
-    var sizeNeeded = test.func(t.maxSize + test.sizeStep, t.maxSize + test.sizeStep);
-    if (sizeNeeded > sharedArrayBufferSize) {
-      sharedArrayBufferSize = sizeNeeded;
+function getSharedArrayBufferSize() {
+  var sharedArrayBufferSize = 0;
+  for (var tt = 0; tt < tests.length; ++tt) {
+    var test = tests[tt];
+    for (var trg = 0; trg < targets.length; ++trg) {
+      var t = targets[trg];
+      var bufferSizeNeeded;
+      if (t.target === gl.TEXTURE_CUBE_MAP) {
+        var positiveTestSize = Math.min(2048, t.maxSize);
+        bufferSizeNeeded = test.func(positiveTestSize, positiveTestSize);
+      } else {
+        bufferSizeNeeded = test.func(t.maxSize, test.sizeStep);
+      }
+      if (bufferSizeNeeded > sharedArrayBufferSize) {
+        sharedArrayBufferSize = bufferSizeNeeded;
+      }
+      bufferSizeNeeded = test.func(t.maxSize + test.sizeStep, t.maxSize + test.sizeStep);
+      // ArrayBuffers can be at most 4GB (minus 1 byte)
+      if (bufferSizeNeeded > sharedArrayBufferSize && bufferSizeNeeded <= 4294967295) {
+        sharedArrayBufferSize = bufferSizeNeeded;
+      }
     }
   }
+  return sharedArrayBufferSize;
 }
-var sharedArrayBuffer = new ArrayBuffer(sharedArrayBufferSize);
+
+// Share an ArrayBuffer among tests to avoid too many large allocations
+var sharedArrayBuffer = new ArrayBuffer(getSharedArrayBufferSize());
 
 gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
 
@@ -198,10 +213,16 @@ function testFormatType(t, test) {
 
       // out of bounds tests
       // width and height out of bounds
-      var pixelsNegativeTest1 = new test.dataType(sharedArrayBuffer, 0, test.func(t.maxSize + test.sizeStep, t.maxSize + test.sizeStep));
-      gl.compressedTexImage2D(target, 0, test.format, t.maxSize + test.sizeStep, t.maxSize + test.sizeStep, 0, pixelsNegativeTest1);
-      wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "width or height out of bounds: should generate INVALID_VALUE."
-          + " level is 0, size is " + (t.maxSize + test.sizeStep) + "x" + (t.maxSize + test.sizeStep));
+      var dataSize = test.func(t.maxSize + test.sizeStep, t.maxSize + test.sizeStep);
+      // this check assumes that each element is 1 byte
+      if (dataSize > sharedArrayBuffer.byteLength) {
+        testPassed("Unable to test texture larger than maximum size due to ArrayBuffer size limitations -- this is legal");
+      } else {
+        var pixelsNegativeTest1 = new test.dataType(sharedArrayBuffer, 0, dataSize);
+        gl.compressedTexImage2D(target, 0, test.format, t.maxSize + test.sizeStep, t.maxSize + test.sizeStep, 0, pixelsNegativeTest1);
+        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "width or height out of bounds: should generate INVALID_VALUE."
+            + " level is 0, size is " + (t.maxSize + test.sizeStep) + "x" + (t.maxSize + test.sizeStep));
+      }
       // level out of bounds
       var pixelsNegativeTest2 = new test.dataType(sharedArrayBuffer, 0, test.func(256, 256));
       gl.compressedTexImage2D(target, numLevels, test.format, 256, 256, 0, pixelsNegativeTest2);


### PR DESCRIPTION
The patches limit tested cube map texture size to 2048x2048 according to discussions on the mailing list. Getting some test coverage of huge cube maps back might be possible in some way, but requires policy decisions around OOM and context loss handling.

The patches also optimize testing TEXTURE_2D further by using rectangular compressed textures instead of square ones, and take ArrayBuffer maximum size into account, which might become relevant at some point in the future.
