### PR TITLE
Don't require FS highp support in multiplication-assignment test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/multiplication-assignment.html
+++ b/sdk/tests/conformance/glsl/bugs/multiplication-assignment.html
@@ -41,7 +41,7 @@ void main(){
 }
 </script>
 <script id="shader-fs" type="x-shader/x-fragment">
-precision highp float;
+precision mediump float;
 uniform mat3 rot;
 float foo(vec3 bar) {
     bar *= rot;


### PR DESCRIPTION
This test should still reproduce the original bug, since precision does not matter on the desktop OpenGL backend where the bug was reported.
