### PR TITLE
Added test to check for the proper prototype chain

### DIFF
--- a/sdk/tests/conformance/context/context-type-test.html
+++ b/sdk/tests/conformance/context/context-type-test.html
@@ -50,7 +50,7 @@ assertMsg(window.WebGLRenderingContext,
           "WebGLRenderingContext should be a member of window");
 assertMsg('WebGLRenderingContext' in window,
           "WebGLRenderingContext should be 'in' window");
-assertMsg(WebGLRenderingContext.prototype.__proto__ === Object.prototype,
+assertMsg(Object.getPrototypeOf(WebGLRenderingContext.prototype) === Object.prototype,
           "WebGLRenderingContext should only have Object in it's prototype chain");
 
 var wtu = WebGLTestUtils;


### PR DESCRIPTION
A strict interpretation of the spec would indicate that the WebGLRenderingContext should only have Object in it's prototype chain. Specifically, it should NOT show WebGLRenderingContextBase in the prototype chain.

This test is currently passing on Firefox and IE11. It passes on stable Chrome but not some of the newer builds because we are accidentally exposing WebGLRenderingContextBase in the prototype chain. The test also fails in Safari, where the next item up in WebGLRenderingContext's prototype chain is a "CanvasRenderingContext"
