### PR TITLE
Added test for -1 index.

### DIFF
--- a/sdk/tests/conformance/rendering/00_test_list.txt
+++ b/sdk/tests/conformance/rendering/00_test_list.txt
@@ -10,6 +10,7 @@ gl-scissor-test.html
 --min-version 1.0.3 many-draw-calls.html
 more-than-65536-indices.html
 multisample-corruption.html
+--min-version 1.0.3 negative-one-index.html
 point-size.html
 --min-version 1.0.3 point-with-gl-pointcoord-in-fragment-shader.html
 --min-version 1.0.3 polygon-offset.html

--- a/sdk/tests/conformance/rendering/negative-one-index.html
+++ b/sdk/tests/conformance/rendering/negative-one-index.html
@@ -1,0 +1,112 @@
+﻿<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+  <head>
+<meta charset="utf-8">
+    <title>-1 Index Rendering Test</title>
+    <link rel="stylesheet" href="../../resources/js-test-style.css"/>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../resources/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="example" width="50" height="50">
+</canvas>
+<div id="description"></div>
+<div id="console"></div>
+    <script id="vshader" type="x-shader/x-vertex">
+        attribute vec4 vPosition;
+        void main()
+        {
+            gl_Position = vPosition;
+        }
+    </script>
+
+    <script id="fshader" type="x-shader/x-fragment">
+        void main()
+        {
+            gl_FragColor = vec4(0.0,1.0,0.0,1.0);
+        }
+    </script>
+
+    <script>
+        "use strict";
+        function init()
+        {
+            description(document.title);
+
+            var wtu = WebGLTestUtils;
+            var gl = wtu.create3DContext("example");
+            var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
+
+            var vertexObject = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
+            var vertexData = new Float32Array(65536 * 3);
+            vertexData[0 * 3 + 0] = 0.0;
+            vertexData[0 * 3 + 1] = 0.5;
+            vertexData[0 * 3 + 2] = 0.0;
+            vertexData[1 * 3 + 0] = -0.5;
+            vertexData[1 * 3 + 1] = -0.5;
+            vertexData[1 * 3 + 2] = 0.0;
+            vertexData[65535 * 3 + 0] = 0.5;
+            vertexData[65535 * 3 + 1] = -0.5;
+            vertexData[65535 * 3 + 2] = 0.0;
+            gl.bufferData(gl.ARRAY_BUFFER, vertexData, gl.STATIC_DRAW);
+            gl.enableVertexAttribArray(0);
+            gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+            var indices = new Uint16Array([0, 1, -1]);
+            var indexBuffer = gl.createBuffer();
+            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+            gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+
+            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+            gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0);
+
+            // This should render a green triangle in the middle of the canvas.
+            // Some implementations may incorrectly interpret the -1 index as
+            // a primitive restart and not render anything.
+
+            // Test several locations
+            // First line should be all black
+            wtu.checkCanvasRect(gl, 0, 0, 50, 1, [0, 0, 0, 0]);
+
+            // Line 15 should be green for at least 10 red pixels starting 20 pixels in
+            wtu.checkCanvasRect(gl, 20, 15, 10, 1, [0, 255, 0, 255]);
+
+            // Last line should be all black
+            wtu.checkCanvasRect(gl, 0, 49, 50, 1, [0, 0, 0, 0]);
+       }
+
+       init();
+       var successfullyParsed = true;
+    </script>
+<script src="../../resources/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Some implementations may treat a -1 in the element array buffer
(65535 for 16-bit indices) as a primitive restart marker.
Instead for ES2 it should always be a valid regular index.
