### PR TITLE
Remove DrawRangeElements from WebGL 2

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -753,9 +753,6 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   void vertexAttribDivisor(GLuint index, GLuint divisor);
   void drawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount);
   void drawElementsInstanced(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei instanceCount);
-  /* TODO(kbr): argue against exposing this because it can't safely
-     offer better performance than drawElements */
-  void drawRangeElements(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, GLintptr offset);
 
   /* Multiple Render Targets */
   void drawBuffers(sequence&lt;GLenum&gt; buffers);
@@ -1348,14 +1345,6 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           </span>
         </p>
       </dt>
-      <dt>
-        <p class="idl-code">void drawRangeElements(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, GLintptr offset)
-          <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-2.8.3">OpenGL ES 3.0.3 &sect;2.8.3</a>,
-            <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDrawRangeElements.xhtml" class="nonnormative">man page</a>)
-          </span>
-        </p>
-      </dt>
     </dl>
 
 <!-- ======================================================================================================= -->
@@ -1816,6 +1805,12 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         This section describes changes made to the WebGL API relative to the
         OpenGL ES 3.0 API to improve portability across various operating
         systems and devices.
+    </p>
+
+    <h3>No DrawRangeElements</h3>
+
+    <p>
+        DrawRangeElements is not supported in the WebGL 2 API.
     </p>
 
     <h3>Draw buffers</h3>


### PR DESCRIPTION
WebGL would require that the implementation handles indices that are
outside the start, end range in a consistent way, but the OpenGL ES 3.0
specification explicitly states that behavior in this case is
implementation-dependent. Because of this, WebGL would need to validate
that the indices are in the start, end range to ensure consistent
behavior, and no performance benefits could be realized by exposing this
function.
