### PR TITLE
Only restore the context on preventDefault

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3113,7 +3113,7 @@ dictionary WebGLContextEventInit : <a href="http://www.w3.org/TR/domcore/#eventi
 
             <li> If the
             event's <a href="http://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html#canceled-flag">canceled
-            flag</a> is set, abort these steps. </li>
+            flag</a> is not set, abort these steps. </li>
 
             <li> Perform the following steps asynchronously. </li>
 


### PR DESCRIPTION
preventDefault() appears to _set_ the cancelled flag, so we should abort context restoration if the cancelled flag is _not_ set.
