### PR TITLE
1.0.1 and 1.0.2 versions of webgl-debug-shaders test had errors

### DIFF
--- a/conformance-suites/1.0.1/conformance/extensions/webgl-debug-shaders.html
+++ b/conformance-suites/1.0.1/conformance/extensions/webgl-debug-shaders.html
@@ -75,9 +75,9 @@ function runTestEnabled() {
 
     // if no source has been defined or compileShader() has not been called,
     // getTranslatedShaderSource() should return an empty string.
-    shouldBeNull("ext.getTranslatedShaderSource(shader)");
+    shouldBe("ext.getTranslatedShaderSource(shader)", '""');
     gl.shaderSource(shader, source);
-    shouldBeNull("ext.getTranslatedShaderSource(shader)");
+    shouldBe("ext.getTranslatedShaderSource(shader)", '""');
     gl.compileShader(shader);
     shouldBeTrue("gl.getShaderParameter(shader, gl.COMPILE_STATUS)");
     var translatedSource = ext.getTranslatedShaderSource(shader);

--- a/conformance-suites/1.0.2/conformance/extensions/webgl-debug-shaders.html
+++ b/conformance-suites/1.0.2/conformance/extensions/webgl-debug-shaders.html
@@ -55,6 +55,7 @@ var shader = null;
 var program = null;
 var info = null;
 var translatedSource;
+var newTranslatedSource;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -117,9 +118,9 @@ function runTestEnabled() {
 
             // if no source has been defined or compileShader() has not been called,
             // getTranslatedShaderSource() should return an empty string.
-            shouldBeNull("ext.getTranslatedShaderSource(shader)");
+            shouldBe("ext.getTranslatedShaderSource(shader)", '""');
             gl.shaderSource(shader, info.source);
-            shouldBeNull("ext.getTranslatedShaderSource(shader)");
+            shouldBe("ext.getTranslatedShaderSource(shader)", '""');
             gl.compileShader(shader);
             shouldBeTrue("gl.getShaderParameter(shader, gl.COMPILE_STATUS)");
             translatedSource = ext.getTranslatedShaderSource(shader);


### PR DESCRIPTION
Tests also weren't spec-conformant. Patch allows them to pass cleanly with the newly perma-enabled extension in Chrome.
