### PR TITLE
Added extension annotations describing compatibility across spec versions

### DIFF
--- a/extensions/ANGLE_instanced_arrays/extension.xml
+++ b/extensions/ANGLE_instanced_arrays/extension.xml
@@ -11,6 +11,7 @@
   <number>19</number>
   <depends>
     <api version="1.0"/>
+    <core version="2.0" />
   </depends>
   <overview>
     <mirrors href="http://www.khronos.org/registry/gles/extensions/ANGLE/ANGLE_instanced_arrays.txt" name="ANGLE_instanced_arrays">

--- a/extensions/EXT_blend_minmax/extension.xml
+++ b/extensions/EXT_blend_minmax/extension.xml
@@ -14,6 +14,7 @@
 
   <depends>
     <api version="1.0"/>
+    <core version="2.0" />
   </depends>
 
   <overview>

--- a/extensions/EXT_frag_depth/extension.xml
+++ b/extensions/EXT_frag_depth/extension.xml
@@ -13,6 +13,9 @@
 
   <depends>
     <api version="1.0"/>
+    <core version="2.0">
+      <glsl version="300 es"/>
+    </core>
   </depends>
 
   <overview>

--- a/extensions/EXT_sRGB/extension.xml
+++ b/extensions/EXT_sRGB/extension.xml
@@ -14,6 +14,9 @@
 
   <depends>
     <api version="1.0"/>
+    <core version="2.0">
+      <addendum>Additional format restrictions apply for CopyTexImage2D</addendum>
+    </core>
   </depends>
 
   <overview>

--- a/extensions/EXT_shader_texture_lod/extension.xml
+++ b/extensions/EXT_shader_texture_lod/extension.xml
@@ -14,6 +14,9 @@
 
   <depends>
     <api version="1.0"/>
+    <core version="2.0">
+      <glsl version="300 es"/>
+    </core>
   </depends>
 
   <overview>

--- a/extensions/OES_element_index_uint/extension.xml
+++ b/extensions/OES_element_index_uint/extension.xml
@@ -12,6 +12,7 @@
   <number>10</number>
   <depends>
     <api version="1.0" />
+    <core version="2.0" />
   </depends>
   <overview>
     <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_element_index_uint.txt" name="OES_element_index_uint"/>

--- a/extensions/OES_standard_derivatives/extension.xml
+++ b/extensions/OES_standard_derivatives/extension.xml
@@ -11,6 +11,9 @@
   <number>4</number>
   <depends>
     <api version="1.0"/>
+    <core version="2.0">
+      <glsl version="300 es"/>
+    </core>
   </depends>
   <overview>
     <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_standard_derivatives.txt" name="OES_standard_derivatives" />

--- a/extensions/OES_vertex_array_object/extension.xml
+++ b/extensions/OES_vertex_array_object/extension.xml
@@ -11,6 +11,7 @@
   <number>5</number>
   <depends>
     <api version="1.0"/>
+    <core version="2.0" />
   </depends>
   <overview>
     <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_vertex_array_object.txt" name="OES_vertex_array_object" />

--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -11,6 +11,9 @@
   <number>18</number>
   <depends>
     <api version="1.0"/>
+    <core version="2.0">
+      <glsl version="300 es"/>
+    </core>
   </depends>
   <overview>
     <mirrors href="https://www.khronos.org/registry/gles/extensions/EXT/EXT_draw_buffers.txt" name="EXT_draw_buffers">

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -198,6 +198,25 @@
   <p> Written against the <xsl:apply-templates select="."/> specification. </p>
 </xsl:template>
 
+<xsl:template match="core" mode="depends">
+  <p> Promoted to core in <xsl:apply-templates select="."/> specification. <xsl:apply-templates select="glsl" mode="requires" /></p>
+
+  <xsl:choose>
+    <xsl:when test="count(addendum)!=0">
+      <p> The following behavioral changes apply in the core spec:</p>
+    <ul>
+      <xsl:for-each select="addendum">
+        <li><xsl:copy-of select="node()" /></li>
+      </xsl:for-each>
+    </ul>
+    </xsl:when>
+  </xsl:choose>
+</xsl:template>
+
+<xsl:template match="removed" mode="depends">
+  <p> No longer available as of the <xsl:apply-templates select="."/> specification. </p>
+</xsl:template>
+
 <xsl:template match="ext" mode="depends">
   <xsl:choose>
 	<xsl:when test="@require='true'">
@@ -211,6 +230,10 @@
 
 <xsl:template match="glsl" mode="depends">
   <p> Written against the <xsl:apply-templates select="."/> specification. </p>
+</xsl:template>
+
+<xsl:template match="glsl" mode="requires">
+  Requires GLSL #version <xsl:value-of select="@version"/>.
 </xsl:template>
 
 <xsl:template match="rfc" mode="depends">

--- a/extensions/standards.xsl
+++ b/extensions/standards.xsl
@@ -3,7 +3,7 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
-  <xsl:template match="api">
+  <xsl:template match="api|core|removed">
     <a href="http://www.khronos.org/registry/webgl/specs/{@version}/">WebGL API <xsl:value-of select="@version"/></a>
   </xsl:template>
 
@@ -15,6 +15,10 @@
 
   <xsl:template match="glsl">
     <xsl:choose>
+      <xsl:when test="@flavor='ES 3.0'">
+        <a href="http://www.khronos.org/registry/gles/specs/3.0/GLSL_ES_Specification_{@version}.{@revision}.pdf">
+        GLSL ES 3.0 (<xsl:value-of select="@version"/>.<xsl:value-of select="@revision"/>)</a>
+      </xsl:when>
       <xsl:when test="@flavor='ES 2.0'">
         <a href="http://www.khronos.org/registry/gles/specs/2.0/GLSL_ES_Specification_{@version}.{@revision}.pdf">
         GLSL ES 2.0 (<xsl:value-of select="@version"/>.<xsl:value-of select="@revision"/>)</a>

--- a/extensions/template/extension.xml
+++ b/extensions/template/extension.xml
@@ -46,6 +46,17 @@ http://www.khronos.org/registry/webgl/extensions/
   <depends>
     <api version="1.0"/>
 
+    <core version="2.0"/> <!-- Version in which the extension functionality was integrated into the core spec -->
+
+    <core version="2.0">
+      <glsl version="300 es"/> <!-- GLSL #version required to use the feature, if any -->
+      <addendum>
+        Difference in core spec from extension.
+      </addendum>
+    </core>
+
+    <removed version="2.0"/> <!-- Version as of which extension is no longer supported -->
+
     <ext name="WEBGL_required_ext" require="true"/>
 
     <ext name="WEBGL_base_ext"/>


### PR DESCRIPTION
I would appreciate some feedback on the verbiage and general display of this information. With the XSLT defined in this pull request, this example XML snippet:

```
   <depends>
    <api version="1.0"/> <!-- This is an existing tag -->
    <core version="2.0">
      <glsl version="300 es"/> <!-- optional -->
      <addendum>SOME_ENUM support was dropped</addendum> <!-- optional -->
    </core>
  </depends>
```

Would produce the following output:

> ### Dependencies
> 
> Written against the [WebGL API 1.0](http://www.khronos.org/registry/webgl/specs/1.0/) specification.
> Promoted to core in [WebGL API 2.0](http://www.khronos.org/registry/webgl/specs/2.0/) specification. Requires GLSL #version 300 es.
> The following behavioral changes apply in the core spec:
> - SOME_ENUM support was dropped
