### PR TITLE
Add conformance tests for TEXTURE_BASE_LEVEL and TEXTURE_MAX_LEVEL.

### DIFF
--- a/sdk/tests/conformance2/core/00_test_list.txt
+++ b/sdk/tests/conformance2/core/00_test_list.txt
@@ -5,3 +5,4 @@ instanced-arrays.html
 tex-new-formats.html
 tex-storage-2d.html
 vertex-array-object.html
+tex-mipmap-levels.html

--- a/sdk/tests/conformance2/core/tex-mipmap-levels.html
+++ b/sdk/tests/conformance2/core/tex-mipmap-levels.html
@@ -1,0 +1,133 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 Non-Power of 2 texture conformance test.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../conformance/resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="2" height="2" style="width: 2px; height: 2px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">
+uniform vec4 uMult;
+attribute vec4 vPosition;
+attribute vec2 texCoord0;
+varying vec2 texCoord;
+void main()
+{
+    gl_Position = vPosition * uMult;
+    texCoord = texCoord0;
+}
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">
+precision mediump float;
+uniform sampler2D tex;
+varying vec2 texCoord;
+void main()
+{
+    gl_FragColor = texture2D(tex, texCoord);
+}
+</script>
+<script>
+"use strict";
+description(document.title);
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example");
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
+
+(function() {
+  debug("");
+  debug("test mipmap level ranges");
+  var tex = gl.createTexture();
+  wtu.setupUnitQuad(gl, 0, 1);
+  var program = wtu.setupProgram(
+      gl, ['vshader', 'fshader'], ['vPosition', 'texCoord0'], [0, 1]);
+
+  gl.disable(gl.DEPTH_TEST);
+  gl.disable(gl.BLEND);
+  gl.uniform1i(gl.getUniformLocation(program, "tex"), 0);
+
+  var multLoc = gl.getUniformLocation(program, "uMult");
+  gl.uniform4f(multLoc, 1, 1, 1, 1);
+
+  // Test that filling partial levels is enough for mipmapping.
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  wtu.fillTexture(gl, tex, 8, 8, [255, 0, 0, 255], 2, gl.RGBA, gl.UNSIGNED_BYTE);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fillTexture(8,8,2) should succeed");
+  wtu.fillTexture(gl, tex, 4, 4, [0, 255, 0, 255], 3, gl.RGBA, gl.UNSIGNED_BYTE);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fillTexture(4,4,3) should succeed");
+  wtu.fillTexture(gl, tex, 2, 2, [0, 0, 255, 255], 4, gl.RGBA, gl.UNSIGNED_BYTE);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fillTexture(2,2,4) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, 2);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_BASE_LEVEL) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAX_LEVEL, 4);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAX_LEVEL) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAG_FILTER) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MIN_FILTER) should succeed");
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
+  wtu.checkCanvas(gl, [0, 0, 255, 255], "should draw with [0, 0, 255, 255]");
+
+  // Test that generateMipmap works with partial levels.
+  gl.generateMipmap(gl.TEXTURE_2D);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "generateMipmap should succeed");
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
+
+  // Test incompleteless for partial levels.
+  var tex = gl.createTexture()
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  wtu.fillTexture(gl, tex, 8, 8, [255, 0, 0, 255], 2, gl.RGBA, gl.UNSIGNED_BYTE);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fillTexture(8,8,2) should succeed");
+  wtu.fillTexture(gl, tex, 4, 4, [255, 0, 0, 255], 3, gl.RGBA, gl.UNSIGNED_BYTE);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fillTexture(4,4,3) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, 2);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_BASE_LEVEL) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAX_LEVEL, 4);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAX_LEVEL) should succeed");
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
+  wtu.checkCanvas(gl, [0, 0, 0, 255], "incomplete; should draw with [0, 0, 0, 255]");
+})();
+
+var successfullyParsed = true;
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
These are a few tests for section 3.8.13 (texture mipmapping completeness) of the ES3 spec; they test that partial ranges can make a texture mipmap complete.
