### PR TITLE
Make insufficient uniform block backing an error in WebGL 2

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1417,8 +1417,9 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
         WebGL 2 performs additional error checking beyond that specified in OpenGL ES 3.0 during calls to
         <code>drawElements</code>, <code>drawArrays</code>, <code>drawRangeElements</code> and their
-        instanced variants. See <a href="#RANGE_CHECKING">Range Checking</a> and
-        <a href="#ENABLED_ATTRIBUTE">Enabled Attribute</a>.
+        instanced variants. See <a href="#RANGE_CHECKING">Range Checking</a>,
+        <a href="#ENABLED_ATTRIBUTE">Enabled Attribute</a>, and <a href="#ACTIVE_UNIFORM_BLOCK_BACKING">Active
+        Uniform Block Backing</a>.
       </dd>
     </dl>
 
@@ -1991,6 +1992,15 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <code>drawRangeElements</code> or their instanced variants generates an <code>INVALID_OPERATION</code>
         error if there is not at least one enabled vertex attribute array that has a divisor of zero and is
         bound to an active generic attribute value in the program used for the draw command.
+    </p>
+
+    <h3><a name="ACTIVE_UNIFORM_BLOCK_BACKING">Active Uniform Block Backing</a></h3>
+
+    <p>
+        In the WebGL 2 API, attempting to draw with <code>drawArrays</code>, <code>drawElements</code>,
+        <code>drawRangeElements</code> or their instanced variants generates an <code>INVALID_OPERATION</code>
+        error if any active uniform block in the program used for the draw command is not backed by a
+        sufficiently large buffer object.
     </p>
 
     <h3>Default Framebuffer</h3>


### PR DESCRIPTION
In GLES3, insufficient backing is allowed to result in GL interruption or
termination. In WebGL, it should be checked.
