### PR TITLE
Fill in the spec for most texture functions in WebGL 2

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 26 August 2014</h2>
+    <h2 class="no-toc">Editor's Draft 10 September 2014</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -1130,6 +1130,13 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <h4>Texture objects</h4>
 
+    <p>
+        Texture objects provide storage and state for texturing operations. If no WebGLTexture is bound
+        (e.g., passing null or 0 to bindTexture) then attempts to modify or query the texture object shall
+        generate an <code>INVALID_OPERATION</code> error. This is indicated in the functions below in cases
+        where The OpenGL ES 3.0 specification allows the function to change the default texture.
+    </p>
+
     <dl class="methods">
       <dt class="idl-code">any getTexParameter(GLenum target, GLenum pname)
           <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-6.1.3">OpenGL ES 3.0.3 &sect;6.1.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetTexParameter.xhtml">man page</a>)</span>
@@ -1142,6 +1149,8 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
               <tr><td>TEXTURE_BASE_LEVEL</td><td>GLint</td></tr>
               <tr><td>TEXTURE_COMPARE_FUNC</td><td>GLenum</td></tr>
               <tr><td>TEXTURE_COMPARE_MODE</td><td>GLenum</td></tr>
+              <tr><td>TEXTURE_IMMUTABLE_FORMAT</td><td>GLboolean</td></tr>
+              <tr><td>TEXTURE_IMMUTABLE_LEVELS</td><td>GLuint</td></tr>
               <tr><td>TEXTURE_MAG_FILTER</td><td>GLenum</td></tr>
               <tr><td>TEXTURE_MAX_LEVEL</td><td>GLint</td></tr>
               <tr><td>TEXTURE_MAX_LOD</td><td>GLfloat</td></tr>
@@ -1168,6 +1177,13 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           </span>
         </p>
       </dt>
+      <dd>
+        Specify all the levels of a two-dimensional or cube-map texture at the same time. <br><br>
+
+        The image contents are set as if a buffer of sufficient size initialized to 0 would be passed to
+        each texImage2D call in the pseudocode in The OpenGL ES 3.0 specification section 3.8.4
+        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-3.8.4">OpenGL ES 3.0.3 &sect;3.8.4</a>)</span>.
+      </dd>
       <dt>
         <p class="idl-code">void texStorage3D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth)
           <span class="gl-spec">
@@ -1176,6 +1192,13 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           </span>
         </p>
       </dt>
+      <dd>
+        Specify all the levels of a three-dimensional texture or two-dimensional array texture. <br><br>
+
+        The image contents are set as if a buffer of sufficient size initialized to 0 would be passed to
+        each texImage3D call in the pseudocode in The OpenGL ES 3.0 specification section 3.8.4
+        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-3.8.4">OpenGL ES 3.0.3 &sect;3.8.4</a>)</span>.
+      </dd>
       <dt>
         <p class="idl-code">void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, ArrayBufferView? pixels)
           <span class="gl-spec">
@@ -1184,14 +1207,64 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           </span>
         </p>
       </dt>
+      <dd>
+        Update a rectangular subregion of the currently bound WebGLTexture. <br><br>
+
+        <div class="note editor">Needs update to determine restrictions for <em>format</em> and
+        <em>pixels</em>. These restrictions also need to be updated for texImage2D and texSubImage2D
+        inherited from the WebGL 1.0 API.</div>
+
+        If an attempt is made to call this function with no WebGLTexture bound (see above), an
+        <code>INVALID_OPERATION</code> error is generated. <br><br>
+
+        <div class="note editor">Needs update to determine restrictions for <em>type</em></div>
+
+        If <code>pixels</code> is null then an </code>INVALID_VALUE</code> error is generated. <br><br>
+
+        See <a href="../1.0/#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific
+        pixel storage parameters that affect the behavior of this function.
+      </dd>
       <dt>
