### PR TITLE
Fix typos in extension tests and add #extension directive test

### DIFF
--- a/sdk/tests/conformance/extensions/oes-vertex-array-object.html
+++ b/sdk/tests/conformance/extensions/oes-vertex-array-object.html
@@ -140,7 +140,7 @@ function runBindingTestEnabled() {
     shouldBe("ext.VERTEX_ARRAY_BINDING_OES", "0x85B5");
     
     gl.getParameter(ext.VERTEX_ARRAY_BINDING_OES);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "VERTEX_ARRAY_BINDING_OES query should succeed if extension is enable");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "VERTEX_ARRAY_BINDING_OES query should succeed if extension is enabled");
     
     // Default value is null
     if (gl.getParameter(ext.VERTEX_ARRAY_BINDING_OES) === null) {

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -177,7 +177,7 @@ if (!gl) {
 function createExtDrawBuffersProgram(scriptId, sub) {
   var fsource = wtu.getScript(scriptId);
   fsource = wtu.replaceParams(fsource, sub);
-  wtu.addShaderSource(output, "fragement shader", fsource);
+  wtu.addShaderSource(output, "fragment shader", fsource);
   return wtu.setupProgram(gl, ["vshader", fsource], ["a_position"]);
 }
 
@@ -245,7 +245,7 @@ function testShaders(tests, sub) {
   tests.forEach(function(test) {
     var shaders = [wtu.getScript(test.shaders[0]), wtu.replaceParams(wtu.getScript(test.shaders[1]), sub)];
     wtu.addShaderSource(output, "vertex shader", shaders[0]);
-    wtu.addShaderSource(output, "fragement shader", shaders[1]);
+    wtu.addShaderSource(output, "fragment shader", shaders[1]);
     var program = wtu.setupProgram(gl, shaders, ["a_position"]);
     var programLinkedSuccessfully = (program != null);
     var expectedProgramToLinkSuccessfully = (test.expectFailure == true);
@@ -278,6 +278,9 @@ function runShadersTestEnabled() {
   testShaders([
     { shaders: ["vshader", "fshaderMacroEnabled"],
     msg: "GL_EXT_draw_buffers should be defined as 1 in GLSL",
+    },
+    { shaders: ["vshader", "fshader"],
+    msg: "fragment shader containing the #extension directive should compile",
     },
   ], sub);
 

--- a/sdk/tests/conformance2/core/draw-buffers.html
+++ b/sdk/tests/conformance2/core/draw-buffers.html
@@ -92,7 +92,7 @@ if (!gl) {
 function createDrawBuffersProgram(scriptId, sub) {
   var fsource = wtu.getScript(scriptId);
   fsource = wtu.replaceParams(fsource, sub);
-  wtu.addShaderSource(output, "fragement shader", fsource);
+  wtu.addShaderSource(output, "fragment shader", fsource);
   return wtu.setupProgram(gl, ["vshader", fsource], ["a_position"]);
 }
 


### PR DESCRIPTION
Testing the #extension directive separately makes it more obvious where a
bug in a WEBGL_draw_buffers implementation might be. Firefox currently
seems to be suffering from a bug where WEBGL_draw_buffers is exposed on
all GLES3-capable devices without checking that they support the GLES2
extension. On a careful reading of the GLES3 spec section 4.2.1, it seems
that multiple draw buffers are not supported for GLSL ES 1.0 shaders on
vanilla GLES3, even though multiple draw buffers are otherwise part of
the specification.
