### PR TITLE
Do not show 1.0.1 and 1.0.2 test subsets in version selector

### DIFF
--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -169,8 +169,6 @@ var OPTIONS = {
 };
 
 var testVersions = [
-  "1.0.1",
-  "1.0.2",
   "1.0.3 (beta)",
   "2.0.0 (beta)"
 ];
@@ -622,7 +620,7 @@ function start() {
       // generate a text summary
       var tx = "";
       tx += "WebGL Conformance Test Results\n";
-      tx += "Subset: Version " + OPTIONS.version + "\n";
+      tx += "Version " + OPTIONS.version + "\n";
       tx += "\n";
       tx += "-------------------\n\n";
       tx += "User Agent: " + (navigator.userAgent ? navigator.userAgent : "(navigator.userAgent is null)") + "\n";
@@ -966,7 +964,7 @@ function start() {
             <div id="info">
               <img src="resources/webgl-logo.png" /><br />
               WebGL Conformance Test Runner<br/>
-              Subset: Version 
+              Version 
               <select id="testVersion">
               </select>
               <br/>


### PR DESCRIPTION
The version selector in the latest version of the conformance suite seems
to be misleading. It suggests to people new to the conformance suite that
they're running the 1.0.1 or 1.0.2 tests, when in fact some of the tests
in the subset might be updated to increase coverage after the old version
of the test suite was frozen. Remove 1.0.1 and 1.0.2 from the selector to
reduce confusion.
