### PR TITLE
Revert "getQueryParameter should be getQueryObject"

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -776,7 +776,8 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   void beginQuery(GLenum target, WebGLQuery? query);
   void endQuery(GLenum target);
   WebGLQuery? getQuery(GLenum target, GLenum pname);
-  GLuint getQueryObject(WebGLQuery? query, GLenum pname);
+  /* TODO: document return type */
+  any getQueryParameter(WebGLQuery? query, GLenum pname);
 
   /* Sampler Objects */
   WebGLSampler? createSampler();

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -411,7 +411,8 @@ interface WebGL2RenderingContextBase
   void beginQuery(GLenum target, WebGLQuery? query);
   void endQuery(GLenum target);
   WebGLQuery? getQuery(GLenum target, GLenum pname);
-  GLuint getQueryObject(WebGLQuery? query, GLenum pname);
+  /* TODO: document return type */
+  any getQueryParameter(WebGLQuery? query, GLenum pname);
 
   /* Sampler Objects */
   WebGLSampler? createSampler();


### PR DESCRIPTION
This reverts commit 0afa2c453b6f2e38614379de9e40cadd625ec15f.

As pointed out by Ken, getQueryParameter is the form taken
by the remainder of the WebGL API.
