### PR TITLE
Matrix Attribute Test

### DIFF
--- a/sdk/tests/conformance/attribs/00_test_list.txt
+++ b/sdk/tests/conformance/attribs/00_test_list.txt
@@ -1,8 +1,8 @@
-gl-enable-vertex-attrib.html
---min-version 1.0.2 gl-vertex-attrib-render.html
 --min-version 1.0.2 gl-disabled-vertex-attrib.html
-gl-vertex-attrib-zero-issues.html
+gl-enable-vertex-attrib.html
+--min-version 1.0.3 gl-matrix-attributes.html
 gl-vertex-attrib.html
-gl-vertexattribpointer-offsets.html
 gl-vertexattribpointer.html
-gl-matrix-attributes.html
+gl-vertexattribpointer-offsets.html
+--min-version 1.0.2 gl-vertex-attrib-render.html
+gl-vertex-attrib-zero-issues.html

--- a/sdk/tests/conformance/attribs/gl-matrix-attributes.html
+++ b/sdk/tests/conformance/attribs/gl-matrix-attributes.html
@@ -150,7 +150,7 @@ for (var mm = 2; mm <= 4; ++mm) {
     debug('');
 }
 
-finishTest();
+var successfullyParsed = true;
 </script>
 <script src="../../resources/js-test-post.js"></script>
 </body>


### PR DESCRIPTION
Add a conformance test that verifies matrix attribute locations do not clash with other shader attributes, regardless of their position in the attribute list.
