### PR TITLE
added missing getParameter checks

### DIFF
--- a/conformance-suites/1.0.2/conformance/state/gl-get-calls.html
+++ b/conformance-suites/1.0.2/conformance/state/gl-get-calls.html
@@ -115,6 +115,29 @@ else {
     shouldBe('context.getParameter(context.STENCIL_BACK_PASS_DEPTH_PASS)', 'context.KEEP');
     shouldBe('context.getParameter(context.STENCIL_BACK_REF)', '0');
 
+    // WebGL 1.0.2 - 5.14.3 types / ES 2.0.25 - 6.2 State tables - 6.18 page 152
+    shouldBeType('context.getParameter(context.SUBPIXEL_BITS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.SUBPIXEL_BITS)', '4');
+    
+    shouldBeType('context.getParameter(context.SAMPLE_BUFFERS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.SAMPLE_BUFFERS)', '0');
+    
+    shouldBeType('context.getParameter(context.SAMPLES)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.SAMPLES)', '0');
+    
+    shouldBeType('context.getParameter(context.DEPTH_BITS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.DEPTH_BITS)', '0');
+    shouldBeType('context.getParameter(context.RED_BITS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.RED_BITS)', '0');
+    shouldBeType('context.getParameter(context.GREEN_BITS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.GREEN_BITS)', '0');
+    shouldBeType('context.getParameter(context.BLUE_BITS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.BLUE_BITS)', '0');
+    shouldBeType('context.getParameter(context.ALPHA_BITS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.ALPHA_BITS)', '0');
+    shouldBeType('context.getParameter(context.STENCIL_BITS)', 'Number');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.STENCIL_BITS)', '0');
+    
     var stencilBits = context.getParameter(context.STENCIL_BITS);
     minimumRequiredStencilMask = (1 << stencilBits) - 1;
 
@@ -142,16 +165,16 @@ else {
     shouldBe('context.getParameter(context.VIEWPORT)', '[0, 0, 2, 2]');
     shouldBeType('context.getParameter(context.VIEWPORT)', 'Int32Array');
 
-    shouldBeTrue('context.getParameter(context.MAX_COMBINED_TEXTURE_IMAGE_UNITS) >= 8');
-    shouldBeTrue('context.getParameter(context.MAX_CUBE_MAP_TEXTURE_SIZE) >= 16');
-    shouldBeTrue('context.getParameter(context.MAX_FRAGMENT_UNIFORM_VECTORS) >= 16');
-    shouldBeTrue('context.getParameter(context.MAX_RENDERBUFFER_SIZE) >= 1');
-    shouldBeTrue('context.getParameter(context.MAX_TEXTURE_IMAGE_UNITS) >= 8');
-    shouldBeTrue('context.getParameter(context.MAX_TEXTURE_SIZE) >= 64');
-    shouldBeTrue('context.getParameter(context.MAX_VARYING_VECTORS) >= 8');
-    shouldBeTrue('context.getParameter(context.MAX_VERTEX_ATTRIBS) >= 8');
-    shouldBeTrue('context.getParameter(context.MAX_VERTEX_TEXTURE_IMAGE_UNITS) >= 0');
-    shouldBeTrue('context.getParameter(context.MAX_VERTEX_UNIFORM_VECTORS) >= 128');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_COMBINED_TEXTURE_IMAGE_UNITS)', '8');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_CUBE_MAP_TEXTURE_SIZE)', '16');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_FRAGMENT_UNIFORM_VECTORS)', '16');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_RENDERBUFFER_SIZE)', '1');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_TEXTURE_IMAGE_UNITS)', '8');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_TEXTURE_SIZE)', '64');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_VARYING_VECTORS)', '8');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_VERTEX_ATTRIBS)', '8');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_VERTEX_TEXTURE_IMAGE_UNITS)', '0');
+    shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_VERTEX_UNIFORM_VECTORS)', '128');
     // Note: This requirement should be removed from the spec IMO. Many impelementations
     // will be based on FBOs and FBOs might have a restriction smaller than the current screen size.
     // especially if there are multiple screens.

--- a/conformance-suites/1.0.2/resources/js-test-pre.js
+++ b/conformance-suites/1.0.2/resources/js-test-pre.js
@@ -421,7 +421,18 @@ function shouldBeType(_a, _type) {
 
 	var _typev = eval(_type);
 
-	if (_av instanceof _typev) {
+    if(_typev === Number){
+        if(_av instanceof Number){
+		    testPassed(_a + " is an instance of Number");
+        }
+        else if(typeof(_av) === 'number'){
+		    testPassed(_a + " is an instance of Number");
+        }
+        else{
+		    testFailed(_a + " is not an instance of Number");
+        }
+    }
+	else if (_av instanceof _typev) {
 		testPassed(_a + " is an instance of " + _type);
 	} else {
 		testFailed(_a + " is not an instance of " + _type);


### PR DESCRIPTION
Some implementation dependent parameters have not been checked for type and minimum maximum, I've added these checks.

The trigger to add these checks was that IE11's implementation does not implement these getParameters correctly (because they wheren't checked).
