### PR TITLE
Fix shader issues in WebGL 2 tests and add new shader tests

### DIFF
--- a/sdk/tests/conformance2/00_test_list.txt
+++ b/sdk/tests/conformance2/00_test_list.txt
@@ -1,2 +1,3 @@
 context/00_test_list.txt
 core/00_test_list.txt
+glsl3/00_test_list.txt

--- a/sdk/tests/conformance2/core/draw-buffers.html
+++ b/sdk/tests/conformance2/core/draw-buffers.html
@@ -38,32 +38,51 @@
 <div id="description"></div>
 <canvas id="canvas" width="64" height="64"> </canvas>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
+<script id="vshaderESSL3" type="x-shader/x-vertex">#version 300 es
+in vec4 a_position;
+void main() {
+    gl_Position = a_position;
+}
+</script>
+<script id="vshaderESSL1" type="x-shader/x-vertex">
 attribute vec4 a_position;
 void main() {
     gl_Position = a_position;
 }
 </script>
-<script id="fshader" type="x-shader/x-fragment">
-#version 300 es
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 uniform vec4 u_colors[$(numDrawingBuffers)];
+
+// Only one out variable - does not need explicit output layout (ESSL 3 section 4.3.8.2)
+out vec4 my_FragData[$(numDrawingBuffers)];
 void main() {
     for (int i = 0; i < $(numDrawingBuffers); ++i) {
-        gl_FragData[i] = u_colors[i];
+        my_FragData[i] = u_colors[i];
     }
 }
 </script>
-<script id="fshaderRed" type="x-shader/x-fragment">
+<script id="fshaderRed" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
+
+out vec4 my_FragColor;
 void main() {
-    gl_FragColor = vec4(1,0,0,1);
+    my_FragColor = vec4(1, 0, 0, 1);
 }
 </script>
-<script id="fshaderBuiltInConstEnabled" type="x-shader/x-fragment">
+<script id="fshaderBlueESSL1" type="x-shader/x-fragment">
 precision mediump float;
+
 void main() {
-    gl_FragColor = (gl_MaxDrawBuffers == $(numDrawingBuffers)) ? vec4(0,1,0,1) : vec4(1,0,0,1);
+    gl_FragColor = vec4(0, 0, 1, 1);
+}
+</script>
+<script id="fshaderBuiltInConstEnabled" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+void main() {
+    my_FragColor = (gl_MaxDrawBuffers == $(numDrawingBuffers)) ? vec4(0, 1, 0, 1) : vec4(1, 0, 0, 1);
 }
 </script>
 <script>
@@ -93,7 +112,7 @@ function createDrawBuffersProgram(scriptId, sub) {
   var fsource = wtu.getScript(scriptId);
   fsource = wtu.replaceParams(fsource, sub);
   wtu.addShaderSource(output, "fragment shader", fsource);
-  return wtu.setupProgram(gl, ["vshader", fsource], ["a_position"]);
+  return wtu.setupProgram(gl, ["vshaderESSL3", fsource], ["a_position"]);
 }
 
 function runShadersTest() {
@@ -152,9 +171,9 @@ function runAttachmentTest() {
     bufs[0] = gl.COLOR_ATTACHMENT1;
     bufs[1] = gl.COLOR_ATTACHMENT0;
     gl.drawBuffers(bufs);
-    glErrorShouldBe(gl, gl.INVALID_OPERATION, "should not be able to call drawBuffers with out of order attachments of size " + maxColorAttachments);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should not be able to call drawBuffers with out of order attachments of size " + maxColorAttachments);
     var bufs = makeColorAttachmentArray(Math.floor(maxDrawingBuffers / 2));
-    glErrorShouldBe(gl, gl.NO_ERROR, "should not be able to call drawBuffers with short array of attachments of size " + maxColorAttachments);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with short array of attachments of size " + bufs.length);
   }
 
   gl.deleteFramebuffer(fb);
@@ -209,7 +228,8 @@ function runDrawTests() {
   });
 
   var checkProgram = wtu.setupTexturedQuad(gl);
