### PR TITLE
Added test for a shader compiler error when using ANGLE's D3D11 backend

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 1.0.3 angle-d3d11-compiler-error.html
 --min-version 1.0.3 array-of-struct-with-int-first-position.html
 --min-version 1.0.3 compare-loop-index-to-uniform.html
 --min-version 1.0.3 complex-glsl-does-not-crash.html

--- a/sdk/tests/conformance/glsl/bugs/angle-d3d11-compiler-error.html
+++ b/sdk/tests/conformance/glsl/bugs/angle-d3d11-compiler-error.html
@@ -29,11 +29,10 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL ShaderL Conformance Tests</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../resources/desktop-gl-constants.js" type="text/javascript"></script>
-<script src="../../resources/js-test-pre.js"></script>
-<script src="../resources/webgl-test-utils.js"></script>
+<title>ANGLE D3D11 Bug - Shader compilation error</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
 </head>
 <body>
 
@@ -60,7 +59,8 @@ void main() {
 <canvas id="canvas" width="2" height="2"> </canvas>
 <script>
 "use strict";
-description("This test checks a ANGLE shader compiler error.");
+// See http://crbug.com/371868 for original failing case.
+description("This test checks an ANGLE D3D11 shader compiler error.");
 
 debug("");
 debug("Canvas.getContext");
@@ -75,10 +75,10 @@ if (!gl) {
   debug("");
   debug("Checking shader compilation and linking.");
 
-  checkCompliation()
+  checkCompilation()
 }
 
-function checkCompliation() {
+function checkCompilation() {
   var vs = gl.createShader(gl.VERTEX_SHADER);
   gl.shaderSource(vs, document.getElementById("vs").text);
   gl.compileShader(vs);
@@ -111,7 +111,7 @@ debug("");
 var successfullyParsed = true;
 
 </script>
-<script src="../../resources/js-test-post.js"></script>
+<script src="../../../resources/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/conformance/programs/00_test_list.txt
+++ b/sdk/tests/conformance/programs/00_test_list.txt
@@ -1,4 +1,3 @@
---min-version 1.0.3 angle-d3d11-compiler-error.html
 get-active-test.html
 gl-bind-attrib-location-test.html
 --min-version 1.0.2 gl-bind-attrib-location-long-names-test.html


### PR DESCRIPTION
See http://crbug.com/371868 for the issue that notified us to this problem.
