### PR TITLE
Replace GetBufferDataDest with ArrayBufferData

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -4,7 +4,6 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <title>WebGL 2 Specification</title>
-    <meta name="generator" content="BBEdit 9.1">
     <link rel="stylesheet" type="text/css" href="../../../resources/Khronos-WD.css" />
     <script src="../../../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
     <script src="../../../resources/generateTOC.js" type="text/javascript"></script>
@@ -28,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 19 September 2014</h2>
+    <h2 class="no-toc">Editor's Draft 1 October 2014</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -686,8 +685,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   // MapBufferRange, in particular its read-only and write-only modes,
   // can not be exposed safely to JavaScript. GetBufferSubData
   // replaces it for the purpose of fetching data back from the GPU.
-  typedef (ArrayBuffer or ArrayBufferView) GetBufferDataDest;
-  void getBufferSubData(GLenum target, GLintptr offset, GetBufferDataDest returnedData);
+  void getBufferSubData(GLenum target, GLintptr offset, ArrayBufferData returnedData);
 
   /* Framebuffer objects */
   void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
@@ -961,7 +959,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         See <a href="COPYING_BUFFERS">Copying Buffers</a> for restrictions imposed by the WebGL 2 API.
       </dd>
       <dt>
-        <p class="idl-code">void getBufferSubData(GLenum target, GLintptr offset, GetBufferDataDest returnedData)
+        <p class="idl-code">void getBufferSubData(GLenum target, GLintptr offset, ArrayBufferData returnedData)
         </p>
       </dt>
       <dd>

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -318,8 +318,7 @@ interface WebGL2RenderingContextBase
   // MapBufferRange, in particular its read-only and write-only modes,
   // can not be exposed safely to JavaScript. GetBufferSubData
   // replaces it for the purpose of fetching data back from the GPU.
-  typedef (ArrayBuffer or ArrayBufferView) GetBufferDataDest;
-  void getBufferSubData(GLenum target, GLintptr offset, GetBufferDataDest returnedData);
+  void getBufferSubData(GLenum target, GLintptr offset, ArrayBufferData returnedData);
 
   /* Framebuffer objects */
   void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
@@ -330,7 +329,7 @@ interface WebGL2RenderingContextBase
   void invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
   void invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments,
                                 GLint x, GLint y, GLsizei width, GLsizei height);
-  void readBuffer(GLenum mode);
+  void readBuffer(GLenum src);
 
   /* Renderbuffer objects */
   void renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat,
@@ -412,11 +411,7 @@ interface WebGL2RenderingContextBase
   [WebGLHandlesContextLoss] GLboolean isSampler(WebGLSampler? sampler);
   void bindSampler(GLuint unit, WebGLSampler? sampler);
   void samplerParameteri(WebGLSampler? sampler, GLenum pname, GLint param);
-  typedef (Int32Array or sequence<GLint>) SamplerParameterIVSource;
-  void samplerParameteriv(WebGLSampler? sampler, GLenum pname, SamplerParameterIVSource param);
   void samplerParameterf(WebGLSampler? sampler, GLenum pname, GLfloat param);
-  typedef (Float32Array or sequence<GLfloat>) SamplerParameterFVSource;
-  void samplerParameterfv(WebGLSampler? sampler, GLenum pname, SamplerParameterFVSource param);
   any getSamplerParameter(WebGLSampler? sampler, GLenum pname);
 
   /* Sync objects */


### PR DESCRIPTION
The typedef for (ArrayBuffer or ArrayBufferView) is now
part of WebIDL:
http://heycam.github.io/webidl/#common-ArrayBufferData

It seems the IDL file was a little out of date to, so this
is the generated file from tip-of-tree.
