### PR TITLE
Loosen fragment shader tolerance in glsl function tests from 0 to 1

### DIFF
--- a/conformance-suites/1.0.1/conformance/resources/glsl-generator.js
+++ b/conformance-suites/1.0.1/conformance/resources/glsl-generator.js
@@ -234,9 +234,9 @@ var runFeatureTest = function(params) {
   var wtu = WebGLTestUtils;
   var gridRes = params.gridRes;
   var vertexTolerance = params.tolerance || 0;
-  var fragmentTolerance = vertexTolerance;
+  var fragmentTolerance = params.tolerance || 1;
   if ('fragmentTolerance' in params)
-    fragmentTolerance = params.fragmentTolerance || 0;
+    fragmentTolerance = params.fragmentTolerance;
 
   description("Testing GLSL feature: " + params.feature);
 

--- a/conformance-suites/1.0.2/conformance/resources/glsl-generator.js
+++ b/conformance-suites/1.0.2/conformance/resources/glsl-generator.js
@@ -252,9 +252,9 @@ var runFeatureTest = function(params) {
   var wtu = WebGLTestUtils;
   var gridRes = params.gridRes;
   var vertexTolerance = params.tolerance || 0;
-  var fragmentTolerance = vertexTolerance;
+  var fragmentTolerance = params.tolerance || 1;
   if ('fragmentTolerance' in params)
-    fragmentTolerance = params.fragmentTolerance || 0;
+    fragmentTolerance = params.fragmentTolerance;
 
   description("Testing GLSL feature: " + params.feature);
 

--- a/conformance-suites/1.0.3/conformance/resources/glsl-generator.js
+++ b/conformance-suites/1.0.3/conformance/resources/glsl-generator.js
@@ -310,9 +310,9 @@ var runFeatureTest = function(params) {
   var wtu = WebGLTestUtils;
   var gridRes = params.gridRes;
   var vertexTolerance = params.tolerance || 0;
-  var fragmentTolerance = vertexTolerance;
+  var fragmentTolerance = params.tolerance || 1;
   if ('fragmentTolerance' in params)
-    fragmentTolerance = params.fragmentTolerance || 0;
+    fragmentTolerance = params.fragmentTolerance;
 
   description("Testing GLSL feature: " + params.feature);
 

--- a/sdk/tests/conformance/resources/glsl-generator.js
+++ b/sdk/tests/conformance/resources/glsl-generator.js
@@ -310,9 +310,9 @@ var runFeatureTest = function(params) {
   var wtu = WebGLTestUtils;
   var gridRes = params.gridRes;
   var vertexTolerance = params.tolerance || 0;
-  var fragmentTolerance = vertexTolerance;
+  var fragmentTolerance = params.tolerance || 1;
   if ('fragmentTolerance' in params)
-    fragmentTolerance = params.fragmentTolerance || 0;
+    fragmentTolerance = params.fragmentTolerance;
 
   description("Testing GLSL feature: " + params.feature);
 


### PR DESCRIPTION
Running the tests with precision emulation enabled revealed slight
differences in results from built-in functions compared to their emulated
counterparts. It is possible that these differences reproduce also on
spec-compliant hardware if a built-in function is compiled to different
assembly instructions with higher internal precision than its emulated
counterpart, for example. Because of this, tolerances for GLSL function
tests need to be loosened for calculations done in mediump.

This change is backported to previous versions of the conformance suite.
