### PR TITLE
Add tests for texture copying feedback loops behavior.

### DIFF
--- a/sdk/tests/conformance/textures/00_test_list.txt
+++ b/sdk/tests/conformance/textures/00_test_list.txt
@@ -41,6 +41,7 @@ texture-active-bind.html
 --min-version 1.0.2 texture-attachment-formats.html
 --min-version 1.0.2 texture-clear.html
 texture-complete.html
+--min-version 1.0.3 texture-copying-feedback-loops.html
 --min-version 1.0.2 texture-hd-dpi.html
 --min-version 1.0.2 texture-formats-test.html
 texture-mips.html

--- a/sdk/tests/conformance/textures/texture-copying-feedback-loops.html
+++ b/sdk/tests/conformance/textures/texture-copying-feedback-loops.html
@@ -1,0 +1,103 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Texture Copying Feedback Loops Test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="example" width="1" height="1" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+"use strict";
+description("Checks that texture copying feedback loops fail correctly.");
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example");
+
+var texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+var texture2 = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture2);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+var framebuffer = gl.createFramebuffer();
+gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+assertMsg(gl.checkFramebufferStatus(gl.FRAMEBUFFER) == gl.FRAMEBUFFER_COMPLETE,
+    "framebuffer should be FRAMEBUFFER_COMPLETE.");
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after setup");
+
+debug("");
+debug("testing copyTexImage2D");
+gl.bindTexture(gl.TEXTURE_2D, texture);
+gl.copyTexImage2D(gl.TEXTURE_2D, 1, gl.RGBA, 0, 0, 2, 2, 0);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+    "after copyTexImage2D to same texture but different level");
+gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 0, 0, 2, 2, 0);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+    "after copyTexImage2D to same texture same level, invalid feedback loop");
+gl.bindTexture(gl.TEXTURE_2D, texture2);
+gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 0, 0, 2, 2, 0);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+    "after copyTexImage2D to different texture");
+
+debug("");
+debug("testing copyTexSubImage2D");
+gl.bindTexture(gl.TEXTURE_2D, texture);
+gl.copyTexSubImage2D(gl.TEXTURE_2D, 1, 0, 0, 0, 0, 1, 1);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+    "after copyTexSubImage2D to same texture but different level");
+gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+    "after copyTexSubImage2D to same texture same level, invalid feedback loop");
+gl.bindTexture(gl.TEXTURE_2D, texture2);
+gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+    "after copyTexSubImage2D to different texture");
+var successfullyParsed = true;
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
I only find the draw feedback loop tests, but not the copyTex{sub}Image. So here they are.
