### PR TITLE
Fix a bug in webgl-draw-buffers.html when the extension is unavailable.

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -161,6 +161,7 @@ if (!gl) {
     testPassed("No WEBGL_draw_buffers support -- this is legal");
 
     runSupportedTest(false);
+    finishTest();
   } else {
     testPassed("Successfully enabled WEBGL_draw_buffers extension");
 


### PR DESCRIPTION
Otherwise the harness won't know the test finished successfully.
