### PR TITLE
bindAttribLocation with aliasing

### DIFF
--- a/sdk/tests/conformance/attribs/00_test_list.txt
+++ b/sdk/tests/conformance/attribs/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 1.0.3 gl-bindAttribLocation-aliasing.html
 --min-version 1.0.3 gl-bindAttribLocation-matrix.html
 --min-version 1.0.2 gl-disabled-vertex-attrib.html
 gl-enable-vertex-attrib.html

--- a/sdk/tests/conformance/attribs/gl-bindAttribLocation-aliasing.html
+++ b/sdk/tests/conformance/attribs/gl-bindAttribLocation-aliasing.html
@@ -1,0 +1,90 @@
+<!--
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/webgl-test-utils.js"></script>
+<title>bindAttribLocation with aliasing</title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="8" height="8" style="width: 8px; height: 8px;"></canvas>
+<script id="vertexShader" type="text/something-not-javascript">
+precision mediump float;
+attribute $(type_1) a_1;
+attribute $(type_2) a_2;
+void main() {
+    gl_Position = $(gl_Position_1) + $(gl_Position_2);
+}
+</script>
+<script>
+"use strict";
+description("This test verifies combinations of valid, active attribute types cannot be bound to the same location with bindAttribLocation.");
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas, {antialias: false});
+var glFragmentShader = wtu.setupSimpleColorFragmentShader(gl);
+var typeInfo = [
+    { type: 'float',    asVec4: 'vec4(0.0, $(var), 0.0, 1.0)' },
+    { type: 'vec2',     asVec4: 'vec4($(var), 0.0, 1.0)' },
+    { type: 'vec3',     asVec4: 'vec4($(var), 1.0)' },
+    { type: 'vec4',     asVec4: '$(var)' },
+];
+var maxAttributes = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+// Test all type combinations of a_1 and a_2.
+typeInfo.forEach(function(typeInfo1) {
+    typeInfo.forEach(function(typeInfo2) {
+        debug('attribute_1: ' + typeInfo1.type + ' attribute_2: ' + typeInfo2.type);
+        var replaceParams = {
+            type_1: typeInfo1.type,
+            type_2: typeInfo2.type,
+            gl_Position_1: wtu.replaceParams(typeInfo1.asVec4, {var: 'a_1'}),
+            gl_Position_2: wtu.replaceParams(typeInfo2.asVec4, {var: 'a_2'})
+        };
+        var strVertexShader = wtu.replaceParams(wtu.getScript('vertexShader'), replaceParams);
+        var glVertexShader = wtu.loadShader(gl, strVertexShader, gl.VERTEX_SHADER);
+        assertMsg(glVertexShader != null, "Vertex shader compiled successfully.");
+        // Bind both a_1 and a_2 to the same position and verify the link fails.  
+        // Do so for all valid positions available.
+        for (var l = 0; l < maxAttributes; l++) {
+            var glProgram = gl.createProgram();
+            gl.bindAttribLocation(glProgram, l, 'a_1');
+            gl.bindAttribLocation(glProgram, l, 'a_2');
+            gl.attachShader(glProgram, glVertexShader);
+            gl.attachShader(glProgram, glFragmentShader);
+            gl.linkProgram(glProgram);
+            assertMsg(!gl.getProgramParameter(glProgram, gl.LINK_STATUS), "Link should fail when both types are aliased to location " + l);
+        }
+    });
+});
+var successfullyParsed = true;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This test verifies combinations of valid, active attribute types cannot be bound to
the same location with bindAttribLocation.

Per the OpenGL spec: It is possible for an application to bind more than one attribute
name to the same location. This is referred to as aliasing. This will only work if
only one of the aliased attributes is active in the executable program, or if no path
through the shader consumes more than one attribute of a set of attributes aliased to
the same location.

vertex shaders take the form:
precision mediump float;
attribute $(type_1) a_1;
attribute $(type_2) a_2;
void main() {
    gl_Position = $(gl_Position_1) + $(gl_Position_2);
}
