### PR TITLE
proposal to move EXT_shader_texture_lod to draft

### DIFF
--- a/extensions/EXT_shader_texture_lod/extension.xml
+++ b/extensions/EXT_shader_texture_lod/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<proposal href="proposals/EXT_shader_texture_lod/">
+<draft href="EXT_shader_texture_lod/">
   <name>EXT_shader_texture_lod</name>
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
@@ -10,7 +10,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>NN</number>
+  <number>27</number>
 
   <depends>
     <api version="1.0"/>
@@ -101,5 +101,8 @@
     <revision date="2014/02/10">
       <change>Initial revision.</change>
     </revision>
+    <revision date="2014/02/18">
+      <change>Moved to draft.</change>
+    </revision>
   </history>
-</proposal>
+</draft>


### PR DESCRIPTION
Due to the fact that implementation patches (by Vladimir) are already pending, and it would be a shame to have to drop them to the floor, I propose to move EXT_shader_texture_lod to draft as soon as possible.