-  var redProgram = wtu.setupProgram(gl, ["vshader", "fshaderRed"], ["a_position"]);
+  var redProgram = wtu.setupProgram(gl, ["vshaderESSL3", "fshaderRed"], ["a_position"]);
+  var blueProgramESSL1 = wtu.setupProgram(gl, ["vshaderESSL1", "fshaderBlueESSL1"], ["a_position"]);
   var drawProgram = createDrawBuffersProgram("fshader", {numDrawingBuffers: maxDrawingBuffers});
   var width = 64;
   var height = 64;
@@ -348,13 +368,26 @@ function runDrawTests() {
 
   checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
 
-  debug("test that gl_FragColor broadcasts");
+  // GLES3 spec section 3.9.2 Shader Outputs
+  debug("test that gl_FragColor only writes to color number zero");
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  gl.drawBuffers(bufs);
+  gl.useProgram(blueProgramESSL1);
+  wtu.drawUnitQuad(gl);
+
+  checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    return (index == 0) ? [0, 0, 255, 255] : [0, 255, 0, 255];
+  });
+
+  debug("test that an OpenGL ES Shading Language 3.00 shader with a single output color only writes to color number zero");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   gl.drawBuffers(bufs);
   gl.useProgram(redProgram);
   wtu.drawUnitQuad(gl);
 
