### PR TITLE
Reduce memory usage of multisample corruption test

### DIFF
--- a/conformance-suites/1.0.2/conformance/resources/iterable-test.js
+++ b/conformance-suites/1.0.2/conformance/resources/iterable-test.js
@@ -69,10 +69,13 @@ IterableTest = (function() {
     };
   }
 
-  // Creates a canvas and a texture then exits. There are
-  // no references to either so both should be garbage collected.
+  // Draws rectangle on a passed canvas with preserveDrawingBuffer
+  // and antialiasing ON, tests rect color on every iteration.
   function createMultisampleCorruptionTest(gl) {
     var lastContext = null;
+    // Allocate a read back buffer in advance and reuse it for all iterations
+    // to avoid memory issues because of late garbage collection.
+    var readBackBuf = new Uint8Array(gl.canvas.width * gl.canvas.height * 4);
 
     var program = wtu.loadStandardProgram(gl);
     var uniforms = wtu.getUniformMap(gl, program);
@@ -120,7 +123,7 @@ IterableTest = (function() {
                   testFailed(msg);
                   return false;
               },
-          debug);
+          debug, readBackBuf);
           document.body.removeChild(lastContext.canvas);
       }
 

--- a/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
@@ -850,15 +850,17 @@ var clearAndDrawIndexedQuad = function(gl, gridRes, opt_color) {
  * @param {!function()} differentFn Function to call if a pixel
  *        is different than color
  * @param {!function()} logFn Function to call for logging.
+ * @param {Uint8Array} opt_readBackBuf typically passed to reuse existing
+ *        buffer while reading back pixels.
  */
-var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn) {
+var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn, opt_readBackBuf) {
   var errorRange = opt_errorRange || 0;
   if (!errorRange.length) {
     errorRange = [errorRange, errorRange, errorRange, errorRange]
   }
   var buf;
   if (gl instanceof WebGLRenderingContext) {
-    buf = new Uint8Array(width * height * 4);
+    buf = opt_readBackBuf ? opt_readBackBuf : new Uint8Array(width * height * 4);
     gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buf);
   } else {
     buf = gl.getImageData(x, y, width, height).data;

--- a/conformance-suites/1.0.3/conformance/resources/iterable-test.js
+++ b/conformance-suites/1.0.3/conformance/resources/iterable-test.js
@@ -94,10 +94,13 @@ IterableTest = (function() {
     };
   }
 
-  // Creates a canvas and a texture then exits. There are
-  // no references to either so both should be garbage collected.
+  // Draws rectangle on a passed canvas with preserveDrawingBuffer
+  // and antialiasing ON, tests rect color on every iteration.
   function createMultisampleCorruptionTest(gl) {
     var lastContext = null;
+    // Allocate a read back buffer in advance and reuse it for all iterations
+    // to avoid memory issues because of late garbage collection.
+    var readBackBuf = new Uint8Array(gl.canvas.width * gl.canvas.height * 4);
 
     var program = wtu.loadStandardProgram(gl);
     var uniforms = wtu.getUniformMap(gl, program);
@@ -145,7 +148,7 @@ IterableTest = (function() {
                   testFailed(msg);
                   return false;
               },
-          debug);
+          debug, readBackBuf);
           document.body.removeChild(lastContext.canvas);
       }
 

--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -1007,8 +1007,10 @@ var isWebGLContext = function(ctx) {
  * @param {!function()} differentFn Function to call if a pixel
  *        is different than color
  * @param {!function()} logFn Function to call for logging.
+ * @param {Uint8Array} opt_readBackBuf typically passed to reuse existing
+ *        buffer while reading back pixels.
  */
-var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn) {
+var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn, opt_readBackBuf) {
   if (isWebGLContext(gl) && !gl.getParameter(gl.FRAMEBUFFER_BINDING)) {
     // We're reading the backbuffer so clip.
     var xr = clipToRange(x, width, 0, gl.canvas.width);
@@ -1029,7 +1031,7 @@ var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRan
   }
   var buf;
   if (isWebGLContext(gl)) {
-    buf = new Uint8Array(width * height * 4);
+    buf = opt_readBackBuf ? opt_readBackBuf : new Uint8Array(width * height * 4);
     gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buf);
   } else {
     buf = gl.getImageData(x, y, width, height).data;

--- a/sdk/tests/conformance/resources/iterable-test.js
+++ b/sdk/tests/conformance/resources/iterable-test.js
@@ -94,10 +94,13 @@ IterableTest = (function() {
     };
   }
 
-  // Creates a canvas and a texture then exits. There are
-  // no references to either so both should be garbage collected.
+  // Draws rectangle on a passed canvas with preserveDrawingBuffer
+  // and antialiasing ON, tests rect color on every iteration.
   function createMultisampleCorruptionTest(gl) {
     var lastContext = null;
+    // Allocate a read back buffer in advance and reuse it for all iterations
+    // to avoid memory issues because of late garbage collection.
+    var readBackBuf = new Uint8Array(gl.canvas.width * gl.canvas.height * 4);
 
     var program = wtu.loadStandardProgram(gl);
     var uniforms = wtu.getUniformMap(gl, program);
@@ -145,7 +148,7 @@ IterableTest = (function() {
                   testFailed(msg);
                   return false;
               },
-          debug);
+          debug, readBackBuf);
           document.body.removeChild(lastContext.canvas);
       }
 

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1007,8 +1007,10 @@ var isWebGLContext = function(ctx) {
  * @param {!function()} differentFn Function to call if a pixel
  *        is different than color
  * @param {!function()} logFn Function to call for logging.
+ * @param {Uint8Array} opt_readBackBuf typically passed to reuse existing
+ *        buffer while reading back pixels.
  */
-var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn) {
+var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn, opt_readBackBuf) {
   if (isWebGLContext(gl) && !gl.getParameter(gl.FRAMEBUFFER_BINDING)) {
     // We're reading the backbuffer so clip.
     var xr = clipToRange(x, width, 0, gl.canvas.width);
@@ -1029,7 +1031,7 @@ var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRan
   }
   var buf;
   if (isWebGLContext(gl)) {
-    buf = new Uint8Array(width * height * 4);
+    buf = opt_readBackBuf ? opt_readBackBuf : new Uint8Array(width * height * 4);
     gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buf);
   } else {
     buf = gl.getImageData(x, y, width, height).data;


### PR DESCRIPTION
Multisample corruption tests create a big canvas and at every
iteration test has to allocate a very big buffer for checking drawn
rectangle color. With large number of iterations, if these buffers
are not garbage collected in time, browser memory utilization goes
very high and browser even hangs or gets killed on platforms like
android.

This change modifies tests to allocate a read back buffer in advance
and reuse it for all iterations.

The fix is backported to 1.0.2 and 1.0.3 test suites.
