### PR TITLE
Improve and expand getExtension test

### DIFF
--- a/sdk/tests/conformance/extensions/get-extension.html
+++ b/sdk/tests/conformance/extensions/get-extension.html
@@ -40,27 +40,42 @@
 <div id="console"></div>
 <script>
 "use strict";
+
+var pseudoRandom = (function() {
+    var seed = 3;
+    return function() {
+        seed = (seed * 11 + 17) % 25;
+        return seed / 25;
+    };
+})();
+
 var randomizeCase = function(str) {
     var newChars = [];
     for (var ii = 0; ii < str.length; ++ii) {
         var c = str.substr(ii, 1);
-        var m = (Math.random() > 0.5) ? c.toLowerCase() : c.toUpperCase();
+        var m = (pseudoRandom() > 0.5) ? c.toLowerCase() : c.toUpperCase();
         newChars.push(m);
     }
     return newChars.join("");
-}
+};
 
 description();
-debug("");
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
 
+var ii;
+
 debug("check every extension advertised can be enabled");
-var extensions = [];
+debug("");
 var extensionNames = gl.getSupportedExtensions();
-for (var ii = 0; ii < extensionNames.length; ++ii) {
+var extensionNamesLower = [];
+for (ii = 0; ii < extensionNames.length; ++ii) {
+    extensionNamesLower.push(extensionNames[ii].toLowerCase());
+}
+
+for (ii = 0; ii < extensionNames.length; ++ii) {
     var originalName = extensionNames[ii];
     var mixedName = randomizeCase(originalName);
     var extension = gl.getExtension(mixedName);
@@ -85,10 +100,18 @@ for (var ii = 0; ii < extensionNames.length; ++ii) {
             extension2.testObjectProperty === kTestObject &&
             extension2.testNumberProperty === kTestNumber,
             "object returned by 2nd call to getExtension has same properties");
+
+        var prefixedVariants = wtu.getExtensionPrefixedNames(originalName);
+        for (var jj = 0; jj < prefixedVariants.length; ++jj) {
+            assertMsg(
+                gl.getExtension(prefixedVariants[jj]) === null ||
+                extensionNamesLower.indexOf(prefixedVariants[jj].toLowerCase()) !== -1,
+                "getExtension('" + prefixedVariants[jj] + "') returns an object only if the name is returned by getSupportedExtensions");
+        }
     }
+    debug("");
 }
 
-debug("");
 var successfullyParsed = true;
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -2060,6 +2060,33 @@ var getExtensionWithKnownPrefixes = function(gl, name) {
   }
 };
 
+/**
+ * Returns possible prefixed versions of an extension's name.
+ * @param {string} name Name of extension. May already include a prefix.
+ * @return {Array.<string>} Variations of the extension name with known
+ *     browser prefixes.
+ */
+var getExtensionPrefixedNames = function(name) {
+  var unprefix = function(name) {
+    for (var ii = 0; ii < browserPrefixes.length; ++ii) {
+      if (browserPrefixes[ii].length > 0 &&
+          name.substring(0, browserPrefixes[ii].length).toLowerCase() ===
+          browserPrefixes[ii].toLowerCase()) {
+        return name.substring(browserPrefixes[ii].length);
+      }
+    }
+    return name;
+  }
+
+  var unprefixed = unprefix(name);
+
+  var variations = [];
+  for (var ii = 0; ii < browserPrefixes.length; ++ii) {
+    variations.push(browserPrefixes[ii] + unprefixed);
+  }
+
+  return variations;
+};
 
 var replaceRE = /\$\((\w+)\)/g;
 
@@ -2434,6 +2461,7 @@ return {
   endsWith: endsWith,
   fillTexture: fillTexture,
   getBytesPerComponent: getBytesPerComponent,
+  getExtensionPrefixedNames: getExtensionPrefixedNames,
   getExtensionWithKnownPrefixes: getExtensionWithKnownPrefixes,
   getFileListAsync: getFileListAsync,
   getLastError: getLastError,


### PR DESCRIPTION
Specification reads "getExtension Returns an object if, and only if, name
is an ASCII case-insensitive match [HTML] for one of the names returned
from getSupportedExtensions; otherwise, returns null." Chrome currently
doesn't behave this way, but rather has opted to not to have both
unprefixed and prefixed versions of the same extension in the list
returned by getSupportedExtensions. Test the spec-compliant behavior.

Also added minor formatting fixes and made the test deterministic.
