### PR TITLE
Use a relative rather than an absolute link for the specs/ redirect.

### DIFF
--- a/specs/latest/index.html
+++ b/specs/latest/index.html
@@ -1,2 +1,2 @@
-<meta http-equiv="refresh" content="0;url=http://www.khronos.org/registry/webgl/specs/latest/1.0/" />
-<a href="http://www.khronos.org/registry/webgl/specs/latest/1.0/">This page has moved.</a>
+<meta http-equiv="refresh" content="0;url=1.0/" />
+<a href="1.0/">This page has moved.</a>


### PR DESCRIPTION
This simplifies local testing of spec changes.
