### PR TITLE
Moving community approved extensions to ratified

### DIFF
--- a/extensions/ANGLE_instanced_arrays/extension.xml
+++ b/extensions/ANGLE_instanced_arrays/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<extension href="ANGLE_instanced_arrays/">
+<ratified href="ANGLE_instanced_arrays/">
   <name>ANGLE_instanced_arrays</name>
   <contact>
     <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)
@@ -42,5 +42,8 @@ interface ANGLE_instanced_arrays {
     <revision date="2013/08/22">
       <change>Clarified non-ANGLE support.</change>
     </revision>
+    <revision date="2014/02/12">
+      <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
   </history>
-</extension>
+</ratified>

--- a/extensions/OES_texture_float_linear/extension.xml
+++ b/extensions/OES_texture_float_linear/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension href="OES_texture_float_linear/">
+<ratified href="OES_texture_float_linear/">
   <name>OES_texture_float_linear</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -39,5 +39,8 @@
     <revision date="2013/08/06">
       <change>Moved to community approved.</change>
     </revision>
+    <revision date="2014/02/12">
+      <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
   </history>
-</extension>
+</ratified>

--- a/extensions/OES_texture_half_float_linear/extension.xml
+++ b/extensions/OES_texture_half_float_linear/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension href="OES_texture_half_float_linear/">
+<ratified href="OES_texture_half_float_linear/">
   <name>OES_texture_half_float_linear</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -39,5 +39,8 @@
     <revision date="2013/08/06">
       <change>Moved to community approved.</change>
     </revision>
+    <revision date="2014/02/12">
+      <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
   </history>
-</extension>
+</ratified>

--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<extension href="WEBGL_draw_buffers/">
+<ratified href="WEBGL_draw_buffers/">
   <name>WEBGL_draw_buffers</name>
   <contact>
     <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)
@@ -144,5 +144,8 @@ interface WEBGL_draw_buffers {
     <revision date="2013/06/07">
       <change>Clarified naming of shader directives.</change>
     </revision>
+    <revision date="2014/02/12">
+      <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
   </history>
-</extension>
+</ratified>


### PR DESCRIPTION
I propose that the board ratify the community approved extensions:
- WEBGL_draw_buffers
- ANGLE_instanced_arrays
- OES_texture_float_linear
- OES_texture_half_float_linear

For these reasons:
- The extensions have not been modified since August 2013
- Implementations of the extensions are available
- As per http://webglstats.com/ support status stands at: WEBGL_draw_buffers 7.2%, ANGLE_instanced_arrays 58%, OES_texture_float_linear 72%, OES_texture_half_float_linear, 70%.

Please use this pull request to merge the changes once ratification is achieved, poll me to update the pull request (with actual dates if required), or throw it away if ratification at this stage is not feasible.
