### PR TITLE
Add information on planned backwards incompatibility in WebGL 2

### DIFF
--- a/extensions/registry.html
+++ b/extensions/registry.html
@@ -22,27 +22,6 @@ ul li+li {
 
     <script src="../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
     <script src="../resources/generateTOC.js" type="text/javascript"></script>
-<!--
-Planned extensions from a recent F2F:
-
-OES_texture_float
-OES_texture_half_float
-OES_depth24
-
-# require shader validator changes
-OES_standard_derivatives
-EXT_shader_texture_lod
-
-# desktop only
-OES_texture_float_linear
-OES_texture_half_float_linear
-
-# future core
-OES_vertex_array_object - same as IMG_vertex_array_object?
-
-OES_rgb8_rgba8
-OES_depth_texture - problematic, ARB/EXT have slightly different semantics; might need to define WEBGL versions
--->
 </head>
 <body>
     <!--begin-logo-->
@@ -86,9 +65,14 @@ OES_depth_texture - problematic, ARB/EXT have slightly different semantics; migh
     </p>
     <p>
         Each extension object is fetched from
-        the <a href="../specs/latest/index.html#WEBGLRENDERINGCONTEXT">WebGLRenderingContext</a> by passing
+        the <a href="../specs/latest/1.0/#WEBGLRENDERINGCONTEXT">WebGLRenderingContextBase</a> by passing
         the name of the extension to the <code>getExtension</code> method,
         i.e.: <code>context.getExtension("OES_texture_float")</code>.
+    </p>
+
+    <p>
+        Extensions which are marked as promoted to core or removed in a certain version of the WebGL
+        API must not be supported in an implementation of that or newer version of the WebGL API.
     </p>
 
     <h2 class="no-toc">Naming conventions</h2>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -112,9 +112,12 @@
     </p>
 
     <p>
-      WebGL 2 is backwards compatible with WebGL 1: existing content will run in WebGL 2 without
-      modification. To access the new behavior provided in this specification, the content
-      explicitly requests a new context (<a href="#CONTEXT_CREATION">details below</a>).
+      WebGL 2 is not entirely backwards compatible with WebGL 1. Existing content written against
+      the core WebGL 1 specification without extensions will often run in WebGL 2 without
+      modification, but this is not always the case. All exceptions to backwards compatibility are
+      recorded in the <a href="#BACKWARDS_INCOMPATIBILITY">Backwards Incompatibility</a> section.
+      To access the new behavior provided in this specification, the content explicitly requests
+      a new context (<a href="#CONTEXT_CREATION">details below</a>).
     </p>
     </div>
 
@@ -1994,6 +1997,23 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <div class="note editor">
         Needs update for WebGL 2.0
+    </div>
+
+    <h3><a name="BACKWARDS_INCOMPATIBILITY">Backwards Incompatibility</a></h3>
+    
+    <p>
+        Some extensions that may have been supported in the WebGL 1 API are removed from the WebGL
+        2 API. For more details, see the
+        <a href="http://www.khronos.org/registry/webgl/extensions/">WebGL Extension Registry</a>.
+    </p>
+
+    <div class="note">
+        Extensions are typically removed only if equivalent functionality is available in the WebGL
+        2 API either in the core specification or in an improved extension. When an application
+        using WebGL 1 extensions is modified to run on the WebGL 2 API, it is often possible to
+        create a dummy extension object for each of the promoted extensions which simply
+        redirects calls to the appropriate WebGL 2 API functions. If the application is using shader
+        language extensions, porting shaders to GLSL ES 3.00 is typically required.
     </div>
 
     <h3>New Features Supported in the WebGL 2 API</h3>


### PR DESCRIPTION
It was decided in the WebGL WG F2F that WebGL 2 will not be entirely
backwards compatible with WebGL 1. In particular, there is agreement
that all extensions are not moving over, and always enabling primitive
restart in WebGL 2 significantly streamlines implementations, so that
could be added to this section of the spec.

Fixes small issues in the extension registry.
