### PR TITLE
Improvements to WEBGL_draw_buffers extension test

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -642,7 +642,7 @@ function runDrawTests() {
     }
   }
 
-  debug("test switching between fbos keeps drawbuffer state");
+  debug("test switching between fbos does not affect any color attachment contents");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
   ext.drawBuffersWEBGL(nones);
 
@@ -652,6 +652,7 @@ function runDrawTests() {
   gl.clear(gl.COLOR_BUFFER_BIT);
   checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
+  // fb2 still has the NONE draw buffers from before, so this draw should be a no-op.
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
   gl.useProgram(drawProgram);
   wtu.drawUnitQuad(gl);


### PR DESCRIPTION
Clarifications, tighter checks for parameters (according to the WebGL
extension spec, MAX_COLOR_ATTACHMENTS_WEBGL should be at least 4 and at
least the same as MAX_DRAW_BUFFERS_WEBGL) and a typo fix.
