### PR TITLE
Add a separate test for accessing texture when none is bound.

### DIFF
--- a/sdk/tests/conformance/extensions/oes-element-index-uint.html
+++ b/sdk/tests/conformance/extensions/oes-element-index-uint.html
@@ -181,20 +181,20 @@ function runDrawTests(drawType) {
         gl.enableVertexAttribArray(opt_positionLocation);
         gl.vertexAttribPointer(opt_positionLocation, 3, gl.FLOAT, false, 0, 0);
     };
-    function testPixel(blackList, whiteList, drawNumber) {
+    function testPixel(blackList, whiteList) {
         function testList(list, expected) {
             for (var n = 0; n < list.length; n++) {
                 var l = list[n];
                 var x = -Math.floor(l * canvas.width / 2) + canvas.width / 2;
                 var y = -Math.floor(l * canvas.height / 2) + canvas.height / 2;
-                wtu.checkCanvasRect(gl, x, y, 1, 1, [expected, expected, expected, 255],
-                    "Draw " + drawNumber + " should pass", 2);
+                wtu.checkCanvasRect(gl, x, y, 1, 1, [expected, expected, expected],
+                    "Draw should pass", 2);
             }
         }
         testList(blackList, 0);
         testList(whiteList, 255);
     };
-    function verifyDraw(drawNumber, s) {
+    function verifyDraw(s) {
         gl.clearColor(1.0, 1.0, 1.0, 1.0);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_INT, 0);
@@ -209,11 +209,11 @@ function runDrawTests(drawType) {
                 whiteList.push(points[n]);
             }
         }
-        testPixel(blackList, whiteList, drawNumber);
+        testPixel(blackList, whiteList);
     };
 
     setupDraw(0.5);
-    verifyDraw(0, 0.5);
+    verifyDraw(0.5);
 }
 
 function runIndexValidationTests(drawType) {

--- a/sdk/tests/conformance/textures/00_test_list.txt
+++ b/sdk/tests/conformance/textures/00_test_list.txt
@@ -1,6 +1,7 @@
 compressed-tex-image.html
 copy-tex-image-and-sub-image-2d.html
 --min-version 1.0.2 copy-tex-image-2d-formats.html
+--min-version 1.0.3 default-texture.html
 --min-version 1.0.2 gl-get-tex-parameter.html
 gl-pixelstorei.html
 gl-teximage.html

--- a/sdk/tests/conformance/textures/default-texture.html
+++ b/sdk/tests/conformance/textures/default-texture.html
@@ -1,0 +1,63 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests texture access with no texture bound</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="example" width="24" height="24"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+var wtu = WebGLTestUtils;
+description();
+
+var gl = wtu.create3DContext("example");
+var program = wtu.setupTexturedQuad(gl);
+
+gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+// When no texture is bound, it is considered an incomplete texture,
+// therefore, [0, 0, 0, 1] should be returned.
+// See OpenGL ES spec 2.0.25, section F.3.5.
+wtu.checkCanvas(gl, [0, 0, 0, 255]);
+
+var successfullyParsed = true;
+</script>
+<script src="../../resources/js-test-post.js"></script>
+
+</body>
+</html>
+


### PR DESCRIPTION
So we remove that behavior from oes-element-index-uint.html
