### PR TITLE
Make WEBGL_depth_texture refer to right section in main spec

### DIFF
--- a/extensions/WEBGL_depth_texture/extension.xml
+++ b/extensions/WEBGL_depth_texture/extension.xml
@@ -65,7 +65,7 @@
       </feature>
       <feature>
         <p>
-          The WebGL-specific constraints about <a href="http://www.khronos.org/registry/webgl/specs/1.0/#6.5">Framebuffer Object Attachments</a> are extended:</p>
+          The WebGL-specific constraints about <a href="http://www.khronos.org/registry/webgl/specs/1.0/#FBO_ATTACHMENTS">Framebuffer Object Attachments</a> are extended:</p>
 
           <ul>
           <li> A texture attached to an FBO's <code>DEPTH_ATTACHMENT</code> attachment point must be allocated with the <code>DEPTH_COMPONENT</code> internal format. </li>
@@ -85,7 +85,7 @@
 
         <p>
           See the section
-          <a href="http://www.khronos.org/registry/webgl/specs/1.0/#6.5">Framebuffer Object Attachments</a>
+          <a href="http://www.khronos.org/registry/webgl/specs/1.0/#FBO_ATTACHMENTS">Framebuffer Object Attachments</a>
           in the WebGL specification for the behavior if these
           constraints are violated.
         </p>

--- a/specs/1.0.2/index.html
+++ b/specs/1.0.2/index.html
@@ -3253,7 +3253,7 @@ or <code>drawElements</code>.
 
 </p>
 
-    <h3>Framebuffer Object Attachments</h3>
+    <h3><a name="FBO_ATTACHMENTS">Framebuffer Object Attachments</a></h3>
 
 <p>
 

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3332,7 +3332,7 @@ or <code>drawElements</code>.
 
 </p>
 
-    <h3>Framebuffer Object Attachments</h3>
+    <h3><a name="FBO_ATTACHMENTS">Framebuffer Object Attachments</a></h3>
 
 <p>
 


### PR DESCRIPTION
Link that was originally right had started to point to the wrong section after a new section was added. Give the link target a name to fix this.
