### PR TITLE
Fix WEBGL_compressed_texture_es3.

### DIFF
--- a/extensions/proposals/WEBGL_compressed_texture_es3/extension.xml
+++ b/extensions/proposals/WEBGL_compressed_texture_es3/extension.xml
@@ -15,7 +15,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture formats defined as core in the 
+      This extension exposes the compressed texture formats defined as core in the
       <a href="hhttp://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.2.pdf">
       OpenGL ES 3.0</a> spec to WebGL.
     </p>
@@ -25,74 +25,13 @@
         <code>COMPRESSED_SIGNED_R11_EAC</code>,
         <code>COMPRESSED_RG11_EAC</code>,
         <code>COMPRESSED_SIGNED_RG11_EAC</code>,
-        <code>COMPRESSED_RGB_ETC2</code>,
+        <code>COMPRESSED_RGB8_ETC2</code>,
         <code>COMPRESSED_SRGB8_ETC2</code>,
         <code>COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2</code>,
         <code>COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2</code>,
         <code>COMPRESSED_RGBA8_ETC2_EAC</code>,
         and <code>COMPRESSED_SRGB8_ALPHA8_ETC2_EAC</code> may be passed to
         the <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code> entry points.
-
-        This format correspond to the format defined in the OES_compressed_ETC1_RGB8_texture OpenGL ES
-        extension. Although the enum name is changed, the numeric value is the same. The correspondence
-        is given by this table:
-        <table>
-          <tr>
-            <th>WebGL format enum</th>
-            <th>OpenGL format enum</th>
-            <th>Numeric value</th>
-          </tr>
-          <tr>
-            <td>COMPRESSED_R11_EAC</td>
-            <td>COMPRESSED_R11_EAC</td>
-            <td>0x9270</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_SIGNED_R11_EAC</td>
-            <td>COMPRESSED_SIGNED_R11_EAC</td>
-            <td>0x9271</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_RG11_EAC</td>
-            <td>COMPRESSED_RG11_EAC</td>
-            <td>0x9272</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_SIGNED_RG11_EAC</td>
-            <td>COMPRESSED_SIGNED_RG11_EAC</td>
-            <td>0x9273</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_RGB_ETC2</td>
-            <td>COMPRESSED_RGB_ETC2</td>
-            <td>0x9274</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_SRGB8_ETC2</td>
-            <td>COMPRESSED_SRGB8_ETC2</td>
-            <td>0x9275</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2</td>
-            <td>COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2</td>
-            <td>0x9276</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2</td>
-            <td>COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2</td>
-            <td>0x9277</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_RGBA8_ETC2_EAC</td>
-            <td>COMPRESSED_RGBA8_ETC2_EAC</td>
-            <td>0x9278</td>
-          </tr>
-          <tr>
-            <td>COMPRESSED_SRGB8_ALPHA8_ETC2_EAC</td>
-            <td>COMPRESSED_SRGB8_ALPHA8_ETC2_EAC</td>
-            <td>0x9279</td>
-          </tr>
-        </table>
       </feature>
       <feature>
         Calling <code>getParameter</code> with the argument <code>COMPRESSED_TEXTURE_FORMATS</code>
@@ -103,7 +42,7 @@
         <dl>
           <dt>COMPRESSED_R11_EAC</dt>
           <dt>COMPRESSED_SIGNED_R11_EAC</dt>
-          <dt>COMPRESSED_RGB_ETC2</dt>
+          <dt>COMPRESSED_RGB8_ETC2</dt>
           <dt>COMPRESSED_SRGB8_ETC2</dt>
           <dt>COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2</dt>
           <dt>COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2</dt>
@@ -137,15 +76,15 @@
 [NoInterfaceObject]
 interface WEBGL_compressed_texture_es3 {
     /* Compressed Texture Format */
-    const GLenum COMPRESSED_R11_EAC                        = 0x9270; 
-    const GLenum COMPRESSED_SIGNED_R11_EAC                 = 0x9271; 
-    const GLenum COMPRESSED_RG11_EAC                       = 0x9272; 
-    const GLenum COMPRESSED_SIGNED_RG11_EAC                = 0x9273; 
-    const GLenum COMPRESSED_RGB_ETC2                       = 0x9274; 
-    const GLenum COMPRESSED_SRGB8_ETC2                     = 0x9275; 
-    const GLenum COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2  = 0x9276; 
-    const GLenum COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9277; 
-    const GLenum COMPRESSED_RGBA8_ETC2_EAC                 = 0x9278; 
+    const GLenum COMPRESSED_R11_EAC                        = 0x9270;
+    const GLenum COMPRESSED_SIGNED_R11_EAC                 = 0x9271;
+    const GLenum COMPRESSED_RG11_EAC                       = 0x9272;
+    const GLenum COMPRESSED_SIGNED_RG11_EAC                = 0x9273;
+    const GLenum COMPRESSED_RGB8_ETC2                      = 0x9274;
+    const GLenum COMPRESSED_SRGB8_ETC2                     = 0x9275;
+    const GLenum COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2  = 0x9276;
+    const GLenum COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9277;
+    const GLenum COMPRESSED_RGBA8_ETC2_EAC                 = 0x9278;
     const GLenum COMPRESSED_SRGB8_ALPHA8_ETC2_EAC          = 0x9279;
 };
   </idl>
@@ -155,6 +94,10 @@ interface WEBGL_compressed_texture_es3 {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2014/12/12">
+      <change>COMPRESSED_RGB_ETC2 should be COMPRESSED_RGB8_ETC2.</change>
+      <change>Remove unnecessary language.</change>
     </revision>
   </history>
 </proposal>


### PR DESCRIPTION
Remove unnecessary language.
s/COMPRESSED_RGB_ETC2/COMPRESSED_RGB8_ETC2/
