### PR TITLE
Remove DataView Constructor

### DIFF
--- a/sdk/tests/conformance/typedarrays/data-view-test.html
+++ b/sdk/tests/conformance/typedarrays/data-view-test.html
@@ -265,17 +265,6 @@ function runConstructorTests()
     arrayBuffer = (new Uint8Array([1, 2])).buffer;
 
     debug("");
-    debug("Test for constructor not called as a function");
-    var expr = "DataView(new ArrayBuffer)";
-    // Use try/catch instead of calling shouldThrow to avoid different exception message being reported from different platform.
-    try {
-        TestEval(expr);
-        testFailed(expr + " does not throw exception");
-    } catch (e) {
-        testPassed(expr + " threw exception");
-    }
-
-    debug("");
     debug("Test for constructor taking 1 argument");
     shouldBeDefined("view = new DataView(arrayBuffer)");
     shouldBe("view.byteOffset", "0");


### PR DESCRIPTION
Since the WebGL spec was first authored, the TypedArray spec has been incorporated
into the ES6 draft spec linked at:
http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts.

data-view-test claims that DataView used as a function should throw an exception. However,
according to the newest draft of ES6, DataView is allowed to be called as a function
as well as a constructor. See section "24.2.2 The DataView Constructor"

Since no WebGL functionality is directly used this particular test, we should remove it
from the WebGL conformance suite and handle it as part of the ECMAScript Conformance Test
Suite.
