### PR TITLE
Pass through shader result should always be true

### DIFF
--- a/sdk/tests/conformance/resources/glsl-constructor-tests-generator.js
+++ b/sdk/tests/conformance/resources/glsl-constructor-tests-generator.js
@@ -606,14 +606,14 @@ function getVertexAndFragmentShaderTestCase(targetType, argExp) {
       vShaderSource:  wtu.replaceParams(constructorVertexTemplate, substitutions),
       vShaderSuccess: expInfo.valid,
       fShaderSource:  passThroughColorFragmentShader,
-      fShaderSuccess: expInfo.valid,
+      fShaderSuccess: true,
       linkSuccess:    expInfo.valid,
       passMsg:        "Vertex shader : " + argCode.typeExp + ", " + expInfo.testMsg,
       render:         expInfo.valid
     }, {
       // Test constructor argument list in fragment shader
       vShaderSource:  GLSLConformanceTester.defaultVertexShader,
-      vShaderSuccess: expInfo.valid,
+      vShaderSuccess: true,
       fShaderSource:  wtu.replaceParams(constructorFragmentTemplate, substitutions),
       fShaderSuccess: expInfo.valid,
       linkSuccess:    expInfo.valid,


### PR DESCRIPTION
Result of compilation of pass through (vertex or fragment) shader should
always be true and not set to the result of the test
