### PR TITLE
Make MAX_DRAW_BUFFERS and MAX_COLOR_ATTACHMENTS equal

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1818,6 +1818,13 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         systems and devices.
     </p>
 
+    <h3>Draw buffers</h3>
+
+    <p>
+        The value of the MAX_COLOR_ATTACHMENTS parameter must be equal to that of the MAX_DRAW_BUFFERS
+        parameter.
+    </p>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>


### PR DESCRIPTION
There's no benefit from having more color attachments than draw buffers,
or vice versa, since the highest-numbered color attachment that is
accessible for rendering is COLOR_ATTACHMENT<min(MAX_DRAW_BUFFERS,
MAX_COLOR_ATTACHMENTS) - 1>. This clarifies the API, like a similar
addition in the WEBGL_draw_buffers spec.
