### PR TITLE
Test that setting line width to NaN is not an error

### DIFF
--- a/sdk/tests/conformance/misc/error-reporting.html
+++ b/sdk/tests/conformance/misc/error-reporting.html
@@ -42,9 +42,8 @@ var wtu = WebGLTestUtils;
 var context = wtu.create3DContext();
 var program = wtu.loadStandardProgram(context);
 
-// Other tests in this directory like getActiveTest and
-// incorrect-context-object-behaviour already test the raising of many
-// synthetic GL errors. This test verifies the raising of certain
+// Other tests like incorrect-context-object-behaviour already test the raising
+// of many synthetic GL errors. This test verifies the raising of certain
 // known real GL errors, and contains a few regression tests for bugs
 // discovered in the synthetic error generation and in the WebGL
 // implementation itself.
@@ -87,6 +86,9 @@ shouldBeUndefined("context.framebufferTexture2D(context.FRAMEBUFFER, context.COL
 // Synthetic OpenGL error
 wtu.glErrorShouldBe(context, context.INVALID_OPERATION);
 // Error state should be clear by this point
+wtu.glErrorShouldBe(context, context.NO_ERROR);
+
+shouldBeUndefined("context.lineWidth(NaN)");
 wtu.glErrorShouldBe(context, context.NO_ERROR);
 
 var successfullyParsed = true;


### PR DESCRIPTION
This exposes an NVIDIA driver bug, where INVALID_VALUE is incorrectly
generated. glLineWidth should only produce an error when width <= 0,
which is false for width NaN.

Rendering with width NaN is undefined, so alternatively the spec could be
changed to disallow setting it, but this is unlikely to become a major
issue.
