### PR TITLE
Add simple benchmark for drawElements index validation overhead

### DIFF
--- a/sdk/tests/extra/webgl-drawelements-validation.html
+++ b/sdk/tests/extra/webgl-drawelements-validation.html
@@ -1,3 +1,31 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
 <html>
 <head>
 <title>Micro-benchmark for WebGL drawElements index validation</title>


### PR DESCRIPTION
The test changes data in an index buffer and calls drawElements on it.
There are always some invalid indices in the buffer, so that any drawing
is not performed but the test just measures the overhead from uploading
data and performing validation.

The test is written to specifically target implementations in Chrome and
Firefox in March 2014, so some of the results might be slightly
misleading on other implementations.
