### PR TITLE
Added check for a potential texture binding regression in Chrome

### DIFF
--- a/sdk/tests/conformance/textures/tex-image-webgl.html
+++ b/sdk/tests/conformance/textures/tex-image-webgl.html
@@ -84,7 +84,7 @@ wtu.clearAndDrawUnitQuad(gl);
 
 wtu.checkCanvas(gl, [0, 255, 0, 255], "Canvas should be green");
 
-// Test a scenario from Chrome where a WebGL context would lose it's active texture binding when its
+// Test a scenario from Chrome where a WebGL context would lose its active texture binding when its
 // canvas was used as the texture source for another WebGL context.
 wtu.clearAndDrawUnitQuad(gl1);
 


### PR DESCRIPTION
Tests a scenario from Chrome where a WebGL context would lose it's active texture binding when its
canvas was used as the texture source for another WebGL context.

(The regression in question never made it into Chrome's source and, with the help of this test, never will. :)
