### PR TITLE
Fix up missing getExtensions in WebGL Shader Translator utility

### DIFF
--- a/sdk/tests/extra/webgl-translate-shader.html
+++ b/sdk/tests/extra/webgl-translate-shader.html
@@ -49,6 +49,7 @@ window.onload = main;
 
 var gl;
 var debugShaders;
+var enabledExtensions = [];
 
 var translateButton;
 var extButton;
@@ -78,6 +79,23 @@ function disable() {
 }
 
 function getExtensions() {
+    if (enabledExtensions.length > 0) {
+        return;
+    }
+    var shaderExtensions = [
+        'EXT_frag_depth',
+        'EXT_shader_texture_lod',
+        'OES_standard_derivatives',
+        'WEBGL_draw_buffers'];
+    for (var i = 0; i < shaderExtensions.length; ++i) {
+        var ext = gl.getExtension(shaderExtensions[i]);
+        if (ext) {
+            enabledExtensions.push(shaderExtensions[i]);
+        }
+    }
+    if (enabledExtensions.length > 0) {
+        document.getElementById('enabled-extensions').textContent = enabledExtensions.join(', ');
+    }
 }
 
 function translateShader() {
@@ -106,11 +124,9 @@ function translateShader() {
         }
     }
 
-    if (!tryCompile(gl.FRAGMENT_SHADER)) {
-        if (!tryCompile(gl.VERTEX_SHADER)) {
-            output.value = 'Invalid shader, compilation failed as both fragment as vertex shader.';
-            shaderType.textContent = 'Shader not';
-        }
+    if (!tryCompile(gl.FRAGMENT_SHADER) && !tryCompile(gl.VERTEX_SHADER)) {
+        output.value = 'Invalid shader, compilation failed as both fragment and vertex shader.';
+        shaderType.textContent = 'Shader not';
     }
 }
 </script>
@@ -132,6 +148,8 @@ is changed before being passed on to the underlying platform's graphics driver.<
 </p>
 <h2><span id="shader-type">Shader</span> translated for graphics driver</h2>
 <textarea id="translated-shader"></textarea>
+<h2>Enabled shader extensions</h2>
+<p id="enabled-extensions">None</p>
 <canvas id="example" width="256" height="16" style="width: 256px; height: 48px;"></canvas>
 </body>
 </html>


### PR DESCRIPTION
I was in a bit of a hurry when submitting this, this pull request adds missing functionality and corrects small mistakes.
