### PR TITLE
Propose WEBGL_compressed_texture_es3 for compressed texture formats core to GLES3

### DIFF
--- a/extensions/proposals/WEBGL_compressed_texture_es3/extension.xml
+++ b/extensions/proposals/WEBGL_compressed_texture_es3/extension.xml
@@ -20,7 +20,16 @@
     </p>
     <features>
       <feature>
-        Compression format <code>COMPRESSED_RGB_ETC2</code>, <code>COMPRESSED_RGB_ETC2</code>, <code>COMPRESSED_RGB_ETC2</code>, <code>COMPRESSED_RGB_ETC2</code>, <code>COMPRESSED_RGB_ETC2</code>, and <code>COMPRESSED_RGB_ETC2</code> may be passed to
+        Compression format <code>COMPRESSED_R11_EAC</code>,
+        <code>COMPRESSED_SIGNED_R11_EAC</code>,
+        <code>COMPRESSED_RG11_EAC</code>,
+        <code>COMPRESSED_SIGNED_RG11_EAC</code>,
+        <code>COMPRESSED_RGB_ETC2</code>,
+        <code>COMPRESSED_SRGB8_ETC2</code>,
+        <code>COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2</code>,
+        <code>COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2</code>,
+        <code>COMPRESSED_RGBA8_ETC2_EAC</code>,
+        and <code>COMPRESSED_SRGB8_ALPHA8_ETC2_EAC</code> may be passed to
         the <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code> entry points.
 
         This format correspond to the format defined in the OES_compressed_ETC1_RGB8_texture OpenGL ES
@@ -139,7 +148,7 @@ interface WEBGL_compressed_texture_es3 {
 };
   </idl>
   <history>
-    <revision date="2013/11/27">
+    <revision date="2013/12/9">
       <change>Initial revision.</change>
     </revision>
   </history>


### PR DESCRIPTION
This was going to be WEBGL_compressed_texture_etc2, but GLES3 also has _EAC formats as core, so this includes those as well under the '_es3' suffix.
