### PR TITLE
Struct Specifiers in Uniforms

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -100,6 +100,7 @@ uniform-location-length-limits.html
 --min-version 1.0.3 struct-equals.html
 --min-version 1.0.3 struct-mixed-array-declarators.html
 --min-version 1.0.3 struct-nesting-of-variable-names.html
+--min-version 1.0.3 struct-specifiers-in-uniforms.html
 --min-version 1.0.3 struct-unary-operators.html
 --min-version 1.0.3 ternary-operators-in-global-initializers.html
 --min-version 1.0.3 ternary-operators-in-initializers.html

--- a/sdk/tests/conformance/glsl/misc/struct-specifiers-in-uniforms.html
+++ b/sdk/tests/conformance/glsl/misc/struct-specifiers-in-uniforms.html
@@ -1,0 +1,84 @@
+<!--
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css" />
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css" />
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+<title></title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragmentShader" type="text/something-not-javascript">
+precision mediump float;
+uniform struct S { $(type) field;} s;
+void main() {
+    // All uniforms are required to be zero initialized. Add the color green 
+    // to make the rendering test pass.
+    gl_FragColor = $(asVec4) + vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script>
+"use strict";
+description("Verifies that structure specifiers work with uniforms.");
+var tests = [];
+var wtu = WebGLTestUtils;
+var typeInfos = [
+    { type: 'float',    asVec4: 'vec4(0.0,s.field,0.0,0.0)' },
+    { type: 'vec2',     asVec4: 'vec4(s.field,0.0,0.0)' },
+    { type: 'vec3',     asVec4: 'vec4(s.field,0.0)' },
+    { type: 'vec4',     asVec4: 's.field' },
+    { type: 'int',      asVec4: 'vec4(0.0,s.field,0.0,0.0)' },
+    { type: 'ivec2',    asVec4: 'vec4(s.field,0.0,0.0)' },
+    { type: 'ivec3',    asVec4: 'vec4(s.field,0.0)' },
+    { type: 'ivec4',    asVec4: 'vec4(s.field)' },
+    { type: 'bool',     asVec4: 'vec4(0.0,s.field,0.0,0.0)' },
+    { type: 'bvec2',    asVec4: 'vec4(s.field,0.0,0.0)' },
+    { type: 'bvec3',    asVec4: 'vec4(s.field,0.0)' },
+    { type: 'bvec4',    asVec4: 'vec4(s.field)' },
+];
+typeInfos.forEach(function (typeInfo) {
+    var replaceParams = {
+        type: typeInfo.type,
+        asVec4: typeInfo.asVec4
+    };
+    tests.push({
+        fShaderSource: wtu.replaceParams(wtu.getScript('fragmentShader'), replaceParams),
+        passMsg: typeInfo.type,
+        fShaderSuccess: true,
+        linkSuccess: true,
+        render:true
+    });
+});
+GLSLConformanceTester.runTests(tests);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Verifies that structure specifiers work with uniforms.

Shaders are of the form:
    precision mediump float;
    uniform struct S { $(type) field;} s;
    void main() {
        // All uniforms are required to be zero initialized. Add the color green
        // to make the rendering test pass.
        gl_FragColor = $(asVec4) + vec4(0.0, 1.0, 0.0, 1.0);
    }
