### PR TITLE
Add a test for out-of-range constant indices failing compilation

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -1,7 +1,6 @@
 attrib-location-length-limits.html
 --min-version 1.0.3 boolean_precision.html
 --min-version 1.0.4 const-variable-initialization.html
---min-version 1.0.4 constant-index-out-of-range.html
 embedded-struct-definitions-forbidden.html
 empty_main.vert.html
 --min-version 1.0.3 expression-list-in-declarator-initializer.html

--- a/sdk/tests/extra/constant-index-out-of-range.html
+++ b/sdk/tests/extra/constant-index-out-of-range.html
@@ -30,11 +30,11 @@
 <head>
 <meta charset="utf-8">
 <title>Indexing with a constant expression should compile only if the index is in range</title>
-<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
-<script src="../../../resources/js-test-pre.js"></script>
-<script src="../../resources/webgl-test-utils.js"></script>
-<script src="../../resources/glsl-conformance-test.js"></script>
+<link rel="stylesheet" href="../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../conformance/resources/glsl-feature-tests.css"/>
+<script src="../resources/js-test-pre.js"></script>
+<script src="../conformance/resources/webgl-test-utils.js"></script>
+<script src="../conformance/resources/glsl-conformance-test.js"></script>
 <script id="VertexArrayTemplate" type="x-shader/x-vertex">
 precision mediump float;
 


### PR DESCRIPTION
ESSL 1.00 spec states that a constant index must generate a compilation
error if it is out of range. Test this with a variety of constant
expressions.