-        <p class="idl-code">void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLenum format, GLenum type, TexImageSource? source)
+        <p class="idl-code">void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLenum format, GLenum type, TexImageSource? source) /* May throw DOMException */
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.3 &sect;3.8.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
       </dt>
+      <dd>
+        Update a rectangular subregion of the currently bound WebGLTexture. <br><br>
+
+        The depth of the updated subregion is set to 1. The width and height of the updated subregion are
+        determined as specified in section <a href="../1.0/#TEXTURE_UPLOAD_SIZE">Texture Upload Width and
+        Height</a>. <br><br>
+
+        See <a href="../1.0/#TEXIMAGE2D_HTML">texImage2D</a> for the interpretation of
+        the <em>format</em> and <em>type</em> arguments, and notes on
+        the <code>UNPACK_PREMULTIPLY_ALPHA_WEBGL</code> pixel storage parameter. <br><br>
+
+        The first pixel transferred from the source to the WebGL implementation corresponds to
+        the upper left corner of the source. This behavior is modified by the
+        the <code>UNPACK_FLIP_Y_WEBGL</code> <a href="../1.0/#PIXEL_STORAGE_PARAMETERS">pixel storage
+        parameter</a>. <br><br>
+
+        If an attempt is made to call this function with no WebGLTexture bound (see above), an
+        <code>INVALID_OPERATION</code> error is generated. <br><br>
+
+        <div class="note editor">Needs update to determine restrictions for <em>type</em></div>
+
+        If this function is called with an <code>HTMLImageElement</code>
+        or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing
+        Document, or with an <code>HTMLCanvasElement</code> whose <i>origin-clean</i> flag is
+        set to false, a <code>SECURITY_ERR</code> exception must be
+        thrown. See <a href="../1.0/#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.<br><br>
+
+        If <code>source</code> is null then an <code>INVALID_VALUE</code> error is
+        generated. <br><br>
+
+        See <a href="../1.0/#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific
+        pixel storage parameters that affect the behavior of this function.
+      </dd>
       <dt>
         <p class="idl-code">void copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height)
           <span class="gl-spec">
@@ -1200,6 +1273,14 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           </span>
         </p>
       </dt>
+      <dd>
+        If an attempt is made to call this function with no WebGLTexture bound (see above), an
+        <code>INVALID_OPERATION</code> error is generated. <br><br>
+
+        For any pixel lying outside the frame buffer, all channels of the associated texel are
+        initialized to 0; see <a href="../1.0/#READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the
+        Framebuffer</a>. <br><br>
+      </dd>
       <dt>
         <p class="idl-code">void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, ArrayBufferView data)
           <span class="gl-spec">
@@ -1216,6 +1297,12 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           </span>
         </p>
       </dt>
+      <dd>
+        If an attempt is made to call these functions with no WebGLTexture bound (see above), an
+        <code>INVALID_OPERATION</code> error is generated. <br><br>
+
+        <div class="note editor">Needs update for WebGL 2.0</div>
+      </dd>
     </dl>
 
 <!-- ======================================================================================================= -->
@@ -2211,6 +2298,18 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         As in the OpenGL ES 3.0 API, multiple fragment shader outputs are only supported for GLSL ES 3.00
         shaders in the WebGL 2 API.
     </p>
+
+    <h3>No TexImage3D</h3>
+
+    <p>
+        The <code>texImage3D</code> entry point is removed from the WebGL 2.0 API. Defining 3D texture images
+        is supported with <code>texStorage3D</code> and <code>compressedTexImage3D</code>.
+    </p>
+
+    <div class="note">
+        <code>texStorage2D</code> should also be considered a preferred alternative to
+        <code>texImage2D</code>, even though <code>texImage2D</code> is supported in the WebGL 2.0 API.
+    </div>
 
 <!-- ======================================================================================================= -->
 


### PR DESCRIPTION
Adds TEXTURE_IMMUTABLE_\* enums to GetTexParameter which were previously
missing, and adds a note about TexImage3D being removed. Some parts like
format restrictions still need some work.

For issue #544 and issue #543.
