### PR TITLE
Fix many-draw-calls.html timeouts on some slow platforms

### DIFF
--- a/sdk/tests/conformance/rendering/many-draw-calls.html
+++ b/sdk/tests/conformance/rendering/many-draw-calls.html
@@ -142,6 +142,12 @@ var doNextDraw = function() {
       break;
   }
 
+  var iterations = numDrawsThisFrame / tilesPerSide;
+  if (iterations % 10 === 0) {
+    // Needed to avoid test timeout within the harness on some slower platforms
+    testPassed("Completed " + iterations + " iterations");
+  }
+
   wtu.requestAnimFrame(doNextDraw);
 }
 


### PR DESCRIPTION
Timeouts could be seen frequently on a debug build of a browser on a
slower ARM platform when running the previous version of the test. The
new version tells the harness it is alive every ten iterations,
preventing the test from timing out.
