### PR TITLE
Expression Lists in Declarator Initializers

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -2,6 +2,7 @@ attrib-location-length-limits.html
 --min-version 1.0.3 boolean_precision.html
 embedded-struct-definitions-forbidden.html
 empty_main.vert.html
+--min-version 1.0.3 expression-list-in-declarator-initializer.html
 gl_position_unset.vert.html
 # this test is intentionally disabled as it is too strict and to hard to simulate
 # glsl-2types-of-textures-on-same-unit.html

--- a/sdk/tests/conformance/glsl/misc/expression-list-in-declarator-initializer.html
+++ b/sdk/tests/conformance/glsl/misc/expression-list-in-declarator-initializer.html
@@ -1,0 +1,87 @@
+<!--
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css" />
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css" />
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+<title></title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragmentShader" type="text/something-not-javascript">
+precision mediump float;
+void main() {
+    $(type) a, b;
+    $(type) c = (b = $(initializer), a = b);
+    gl_FragColor = $(asVec4);
+}
+</script>
+<script>
+"use strict";
+description("Verifies expression lists in declarator initializers work correctly.");
+var tests = [];
+var wtu = WebGLTestUtils;
+var typeInfos = [
+    { type: 'float',    initializer: '1.0',                         asVec4: 'vec4(0.0,$(var),0.0,1.0)' },
+    { type: 'vec2',     initializer: 'vec2(0.0, 1.0)',              asVec4: 'vec4($(var),0.0,1.0)' },
+    { type: 'vec3',     initializer: 'vec3(0.0, 1.0, 0.0)',         asVec4: 'vec4($(var),1.0)' },
+    { type: 'vec4',     initializer: 'vec4(0.0, 1.0, 0.0, 1.0)',    asVec4: '$(var)' },
+    { type: 'int',      initializer: '1',                           asVec4: 'vec4(0.0,$(var),0.0,1.0)' },
+    { type: 'ivec2',    initializer: 'ivec2(0, 1)',                 asVec4: 'vec4($(var),0.0,1.0)' },
+    { type: 'ivec3',    initializer: 'ivec3(0, 1, 0)',              asVec4: 'vec4($(var),1.0)' },
+    { type: 'ivec4',    initializer: 'ivec4(0, 1, 0, 1)',           asVec4: 'vec4($(var))' },
+    { type: 'bool',     initializer: 'true',                        asVec4: 'vec4(0.0,$(var),0.0,1.0)' },
+    { type: 'bvec2',    initializer: 'bvec2(false, true)',          asVec4: 'vec4($(var),0.0,1.0)' },
+    { type: 'bvec3',    initializer: 'bvec3(false, true, false)',   asVec4: 'vec4($(var),1.0)' },
+    { type: 'bvec4',    initializer: 'bvec4(false,true,false,true)',asVec4: 'vec4($(var))' },
+];
+// Ensure that each variable is properly initialized to green, not just c.
+['a', 'b', 'c'].forEach(function(varName) {
+    typeInfos.forEach(function (typeInfo) {
+        var replaceParams = {
+            type: typeInfo.type,
+            initializer: typeInfo.initializer,
+            asVec4: wtu.replaceParams(typeInfo.asVec4, {var: varName}),
+        };
+        tests.push({
+            fShaderSource: wtu.replaceParams(wtu.getScript('fragmentShader'), replaceParams),
+            passMsg: typeInfo.type + ' with contents of ' + varName + ' rendered',
+            fShaderSuccess: true,
+            linkSuccess: true,
+            render:true
+        });
+    });
+});
+GLSLConformanceTester.runTests(tests);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Verifies expression lists in declarator initializers work correctly.

Shaders are of the form:
  precision mediump float;
  void main() {
      $(type) a, b;
      $(type) c = (b = $(initializer), a = b);
      gl_FragColor = $(asVec4);
  }

Test ensures c, b and a are initialized correctly.
