### PR TITLE
Fix binding attributes to matching locations.

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/conditional-discard-in-loop.html
+++ b/sdk/tests/conformance/glsl/bugs/conditional-discard-in-loop.html
@@ -137,8 +137,8 @@ if (!gl) {
   gl.clearColor(1.0, 0.0, 0.0, 1.0);
   gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
   
-  var attribBuffers = wtu.setupUnitQuad(gl);
-  var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], attribBuffers);
+  var attribBuffers = wtu.setupUnitQuad(gl, 0, 1);
+  var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["a_position", "a_tex_coords"], [0, 1]);
 
   // Bind texture  
   var uniformMap = wtu.getUniformMap(gl, program);


### PR DESCRIPTION
This fixes passing this test with SwiftShader. The test was assuming that the position attribute had location 0 and the texture coordinates had location 1, while SwiftShader assigned them in the reverse order (which it is free to do in the absence of glBindAttribLocation calls).
