### PR TITLE
Partially revert "Test that setting line width to NaN is not an error"

### DIFF
--- a/sdk/tests/conformance/misc/error-reporting.html
+++ b/sdk/tests/conformance/misc/error-reporting.html
@@ -88,9 +88,6 @@ wtu.glErrorShouldBe(context, context.INVALID_OPERATION);
 // Error state should be clear by this point
 wtu.glErrorShouldBe(context, context.NO_ERROR);
 
-shouldBeUndefined("context.lineWidth(NaN)");
-wtu.glErrorShouldBe(context, context.NO_ERROR);
-
 var successfullyParsed = true;
 </script>
 


### PR DESCRIPTION
This turned out to be not a driver bug after all, but within allowed
behavior. GL specs say that providing NaN or infinity to a function
accepting floating point data yields unspecified results (GLES3.0 2.1.1).
So actually, generating an error is allowed in this case.

Keep the part of the commit that fixed a comment in the test file.

This reverts commit cf16a1cae5179c76397e7bb6f56e6e91dd0cf650.
