### PR TITLE
More cleanup: use waitForComposite() in buffer-offscreen-test.html

### DIFF
--- a/sdk/tests/conformance/canvas/buffer-offscreen-test.html
+++ b/sdk/tests/conformance/canvas/buffer-offscreen-test.html
@@ -37,9 +37,6 @@ body {
     height: 3000px;
 }
 </style>
-<script type="text/javascript">
-
-</script>
 </head>
 <body>
 <div id="description"></div>


### PR DESCRIPTION
The original test use some window scroll and timed delay to ensure compositing, whereas we have wtu.waitForComposite exactly for that purpose.
