### PR TITLE
Clean up texture-npot-video.html test

### DIFF
--- a/sdk/tests/conformance/textures/texture-npot-video.html
+++ b/sdk/tests/conformance/textures/texture-npot-video.html
@@ -37,7 +37,6 @@ var wtu = WebGLTestUtils;
 var gl = null;
 var textureLoc = null;
 var successfullyParsed = false;
-var video;
 
 initTestingHarness();
 
@@ -51,30 +50,21 @@ function init()
 
     gl.clearColor(0,0,0,1);
     gl.clearDepth(1);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    // Disable any writes to the alpha channel
+    gl.colorMask(1, 1, 1, 0);
 
     textureLoc = gl.getUniformLocation(program, "tex");
 
-    video = document.getElementById("vid");
+    var video = document.getElementById("vid");
     wtu.startPlayingAndWaitForVideo(video, runTest);
 }
-
-// These two declarations need to be global for "shouldBe" to see them
-var buf = null;
-var idx = 0;
-var pixel = [0, 0, 0];
-var correctColor = null;
-var texture;
 
 function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottomColor, badMinFilter, badClamp, genMips)
 {
     debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
           ' with flipY=' + flipY);
-    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-    // Disable any writes to the alpha channel
-    gl.colorMask(1, 1, 1, 0);
-    if (!texture) {
-        texture = gl.createTexture();
-    }
+    var texture = gl.createTexture();
     // Bind the texture to texture unit 0
     gl.bindTexture(gl.TEXTURE_2D, texture);
     // Set up pixel store parameters
@@ -83,13 +73,11 @@ function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottom
     debug("size: " + videoElement.videoWidth + "x" + videoElement.videoHeight);
     if (useTexSubImage2D) {
         // Initialize the texture to black first
-        debug("use texSubImage2D");
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA,
                       videoElement.videoWidth, videoElement.videoHeight, 0,
                       gl.RGBA, gl.UNSIGNED_BYTE, null);
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, videoElement);
     } else {
-        debug("use texImage2D");
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, videoElement);
     }
 
@@ -116,9 +104,6 @@ function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottom
         gl.generateMipmap(gl.TEXTURE_2D);
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should be INVALID_OPERATION");
     }
-
-    gl.bindTexture(gl.TEXTURE_2D, null);
-    gl.bindTexture(gl.TEXTURE_2D, texture);
 
 //    var c = document.createElement("canvas");
 //    c.width = 16;


### PR DESCRIPTION
Remove unused or unnecessary global variables, duplicate printouts,
clearing before calling clearAndDrawUnitQuad and re-binding the texture
in the middle of the test.
