### PR TITLE
Improve VAO extension test

### DIFF
--- a/sdk/tests/conformance/extensions/oes-vertex-array-object.html
+++ b/sdk/tests/conformance/extensions/oes-vertex-array-object.html
@@ -407,7 +407,7 @@ function runDrawTests() {
             var x = Math.round((1 - points[n]) * canvas.width / 2);
             var y = Math.round((1 - points[n]) * canvas.height / 2);
             var source = readLocation(x, y);
-            if (Math.abs(source[0] - expected) > 5) {
+            if (Math.abs(source[0] - expected) > 2) {
                 return false;
             }
         }


### PR DESCRIPTION
This commit makes the following improvements to the VAO extension test:
-Adds testing switching between VAOs that have different number of arrays
enabled.
-Uses a color attribute instead of using a texture coordinate attribute
which is meaningless since a texture is not used.
-Refactors testing pixels to remove unnecessary indirection.
-Fixes typos and makes the test output more descriptive.
