### PR TITLE
additional check to make sure that vertexAttribPointer isn't called for ...

### DIFF
--- a/sdk/tests/conformance/more/util.js
+++ b/sdk/tests/conformance/more/util.js
@@ -841,7 +841,7 @@ VBO.prototype = {
     if (!this.initialized) this.init();
     var gl = this.gl;
     for (var i=0; i<arguments.length; i++) {
-      if (arguments[i] == null) continue;
+      if (arguments[i] == null || arguments[i] == -1) continue;
       gl.bindBuffer(gl.ARRAY_BUFFER, this.vbos[i]);
       gl.vertexAttribPointer(arguments[i], this.data[i].size, gl.FLOAT, false, 0, 0);
       gl.enableVertexAttribArray(arguments[i]);


### PR DESCRIPTION
Some implementations can optimize out unused attributes (`getAttribLocation` returns `-1` for optimized out attributes). For example in test `tests/conformance/more/functions/uniformf.html` attribute `Tex` potentially could be optimized out (one can note that only the Z component of `texCoord0` is used in fragment shader, while Tex attribute is set into XY of `texCoord0` variable therefore `Tex` is unneeded):

```
<script id="foobar-vert" type="x-shader/x-vertex">
attribute vec3 Vertex;
attribute vec2 Tex;

uniform float bar;

varying vec4 texCoord0;
void main()
{
    texCoord0 = vec4(Tex.s, 1.0-Tex.t, bar, 0.0);
    gl_Position = vec4(Vertex, 1.0);
}
</script>
<script id="foobar-frag" type="x-shader/x-fragment">
precision mediump float;

uniform vec4 foo;

varying vec4 texCoord0;
void main()
{
    gl_FragColor = vec4(foo.r/255.0, foo.g/255.0, foo.b/255.0, foo.a*texCoord0.z/255.0);
}
</script>
```

Currently, classes from `utils.js` don't check for situation when `getAttribLocation` returns `-1`. In particular `use` function in `VBO` class will try to invoke `vertexAttribPointer` function with `-1` as `indx` parameter what will result in INVALID_VALUE error. Attached fix will prevent from doing so.
