### PR TITLE
Fix for Issue #441: gl-disabled-vertex-attrib.html too strict

### DIFF
--- a/conformance-suites/1.0.2/conformance/attribs/gl-disabled-vertex-attrib.html
+++ b/conformance-suites/1.0.2/conformance/attribs/gl-disabled-vertex-attrib.html
@@ -1,7 +1,7 @@
 <!--
 
 /*
-** Copyright (c) 2012 The Khronos Group Inc.
+** Copyright (c) 2013 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the
@@ -44,20 +44,20 @@
 attribute vec4 a_position;
 attribute vec4 a_color;
 varying vec4 v_color;
+bool isCorrectColor(vec4 v) {
+  return v.x == 0.0 && v.y == 0.0 && v.z == 0.0 && v.w == 1.0;
+}
 void main() {
   gl_Position = a_position;
-  v_color = a_color;
+  v_color = isCorrectColor(a_color) ? vec4(0, 1, 0, 1) : vec4(1, 0, 0, 1);
 }
 </script>
 
 <script id="fshader" type="x-shader/x-fragment">
 precision mediump float;
 varying vec4 v_color;
-bool isCorrectColor(vec4 v) {
-  return v.x == 0.0 && v.y == 0.0 && v.z == 0.0 && v.w == 1.0;
-}
 void main() {
-  gl_FragColor = isCorrectColor(v_color) ? vec4(0, 1, 0, 1) : vec4(1, 0, 0, 1);
+  gl_FragColor = v_color;
 }
 </script>
 


### PR DESCRIPTION
Move the test from the fragment shader to the vertex shader to avoid relying on the accuracy of the perspective correction implementation.