-  checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+  checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    return (index == 0) ? [255, 0, 0, 255] : [0, 255, 0, 255];
+  });
 
   if (maxUsable > 1) {
     var bufs1 = makeColorAttachmentArray(maxUsable);
@@ -480,13 +513,16 @@ function runDrawTests() {
     shouldBe("gl.getParameter(gl.DRAW_BUFFER0 + " + ii + ")", "gl.NONE");
   }
 
+  // GLES3.0 spec section 4.4.4: Mismatching attachment size is not an error.
   debug("test attachment size mis-match");
   gl.bindTexture(gl.TEXTURE_2D, attachments[0].texture);
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width * 2, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
-  shouldBeTrue("gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE");
+  shouldBeTrue("gl.checkFramebufferStatus(gl.FRAMEBUFFER) == gl.FRAMEBUFFER_COMPLETE");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
-  shouldBeTrue("gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE");
+  shouldBeTrue("gl.checkFramebufferStatus(gl.FRAMEBUFFER) == gl.FRAMEBUFFER_COMPLETE");
+
+  // TODO: Rendering when framebuffer attachments have mismatched size should be tested, maybe in a separate test.
 
   gl.deleteFramebuffer(fb);
   gl.deleteFramebuffer(fb2);

--- a/sdk/tests/conformance2/core/frag-depth.html
+++ b/sdk/tests/conformance2/core/frag-depth.html
@@ -41,44 +41,54 @@
 <!-- Shaders for testing fragment depth writing -->
 
 <!-- Shader omitting the required #version -->
-<script id="missingPragmaFragmentShader" type="x-shader/x-fragment">
+<script id="fragmentShaderESSL1" type="x-shader/x-fragment">
 precision mediump float;
 void main() {
     gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
     gl_FragDepth = 1.0;
 }
 </script>
-
 <!-- Shader with required #version -->
-<script id="testFragmentShader" type="x-shader/x-fragment">
-#version 300 es
+<script id="fragmentShaderESSL3" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
+out vec4 my_FragColor;
 void main() {
-    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    my_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
     gl_FragDepth = 1.0;
+}
+</script>
+<!-- Shader using the EXT suffix -->
+<script id="fragmentShaderESSL3EXT" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+void main() {
+    my_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragDepthEXT = 1.0;
 }
 </script>
 <!-- Shaders to link with test fragment shaders -->
-<script id="goodVertexShader" type="x-shader/x-vertex">
+<script id="vertexShaderESSL1" type="x-shader/x-vertex">
 attribute vec4 vPosition;
 void main() {
     gl_Position = vPosition;
 }
 </script>
-<!-- Shaders to test output -->
-<script id="outputVertexShader" type="x-shader/x-vertex">
-attribute vec4 vPosition;
+<script id="vertexShaderESSL3" type="x-shader/x-vertex">#version 300 es
+in vec4 vPosition;
 void main() {
     gl_Position = vPosition;
 }
 </script>
-<script id="outputFragmentShader" type="x-shader/x-fragment">
-#version 300 es
+
+<!-- Shader to test output -->
+<script id="outputFragmentShader" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 uniform float uDepth;
+
+out vec4 my_FragColor;
 void main() {
-    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
-    gl_FragDepthEXT = uDepth;
+    my_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    gl_FragDepth = uDepth;
 }
 </script>
 
@@ -98,6 +108,7 @@ if (!gl) {
     testPassed("WebGL context exists");
 
     runShaderTests();
+    debug("");
     runOutputTests();
 }
 
@@ -105,38 +116,45 @@ function runShaderTests() {
     debug("");
     debug("Testing various shader compiles");
 
-    // Always expect the shader missing the #version to fail
-    var missingPragmaFragmentProgram = wtu.loadProgramFromScriptExpectError(gl, "goodVertexShader", "missingPragmaFragmentShader");
-    if (missingPragmaFragmentProgram) {
-        testFailed("Shader built-ins allowed without #version");
+    // Always expect ESSL1 shaders to fail
+    var fragmentProgramESSL1 = wtu.loadProgramFromScriptExpectError(gl, "vertexShaderESSL1", "fragmentShaderESSL1");
+    if (fragmentProgramESSL1) {
+        testFailed("gl_FragDepth allowed in ESSL1 shader - should be disallowed");
     } else {
-        testPassed("Shader built-ins disallowed without #version");
+        testPassed("gl_FragDepth disallowed in ESSL1 shader");
     }
 
     // Try to compile a shader using the built-ins that should only succeed if enabled
-    var testFragmentProgram = wtu.loadProgramFromScriptExpectError(gl, "goodVertexShader", "testFragmentShader");
+    var testFragmentProgram = wtu.loadProgramFromScriptExpectError(gl, "vertexShaderESSL3", "fragmentShaderESSL3");
     if (testFragmentProgram) {
-        testPassed("Shader built-ins compiled successfully");
+        testPassed("gl_FragDepth allowed in ESSL3 shader");
     } else {
-        testFailed("Shader built-ins failed to compile");
+        testFailed("gl_FragDepth disallowed in ESSL3 shader");
+    }
+
+    var testFragmentProgram = wtu.loadProgramFromScriptExpectError(gl, "vertexShaderESSL3", "fragmentShaderESSL3EXT");
+    if (testFragmentProgram) {
+        testFailed("gl_FragDepthEXT allowed in ESSL3 shader - should only allow gl_FragDepth");
+    } else {
+        testPassed("gl_FragDepthEXT disallowed in ESSL3 shader");
     }
 }
 
 function runOutputTests() {
-    debug("Testing various draws for valid built-in function behavior");
+    debug("Testing rendering results from writing to gl_FragData");
 
     canvas.width = 50; canvas.height = 50;
     gl.viewport(0, 0, canvas.width, canvas.height);
     
     // Enable depth testing with a clearDepth of 0.5
     // This makes it so that fragments are only rendered when
-    // gl_fragDepth is < 0.5
+    // gl_FragDepth is < 0.5
     gl.clearDepth(0.5);
     gl.enable(gl.DEPTH_TEST);
 
     var positionLoc = 0;
     var texcoordLoc = 1;
-    var program = wtu.setupProgram(gl, ["outputVertexShader", "outputFragmentShader"], ['vPosition'], [0]);
+    var program = wtu.setupProgram(gl, ["vertexShaderESSL3", "outputFragmentShader"], ['vPosition'], [0]);
     var quadParameters = wtu.setupUnitQuad(gl, 0, 1);
     var depthUniform = gl.getUniformLocation(program, "uDepth");
 

--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -1,0 +1,2 @@
+misplaced-version-directive.html
+shader-linking.html

--- a/sdk/tests/conformance2/glsl3/misplaced-version-directive.html
+++ b/sdk/tests/conformance2/glsl3/misplaced-version-directive.html
@@ -1,0 +1,132 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>#version directive should be on the very first line of a OpenGL ES Shading Language 3.00 shader</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../conformance/resources/glsl-feature-tests.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../conformance/resources/webgl-test-utils.js"></script>
+<script src="../../conformance/resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<!-- Version directive should be on the very first line in ESSL 3, see ESSL 3 section 3.3 -->
+<script id="VertexShaderCommentBeforeVersion" type="x-shader/x-vertex">// This shader is wrong, this is the first line that should have version
+#version 300 es
+precision mediump float;
+in vec4 aPosition;
+
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+<script id="VertexShaderNewlineBeforeVersion" type="x-shader/x-vertex">
+#version 300 es
+precision mediump float;
+in vec4 aPosition;
+
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+<script id="CorrectVertexShader" type="x-shader/x-vertex">#version 300 es
+precision mediump float;
+in vec4 aPosition;
+
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+<script id="FragmentShaderCommentBeforeVersion" type="x-shader/x-fragment">// This shader is wrong, this is the first line that should have version
+#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+void main() {
+    my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script id="FragmentShaderNewlineBeforeVersion" type="x-shader/x-fragment">
+#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+void main() {
+    my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script id="CorrectFragmentShader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+void main() {
+    my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description();
+GLSLConformanceTester.runTests([
+  {
+    vShaderId: "VertexShaderNewlineBeforeVersion",
+    vShaderSuccess: false,
+    fShaderId: "CorrectFragmentShader",
+    fShaderSuccess: true,
+    linkSuccess: false,
+    passMsg: "Vertex shader with a newline before the version directive should fail."
+  },
+  {
+    vShaderId: "VertexShaderCommentBeforeVersion",
+    vShaderSuccess: false,
+    fShaderId: "CorrectFragmentShader",
+    fShaderSuccess: true,
+    linkSuccess: false,
+    passMsg: "Vertex shader with a comment before the version directive should fail."
+  },
+  {
+    vShaderId: "CorrectVertexShader",
+    vShaderSuccess: true,
+    fShaderId: "FragmentShaderCommentBeforeVersion",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Fragment shader with a comment before the version directive should fail."
+  },
+  {
+    vShaderId: "CorrectVertexShader",
+    vShaderSuccess: true,
+    fShaderId: "FragmentShaderNewlineBeforeVersion",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Fragment shader with a newline before the version directive should fail."
+  }
+]);
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/glsl3/shader-linking.html
+++ b/sdk/tests/conformance2/glsl3/shader-linking.html
@@ -1,0 +1,105 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>OpenGL ES Shading Language 1.00 and OpenGL ES Shading Language 3.00 shaders should not link with each other</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../conformance/resources/glsl-feature-tests.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../conformance/resources/webgl-test-utils.js"></script>
+<script src="../../conformance/resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="ES3VertexShader" type="x-shader/x-vertex">#version 300 es
+precision mediump float;
+in vec4 aPosition;
+
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+<script id="ES3FragmentShader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+void main() {
+    my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script id="ESSL1VertexShader" type="x-shader/x-vertex">
+precision mediump float;
+attribute vec4 aPosition;
+
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+<script id="ESSL1FragmentShader" type="x-shader/x-fragment">
+precision mediump float;
+
+void main() {
+    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description();
+// See OpenGL ES Shading Language 3.00 spec section 1.5 or 3.3
+GLSLConformanceTester.runTests([
+  {
+    vShaderId: "ES3VertexShader",
+    vShaderSuccess: true,
+    fShaderId: "ES3FragmentShader",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: "OpenGL ES Shading Language 3.00 vertex shader should link with OpenGL ES Shading Language 3.00 fragment shader."
+  },
+  {
+    vShaderId: "ES3VertexShader",
+    vShaderSuccess: true,
+    fShaderId: "ESSL1FragmentShader",
+    fShaderSuccess: true,
+    linkSuccess: false,
+    passMsg: "OpenGL ES Shading Language 3.00 vertex shader should not link with OpenGL ES Shading Language 1.00 fragment shader."
+  },
+  {
+    vShaderId: "ESSL1VertexShader",
+    vShaderSuccess: true,
+    fShaderId: "ES3FragmentShader",
+    fShaderSuccess: true,
+    linkSuccess: false,
+    passMsg: "OpenGL ES Shading Language 1.00 vertex shader should not link with OpenGL ES Shading Language 3.00 fragment shader."
+  }
+]);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
The new shader tests test that #version directive must be on the first
line and that linking shaders written in different versions of ESSL is
not allowed.

Draw buffers test is edited to not mix shaders with different ESSL
versions, have the #version directives on the right line, not to use
undefined built-ins, and to test writing to a single output color and
mis-matched attachment sizes according to the spec. Some other
miscellaneous errors are also fixed.

Frag depth test is edited to not mix shaders with different ESSL
versions, have the #version directives on the right line, and not to use
undefined built-ins. A test case is added to confirm that gl_FragDepthEXT
with the EXT suffix is not allowed.
