### PR TITLE
Make sure buffer access is synchronized in WebGL 2

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -968,7 +968,13 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         If <code>returnedData</code> is null then an <code>INVALID_VALUE</code> error is generated.
         If <code>offset</code> is less than zero, an <code>INVALID_VALUE</code> error is generated.
         If zero is bound to <code>target</code>, an <code>INVALID_OPERATION</code> error is generated.
+        If <code>target</code> is <code>TRANSFORM_FEEDBACK_BUFFER</code>, and any transform feedback object
+        is currently active, an <code>INVALID_OPERATION</code> error is generated.
         If any error is generated, no data is written to <code>returnedData</code>.
+        <br><br>
+        If the buffer is written and read sequentially by other operations and <code>getBufferSubData</code>,
+        it is the responsibility of the WebGL API to ensure that data are accessed consistently. This applies
+        even if the buffer is currently bound to a transform feedback binding point.
       </dd>
     </dl>
 
@@ -2032,6 +2038,12 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
     <p>
         These restrictions are similar to <a href="../1.0/#BUFFER_OBJECT_BINDING">buffer object binding
         restrictions in the WebGL 1 specification</a>.
+    </p>
+
+    <p>
+        In addition, a buffer can not be simultaneously bound to a transform feedback buffer binding point
+        and another buffer binding point in the WebGL 2 API. Attempting to violate this rule generates an
+        <code>INVALID_OPERATION</code> error, and the state of the binding point will remain untouched.
     </p>
 
     <h3>Draw buffers</h3>


### PR DESCRIPTION
Performing reads and writes on a buffer that is currently bound for
transform feedback causes undefined results in GLES3.0 and OpenGL 4.5. In
practice results of reads and writes might be consistent as long as
transform feedback objects are not active, but neither GLES3.0 nor OpenGL
4.5 spec guarantees this - just being bound for transform feedback is
sufficient to cause undefined results.

Address this by adding an error for getBufferSubData when the buffer is
bound to a transform feedback binding point and any transform feedback
object is active. With this error in place, an underlying OpenGL-based
WebGL implementation can ensure correct behavior by unbinding the buffer
from transform feedback prior to mapping it for reading, and then binding
it again for transform feedback once being done with reading.

Also add an error for binding a buffer that is bound to a transform
feedback binding point to another binding point, so that other kinds of
buffer reads and writes with undefined results are not possible. We might
try to relax this rule later if it seems necessary, but it's simpler to
start with some behavior disallowed and later allowing it rather than the
other way around, which could cause backwards compatibility issues.

Also clarify that getBufferSubData returns data that is consistent with
the execution of all prior GL commands. This is technically covered by
GLES3.0 spec section 2.1, but this specific case is hard enough to
interpret that a clarification is warranted.

Related to issue #669.
