### PR TITLE
Add MaxInt tests to gl-uniform-arrays.html

### DIFF
--- a/sdk/tests/conformance/uniforms/gl-uniform-arrays.html
+++ b/sdk/tests/conformance/uniforms/gl-uniform-arrays.html
@@ -75,7 +75,8 @@
 "use strict";
 description();
 debug("");
-var MaxInt = 4294967296;
+// MaxInt32 is 2^32-1. We need +1 of that to test overflow conditions.
+var MaxInt32PlusOne = 4294967296;
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext("example");
 
@@ -235,7 +236,7 @@ for (var tt = 0; tt < typeInfos.length; ++tt) {
   var info = gl.getActiveUniform(program, 0);
   assertMsg(info.name == "color[0]",
             "uniform name is 'color[0]' not 'color' as per OpenGL ES 2.0.24 section 2.10");
-  shouldBeNull("gl.getUniformLocation(program, 'color[" + MaxInt + "]');");
+  shouldBeNull("gl.getUniformLocation(program, 'color[" + MaxInt32PlusOne + "]');");
   var loc = gl.getUniformLocation(program, "color[0]");
   var srcValues = typeInfo.srcValues;
   var srcValuesLess = typeInfo.srcValuesLess;
@@ -273,7 +274,7 @@ for (var tt = 0; tt < typeInfos.length; ++tt) {
   assertMsg(typeInfo.checkType(values),
             "gl.getUniform returns the correct type.");
   for (var ii = 0; ii < typeInfo.numSrcValues; ++ii) {
-    shouldBeNull("gl.getUniformLocation(program, 'color[" + (MaxInt + ii) + "]')");
+    shouldBeNull("gl.getUniformLocation(program, 'color[" + (MaxInt32PlusOne + ii) + "]')");
     var elemLoc = gl.getUniformLocation(program, "color[" + ii + "]");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR,
                     "can get location of element " + ii +
@@ -427,10 +428,10 @@ function testUniformOptimizationIssues(testIndex) {
     gl.uniform4fv(colorbLocation, [0, 1, 0, 0]);
   }
 
-  // Ensure that requesting an array uniform past MaxInt returns no uniform
-  var nameMaxInt = test.arrayName + "[" + (test.usedUniformVector + MaxInt) + "]";
-  assertMsg(gl.getUniformLocation(program, nameMaxInt) === null, 
-    "Requesting " + nameMaxInt + " uniform should return a null uniform location");
+  // Ensure that requesting an array uniform past MaxInt32PlusOne returns no uniform
+  var nameMaxInt32PlusOne = test.arrayName + "[" + (test.usedUniformVector + MaxInt32PlusOne) + "]";
+  assertMsg(gl.getUniformLocation(program, nameMaxInt32PlusOne) === null, 
+    "Requesting " + nameMaxInt32PlusOne + " uniform should return a null uniform location");
 
   // Set just the used uniform
   var name = test.arrayName + "[" + test.usedUniformVector + "]";


### PR DESCRIPTION
Add tests to gl-uniform-arrays.html that ensure there is no overflow when calling
getUniformLocation with an array uniform that has an index greater than or equal
to MaxInt.

For instance, 'gl.getUniformLocation(program, "myuniform[4294967296]")' should
fail.
