### PR TITLE
bindAttribLocation with matrix attributes

### DIFF
--- a/sdk/tests/conformance/attribs/00_test_list.txt
+++ b/sdk/tests/conformance/attribs/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 1.0.3 gl-bindAttribLocation-matrix.html
 --min-version 1.0.2 gl-disabled-vertex-attrib.html
 gl-enable-vertex-attrib.html
 --min-version 1.0.3 gl-matrix-attributes.html

--- a/sdk/tests/conformance/attribs/gl-bindAttribLocation-matrix.html
+++ b/sdk/tests/conformance/attribs/gl-bindAttribLocation-matrix.html
@@ -1,0 +1,119 @@
+﻿<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/webgl-test-utils.js"></script>
+<title>WebGL bindAttribLocation with Matrix Attributes Conformance Test</title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="8" height="8" style="width: 8px; height: 8px;"></canvas>
+<script>
+"use strict";
+description("This test verifies that vectors placed via bindAttribLocation right after matricies will fail if there is insufficient room for the matrix.");
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas, {antialias: false});
+
+// Make sure we have room for at least a mat4.
+var maxAttributes = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+debug('MAX_VERTEX_ATTRIBUTES is ' + maxAttributes);
+shouldBeGreaterThanOrEqual('maxAttributes', '4');
+
+var glFragmentShader = wtu.setupSimpleColorFragmentShader(gl);
+
+// Given a matrix dimension, load a vertex shader with a matrix of that dimension
+// and a vector. Ensure that both the vector and matrix are active attributes.
+// Return the compiled vertex shader.
+function loadVertexShader(numMatrixDimensions) {
+    var strVertexShader =
+        'attribute mat' + numMatrixDimensions + ' matrix;\n' +
+        'attribute vec' + numMatrixDimensions + ' vector;\n' +
+        'void main(void) { gl_Position = vec4(vector*matrix';
+    // Ensure the vec4 has the correct number of dimensions in order to be assignable
+    // to gl_Position.
+    for (var ii = numMatrixDimensions; ii < 4; ++ii) {
+        strVertexShader += ",0.0";
+    }
+    strVertexShader += ");}\n";
+    return wtu.loadShader(gl, strVertexShader, gl.VERTEX_SHADER);
+}
+
+// Given a vertex shader, matrix location and vector location, create and link
+// a program with glFragmentShader and a vertex shader returned by loadVertexShader
+// attached. Bind the matrix to matrixLocation and the vector to vectorLocation.
+// Return whether the link was successful.
+function createAndLinkProgram(glVertexShader, matrixLocation, vectorLocation) {
+    var glProgram = gl.createProgram();
+    gl.bindAttribLocation(glProgram, matrixLocation, 'matrix');
+    gl.bindAttribLocation(glProgram, vectorLocation, 'vector');
+    gl.attachShader(glProgram, glVertexShader);
+    gl.attachShader(glProgram, glFragmentShader);
+    gl.linkProgram(glProgram);
+    return gl.getProgramParameter(glProgram, gl.LINK_STATUS);
+}
+
+// For each matrix dimension (mat2, mat3 and mat4)
+for (var mm = 2; mm <= 4; ++mm) {
+    debug('Testing ' + mm + ' dimensional matrices');
+    var glVertexShader = loadVertexShader(mm);
+    // Per the WebGL spec: "LinkProgram will fail if the attribute bindings assigned
+    // by bindAttribLocation do not leave enough space to assign a location for an
+    // active matrix attribute which requires multiple contiguous generic attributes."
+    // We will test this by placing the vector after the matrix attribute such that there
+    // is not enough room for the matrix. Vertify the link operation fails.
+
+    // Run the test for each available attribute slot.  Go to maxAttributes-mm to leave enough room
+    // for the matrix itself. Leave another slot open for the vector following the matrix.
+    for (var pp = 0; pp <= maxAttributes - mm - 1; ++pp) {
+        // For each matrix dimension, bind the vector right after the matrix such that we leave
+        // insufficient room for the matrix. Verify doing this will fail the link operation.
+        for (var ll = 0; ll < mm; ++ll) {
+            var vectorLocation = pp + ll;
+            assertMsg(!createAndLinkProgram(glVertexShader, /*matrixLocation*/pp, vectorLocation),
+                "Matrix with location " + pp + " and vector with location " + vectorLocation + " should not link.");
+        }
+        // Ensure that once we have left enough room for the matrix, the program links successfully.
+        var vectorLocation = pp + ll;
+        assertMsg(createAndLinkProgram(glVertexShader, /*matrixLocation*/pp, vectorLocation),
+            "Matrix with location " + pp + " and vector with location " + vectorLocation + " should link.");
+        debug('');
+    }
+    debug('');
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This test verifies that vectors placed via bindAttribLocation right after matricies will fail if there is insufficient room for the matrix.
