### PR TITLE
Improve the explanation of viewport and scissor in the WebGL 1 spec

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 19 September 2014</h2>
+    <h2 class="no-toc">Editor's Draft 27 October 2014</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -366,7 +366,7 @@
     
 <!-- ======================================================================================================= -->
 
-    <h3>The WebGL Viewport</h3>
+    <h3><a name="WEBGL_VIEWPORT">The WebGL Viewport</a></h3>
 
     <p>
         OpenGL manages a rectangular viewport as part of its state which defines the placement of
@@ -2069,14 +2069,20 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
     <h4>Viewing and clipping</h4>
 
     <p>
-        The viewport specifies the affine transformation of x and y from normalized device 
-        coordinates to window coordinates. The size of the drawing buffer is determined by 
-        the HTMLCanvasElement. The scissor box defines a rectangle which constrains drawing.
-        When the scissor test is enabled only pixels that lie within  the scissor box can 
-        be modified by drawing commands. When enabled drawing can only occur inside the 
-        intersection of the viewport, canvas area and the scissor box. When the scissor test
-        is not enabled drawing can only occur inside the intersection of the viewport and 
-        canvas area.
+        Drawing commands can only modify pixels inside the currently bound framebuffer. In
+        addition, the viewport and the scissor box affect drawing.
+    </p>
+
+    <p>
+        The viewport specifies the affine transformation of x and y from normalized device
+        coordinates to window coordinates. The size of the viewport is initially determined
+        as specified in section <a href="#WEBGL_VIEWPORT">The WebGL Viewport</a>.
+        The scissor box defines a rectangle which constrains drawing. When the scissor test is
+        enabled only pixels that lie within the scissor box can be modified by drawing commands
+        including <code>clear</code>, and primitives can only be drawn inside the intersection
+        of the viewport, the currently bound framebuffer, and the scissor box. When the scissor
+        test is not enabled primitives can only be drawn inside the intersection of the viewport
+        and the currently bound framebuffer.
     </p>
 
     <dl class="methods">


### PR DESCRIPTION
The spec mentioned that drawing was constrained by canvas area, but it
should instead refer to framebuffer area, since rendering to an FBO
should not be constrained by the size of the canvas. Also, clarify that
the viewport only constrains the drawing of primitives, and not clearing
the framebuffer. This should remove the most glaring contradictions with
the GLES2.0 spec.

A mention of how the drawing buffer size is initialized is removed from
this section, as it was redundant and confusing.

Add a clear mention that drawing commands can only modify pixels inside
the currently bound framebuffer, since the GLES2.0 spec does not seem to
clearly address what happens when the viewport extends outside the
framebuffer and draw commands are called.
