### PR TITLE
Conditional discard in loop test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -10,3 +10,4 @@
 --min-version 1.0.3 sampler-array-using-loop-index.html
 --min-version 1.0.3 temp-expressions-should-not-crash.html
 --min-version 1.0.3 uniforms-should-not-lose-values.html
+--min-version 1.0.3 conditional-discard-in-loop.html

--- a/sdk/tests/conformance/glsl/bugs/conditional-discard-in-loop.html
+++ b/sdk/tests/conformance/glsl/bugs/conditional-discard-in-loop.html
@@ -1,0 +1,161 @@
+<!--
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Conditional discard in loop issue</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+</head>
+
+<body>
+<canvas id="output" style="border: none;" width="256" height="256"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script id="shader-vs" type="x-shader/x-vertex">
+// Inputs
+attribute vec4 a_position; 
+attribute vec2 a_tex_coords; 
+
+// Output
+varying vec2   v_tex_coords; 
+    
+void main(void) { 
+    v_tex_coords = a_tex_coords; 
+    gl_Position  = a_position;
+} 
+</script>
+
+<script id="shader-fs" type="x-shader/x-fragment">
+precision mediump float; 
+
+// Constants
+const float TEXEL_COUNT_V = 256.0; 
+const float TEXEL_HEIGHT  = 1.0 / TEXEL_COUNT_V; 
+const float SEP_IX        = TEXEL_COUNT_V / 2.0;
+
+const vec4 GREEN = vec4(0.0, 1.0, 0.0, 1.0); 
+const vec4 BLUE  = vec4(0.0, 0.0, 1.0, 1.0); 
+
+// Input
+varying vec2 v_tex_coords; 
+
+uniform sampler2D u_data; 
+
+// Without this function or directly returning the data, the issue does not occur
+mediump vec4 UnpackData(in vec4 inData) {
+     float s = inData.x;
+     // Note s is always 0 
+     // mod(0, 1) = 0 
+     // So return value = (0, 0, -1, 0) 
+    return vec4(0.0, 0.0, mod(s, 1.0) - 1.0, 0.0);
+    
+    // Comment out the line above and uncomment the line below and the test succeeds on angle-dx11
+    // return vec4(0.0, 0.0, -1.0, 0.0);
+} 
+
+void main(void) {
+     // Set initial color 
+    gl_FragColor = BLUE; 
+
+    if (gl_FragCoord.y <= SEP_IX) {
+        mediump vec2 addr = vec2(v_tex_coords.x, TEXEL_HEIGHT);
+
+        for (float e_ix = 0.0; e_ix < TEXEL_COUNT_V; ++e_ix) {
+            vec4 entry = texture2D(u_data, addr);
+            mediump vec4 unpack = UnpackData(entry);
+
+            // Buffer is filled with 0, unpack is always (0, 0, -1, 0) 
+            // So discard is always triggered  
+            if (unpack.z == -1.0) {
+                discard;
+            }
+
+            addr.y += unpack.z * TEXEL_HEIGHT;
+        }
+        // If discard is not triggered the output color is blue
+    }
+    else {
+        gl_FragColor = GREEN;
+    }
+}
+</script>
+
+
+<script>
+"use strict";
+
+description();
+debug("");
+debug("If the code is executed correctly, the upper half of the viewport will be green, the lower half will be red.");
+debug("This is a conformance suite test for the issue reported here : https://code.google.com/p/angleproject/issues/detail?id=706");
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("output");
+var gl = wtu.create3DContext(canvas);
+if (!gl) {
+  testFailed("context does not exist");
+} else {
+
+  // Create texture filled with zero's  
+  var tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, 	 gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, 	 gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  wtu.fillTexture(gl, tex, 256, 256, [0, 0, 0, 0]);
+
+  // Clear complete viewport to red    
+  gl.clearColor(1.0, 0.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+  
+  var attribBuffers = wtu.setupUnitQuad(gl);
+  var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], attribBuffers);
+
+  // Bind texture  
+  var uniformMap = wtu.getUniformMap(gl, program);
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.uniform1i(uniformMap.u_data.location, 0);
+
+  // Draw
+  wtu.drawUnitQuad(gl);
+  
+  // Verify output
+  wtu.checkCanvasRect(gl, 0,   0, 256, 128, [ 255,   0,   0, 255 ], "should be red",    1);
+  wtu.checkCanvasRect(gl, 0, 128, 256, 128, [   0, 255,   0, 255 ], "should be green",  1);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Test for issue with conditional discard in loop for angle directx 11 implementation.
Conformance suite test for reported issue : https://code.google.com/p/angleproject/issues/detail?id=706
Chrome stable 36.0.1985.125 m, Chrome canary 38.0.2117.2 canary and Opera 23.0.1522.72 fail this test.
All are using angle with directx 11 as backend.
Firefox (both native and angle dx9) , maxthon and IE 11 pass the test.
Also the Chrome builds with angle dx9 backend (--disable-d3d11 on commandline)  pass the test.
