### PR TITLE
Specify an error for setting line width to NaN

### DIFF
--- a/sdk/tests/conformance/misc/webgl-specific.html
+++ b/sdk/tests/conformance/misc/webgl-specific.html
@@ -119,6 +119,10 @@ debug("Verify that bindAttribLocation rejects names start with webgl_ or _webgl_
 wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindAttribLocation(program, 0, 'webgl_a')");
 wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindAttribLocation(program, 0, '_webgl_a')");
 
+debug("");
+debug("Verify that NaN line width is not accepted");
+wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "gl.lineWidth(NaN)");
+
 var successfullyParsed = true;
 </script>
 

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -2029,6 +2029,9 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             flag</a> is set.
         <dt class="idl-code">void lineWidth(GLfloat width)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.4">OpenGL ES 2.0 &sect;3.4</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glLineWidth.xml">man page</a>)</span>
+        <dd>
+            See <a href="#NAN_LINE_WIDTH">NaN Line Width</a> for restrictions specified for WebGL.
+        </dd>
         <dt class="idl-code">void pixelStorei(GLenum pname, GLint param)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.6.1">OpenGL ES 2.0 &sect;3.6.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glPixelStorei.xml">man page</a>)</span>
             <dd>
@@ -3674,6 +3677,12 @@ extensions.
     <li> <code>copyTexSubImage2D</code>
     <li> <code>readPixels</code>
     </ul>
+</p>
+
+<h3><a name="NAN_LINE_WIDTH">NaN Line Width</a></h3>
+<p>
+    In the WebGL API, if the <code>width</code> parameter passed to <code>lineWidth</code> is set
+    to NaN, an <code>INVALID_VALUE</code> error is generated and the line width is not changed.
 </p>
 
 <!-- ======================================================================================================= -->


### PR DESCRIPTION
OpenGL drivers are allowed to generate errors when NaN is supplied to
functions under GLES 3.1 section 2.3.3.1 or OpenGL 4.5 section 2.3.4.1.
Similar clauses exist in earlier versions of the specs as well. NVIDIA
OpenGL driver generates an error when NaN is supplied to glLineWidth.
Make this behavior consistent for WebGL, which removes the possibility of
drawing with an undefined line width.

Functions which supply data to shaders are not changed, as this would
have an undesirable performance cost and only a small benefit, since it
would not prevent shaders themselves to generate NaNs.
