### PR TITLE
Some funcs should return null on error.

### DIFF
--- a/sdk/tests/conformance/misc/bad-arguments-test.html
+++ b/sdk/tests/conformance/misc/bad-arguments-test.html
@@ -71,15 +71,13 @@ function shouldBeEmptyString(command) {
 }
 
 for (var i = 0; i < testArguments.length; ++i) {
-  var func, func2, func3;
+  var func, func2;
   if (testArguments[i].throws) {
     func = shouldThrow;
     func2 = shouldThrow;
-    func3 = shouldThrow;
   } else {
     func = shouldBeUndefined;
     func2 = shouldBeNull;
-    func3 = shouldBeEmptyString;
   }
   argument = testArguments[i].value;
   func("context.compileShader(argument)");
@@ -101,15 +99,15 @@ for (var i = 0; i < testArguments.length; ++i) {
   func("context.uniform2iv(argument, new Int32Array([0, 0]))");
   func("context.uniformMatrix2fv(argument, false, new Float32Array([0.0, 0.0, 0.0, 0.0]))");
 
+  func2("context.getProgramInfoLog(argument)");
   func2("context.getProgramParameter(argument, 0)");
+  func2("context.getShaderInfoLog(argument)");
   func2("context.getShaderParameter(argument, 0)");
+  func2("context.getShaderSource(argument)");
   func2("context.getUniform(argument, loc)");
   func2("context.getUniform(program, argument)");
   func2("context.getUniformLocation(argument, 'u_modelViewProjMatrix')");
 
-  func3("context.getProgramInfoLog(argument)");
-  func3("context.getShaderInfoLog(argument)");
-  func3("context.getShaderSource(argument)");
 }
 
 var successfullyParsed = true;


### PR DESCRIPTION
They were expected to return the empty string previously. The spec
requires returning null, though.

We might want to backport this to previous snapshots, but I only fix trunk here.
