### PR TITLE
Ternary Operators in Initializers

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -94,3 +94,4 @@ uniform-location-length-limits.html
 --min-version 1.0.2 shader-with-global-variable-precision-mismatch.html
 --min-version 1.0.2 large-loop-compile.html
 --min-version 1.0.3 struct-equals.html
+--min-version 1.0.3 ternary-operators-in-initializers.html

--- a/sdk/tests/conformance/glsl/misc/ternary-operators-in-initializers.html
+++ b/sdk/tests/conformance/glsl/misc/ternary-operators-in-initializers.html
@@ -1,0 +1,143 @@
+<!--
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css" />
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css" />
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+<title></title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="intFragShader" type="text/something-not-javascript">
+void main() {
+    int i = 2, j = (i > 1) ? 1 : 0;
+    gl_FragColor = vec4(0.0, j, 0.0, 1.0);
+}
+</script>
+<script id="ivec2FragShader" type="text/something-not-javascript">
+void main() {
+    ivec2 i = ivec2(2, 0), j = (i.x > 1) ? ivec2(0, 1) : ivec2(0, 0);
+    gl_FragColor = vec4(j, 0.0, 1.0);
+}
+</script>
+<script id="ivec3FragShader" type="text/something-not-javascript">
+void main() {
+    ivec3 i = ivec3(0, 2, 0), j = (i.y > 1) ? ivec3(0, 1, 0) : ivec3(0, 0, 0);
+    gl_FragColor = vec4(j, 1.0);
+}
+</script>
+<script id="ivec4FragShader" type="text/something-not-javascript">
+void main() {
+    ivec4 i = ivec4(0.0, 0.0, 2.0, 0.0), j = (i.z > 1) ? ivec4(0, 1, 0, 1) : ivec4(0, 0, 0, 1);
+    gl_FragColor = vec4(j);
+}
+</script>
+<script id="floatFragShader" type="text/something-not-javascript">
+void main() {
+    precision mediump float;
+    float i = 2.0, j = (i > 1.0) ? 1.0 : 0.0;
+    gl_FragColor = vec4(0.0, j, 0.0, 1.0);
+}
+</script>
+<script id="vec2FragShader" type="text/something-not-javascript">
+void main() {
+    precision mediump float;
+    vec2 i = vec2(2.0, 0.0), j = (i.x > 1.0) ? vec2(0.0, 1.0) : vec2(0.0, 0.0);
+    gl_FragColor = vec4(j, 0.0, 1.0);
+}
+</script>
+<script id="vec3FragShader" type="text/something-not-javascript">
+void main() {
+    precision mediump float;
+    vec3 i = vec3(0.0, 2.0, 0.0), j = (i.y > 1.0) ? vec3(0.0, 1.0, 0.0) : vec3(0.0, 0.0, 0.0);
+    gl_FragColor = vec4(j, 1.0);
+}
+</script>
+<script id="vec4FragShader" type="text/something-not-javascript">
+void main() {
+    precision mediump float;
+    vec4 i = vec4(0.0, 0.0, 2.0, 0.0), j = (i.z > 1.0) ? vec4(0.0, 1.0, 0.0, 1.0) : vec4(0.0, 0.0, 0.0, 1.0);
+    gl_FragColor = j;
+}
+</script>
+<script id="boolFragShader" type="text/something-not-javascript">
+void main() {
+    bool i = true, j = i ? true : false;
+    gl_FragColor = vec4(0.0, j, 0.0, 1.0);
+}
+</script>
+<script id="bvec2FragShader" type="text/something-not-javascript">
+void main() {
+    bvec2 i = bvec2(true, false), j = i.x ? bvec2(false, true) : bvec2(false, false);
+    gl_FragColor = vec4(j, 0.0, 1.0);
+}
+</script>
+<script id="bvec3FragShader" type="text/something-not-javascript">
+void main() {
+    bvec3 i = bvec3(false, true, false), j = i.y ? bvec3(false, true, false) : bvec3(false, false, false);
+    gl_FragColor = vec4(j, 1.0);
+}
+</script>
+<script id="bvec4FragShader" type="text/something-not-javascript">
+void main() {
+    bvec4 i = bvec4(false, false, true, true), j = i.z ? bvec4(false, true, false, true) : bvec4(false, false, false, true);
+    gl_FragColor = vec4(j);
+}
+</script>
+<script>
+"use strict";
+description("This test verifies initializers with ternary operators correctly initialize all variables.");
+// Test fragment shaders are of the form
+//     void main() {
+//         {type} i = {initializer}, j = {ternary test using i that succeeds} ? : {green} : {black};
+//         gl_FragColor = vec4(...); // Emit green so that test will pass
+//     }
+// The fragment shader must compile and link with the default vertex shader. J must be able to use the values of I as well as have its own
+// values properly initialized.
+var tests = [
+    { fShaderId: 'intFragShader', passMsg: 'Ternary operator in integer initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'ivec2FragShader', passMsg: 'Ternary operator in ivec2 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'ivec3FragShader', passMsg: 'Ternary operator in ivec3 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'ivec4FragShader', passMsg: 'Ternary operator in ivec4 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'floatFragShader', passMsg: 'Ternary operator in float initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'vec2FragShader', passMsg: 'Ternary operator in vec2 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'vec3FragShader', passMsg: 'Ternary operator in vec3 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'vec4FragShader', passMsg: 'Ternary operator in vec4 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'boolFragShader', passMsg: 'Ternary operator in bool initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'bvec2FragShader', passMsg: 'Ternary operator in bvec2 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'bvec3FragShader', passMsg: 'Ternary operator in bvec3 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+    { fShaderId: 'bvec4FragShader', passMsg: 'Ternary operator in bvec4 initalization', fShaderSuccess: true, linkSuccess: true, render: true },
+];
+GLSLConformanceTester.runTests(tests);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
This test verifies initializers with ternary operators correctly initialize all variables.

Test fragment shaders are of the form:
    void main() {
        {type} i = {initializer}, j = {ternary test using i that succeeds} ? : {green} : {black};
        gl_FragColor = vec4(...); // Emit green so that test will pass
    }
The fragment shader must compile and link with the default vertex shader. J must be able to use the values of I as well as have its own values properly initialized.
