### PR TITLE
Promote color-buffer-float exts to Community Approved.

### DIFF
--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_color_buffer_half_float/">
+<extension href="EXT_color_buffer_half_float/">
   <name>EXT_color_buffer_half_float</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list">WebGL
@@ -70,7 +70,7 @@ interface EXT_color_buffer_half_float {
   const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
   const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
 }; // interface EXT_color_buffer_half_float
-</idl>
+  </idl>
 
   <additions>
     <p>In section 5.13.12 <cite>Reading back pixels</cite>, change the allowed
@@ -101,7 +101,6 @@ interface EXT_color_buffer_half_float {
               <td>RGBA</td>
               <td>FLOAT</td>
             </tr>
-
           </tbody>
         </table>
       </dd>
@@ -131,5 +130,9 @@ interface EXT_color_buffer_half_float {
     <revision date="2014/07/15">
       <change>Removed webgl module. Added NoInterfaceObject extended attribute.</change>
     </revision>
+
+    <revision date="2014/11/24">
+      <change>Move to community approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="WEBGL_color_buffer_float/">
+<extension href="WEBGL_color_buffer_float/">
   <name>WEBGL_color_buffer_float</name>
 
   <contact><a href="https://www.khronos.org/webgl/public-mailing-list">WebGL
@@ -66,7 +66,7 @@ interface WEBGL_color_buffer_float {
   const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
   const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
 }; // interface WEBGL_color_buffer_float
-</idl>
+  </idl>
 
   <newtok>
     <function name="renderbufferStorage" type="void"><param name="target"
@@ -115,6 +115,9 @@ interface WEBGL_color_buffer_float {
 
     <revision date="2014/11/24">
       <change>Removed the support for RGB32F, since it is not natively supported on all platforms where WebGL is implemented.</change>
+
+    <revision date="2014/11/24">
+      <change>Move to community approved.</change>
     </revision>
   </history>
-</draft>
+</extension>


### PR DESCRIPTION
The float-texture extensions implicitly enable these extensions, so they should clearly come out from draft.
