### PR TITLE
Add a test for querying SAMPLES after switching framebuffers

### DIFF
--- a/sdk/tests/conformance/state/00_test_list.txt
+++ b/sdk/tests/conformance/state/00_test_list.txt
@@ -5,4 +5,4 @@ gl-geterror.html
 gl-getstring.html
 gl-object-get-calls.html
 --min-version 1.0.3 state-uneffected-after-compositing.html
-
+--min-version 1.0.4 --max-version 1.9.9 gl-samples-framebuffer-switch.html

--- a/sdk/tests/conformance/state/gl-samples-framebuffer-switch.html
+++ b/sdk/tests/conformance/state/gl-samples-framebuffer-switch.html
@@ -1,0 +1,67 @@
+<!--
+
+/*
+** Copyright (c) 2014 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL getParameter(SAMPLES) after framebuffer binding in WebGL 1.0</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="2" height="2"> </canvas>
+<script>
+"use strict";
+description();
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext('canvas', {antialias: true});
+if (!gl)
+    testFailed('context does not exist');
+else {
+    testPassed('context created');
+
+    var default_samples = gl.getParameter(gl.SAMPLES);
+    debug('Sample count while default framebuffer is bound: ' + samples);
+    var fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, 'no errors from setting up a framebuffer object');
+    // The value of gl.SAMPLES is specified as implementation-dependent in GLES 2.0 spec section 3.2 Multisampling.
+    // It should not change when framebuffer binding is changed, unlike in later versions of the GLES/WebGL spec.
+    shouldBe('gl.getParameter(gl.SAMPLES)', 'default_samples');
+}
+
+var successfullyParsed = true;
+finishTest();
+
+</script>
+</body>
+</html>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -2242,6 +2242,14 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-2.8.3">OpenGL ES 3.0.3 &sect;2.8.3</a>)</span>
     </p>
 
+    <h3>Multisampling</h3>
+
+    <p>
+        Multisample renderbuffers are supported in the WebGL 2 API. Querying <code>SAMPLES</code> with
+        <code>getParameter()</code> returns a framebuffer-dependent constant in WebGL 2.0, instead of an
+        implementation-dependent constant.
+    </p>
+
 <!-- ======================================================================================================= -->
 
     <h2><a name="webgl_gl_differences">Differences Between WebGL and OpenGL ES 3.0</a></h2>


### PR DESCRIPTION
According to the spec the returned value should not change when
framebuffers are switched.

Also add a note about how this changes in WebGL 2.
