### PR TITLE
Renamed 'console' variable that was causing problems with test harnesses

### DIFF
--- a/sdk/tests/conformance/glsl/misc/large-loop-compile.html
+++ b/sdk/tests/conformance/glsl/misc/large-loop-compile.html
@@ -167,12 +167,12 @@ if (!gl) {
   finishTest();
 } else {
   var startTime = Date.now();
-  var console = document.getElementById("console");
+  var consoleDiv = document.getElementById("console");
   var vSource = document.getElementById("vertexShader").text;
   var fSource = document.getElementById("fragmentShader").text;
-  wtu.addShaderSource(console, "test vertex shader", vSource);
+  wtu.addShaderSource(consoleDiv, "test vertex shader", vSource);
   var vShader = wtu.loadShader(gl, vSource, gl.VERTEX_SHADER);
-  wtu.addShaderSource(console, "test fragment shader", fSource);
+  wtu.addShaderSource(consoleDiv, "test fragment shader", fSource);
   var fShader = wtu.loadShader(gl, fSource, gl.FRAGMENT_SHADER);
   if (vShader && fShader) {
     var program = gl.createProgram();


### PR DESCRIPTION
And really, naming a local variable "console" is pretty terrible style anyway. Just don't do it!

Annoyingly the div must retain the id "console", as it's apparently a magic name for these tests. :(
