### PR TITLE
Add information on range checking and primitive restart in WebGL 2

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -847,12 +847,9 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <dl class="methods">
         <dt class="idl-code"><a name="GETPARAMETER">any getParameter</a>(GLenum pname)
-            <a class="gl-spec" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGet.xhtml">
-                (glGet OpenGL ES 3.0 man page)
-            </a>
-            <a class="gl-spec" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetString.xhtml">
-                (glGetString OpenGL ES 3.0 man page)
-            </a>
+            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-6.1.1">OpenGL ES 3.0.3 &sect;6.1.1</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGet.xhtml">glGet OpenGL ES 3.0 man page</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetString.xhtml">glGetString OpenGL ES 3.0 man page</a>)</span>
         <dd>
             Return the value for the passed pname. As well as supporting all
             the pname/type values from WebGL 1.0, the following parameters are supported:
@@ -900,6 +897,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
                 <tr><td>PIXEL_PACK_BUFFER_BINDING</td><td>WebGLBuffer</td></tr>
                 <tr><td>PIXEL_UNPACK_BUFFER_BINDING</td><td>WebGLBuffer</td></tr>
                 <tr><td>PRIMITIVE_RESTART_FIXED_INDEX</td><td>GLboolean</td></tr>
+                <tr><td>RASTERIZER_DISCARD</td><td>GLboolean</td></tr>
                 <tr><td>READ_BUFFER</td><td>GLenum</td></tr>
                 <tr><td>READ_FRAMEBUFFER_BINDING</td><td>WebGLFramebuffer</td></tr>
                 <tr><td>SAMPLE_ALPHA_TO_COVERAGE</td><td>GLboolean</td></tr>
@@ -942,6 +940,11 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
             <p>If <code class="param">target</code> is not in the table above, generates an <code>INVALID_ENUM</code> error.</p>
             <p>If <code class="param">index</code> is outside of the valid range for the indexed state <code class="param">target</code>, generates an <code>INVALID_VALUE</code> error.</p>
             <p>If an OpenGL error is generated, returns null.</p>
+        <dt class="idl-code"><a name="ISENABLED">GLboolean isEnabled</a>(GLenum cap)
+            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-6.1.1">OpenGL ES 3.0.3 &sect;6.1.1</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsEnabled.xhtml">OpenGL ES 3.0 man page</a>)</span>
+        <dd>
+            In addition to all of the <code class="param">cap</code> values from WebGL 1.0, PRIMITIVE_RESTART_FIXED_INDEX and RASTERIZER_DISCARD are supported.
     </dl>
 
 <!-- ======================================================================================================= -->


### PR DESCRIPTION
Includes filling out some differences between WebGL 1 and WebGL 2.
