### PR TITLE
DataView() can be called as a function

### DIFF
--- a/conformance-suites/1.0.2/conformance/typedarrays/data-view-test.html
+++ b/conformance-suites/1.0.2/conformance/typedarrays/data-view-test.html
@@ -265,17 +265,6 @@ function runConstructorTests()
     arrayBuffer = (new Uint8Array([1, 2])).buffer;
 
     debug("");
-    debug("Test for constructor not called as a function");
-    var expr = "DataView(new ArrayBuffer)";
-    // Use try/catch instead of calling shouldThrow to avoid different exception message being reported from different platform.
-    try {
-        TestEval(expr);
-        testFailed(expr + " does not throw exception");
-    } catch (e) {
-        testPassed(expr + " threw exception");
-    }
-
-    debug("");
     debug("Test for constructor taking 1 argument");
     shouldBeDefined("view = new DataView(arrayBuffer)");
     shouldBe("view.byteOffset", "0");

--- a/sdk/tests/conformance/typedarrays/data-view-test.html
+++ b/sdk/tests/conformance/typedarrays/data-view-test.html
@@ -270,9 +270,9 @@ function runConstructorTests()
     // Use try/catch instead of calling shouldThrow to avoid different exception message being reported from different platform.
     try {
         TestEval(expr);
-        testFailed(expr + " does not throw exception");
+        testPassed(expr + " does not throw exception");
     } catch (e) {
-        testPassed(expr + " threw exception");
+        testFailed(expr + " threw exception");
     }
 
     debug("");


### PR DESCRIPTION
See Issue 446. The latest ECMAScript draft says that
calling DataView(new ArrayBuffer) without the "new"
keyword is valid.

I've updated the conformance test to reflect this.

However, for the 1.0.2 version, I've removed the
sub-test completely, because the update would cause
existing conforming implementations to begin failing.
