### PR TITLE
Optimize context-creation-and-destruction test

### DIFF
--- a/conformance-suites/1.0.2/conformance/context/context-creation-and-destruction.html
+++ b/conformance-suites/1.0.2/conformance/context/context-creation-and-destruction.html
@@ -47,6 +47,8 @@ var count = 0;
 description();
 doNextTest();
 
+var textureSize = null;
+
 // Creates a canvas and a texture then exits. There are
 // no references to either so both should be garbage collected.
 function test() {
@@ -55,12 +57,14 @@ function test() {
   canvas.width = 2048;
   canvas.height = 2048;
   var gl = wtu.create3DContext(canvas);
-  var maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-  var size = Math.min(1024, maxTextureSize);
+  if (textureSize === null) {
+    var maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    textureSize = Math.min(1024, maxTextureSize);
+  }
   var tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE,
-                new Uint8Array(size * size * 4));
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, textureSize, textureSize, 0, gl.RGBA, gl.UNSIGNED_BYTE,
+                null);
   gl.clear(gl.COLOR_BUFFER_BIT);
   glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors");
 }

--- a/sdk/tests/conformance/context/context-creation-and-destruction.html
+++ b/sdk/tests/conformance/context/context-creation-and-destruction.html
@@ -46,6 +46,8 @@ var count = 0;
 description();
 doNextTest();
 
+var textureSize = null;
+
 // Creates a canvas and a texture then exits. There are
 // no references to either so both should be garbage collected.
 function test() {
@@ -54,12 +56,14 @@ function test() {
   canvas.width = 2048;
   canvas.height = 2048;
   var gl = wtu.create3DContext(canvas);
-  var maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-  var size = Math.min(1024, maxTextureSize);
+  if (textureSize === null) {
+    var maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+    textureSize = Math.min(1024, maxTextureSize);
+  }
   var tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE,
-                new Uint8Array(size * size * 4));
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, textureSize, textureSize, 0, gl.RGBA, gl.UNSIGNED_BYTE,
+                null);
   gl.clear(gl.COLOR_BUFFER_BIT);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors");
 }


### PR DESCRIPTION
This test is very long-running, and taking out the unnecessary Uint8Array
construction on every iteration reduced run time by roughly 5% on a
high-end workstation. Additionally, query maximum texture size only once
for some more marginal gains. The changes have no significant effect on
test coverage and are also done to the 1.0.2 version of the test.
