### PR TITLE
Ternary Operators in Global Initializers

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -98,4 +98,5 @@ uniform-location-length-limits.html
 --min-version 1.0.3 struct-equals.html
 --min-version 1.0.3 struct-nesting-of-variable-names.html
 --min-version 1.0.3 struct-unary-operators.html
+--min-version 1.0.3 ternary-operators-in-global-initializers.html
 --min-version 1.0.3 ternary-operators-in-initializers.html

--- a/sdk/tests/conformance/glsl/misc/ternary-operators-in-global-initializers.html
+++ b/sdk/tests/conformance/glsl/misc/ternary-operators-in-global-initializers.html
@@ -1,0 +1,86 @@
+<!--
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css" />
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css" />
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+<title>Ternary Operators in Global Initializers</title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragmentShader" type="text/something-not-javascript">
+precision mediump float;
+$(type) green = $(green);
+$(type) black = $(black);
+$(type) var = (true) ? green : black;
+void main() {
+    gl_FragColor = $(asVec4);
+}
+</script>
+<script>
+"use strict";
+description("This test verifies that ternary operators can be used in global initializers.");
+var tests = [];
+var wtu = WebGLTestUtils;
+var typeInfos = [
+    { type: 'float', green: '1.0',                         black: '0.0',                            asVec4: 'vec4(0.0,var,0.0,1.0)' },
+    { type: 'vec2',  green: 'vec2(0.0,1.0)',               black: 'vec2(0.0,0.0)',                  asVec4: 'vec4(var,0.0,1.0)' },
+    { type: 'vec3',  green: 'vec3(0.0,1.0,0.0)',           black: 'vec3(0.0,0.0,0.0)',              asVec4: 'vec4(var,1.0)' },
+    { type: 'vec4',  green: 'vec4(0.0,1.0,0.0,1.0)',       black: 'vec4(0.0,0.0,0.0,0.0)',          asVec4: 'var' },
+    { type: 'int',   green: '1',                           black: '0',                              asVec4: 'vec4(0.0,var,0.0,1.0)' },
+    { type: 'ivec2', green: 'ivec2(0,1)',                  black: 'ivec2(0,0)',                     asVec4: 'vec4(var,0.0,1.0)' },
+    { type: 'ivec3', green: 'ivec3(0,1,0)',                black: 'ivec3(0,0,0)',                   asVec4: 'vec4(var,1.0)' },
+    { type: 'ivec4', green: 'ivec4(0,1,0,1)',              black: 'ivec4(0,0,0,0)',                 asVec4: 'vec4(var)' },
+    { type: 'bool',  green: 'true',                        black: 'false',                          asVec4: 'vec4(0.0,var,0.0,1.0)' },
+    { type: 'bvec2', green: 'bvec2(false,true)',           black: 'bvec2(false,false)',             asVec4: 'vec4(var,0.0,1.0)' },
+    { type: 'bvec3', green: 'bvec3(false,true,false)',     black: 'bvec3(false,false,false)',       asVec4: 'vec4(var,1.0)' },
+    { type: 'bvec4', green: 'bvec4(false,true,false,true)',black: 'bvec4(false,false,false,false)', asVec4: 'vec4(var)' },
+];
+typeInfos.forEach(function (typeInfo) {
+    var replaceParams = {
+        type: typeInfo.type,
+        green: typeInfo.green,
+        black: typeInfo.black,
+        asVec4: typeInfo.asVec4,
+    };
+    tests.push({
+        fShaderSource: wtu.replaceParams(wtu.getScript('fragmentShader'), replaceParams),
+        passMsg: typeInfo.type,
+        fShaderSuccess: true,
+        linkSuccess: true,
+        render: true
+    });
+});
+GLSLConformanceTester.runTests(tests);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Add a test to verify that ternary operators can be used in global initializers.

Fragment shaders are of the form:
  precision mediump float;
  $(type) green = $(green);
  $(type) black = $(black);
  $(type) var = (true) ? green : black;
  void main() {
      gl_FragColor = $(asVec4);
  }

In order to pass, program should successfully link and output green.
