### PR TITLE
Add a test for constant variable precision qualifiers

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -4,6 +4,7 @@
 --min-version 1.0.3 compare-loop-index-to-uniform.html
 --min-version 1.0.3 complex-glsl-does-not-crash.html
 --min-version 1.0.3 conditional-discard-optimization.html
+--min-version 1.0.3 constant-precision-qualifier.html
 --min-version 1.0.3 floored-division-accuracy.html
 --min-version 1.0.3 fragcoord-linking-bug.html
 --min-version 1.0.3 long-expressions-should-not-crash.html

--- a/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
+++ b/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
@@ -1,0 +1,99 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Bug - the precision qualifier of a constant variable should affect the precision of a consuming operation</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="256" height="256"> </canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+
+void main() {
+    gl_Position = vec4(aPosition, 1);
+}
+</script>
+<script id="fshader" type="x-shader/x-fragment">
+// It is assumed that uTest is set to 0. It's here to make the expression not constant.
+uniform mediump float uTest;
+
+void main() {
+    // exact representation of 4096.5 requires 13 bits of relative precision.
+    const highp float c = 4096.5;
+    mediump float a = 0.0;
+    // Below, addition should be evaluated at highp, since one of the operands has the highp qualifier.
+    // Thus fract should also be evaluated at highp.
+    // See OpenGL ES Shading Language spec section 4.5.2.
+    // This should make the result 0.5, since highp provides at least 16 bits of relative precision.
+    // (exceptions for operation precision are allowed for a small number of computationally
+    // intensive built-in functions, but it is reasonable to think that fract is not one of those).
+    // However, if fract() is incorrectly evaluated at minimum precision fulfilling mediump criteria,
+    // or at IEEE half float precision, the result is 0.0.
+    a = fract(c + uTest);
+
+    // Multiply by 2.0 to make the color green.
+    gl_FragColor = vec4(0.0, 2.0 * a, 0.0, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description();
+var wtu = WebGLTestUtils;
+
+function test() {
+  var gl = wtu.create3DContext("canvas");
+  if (!gl) {
+    testFailed("context does not exist");
+    return;
+  }
+  if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision == 0) {
+    testPassed("highp precision not supported");
+  } else {
+    wtu.setupUnitQuad(gl);
+    var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["aPosition"], undefined, true);
+    var uniformLoc = gl.getUniformLocation(program, 'uTest');
+    gl.uniform1f(uniformLoc, 0);
+    wtu.drawUnitQuad(gl);
+    wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);
+  }
+};
+
+test();
+var successfullyParsed = true;
+finishTest();
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
The test checks that a precision qualifier of a constant variable affects
the precision of a consuming operation. It targets platforms which
implement different precisions for mediump and highp in hardware, it
will pass on all hardware that only has one precision corresponding to
highp. Also if the test is run on a platform that does not support highp,
it passes without running the shader.
