### PR TITLE
Remove outdated spec section about implementation color read format

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 15 April 2014</h2>
+    <h2 class="no-toc">Editor's Draft 17 April 2014</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -3540,20 +3540,6 @@ In the WebGL API, the <code>EXTENSIONS</code> enumerant has been removed.
 Instead, <code>getSupportedExtensions</code> must be called to determine the set of available
 extensions.
 
-</p>
-
-    <h3><a name="IMPLEMENTATION_READ_FORMAT">Implementation Color Read Format and Type</a></h3>
-
-<p>
-
-    In the OpenGL ES 2.0 API, the
-    <code>IMPLEMENTATION_COLOR_READ_FORMAT</code> and
-    <code>IMPLEMENTATION_COLOR_READ_TYPE</code> parameters are used to inform applications of an
-    additional format and type combination that may be passed to <code>ReadPixels</code>, in
-    addition to the required <ncode>RGBA</code>/<code>UNSIGNED_BYTE</code> pair.  In WebGL 1.0,
-    the supported format and type combinations to <code>ReadPixels</code> are documented in the
-    <a href="#readpixels">Reading back pixels</a> section.  The <code>IMPLEMENTATION_COLOR_READ_FORMAT</code>
-    and <code>IMPLEMENTATION_COLOR_READ_TYPE</code> enumerants have been removed.
 </p>
 
     <h3><a name="COMPRESSED_TEXTURE_SUPPORT">Compressed Texture Support</a></h3>


### PR DESCRIPTION
IMPLEMENTATION_COLOR_READ_TYPE and IMPLEMENTATION_COLOR_READ_FORMAT were
reintroduced to WebGL recently. Remove the section that still claims
they're not included.
