### PR TITLE
Add test for struct nesting of variable names

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -95,4 +95,5 @@ uniform-location-length-limits.html
 --min-version 1.0.2 shader-with-global-variable-precision-mismatch.html
 --min-version 1.0.2 large-loop-compile.html
 --min-version 1.0.3 struct-equals.html
+--min-version 1.0.3 struct-nesting-of-variable-names.html
 --min-version 1.0.3 ternary-operators-in-initializers.html

--- a/sdk/tests/conformance/glsl/misc/struct-nesting-of-variable-names.html
+++ b/sdk/tests/conformance/glsl/misc/struct-nesting-of-variable-names.html
@@ -1,0 +1,93 @@
+<!--
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css" />
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css" />
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+<title></title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragmentShader" type="text/something-not-javascript">
+precision mediump float;
+struct S { $(outer_type) u; };
+void main() {
+    S S;   // This is legal, 'S' as a typename is defined in another scope.
+    {
+        struct S { $(inner_type) a; };  // This is legal as well, 'S' is now defined as a variable name in an ancestor scope
+        S newvar;
+        newvar.a = $(initializer);
+        gl_FragColor = $(fragColor);
+    }
+}
+</script>
+<script>
+"use strict";
+description("This test verifies that defining a typename in a new scope when the typename is the name of a variable that hides a typename declaration succeeds for all combinations of GLSL types.");
+var tests = [];
+var wtu = WebGLTestUtils;
+var typeInfo = [
+    { Type: 'float',    initializer: '1.0',                         fragColor: 'vec4(0.0, newvar.a, 0.0, 1.0)' },
+    { Type: 'vec2',     initializer: 'vec2(0.0, 1.0)',              fragColor: 'vec4(newvar.a, 0.0, 1.0)' },
+    { Type: 'vec3',     initializer: 'vec3(0.0, 1.0, 0.0)',         fragColor: 'vec4(newvar.a, 1.0)' },
+    { Type: 'vec4',     initializer: 'vec4(0.0, 1.0, 0.0, 1.0)',    fragColor: 'newvar.a' },
+    { Type: 'int',      initializer: '1',                           fragColor: 'vec4(0.0, newvar.a, 0.0, 1.0)' },
+    { Type: 'ivec2',    initializer: 'ivec2(0, 1)',                 fragColor: 'vec4(newvar.a, 0.0, 1.0)' },
+    { Type: 'ivec3',    initializer: 'ivec3(0, 1, 0)',              fragColor: 'vec4(newvar.a, 1.0)' },
+    { Type: 'ivec4',    initializer: 'ivec4(0, 1, 0, 1)',           fragColor: 'vec4(newvar.a)' },
+    { Type: 'bool',     initializer: 'true',                        fragColor: 'vec4(0.0, newvar.a, 0.0, 1.0)' },
+    { Type: 'bvec2',    initializer: 'bvec2(false, true)',          fragColor: 'vec4(newvar.a, 0.0, 1.0)' },
+    { Type: 'bvec3',    initializer: 'bvec3(false, true, false)',   fragColor: 'vec4(newvar.a, 1.0)' },
+    { Type: 'bvec4',    initializer: 'bvec4(false,true,false,true)',fragColor: 'vec4(newvar.a)' },
+];
+typeInfo.forEach(function (outerType) {
+    typeInfo.forEach(function (innerType) {
+        var replaceParams = {
+            outer_type: outerType.Type,
+            inner_type: innerType.Type,
+            // use the initializer and fragColor for the inner type. Its definition should override the variable name in the outerscope.
+            initializer: innerType.initializer,
+            fragColor: innerType.fragColor
+        };
+        tests.push({
+            fShaderSource: wtu.replaceParams(wtu.getScript('fragmentShader'), replaceParams),
+            passMsg: 'Outer struct type: ' + outerType.Type + ' inner struct type: ' + innerType.Type,
+            fShaderSuccess: true,
+            linkSuccess: true,
+            render: true
+        });
+    })
+})
+GLSLConformanceTester.runTests(tests);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
This test verifies that defining a typename in a new scope when the typename is the name of a variable that hides a typename declaration succeeds for all combinations of GLSL types.

Example fragment shader is of the form:
  struct S { $(outer_type) u; };
  void main() {
      S S;   // This is legal, 'S' as a typename is defined in another scope.
      {
          struct S { $(inner_type) a; };  // This is legal as well, 'S' is now defined as a variable name in an ancestor scope
          S newvar;
          newvar.a = $(initializer);
          gl_FragColor = $(fragColor);
      }
  }
