### PR TITLE
Fix up WEBGL_debug_shaders test.

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-debug-shaders.html
+++ b/sdk/tests/conformance/extensions/webgl-debug-shaders.html
@@ -53,6 +53,7 @@ var shader = null;
 var program = null;
 var info = null;
 var translatedSource;
+var newTranslatedSource;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -115,9 +116,9 @@ function runTestEnabled() {
 
             // if no source has been defined or compileShader() has not been called,
             // getTranslatedShaderSource() should return an empty string.
-            shouldBeNull("ext.getTranslatedShaderSource(shader)");
+            shouldBe("ext.getTranslatedShaderSource(shader)", '""');
             gl.shaderSource(shader, info.source);
-            shouldBeNull("ext.getTranslatedShaderSource(shader)");
+            shouldBe("ext.getTranslatedShaderSource(shader)", '""');
             gl.compileShader(shader);
             shouldBeTrue("gl.getShaderParameter(shader, gl.COMPILE_STATUS)");
             translatedSource = ext.getTranslatedShaderSource(shader);


### PR DESCRIPTION
getTranslatedShaderSource() should return "" instead of null on failure.
Fixed JS error where newTranslatedSource was not forward-declared.
