### PR TITLE
Fix minor issues in float texture extension specs

### DIFF
--- a/extensions/OES_texture_float/extension.xml
+++ b/extensions/OES_texture_float/extension.xml
@@ -36,13 +36,13 @@
 
       <feature>Implementations supporting float rendering via this extension
       will implicitly enable the <a
-      href="WEBGL_color_buffer_float.html">WEBGL_color_buffer_float</a>
+      href="../WEBGL_color_buffer_float/">WEBGL_color_buffer_float</a>
       extension and follow its requirements. This ensures correct behavior
       when a texture with pixel type <code>FLOAT</code> is attached to an FBO.
       Although this feature has historically been allowed, new implementations
       should not implicitly support float rendering and applications should be
       modified to explicitly enable <a
-      href="WEBGL_color_buffer_float.html">WEBGL_color_buffer_float</a>.</feature>
+      href="../WEBGL_color_buffer_float/">WEBGL_color_buffer_float</a>.</feature>
     </features>
   </overview>
 
@@ -81,6 +81,10 @@ interface OES_texture_float { }; </idl>
 
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+
+    <revision date="2014/09/11">
+      <change>Corrected link to WEBGL_color_buffer_float.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OES_texture_half_float/extension.xml
+++ b/extensions/OES_texture_half_float/extension.xml
@@ -36,13 +36,13 @@
 
       <feature>Implementations supporting float rendering via this extension
       will implicitly enable the <a
-      href="OES_color_buffer_half_float.html">OES_color_buffer_half_float</a>
+      href="../EXT_color_buffer_half_float/">EXT_color_buffer_half_float</a>
       extension and follow its requirements. This ensures correct behavior
       when a texture with pixel type <code>HALF_FLOAT_OES</code> is attached
       to an FBO. Although this feature has historically been allowed, new
       implementations should not implicitly support float rendering and
       applications should be modified to explicitly enable <a
-      href="OES_color_buffer_half_float.html">OES_color_buffer_half_float</a>.</feature>
+      href="../EXT_color_buffer_half_float/">EXT_color_buffer_half_float</a>.</feature>
     </features>
   </overview>
 
@@ -85,6 +85,10 @@ interface OES_texture_half_float {
 
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+
+    <revision date="2014/09/11">
+      <change>Corrected link to EXT_color_buffer_half_float.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -60,12 +60,12 @@
 
   <idl xml:space="preserve">
 [NoInterfaceObject]
-interface EXT_color_buffer_float {
+interface WEBGL_color_buffer_float {
   const GLenum RGBA32F_EXT = 0x8814;
   const GLenum RGB32F_EXT = 0x8815;
   const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
   const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
-}; // interface EXT_color_buffer_float
+}; // interface WEBGL_color_buffer_float
 </idl>
 
   <newtok>
@@ -106,6 +106,10 @@ interface EXT_color_buffer_float {
 
     <revision date="2014/07/15">
       <change>Removed webgl module. Added NoInterfaceObject extended attribute.</change>
+    </revision>
+
+    <revision date="2014/09/11">
+      <change>Fixed the name of the interface from EXT_color_buffer_float to WEBGL_color_buffer_float.</change>
     </revision>
   </history>
 </draft>


### PR DESCRIPTION
WEBGL_color_buffer_float had a wrong name for the interface, increasing
confusion between it and EXT_color_buffer_float. Also OES_texture_float
and OES_texture_half_float extensions had broken links.
OES_texture_half_float also incorrectly used OES prefix for
EXT_color_buffer_half_float.
