### PR TITLE
Moving EXT_blend_minmax to draft

### DIFF
--- a/extensions/EXT_blend_minmax/extension.xml
+++ b/extensions/EXT_blend_minmax/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<proposal href="proposals/EXT_blend_minmax/">
+<draft href="EXT_blend_minmax/">
   <name>EXT_blend_minmax</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -10,7 +10,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>NN</number>
+  <number>25</number>
 
   <depends>
     <api version="1.0"/>
@@ -66,5 +66,8 @@
     <revision date="2012/12/12">
       <change>Initial revision.</change>
     </revision>
+    <revision date="2014/02/12">
+      <change>Moved to draft.</change>
+    </revision>
   </history>
-</proposal>
+</draft>


### PR DESCRIPTION
Proposing to move EXT_blend_minmax to draft because ES 3.0 defines MIN and MAX blending in its core profile with the identical semantics.
