### PR TITLE
Fixed logic error in greaterThanOrEqualToVersion

### DIFF
--- a/sdk/tests/resources/webgl-test-harness.js
+++ b/sdk/tests/resources/webgl-test-harness.js
@@ -247,6 +247,9 @@ var greaterThanOrEqualToVersion = function(have, want) {
   for (var ii = 0; ii < want.length; ++ii) {
     var wantNum = parseInt(want[ii]);
     var haveNum = have[ii] ? parseInt(have[ii]) : 0
+    if (haveNum > wantNum) {
+      return true; // 2.0.0 is greater than 1.2.3
+    }
     if (haveNum < wantNum) {
       return false;
     }

--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -160,10 +160,10 @@
 <script type="text/javascript" src="resources/webgl-test-harness.js"></script>
 <script>
 "use strict";
-var CONFORMANCE_TEST_VERSION = "2.0.0 (beta)";
+var DEFAULT_CONFORMANCE_TEST_VERSION = "1.0.3 (beta)";
 
 var OPTIONS = {
-  version: CONFORMANCE_TEST_VERSION,
+  version: DEFAULT_CONFORMANCE_TEST_VERSION,
   frames: 1,
   allowSkip: 0
 };


### PR DESCRIPTION
Also reset the default conformance version to 1.0.3
