### PR TITLE
getQuery can only return a WebGLQuery object or null

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -748,8 +748,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   void beginQuery(GLenum target, WebGLQuery? query);
   void endQuery(GLenum target);
   WebGLQuery? getQuery(GLenum target, GLenum pname);
-  /* TODO: document return type */
-  any getQueryParameter(WebGLQuery? query, GLenum pname);
+  GLuint getQueryObject(WebGLQuery? query, GLenum pname);
 
   /* Sampler Objects */
   WebGLSampler? createSampler();

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -411,8 +411,7 @@ interface WebGL2RenderingContextBase
   void beginQuery(GLenum target, WebGLQuery? query);
   void endQuery(GLenum target);
   WebGLQuery? getQuery(GLenum target, GLenum pname);
-  /* TODO: document return type */
-  any getQueryParameter(WebGLQuery? query, GLenum pname);
+  GLuint getQueryObject(WebGLQuery? query, GLenum pname);
 
   /* Sampler Objects */
   WebGLSampler? createSampler();


### PR DESCRIPTION
I'd like a review on this one. My reading of the ES2 spec suggests that this can only return the name of the currently active query target, or null.
