### PR TITLE
Disable toDataURL() image smoothing.

### DIFF
--- a/sdk/tests/conformance/canvas/to-data-url-test.html
+++ b/sdk/tests/conformance/canvas/to-data-url-test.html
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 
 /*
 ** Copyright (c) 2012 The Khronos Group Inc.
@@ -81,6 +81,7 @@ var main = function() {
     var img = wtu.makeImageFromCanvas(gl.canvas, function() {
       ctx.canvas.width = width;
       ctx.canvas.height = height;
+      ctx.imageSmoothingEnabled = false;
       ctx.drawImage(img, 0, 0);
       wtu.checkCanvasRect(ctx, 0, 0, width - 1, topHeight, topColor);
       wtu.checkCanvasRect(ctx, 0, topHeight, width - 1, halfHeight, bottomColor);


### PR DESCRIPTION
Exact pixel copies are expected, but some OpenGL implementations lose precision
on texture filtering of images larger than 256x256.
