### PR TITLE
moved EXT_frag_depth to community approved

### DIFF
--- a/extensions/EXT_frag_depth/extension.xml
+++ b/extensions/EXT_frag_depth/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_frag_depth/">
+<extension href="EXT_frag_depth/">
   <name>EXT_frag_depth</name>
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
@@ -53,5 +53,8 @@
     <revision date="2012/12/17">
       <change>Moved to draft.</change>
     </revision>
+    <revision date="2014/05/13">
+      <change>Moved to community approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>


### PR DESCRIPTION
I propose to move EXT_frag_depth to community approved because google chrome now has it live in a stable release behind the draft flag.
