### PR TITLE
Show translated shader source using WEBGL_debug_shaders in glsl tests

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
+++ b/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
@@ -64,9 +64,6 @@ void main() {
 description("Comparing loop index to an uniform in a fragment shader should work.");
 debug("");
 var wtu = WebGLTestUtils;
-
-var console = document.getElementById('console');
-
 function test() {
   var gl = wtu.create3DContext("canvas");
   if (!gl) {
@@ -74,16 +71,7 @@ function test() {
     return;
   }
   wtu.setupUnitQuad(gl);
-
-  var vsSource = wtu.getScript("vshader");
-  var vs = wtu.loadShader(gl, vsSource, gl.VERTEX_SHADER);
-  wtu.addShaderSources(gl, console, 'vertex shader', vs, vsSource);
-  var fsSource = wtu.getScript("fshader");
-  var fs = wtu.loadShader(gl, fsSource, gl.FRAGMENT_SHADER);
-  wtu.addShaderSources(gl, console, 'fragment shader', fs, fsSource);
-
-  var program = wtu.setupProgram(gl, [vs, fs], ["aPosition"]);
-  gl.useProgram(program);
+  var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["aPosition"], undefined, true);
   var uniformLoc = gl.getUniformLocation(program, 'uCount');
   gl.uniform1i(uniformLoc, 5);
   wtu.drawUnitQuad(gl);

--- a/sdk/tests/conformance/glsl/bugs/conditional-discard-optimization.html
+++ b/sdk/tests/conformance/glsl/bugs/conditional-discard-optimization.html
@@ -91,7 +91,7 @@ if (!gl) {
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 wtu.setupUnitQuad(gl);
-var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"]);
+var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"], undefined, true);
 wtu.drawUnitQuad(gl);
 wtu.checkCanvasRect(gl, 128, 128, 128, 128, [ 0, 255, 0, 255 ], "should be green", 1);
 

--- a/sdk/tests/conformance/glsl/bugs/floored-division-accuracy.html
+++ b/sdk/tests/conformance/glsl/bugs/floored-division-accuracy.html
@@ -81,7 +81,7 @@ if (!gl) {
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 wtu.setupUnitQuad(gl);
-var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"]);
+var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"], undefined, true);
 gl.uniform1f(gl.getUniformLocation(program, "divisor"), 3);
 wtu.drawUnitQuad(gl);
 wtu.checkCanvasRect(gl, 128, 128, 128, 128, [ 0, 255, 0, 255 ], "should be green", 1);

--- a/sdk/tests/conformance/glsl/bugs/modulo-arithmetic-accuracy.html
+++ b/sdk/tests/conformance/glsl/bugs/modulo-arithmetic-accuracy.html
@@ -81,7 +81,7 @@ if (!gl) {
 gl.clearColor(0.0, 0.0, 0.0, 1.0);
 gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 wtu.setupUnitQuad(gl);
-var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"]);
+var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"], undefined, true);
 gl.uniform1f(gl.getUniformLocation(program, "divisor"), 3);
 wtu.drawUnitQuad(gl);
 wtu.checkCanvasRect(gl, 128, 128, 128, 128, [ 0, 255, 0, 255 ], "should be green", 1);

--- a/sdk/tests/conformance/glsl/bugs/sampler-array-using-loop-index.html
+++ b/sdk/tests/conformance/glsl/bugs/sampler-array-using-loop-index.html
@@ -77,7 +77,7 @@ var program = wtu.setupTexturedQuad(gl);
 
 //------------------------------------------------------------------------------
 var program = wtu.setupProgram(
-    gl, ['vshader', 'fshader'], ['vPosition'], [0]);
+    gl, ['vshader', 'fshader'], ['vPosition'], undefined, true);
 
 for (var ii = 0; ii < 2; ++ii) {
   var loc = gl.getUniformLocation(program, "uni[" + ii + "]");

--- a/sdk/tests/conformance/glsl/bugs/uniforms-should-not-lose-values.html
+++ b/sdk/tests/conformance/glsl/bugs/uniforms-should-not-lose-values.html
@@ -67,7 +67,7 @@ function test() {
   }
 
   wtu.setupUnitQuad(gl);
-  var program = wtu.setupProgram(gl, ["vshader", "fshader"],["a"]);
+  var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["a"], undefined, true);
 
   var setUniformf = function(name, val) {
     var loc = gl.getUniformLocation(program, name);

--- a/sdk/tests/conformance/glsl/misc/large-loop-compile.html
+++ b/sdk/tests/conformance/glsl/misc/large-loop-compile.html
@@ -167,20 +167,7 @@ if (!gl) {
   finishTest();
 } else {
   var startTime = Date.now();
-  var consoleDiv = document.getElementById("console");
-  var vSource = wtu.getScript("vertexShader");
-  var vShader = wtu.loadShader(gl, vSource, gl.VERTEX_SHADER);
-  wtu.addShaderSources(gl, consoleDiv, "test vertex shader", vShader, vSource);
-  var fSource = wtu.getScript("fragmentShader");
-  var fShader = wtu.loadShader(gl, fSource, gl.FRAGMENT_SHADER);
-  wtu.addShaderSources(gl, consoleDiv, "test fragment shader", fShader, fSource);
-  if (vShader && fShader) {
-    var program = gl.createProgram();
-    gl.attachShader(program, vShader);
-    gl.attachShader(program, fShader);
-    gl.linkProgram(program);
-    gl.getProgramParameter(program, gl.LINK_STATUS);
-  }
+  wtu.setupProgram(gl, ["vertexShader", "fragmentShader"], undefined, undefined, true);
   gl.clearColor(0.0, 1.0, 0.0, 1.0);
   gl.clear(gl.COLOR_BUFFER_BIT);
   wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);

--- a/sdk/tests/conformance/glsl/misc/shader-with-non-reserved-words.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-non-reserved-words.html
@@ -633,7 +633,6 @@ description();
 
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
-var console = document.getElementById("console");
 
 var badWords = [
   { words: DXWords },
@@ -691,27 +690,15 @@ function testWord(word) {
   debug("");
   debug("testing: " + word);
 
-  var program;
-
   for (var ii = 0; ii < src.length; ++ii) {
-    var vsSource = src[ii].vsrc.replace(/\$replaceMe/g, word);
-    var fsSource = src[ii].fsrc.replace(/\$replaceMe/g, word);
+    var vs = src[ii].vsrc.replace(/\$replaceMe/g, word);
+    var fs = src[ii].fsrc.replace(/\$replaceMe/g, word);
 
     var success = true;
-    var noSuccess = function(msg) {
+    var program = wtu.loadProgram(gl, vs, fs, function(msg) {
       debug(msg);
       success = false;
-    };
-
-    var vs = wtu.loadShader(gl, vsSource, gl.VERTEX_SHADER, noSuccess);
-    wtu.addShaderSources(gl, console, "vertex shader", vs, vsSource);
-    var fs = wtu.loadShader(gl, fsSource, gl.FRAGMENT_SHADER, noSuccess);
-    wtu.addShaderSources(gl, console, "fragment shader", fs, fsSource);
-
-    if (vs && fs) {
-      program = wtu.createProgram(gl, vs, fs, noSuccess);
-    }
-
+    }, true);
     if (success) {
       testPassed("shader with: '" + word + "' compiled");
     } else {

--- a/sdk/tests/conformance/glsl/misc/shader-with-reserved-words.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-reserved-words.html
@@ -220,7 +220,6 @@ description();
 
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
-var console = document.getElementById("console");
 
 var reservedWordsLists = [
   GLSL_1_0_17_words,
@@ -259,25 +258,15 @@ function testWord(word) {
   debug("");
   debug("testing: " + word);
 
-  var program;
-
   for (var ii = 0; ii < src.length; ++ii) {
-    var vsSource = src[ii].vsrc.replace(/\$replaceMe/g, word);
-    var fsSource = src[ii].fsrc.replace(/\$replaceMe/g, word);
+    var vs = src[ii].vsrc.replace(/\$replaceMe/g, word);
+    var fs = src[ii].fsrc.replace(/\$replaceMe/g, word);
 
     var success = true;
-    var noSuccess = function() {
+    var program = wtu.loadProgram(gl, vs, fs, function(msg) {
+      //debug(msg);
       success = false;
-    };
-
-    var vs = wtu.loadShader(gl, vsSource, gl.VERTEX_SHADER, noSuccess);
-    wtu.addShaderSources(gl, console, "vertex shader", vs, vsSource);
-    var fs = wtu.loadShader(gl, fsSource, gl.FRAGMENT_SHADER, noSuccess);
-    wtu.addShaderSources(gl, console, "fragment shader", fs, fsSource);
-
-    if (vs && fs) {
-      program = wtu.createProgram(gl, vs, fs, noSuccess);
-    }
+    }, true);
     if (success) {
       testFailed("shader with: '" + word + "' compiled even though it should not");
     } else {

--- a/sdk/tests/conformance/glsl/misc/shader-with-short-circuiting-operators.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-short-circuiting-operators.html
@@ -105,7 +105,6 @@
 
       var wtu = WebGLTestUtils;
       var gl = wtu.create3DContext();
-      var console = document.getElementById("console");
 
       wtu.setupUnitQuad(gl, [0, 1]);
 
@@ -148,23 +147,15 @@
           gl.clear(gl.COLOR_BUFFER_BIT);
           var template = shaderTemplates[ii];
 
-          var vsSource = wtu.replaceParams(template.vs, test);
-          var fsSource = wtu.replaceParams(template.fs, test);
+          var vs = wtu.replaceParams(template.vs, test);
+          var fs = wtu.replaceParams(template.fs, test);
 
-          var vs = wtu.loadShader(gl, vsSource, gl.VERTEX_SHADER);
-          wtu.addShaderSources(gl, console, "vertex shader", vs, vsSource);
-          var fs = wtu.loadShader(gl, fsSource, gl.FRAGMENT_SHADER);
-          wtu.addShaderSources(gl, console, "fragment shader", fs, fsSource);
-          var program = wtu.createProgram(gl, vs, fs);
-
-          gl.useProgram(program);
+          var program = wtu.setupProgram(gl, [vs, fs], ['vPosition'], undefined, true);
 
           wtu.clearAndDrawUnitQuad(gl);
           wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
 
           gl.deleteProgram(program);
-          gl.deleteShader(vs);
-          gl.deleteShader(fs);
 
           wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no GL errors");
         }

--- a/sdk/tests/conformance/glsl/variables/glsl-built-ins.html
+++ b/sdk/tests/conformance/glsl/variables/glsl-built-ins.html
@@ -98,7 +98,6 @@ var shaderPairs = [
 ];
 
 wtu.setupUnitQuad(gl);
-var console = document.getElementById("console");
 
 variables.forEach(function(variable) {
   debug("");
@@ -108,18 +107,10 @@ variables.forEach(function(variable) {
     expectTrue(variable.max >= variable.min, "gl.getParameter(gl." + toUnderscore(variable.name) + ") >= " + variable.min);
   }
   shaderPairs.forEach(function(pair) {
-    var shaderSources = [wtu.replaceParams(pair[0], variable), wtu.replaceParams(pair[1], variable)];
-    var shaders = [wtu.loadShader(gl, shaderSources[0], gl.VERTEX_SHADER),
-                   wtu.loadShader(gl, shaderSources[1], gl.FRAGMENT_SHADER)];
-    wtu.addShaderSources(gl, console, "vertex shader", shaders[0], shaderSources[0]);
-    wtu.addShaderSources(gl, console, "fragment shader", shaders[1], shaderSources[1]);
-    if (shaders[0] && shaders[1]) {
-      var program = wtu.setupProgram(gl, shaders, ["a_position"]);
-      wtu.clearAndDrawUnitQuad(gl);
-      wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green");
-    } else {
-      testFailed('Shader compilation failed');
-    }
+    var shaders = [wtu.replaceParams(pair[0], variable), wtu.replaceParams(pair[1], variable)];
+    var program = wtu.setupProgram(gl, shaders, ["a_position"], undefined, true);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green");
   });
 });
 

--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -563,11 +563,13 @@ function runProgram(programInfo, test, label, callback) {
       var result;
       if (shaders.length == 2) {
         debug("");
-        var console = document.getElementById("console");
-        wtu.addShaderSource(
-            console, label + " vertex shader", source[0], programInfo.vertexShader);
-        wtu.addShaderSource(
-            console, label + " fragment shader", source[1], programInfo.fragmentShader);
+        var consoleDiv = document.getElementById("console");
+        wtu.addShaderSources(
+            gl, consoleDiv, label + " vertex shader", shaders[0], source[0],
+            programInfo.vertexShader);
+        wtu.addShaderSources(
+            gl, consoleDiv, label + " fragment shader", shaders[1], source[1],
+            programInfo.fragmentShader);
         var program = wtu.createProgram(gl, shaders[0], shaders[1]);
         result = drawWithProgram(program, programInfo, test);
       }

--- a/sdk/tests/conformance/resources/glsl-conformance-test.js
+++ b/sdk/tests/conformance/resources/glsl-conformance-test.js
@@ -60,12 +60,12 @@ var fShaderDB = {};
  * render: if true render to unit quad. Green = success
  *
  */
-function runOneTest(gl, debugShaders, info) {
+function runOneTest(gl, info) {
   var passMsg = info.passMsg
   debug("");
   debug("test: " + passMsg);
 
-  var console = document.getElementById("console");
+  var consoleDiv = document.getElementById("console");
 
   if (info.vShaderSource === undefined) {
     if (info.vShaderId) {
@@ -90,7 +90,7 @@ function runOneTest(gl, debugShaders, info) {
   var vSource = info.vShaderPrep ? info.vShaderPrep(info.vShaderSource) :
     info.vShaderSource;
 
-  wtu.addShaderSource(console, vLabel, vSource);
+  wtu.addShaderSource(consoleDiv, vLabel, vSource);
 
   // Reuse identical shaders so we test shared shader.
   var vShader = vShaderDB[vSource];
@@ -114,15 +114,16 @@ function runOneTest(gl, debugShaders, info) {
     }
   }
 
+  var debugShaders = gl.getExtension('WEBGL_debug_shaders');
   if (debugShaders && vShader) {
-    wtu.addShaderSource(console, vLabel + " translated for driver",
+    wtu.addShaderSource(consoleDiv, vLabel + " translated for driver",
                         debugShaders.getTranslatedShaderSource(vShader));
   }
 
   var fSource = info.fShaderPrep ? info.fShaderPrep(info.fShaderSource) :
     info.fShaderSource;
 
-  wtu.addShaderSource(console, fLabel, fSource);
+  wtu.addShaderSource(consoleDiv, fLabel, fSource);
 
   // Reuse identical shaders so we test shared shader.
   var fShader = fShaderDB[fSource];
@@ -149,7 +150,7 @@ function runOneTest(gl, debugShaders, info) {
   }
 
   if (debugShaders && fShader) {
-    wtu.addShaderSource(console, fLabel + " translated for driver",
+    wtu.addShaderSource(consoleDiv, fLabel + " translated for driver",
                         debugShaders.getTranslatedShaderSource(fShader));
   }
 
@@ -194,7 +195,7 @@ function runOneTest(gl, debugShaders, info) {
   div.className = "testimages";
   wtu.insertImage(div, "result", wtu.makeImage(gl.canvas));
   div.appendChild(document.createElement('br'));
-  console.appendChild(div);
+  consoleDiv.appendChild(div);
   wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
 }
 
@@ -210,8 +211,6 @@ function runTests(shaderInfos) {
     return;
   }
 
-  var debugShaders = gl.getExtension('WEBGL_debug_shaders');
-
   var testIndex = 0;
   var runNextTest = function() {
     if (testIndex == shaderInfos.length) {
@@ -219,7 +218,7 @@ function runTests(shaderInfos) {
       return;
     }
 
-    runOneTest(gl, debugShaders, shaderInfos[testIndex++]);
+    runOneTest(gl, shaderInfos[testIndex++]);
     setTimeout(runNextTest, 1);
   }
   runNextTest();

--- a/sdk/tests/conformance/resources/glsl-generator.js
+++ b/sdk/tests/conformance/resources/glsl-generator.js
@@ -261,7 +261,7 @@ var runFeatureTest = function(params) {
   var width = 32;
   var height = 32;
 
-  var console = document.getElementById("console");
+  var consoleDiv = document.getElementById("console");
   var canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
@@ -338,24 +338,12 @@ var runFeatureTest = function(params) {
           params,
           tests[ii]);
 
-      var referenceVertexShader = wtu.loadShader(gl, referenceVertexShaderSource, gl.VERTEX_SHADER, testFailed);
-      var referenceFragmentShader = wtu.loadShader(gl, referenceFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed);
-      var testVertexShader = wtu.loadShader(gl, testVertexShaderSource, gl.VERTEX_SHADER, testFailed);
-      var testFragmentShader = wtu.loadShader(gl, testFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed);
 
       debug("");
-      wtu.addShaderSources(
-          gl, console, "reference vertex shader", referenceVertexShader,
-          referenceVertexShaderSource);
-      wtu.addShaderSources(
-          gl, console, "reference fragment shader", referenceFragmentShader,
-          referenceFragmentShaderSource);
-      wtu.addShaderSources(
-          gl, console, "test vertex shader", testVertexShader,
-          testVertexShaderSource);
-      wtu.addShaderSources(
-          gl, console, "test fragment shader", testFragmentShader,
-          testFragmentShaderSource);
+      var referenceVertexShader = wtu.loadShader(gl, referenceVertexShaderSource, gl.VERTEX_SHADER, testFailed, true, 'reference');
+      var referenceFragmentShader = wtu.loadShader(gl, referenceFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed, true, 'reference');
+      var testVertexShader = wtu.loadShader(gl, testVertexShaderSource, gl.VERTEX_SHADER, testFailed, true, 'test');
+      var testFragmentShader = wtu.loadShader(gl, testFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed, true, 'test');
       debug("");
 
       var refData = draw(
@@ -412,7 +400,7 @@ var runFeatureTest = function(params) {
     div.appendChild(document.createElement('br'));
 
 
-    console.appendChild(div);
+    consoleDiv.appendChild(div);
 
     if (!same) {
       testFailed("images are different");
@@ -420,7 +408,7 @@ var runFeatureTest = function(params) {
       testPassed("images are the same");
     }
 
-    console.appendChild(document.createElement('hr'));
+    consoleDiv.appendChild(document.createElement('hr'));
   }
 
   function draw(vertexShader, fragmentShader) {
@@ -453,7 +441,7 @@ var runBasicTest = function(params) {
   var width = 32;
   var height = 32;
 
-  var console = document.getElementById("console");
+  var consoleDiv = document.getElementById("console");
   var canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
@@ -530,24 +518,11 @@ var runBasicTest = function(params) {
           test.test.shader,
           test.test.subs);
 
-      var referenceVertexShader = wtu.loadShader(gl, referenceVertexShaderSource, gl.VERTEX_SHADER, testFailed);
-      var referenceFragmentShader = wtu.loadShader(gl, referenceFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed);
-      var testVertexShader = wtu.loadShader(gl, testVertexShaderSource, gl.VERTEX_SHADER, testFailed);
-      var testFragmentShader = wtu.loadShader(gl, testFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed);
-
       debug("");
-      wtu.addShaderSources(
-          gl, console, "reference vertex shader", referenceVertexShader,
-          referenceVertexShaderSource);
-      wtu.addShaderSources(
-          gl, console, "reference fragment shader", referenceFragmentShader,
-          referenceFragmentShaderSource);
-      wtu.addShaderSources(
-          gl, console, "test vertex shader", testVertexShader,
-          testVertexShaderSource);
-      wtu.addShaderSources(
-          gl, console, "test fragment shader", testFragmentShader,
-          testFragmentShaderSource);
+      var referenceVertexShader = wtu.loadShader(gl, referenceVertexShaderSource, gl.VERTEX_SHADER, testFailed, true, 'reference');
+      var referenceFragmentShader = wtu.loadShader(gl, referenceFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed, true, 'reference');
+      var testVertexShader = wtu.loadShader(gl, testVertexShaderSource, gl.VERTEX_SHADER, testFailed, true, 'test');
+      var testFragmentShader = wtu.loadShader(gl, testFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed, true, 'test');
       debug("");
 
       var refData = draw(referenceVertexShader, referenceFragmentShader);
@@ -600,7 +575,7 @@ var runBasicTest = function(params) {
     }
     div.appendChild(document.createElement('br'));
 
-    console.appendChild(div);
+    consoleDiv.appendChild(div);
 
     if (!same) {
       testFailed("images are different");
@@ -608,7 +583,7 @@ var runBasicTest = function(params) {
       testPassed("images are the same");
     }
 
-    console.appendChild(document.createElement('hr'));
+    consoleDiv.appendChild(document.createElement('hr'));
   }
 
   function draw(vertexShader, fragmentShader) {
@@ -641,7 +616,7 @@ var runReferenceImageTest = function(params) {
   var width = 32;
   var height = 32;
 
-  var console = document.getElementById("console");
+  var consoleDiv = document.getElementById("console");
   var canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
@@ -731,16 +706,9 @@ var runReferenceImageTest = function(params) {
           isVertex ? gridRes : height,
           isVertex);
 
-      var testVertexShader = wtu.loadShader(gl, testVertexShaderSource, gl.VERTEX_SHADER, testFailed);
-      var testFragmentShader = wtu.loadShader(gl, testFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed);
-
       debug("");
-      wtu.addShaderSources(
-          gl, console, "test vertex shader", testVertexShader,
-          testVertexShaderSource);
-      wtu.addShaderSources(
-          gl, console, "test fragment shader", testFragmentShader,
-          testFragmentShaderSource);
+      var testVertexShader = wtu.loadShader(gl, testVertexShaderSource, gl.VERTEX_SHADER, testFailed, true);
+      var testFragmentShader = wtu.loadShader(gl, testFragmentShaderSource, gl.FRAGMENT_SHADER, testFailed, true);
       debug("");
 
       var refData;
@@ -785,7 +753,7 @@ var runReferenceImageTest = function(params) {
             Math.abs(refData[offset + 1] - testData[offset + 1]) > tolerance ||
             Math.abs(refData[offset + 2] - testData[offset + 2]) > tolerance ||
             Math.abs(refData[offset + 3] - testData[offset + 3]) > tolerance) {
-          console.appendChild(document.createTextNode('at (' + xx + ',' + yy + '): ref=(' +
+          consoleDiv.appendChild(document.createTextNode('at (' + xx + ',' + yy + '): ref=(' +
                                                       refData[offset + 0] + ',' +
                                                       refData[offset + 1] + ',' +
                                                       refData[offset + 2] + ',' +
@@ -794,9 +762,7 @@ var runReferenceImageTest = function(params) {
                                                       testData[offset + 1] + ',' +
                                                       testData[offset + 2] + ',' +
                                                       testData[offset + 3] + ')'));
-          console.appendChild(document.createElement('br'));          
-
-
+          consoleDiv.appendChild(document.createElement('br'));
 
           imgData.data[imgOffset] = 255;
           same = false;
@@ -819,7 +785,7 @@ var runReferenceImageTest = function(params) {
     }
     div.appendChild(document.createElement('br'));
 
-    console.appendChild(div);
+    consoleDiv.appendChild(div);
 
     if (!same) {
       testFailed("images are different");
@@ -827,7 +793,7 @@ var runReferenceImageTest = function(params) {
       testPassed("images are the same");
     }
 
-    console.appendChild(document.createElement('hr'));
+    consoleDiv.appendChild(document.createElement('hr'));
   }
 
   function draw(vertexShader, fragmentShader) {


### PR DESCRIPTION
The translated shader source can be useful when debugging shader
translator or GPU driver issues, so display it alongside the original
source if WEBGL_debug_shaders is available.

Also includes some cleanup of related code.
