### PR TITLE
Updated IDLs with correct 'implements' syntax

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1775,9 +1775,10 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 };
 
-interface <dfn id="WebGLRenderingContext">WebGLRenderingContext</dfn> implements WebGLRenderingContextBase
+interface <dfn id="WebGLRenderingContext">WebGLRenderingContext</dfn>
 {
 };
+WebGLRenderingContext implements WebGLRenderingContextBase;
 </pre>
 
 <!-- ======================================================================================================= -->

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -727,9 +727,10 @@ interface WebGLRenderingContextBase
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 };
 
-interface WebGLRenderingContext implements WebGLRenderingContextBase
+interface WebGLRenderingContext
 {
 };
+WebGLRenderingContext implements WebGLRenderingContextBase;
 
 
 [Constructor(DOMString type, optional WebGLContextEventInit eventInit)]

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -294,7 +294,7 @@ typedef unsigned long long GLuint64;
 
     <pre class="idl">
 [NoInterfaceObject]
-interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn> implements WebGLRenderingContextBase
+interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
 {
   const GLenum READ_BUFFER                                   = 0x0C02;
   const GLenum UNPACK_ROW_LENGTH                             = 0x0CF2;
@@ -752,10 +752,12 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn> 
    *  - Deliberately not exposing glGetProgramBinary, glProgramBinary, glProgramParameteri
    */
 };
+WebGL2RenderingContextBase implements WebGLRenderingContextBase;
 
-interface <dfn id="WebGL2RenderingContext">WebGL2RenderingContext</dfn> implements WebGL2RenderingContextBase
+interface <dfn id="WebGL2RenderingContext">WebGL2RenderingContext</dfn>
 {
 };
+WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
 </pre>
 

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -10,17 +10,6 @@ typedef long long GLint64;
 typedef unsigned long long GLuint64;
 
 
-dictionary WebGLContextAttributes {
-    GLboolean alpha = true;
-    GLboolean depth = true;
-    GLboolean stencil = false;
-    GLboolean antialias = true;
-    GLboolean premultipliedAlpha = true;
-    GLboolean preserveDrawingBuffer = false;
-    GLint version = 1; /* New in WebGL 2.0 */
-    GLboolean preferLowPowerToHighPerformance = false;
-};
-
 interface WebGLQuery : WebGLObject {
 };
 
@@ -37,7 +26,7 @@ interface WebGLVertexArrayObject : WebGLObject {
 };
 
 [NoInterfaceObject]
-interface WebGL2RenderingContextBase implements WebGLRenderingContextBase
+interface WebGL2RenderingContextBase
 {
   const GLenum READ_BUFFER                                   = 0x0C02;
   const GLenum UNPACK_ROW_LENGTH                             = 0x0CF2;
@@ -495,9 +484,11 @@ interface WebGL2RenderingContextBase implements WebGLRenderingContextBase
    *  - Deliberately not exposing glGetProgramBinary, glProgramBinary, glProgramParameteri
    */
 };
+WebGL2RenderingContextBase implements WebGLRenderingContextBase;
 
-interface WebGL2RenderingContext implements WebGL2RenderingContextBase
+interface WebGL2RenderingContext
 {
 };
+WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
 


### PR DESCRIPTION
Addresses #485.

Updates the IDLs to match the ImplementsStatement syntax defined in the WebIDL spec. (http://heycam.github.io/webidl/#proddef-ImplementsStatement)

@arv: Do you mind giving this a sanity check? 
