### PR TITLE
Removed unnecessary function and enums from EXT_blend_minmax spec

### DIFF
--- a/extensions/EXT_blend_minmax/extension.xml
+++ b/extensions/EXT_blend_minmax/extension.xml
@@ -39,7 +39,7 @@
   <samplecode xml:space="preserve">
     <pre>
         var ext = gl.getExtension('EXT_blend_minmax');
-        ext.blendEquation(ext.MAX_EXT);
+        gl.blendEquation(ext.MAX_EXT);
         gl.getParameter(gl.BLEND_EQUATION) == ext.MAX_EXT;
     </pre>
   </samplecode>


### PR DESCRIPTION
In the EXT_blend_minmax spec we're currently specifying that a blendEquationEXT function be added, as well as the FUNC_ADD_EXT and BLEND_EQUATION_EXT enums. This is inline with the original GLES extension, but fails to account for the fact that the original extension was written against ES 1, which didn't have blendEquation. ES 2 does include blendEquation (and blendEquationSeparate), and as such the enums should simply be passed to it. Similarly, FUNC_ADD and BLEND_EQUATION are already part of the WebGL spec and don't need redefining.
