### PR TITLE
Fix tex-new-formats to reflect WebGL2 sRGB semantics

### DIFF
--- a/sdk/tests/conformance2/core/tex-new-formats.html
+++ b/sdk/tests/conformance2/core/tex-new-formats.html
@@ -268,12 +268,12 @@ function runTexFormatsTest()
         },
         {
             sizedformat: "SRGB8",
-            unsizedformat: "SRGB",
+            unsizedformat: "RGB",
             type: "UNSIGNED_BYTE",
         },
         {
             sizedformat: "SRGB8_ALPHA8",
-            unsizedformat: "SRGB_ALPHA",
+            unsizedformat: "RGBA",
             type: "UNSIGNED_BYTE",
         },
         {


### PR DESCRIPTION
I didn't realize this when I wrote this test, but this is a substantial difference between WebGL2 (i.e. ES 3) and the old EXT_sRGB. In WebGL2 / ES3, there is not even a SRGB_ALPHA constant. Instead, people are expected to use RGB and RGBA for format. In other words, WebGL2 / ES3 does not have 1:1 mapping between sized formats, and (unsized format, type) pairs. The (RGBA, UNSIGNED_BYTE) pair corresponds to both plain old RGBA8, and to SRGB8_ALPHA8.
