### PR TITLE
Make tex-image-and-sub-image-2d-with-webgl-canvas-* cover TEXTURE_CUBE_MAP.

### DIFF
--- a/sdk/tests/conformance/resources/red-green.svg
+++ b/sdk/tests/conformance/resources/red-green.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" width="1" height="2">
-  <rect fill="#f00" width="1" height="1"/>
-  <rect fill="#0f0" y="1" width="1" height="1"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2">
+  <rect fill="#f00" width="2" height="1"/>
+  <rect fill="#0f0" y="1" width="2" height="1"/>
 </svg>

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
@@ -37,8 +37,6 @@ function generateTest(pixelFormat, pixelType, prologue) {
             return;
         }
 
-        var program = wtu.setupTexturedQuad(gl);
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -57,7 +55,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
       ctx.fillRect(0, halfHeight, width, height - halfHeight);
     }
 
-    function drawTextInCanvas(ctx) {
+    function drawTextInCanvas(ctx, bindingTarget) {
       var width = ctx.canvas.width;
       var height = ctx.canvas.height;
       ctx.fillStyle = "#ffffff";
@@ -69,33 +67,39 @@ function generateTest(pixelFormat, pixelType, prologue) {
       ctx.fillText("1234567890", width / 2, height / 4);
     }
 
-    function setCanvasTo257x257(ctx) {
+    function setCanvasTo257x257(ctx, bindingTarget) {
       ctx.canvas.width = 257;
       ctx.canvas.height = 257;
       setCanvasToRedGreen(ctx);
     }
 
-    function setCanvasTo1x2(ctx) {
-      ctx.canvas.width = 1;
+    function setCanvasToMin(ctx, bindingTarget) {
+      if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+        // cube map texture must be square.
+        ctx.canvas.width = 2;
+      } else {
+        ctx.canvas.width = 1;
+      }
       ctx.canvas.height = 2;
       setCanvasToRedGreen(ctx);
     }
 
-    function runOneIteration(canvas, useTexSubImage2D, flipY, opt_texture, opt_fontTest)
+    function runOneIteration(canvas, useTexSubImage2D, flipY, program, bindingTarget, opt_texture, opt_fontTest)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' canvas size: ' + canvas.width + 'x' + canvas.height +
+              ' with flipY=' + flipY + ' bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP') +
+              ' canvas size: ' + canvas.width + 'x' + canvas.height +
               (opt_fontTest ? " with fonts" : " with red-green"));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         if (!opt_texture) {
             var texture = gl.createTexture();
             // Bind the texture to texture unit 0
-            gl.bindTexture(gl.TEXTURE_2D, texture);
+            gl.bindTexture(bindingTarget, texture);
             // Set up texture parameters
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
         } else {
             var texture = opt_texture;
         }
@@ -103,18 +107,26 @@ function generateTest(pixelFormat, pixelType, prologue) {
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
         gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
-        // Upload the image into the texture
-        if (useTexSubImage2D) {
-            // Initialize the texture to black first
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], canvas.width, canvas.height, 0,
-                          gl[pixelFormat], gl[pixelType], null);
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl[pixelFormat], gl[pixelType], canvas);
-        } else {
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], canvas);
+        var targets = [gl.TEXTURE_2D];
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
         }
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 255, 0, 255]);
+        // Upload the image into the texture
+        for (var tt = 0; tt < targets.length; ++tt) {
+            // Initialize the texture to black first
+            if (useTexSubImage2D) {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], canvas.width, canvas.height, 0,
+                              gl[pixelFormat], gl[pixelType], null);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], canvas);
+            } else {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], canvas);
+            }
+        }
 
         var width = gl.canvas.width;
         var height = gl.canvas.height;
@@ -122,33 +134,46 @@ function generateTest(pixelFormat, pixelType, prologue) {
         var top = flipY ? 0 : (height - halfHeight);
         var bottom = flipY ? (height - halfHeight) : 0;
 
-        if (opt_fontTest) {
-            // check half is a solid color.
-            wtu.checkCanvasRect(
-                  gl, 0, top, width, halfHeight,
-                  [255, 255, 255, 255],
-                  "should be white");
-            // check other half is not a solid color.
-            wtu.checkCanvasRectColor(
-                  gl, 0, bottom, width, halfHeight,
-                  [255, 255, 255, 255], 0,
-                  function() {
-                    testFailed("font missing");
-                  },
-                  function() {
-                    testPassed("font renderered");
-                  },
-                  debug);
-        } else {
-            // Check the top and bottom halves and make sure they have the right color.
-            var red = [255, 0, 0];
-            var green = [0, 255, 0];
-            debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, red,
-                                "shouldBe " + red);
-            debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, 0, top, width, halfHeight, green,
-                                "shouldBe " + green);
+        var loc;
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            loc = gl.getUniformLocation(program, "face");
+        }
+
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                gl.uniform1i(loc, targets[tt]);
+            }
+            // Draw the triangles
+            wtu.clearAndDrawUnitQuad(gl, [0, 255, 0, 255]);
+
+            if (opt_fontTest) {
+                // check half is a solid color.
+                wtu.checkCanvasRect(
+                      gl, 0, top, width, halfHeight,
+                      [255, 255, 255, 255],
+                      "should be white");
+                // check other half is not a solid color.
+                wtu.checkCanvasRectColor(
+                      gl, 0, bottom, width, halfHeight,
+                      [255, 255, 255, 255], 0,
+                      function() {
+                        testFailed("font missing");
+                      },
+                      function() {
+                        testPassed("font renderered");
+                      },
+                      debug);
+            } else {
+                // Check the top and bottom halves and make sure they have the right color.
+                var red = [255, 0, 0];
+                var green = [0, 255, 0];
+                debug("Checking " + (flipY ? "top" : "bottom"));
+                wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, red,
+                                    "shouldBe " + red);
+                debug("Checking " + (flipY ? "bottom" : "top"));
+                wtu.checkCanvasRect(gl, 0, top, width, halfHeight, green,
+                                    "shouldBe " + green);
+            }
         }
 
         if (false) {
@@ -164,11 +189,8 @@ function generateTest(pixelFormat, pixelType, prologue) {
     {
         var ctx = canvas.getContext("2d");
 
-        var count = 4;
-        var caseNdx = 0;
-
         var cases = [
-            { sub: false, flipY: true,  font: false, init: setCanvasTo1x2 },
+            { sub: false, flipY: true,  font: false, init: setCanvasToMin },
             { sub: false, flipY: false, font: false },
             { sub: true,  flipY: true,  font: false },
             { sub: true,  flipY: false, font: false },
@@ -182,30 +204,49 @@ function generateTest(pixelFormat, pixelType, prologue) {
             { sub: true,  flipY: false, font: true },
         ];
 
-        var texture;
-        function runNextTest() {
-            var c = cases[caseNdx];
-            if (c.init) {
-              c.init(ctx);
+        function runTexImageTest(bindingTarget) {
+            var program;
+            if (bindingTarget == gl.TEXTURE_2D) {
+                program = wtu.setupTexturedQuad(gl);
+            } else {
+                program = wtu.setupTexturedQuadWithCubeMap(gl);
             }
-            texture = runOneIteration(canvas, c.sub, c.flipY, texture, c.font);
-            // for the first 2 iterations always make a new texture.
-            if (count > 2) {
-              texture = undefined;
-            }
-            ++caseNdx;
-            if (caseNdx == cases.length) {
-                caseNdx = 0;
-                --count;
-                if (!count) {
-                    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-                    finishTest();
-                    return;
+
+            return new Promise(function(resolve, reject) {
+                var count = 4;
+                var caseNdx = 0;
+                var texture = undefined;
+                function runNextTest() {
+                    var c = cases[caseNdx];
+                    if (c.init) {
+                      c.init(ctx, bindingTarget);
+                    }
+                    texture = runOneIteration(canvas, c.sub, c.flipY, program, bindingTarget, texture, c.font);
+                    // for the first 2 iterations always make a new texture.
+                    if (count > 2) {
+                      texture = undefined;
+                    }
+                    ++caseNdx;
+                    if (caseNdx == cases.length) {
+                        caseNdx = 0;
+                        --count;
+                        if (!count) {
+                            resolve("SUCCESS");
+                            return;
+                        }
+                    }
+                    wtu.waitForComposite(runNextTest);
                 }
-            }
-            wtu.waitForComposite(runNextTest);
+                runNextTest();
+            });
         }
-        runNextTest();
+
+        runTexImageTest(gl.TEXTURE_2D).then(function(val) {
+            runTexImageTest(gl.TEXTURE_CUBE_MAP).then(function(val) {
+                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+                finishTest();
+            });
+        })
     }
 
     return init;

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image-data.js
@@ -24,7 +24,6 @@
 function generateTest(pixelFormat, pixelType, prologue) {
     var wtu = WebGLTestUtils;
     var gl = null;
-    var textureLoc = null;
     var successfullyParsed = false;
     var imageData = null;
 
@@ -39,94 +38,124 @@ function generateTest(pixelFormat, pixelType, prologue) {
             return;
         }
 
-        var program = wtu.setupTexturedQuad(gl);
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
         gl.disable(gl.BLEND);
 
-        textureLoc = gl.getUniformLocation(program, "tex");
-
         var canvas2d = document.getElementById("texcanvas");
         var context2d = canvas2d.getContext("2d");
-        imageData = context2d.createImageData(1, 2);
+        imageData = context2d.createImageData(2, 2);
         var data = imageData.data;
         data[0] = 255;
         data[1] = 0;
         data[2] = 0;
         data[3] = 255;
-        data[4] = 0;
-        data[5] = 255;
+        data[4] = 255;
+        data[5] = 0;
         data[6] = 0;
-        data[7] = 0;
+        data[7] = 255;
+        data[8] = 0;
+        data[9] = 255;
+        data[10] = 0;
+        data[11] = 0;
+        data[12] = 0;
+        data[13] = 255;
+        data[14] = 0;
+        data[15] = 0;
 
         runTest();
     }
 
-    function runOneIteration(useTexSubImage2D, flipY, premultiplyAlpha, topColor, bottomColor)
+    function runOneIteration(useTexSubImage2D, flipY, premultiplyAlpha, topColor, bottomColor, bindingTarget, program)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha);
+              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
+              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Enable writes to the RGBA channels
         gl.colorMask(1, 1, 1, 0);
         var texture = gl.createTexture();
         // Bind the texture to texture unit 0
-        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.bindTexture(bindingTarget, texture);
         // Set up texture parameters
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultiplyAlpha);
+        var targets = [gl.TEXTURE_2D];
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
+        }
         // Upload the image into the texture
-        if (useTexSubImage2D) {
-            // Initialize the texture to black first
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], 1, 2, 0,
-                          gl[pixelFormat], gl[pixelType], null);
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl[pixelFormat], gl[pixelType], imageData);
-        } else {
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], imageData);
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (useTexSubImage2D) {
+                // Initialize the texture to black first
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], imageData.width, imageData.height, 0,
+                              gl[pixelFormat], gl[pixelType], null);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], imageData);
+            } else {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], imageData);
+            }
         }
 
-        // Point the uniform sampler to texture unit 0
-        gl.uniform1i(textureLoc, 0);
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+        var loc;
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            loc = gl.getUniformLocation(program, "face");
+        }
 
-        // Check the top pixel and bottom pixel and make sure they have
-        // the right color.
-        debug("Checking bottom pixel");
-        wtu.checkCanvasRect(gl, 0, 0, 1, 1, bottomColor, "shouldBe " + bottomColor);
-        debug("Checking top pixel");
-        wtu.checkCanvasRect(gl, 0, 1, 1, 1, topColor, "shouldBe " + topColor);
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                gl.uniform1i(loc, targets[tt]);
+            }
+            // Draw the triangles
+            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+
+            // Check the top pixel and bottom pixel and make sure they have
+            // the right color.
+            debug("Checking bottom pixel");
+            wtu.checkCanvasRect(gl, 0, 0, 1, 1, bottomColor, "shouldBe " + bottomColor);
+            debug("Checking top pixel");
+            wtu.checkCanvasRect(gl, 0, 1, 1, 1, topColor, "shouldBe " + topColor);
+        }
     }
 
     function runTest()
     {
+        var program = wtu.setupTexturedQuad(gl);
+        runTestOnBindingTarget(gl.TEXTURE_2D, program);
+        program = wtu.setupTexturedQuadWithCubeMap(gl);
+        runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
+
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+        finishTest();
+    }
+
+    function runTestOnBindingTarget(bindingTarget, program) {
         var red = [255, 0, 0, 255];
         var green = [0, 255, 0, 255];
         var redPremultiplyAlpha = [255, 0, 0, 255];
         var greenPremultiplyAlpha = [0, 0, 0, 255];
+        var cases = [
+            { sub: false, flipY: true, premultiplyAlpha: false, topColor: red, bottomColor: green },
+            { sub: false, flipY: false, premultiplyAlpha: false, topColor: green, bottomColor: red },
+            { sub: false, flipY: true, premultiplyAlpha: true, topColor: redPremultiplyAlpha, bottomColor: greenPremultiplyAlpha },
+            { sub: false, flipY: false, premultiplyAlpha: true, topColor: greenPremultiplyAlpha, bottomColor: redPremultiplyAlpha },
+            { sub: true, flipY: true, premultiplyAlpha: false, topColor: red, bottomColor: green },
+            { sub: true, flipY: false, premultiplyAlpha: false, topColor: green, bottomColor: red },
+            { sub: true, flipY: true, premultiplyAlpha: true, topColor: redPremultiplyAlpha, bottomColor: greenPremultiplyAlpha },
+            { sub: true, flipY: false, premultiplyAlpha: true, topColor: greenPremultiplyAlpha, bottomColor: redPremultiplyAlpha },
+        ];
 
-        runOneIteration(false, true, false,
-                        red, green);
-        runOneIteration(false, false, false,
-                        green, red);
-        runOneIteration(false, true, true,
-                        redPremultiplyAlpha, greenPremultiplyAlpha);
-        runOneIteration(false, false, true,
-                        greenPremultiplyAlpha, redPremultiplyAlpha);
-        runOneIteration(true, true, false,
-                        red, green);
-        runOneIteration(true, false, false,
-                        green, red);
-        runOneIteration(true, true, true,
-                        redPremultiplyAlpha, greenPremultiplyAlpha);
-        runOneIteration(true, false, true,
-                        greenPremultiplyAlpha, redPremultiplyAlpha);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
+        for (var i in cases) {
+            runOneIteration(cases[i].sub, cases[i].flipY, cases[i].premultiplyAlpha,
+                            cases[i].topColor, cases[i].bottomColor, bindingTarget, program);
+        }
     }
 
     return init;

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
@@ -24,7 +24,6 @@
 function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
     var wtu = WebGLTestUtils;
     var gl = null;
-    var textureLoc = null;
     var successfullyParsed = false;
     var imgCanvas;
     var red = [255, 0, 0];
@@ -41,62 +40,98 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
             return;
         }
 
-        var program = wtu.setupTexturedQuad(gl);
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
-
-        textureLoc = gl.getUniformLocation(program, "tex");
 
         wtu.loadTexture(gl, pathToTestRoot + "/resources/red-green.png", runTest);
     }
 
-    function runOneIteration(image, useTexSubImage2D, flipY, topColor, bottomColor)
+    function runOneIteration(image, useTexSubImage2D, flipY, topColor, bottomColor,
+                             bindingTarget, program)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY);
+              ' with flipY=' + flipY + ' bindingTarget=' +
+              (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Disable any writes to the alpha channel
         gl.colorMask(1, 1, 1, 0);
         var texture = gl.createTexture();
         // Bind the texture to texture unit 0
-        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.bindTexture(bindingTarget, texture);
         // Set up texture parameters
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
         gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        var targets = [gl.TEXTURE_2D];
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
+        }
         // Upload the image into the texture
-        if (useTexSubImage2D) {
-            // Initialize the texture to black first
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], image.width, image.height, 0,
-                          gl[pixelFormat], gl[pixelType], null);
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl[pixelFormat], gl[pixelType], image);
-        } else {
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], image);
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (useTexSubImage2D) {
+                // Initialize the texture to black first
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], image.width, image.height, 0,
+                              gl[pixelFormat], gl[pixelType], null);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], image);
+            } else {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], image);
+            }
         }
 
-        // Point the uniform sampler to texture unit 0
-        gl.uniform1i(textureLoc, 0);
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-        // Check a few pixels near the top and bottom and make sure they have
-        // the right color.
-        debug("Checking lower left corner");
-        wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
-                            "shouldBe " + bottomColor);
-        debug("Checking upper left corner");
-        wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
-                            "shouldBe " + topColor);
+        var loc;
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            loc = gl.getUniformLocation(program, "face");
+        }
+
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                gl.uniform1i(loc, targets[tt]);
+            }
+
+            // Draw the triangles
+            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+            // Check a few pixels near the top and bottom and make sure they have
+            // the right color.
+            debug("Checking lower left corner");
+            wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
+                                "shouldBe " + bottomColor);
+            debug("Checking upper left corner");
+            wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
+                                "shouldBe " + topColor);
+        }
     }
 
     function runTestOnImage(image) {
-        runOneIteration(image, false, true, red, green);
-        runOneIteration(image, false, false, green, red);
-        runOneIteration(image, true, true, red, green);
-        runOneIteration(image, true, false, green, red);
+        var cases = [
+            { sub: false, flipY: true, topColor: red, bottomColor: green },
+            { sub: false, flipY: false, topColor: green, bottomColor: red },
+            { sub: true, flipY: true, topColor: red, bottomColor: green },
+            { sub: true, flipY: false, topColor: green, bottomColor: red },
+        ];
+
+        var program = wtu.setupTexturedQuad(gl);
+        for (var i in cases) {
+            runOneIteration(image, cases[i].sub, cases[i].flipY,
+                            cases[i].topColor, cases[i].bottomColor,
+                            gl.TEXTURE_2D, program);
+        }
+        // cube map texture must be square.
+        if (image.width != image.height)
+            return;
+        program = wtu.setupTexturedQuadWithCubeMap(gl);
+        for (var i in cases) {
+            runOneIteration(image, cases[i].sub, cases[i].flipY,
+                            cases[i].topColor, cases[i].bottomColor,
+                            gl.TEXTURE_CUBE_MAP, program);
+        }
     }
 
     function runTest(image)
@@ -104,18 +139,21 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
         runTestOnImage(image);
 
         imgCanvas = document.createElement("canvas");
-        imgCanvas.width = 1;
+        imgCanvas.width = 2;
         imgCanvas.height = 2;
         var imgCtx = imgCanvas.getContext("2d");
         var imgData = imgCtx.createImageData(1, 2);
-        imgData.data[0] = red[0];
-        imgData.data[1] = red[1];
-        imgData.data[2] = red[2];
-        imgData.data[3] = 255;
-        imgData.data[4] = green[0];
-        imgData.data[5] = green[1];
-        imgData.data[6] = green[2];
-        imgData.data[7] = 255;
+        for (var i = 0; i < 2; i++) {
+            var stride = i * 8;
+            imgData.data[stride + 0] = red[0];
+            imgData.data[stride + 1] = red[1];
+            imgData.data[stride + 2] = red[2];
+            imgData.data[stride + 3] = 255;
+            imgData.data[stride + 4] = green[0];
+            imgData.data[stride + 5] = green[1];
+            imgData.data[stride + 6] = green[2];
+            imgData.data[stride + 7] = 255;
+        }
         imgCtx.putImageData(imgData, 0, 0);
 
         // apparently Image is different than <img>.

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
@@ -24,7 +24,6 @@
 function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
     var wtu = WebGLTestUtils;
     var gl = null;
-    var textureLoc = null;
     var successfullyParsed = false;
     var imgCanvas;
     var red = [255, 0, 0];
@@ -41,64 +40,96 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
             return;
         }
 
-        var program = wtu.setupTexturedQuad(gl);
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
-
-        textureLoc = gl.getUniformLocation(program, "tex");
 
         wtu.loadTexture(gl, pathToTestRoot + "/resources/red-green.svg", runTest);
     }
 
-    function runOneIteration(image, useTexSubImage2D, flipY, topColor, bottomColor)
+    function runOneIteration(image, useTexSubImage2D, flipY, topColor, bottomColor, bindingTarget, program)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY);
+              ' with flipY=' + flipY + ' bindingTarget=' +
+              (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Disable any writes to the alpha channel
         gl.colorMask(1, 1, 1, 0);
         var texture = gl.createTexture();
         // Bind the texture to texture unit 0
-        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.bindTexture(bindingTarget, texture);
         // Set up texture parameters
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
         gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        var targets = [gl.TEXTURE_2D];
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
+        }
         // Upload the image into the texture
-        if (useTexSubImage2D) {
-            // Initialize the texture to black first
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], image.width, image.height, 0,
-                          gl[pixelFormat], gl[pixelType], null);
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl[pixelFormat], gl[pixelType], image);
-        } else {
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], image);
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (useTexSubImage2D) {
+                // Initialize the texture to black first
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], image.width, image.height, 0,
+                              gl[pixelFormat], gl[pixelType], null);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], image);
+            } else {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], image);
+            }
         }
 
-        // Point the uniform sampler to texture unit 0
-        gl.uniform1i(textureLoc, 0);
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-        // Check a few pixels near the top and bottom and make sure they have
-        // the right color.
-        debug("Checking lower left corner");
-        wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
-                            "shouldBe " + bottomColor);
-        debug("Checking upper left corner");
-        wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
-                            "shouldBe " + topColor);
+        var loc;
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            loc = gl.getUniformLocation(program, "face");
+        }
+
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                gl.uniform1i(loc, targets[tt]);
+            }
+            // Draw the triangles
+            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+            // Check a few pixels near the top and bottom and make sure they have
+            // the right color.
+            debug("Checking lower left corner");
+            wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
+                                "shouldBe " + bottomColor);
+            debug("Checking upper left corner");
+            wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
+                                "shouldBe " + topColor);
+        }
     }
 
     function runTest(image)
     {
-        runOneIteration(image, false, true, red, green);
-        runOneIteration(image, false, false, green, red);
-        runOneIteration(image, true, true, red, green);
-        runOneIteration(image, true, false, green, red);
+        var program = wtu.setupTexturedQuad(gl);
+        runTestOnBindingTarget(image, gl.TEXTURE_2D, program);
+        program = wtu.setupTexturedQuadWithCubeMap(gl);
+        runTestOnBindingTarget(image, gl.TEXTURE_CUBE_MAP, program);
+
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
         finishTest();
+    }
+
+    function runTestOnBindingTarget(image, bindingTarget, program) {
+        var cases = [
+            { sub: false, flipY: true, topColor: red, bottomColor: green },
+            { sub: false, flipY: false, topColor: green, bottomColor: red },
+            { sub: true, flipY: true, topColor: red, bottomColor: green },
+            { sub: true, flipY: false, topColor: green, bottomColor: red },
+        ];
+        for (var i in cases) {
+            runOneIteration(image, cases[i].sub, cases[i].flipY,
+                            cases[i].topColor, cases[i].bottomColor,
+                            bindingTarget, program);
+        }
     }
 
     return init;

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
@@ -35,7 +35,6 @@ var debug = function(msg) {
 function generateTest(pixelFormat, pixelType, prologue) {
     var wtu = WebGLTestUtils;
     var gl = null;
-    var textureLoc = null;
     var successfullyParsed = false;
 
     // Test each format separately because many browsers implement each
@@ -45,42 +44,6 @@ function generateTest(pixelFormat, pixelType, prologue) {
       { src: "../resources/red-green.webmvp8.webm", type: 'video/webm; codecs="vp8, vorbis"',           },
       { src: "../resources/red-green.theora.ogv",   type: 'video/ogg; codecs="theora, vorbis"',         },
     ];
-
-    var videoNdx = 0;
-    var video;
-
-    function runNextVideo() {
-        if (video) {
-            video.pause();
-        }
-
-        if (videoNdx == videos.length) {
-            finishTest();
-            return;
-        }
-
-        var info = videos[videoNdx++];
-        debug("");
-        debug("testing: " + info.type);
-        video = document.createElement("video");
-        var canPlay = true;
-        if (!video.canPlayType) {
-          testFailed("video.canPlayType required method missing");
-          runNextVideo();
-          return;
-        }
-
-        if(!video.canPlayType(info.type).replace(/no/, '')) {
-          debug(info.type + " unsupported");
-          runNextVideo();
-          return;
-        };
-
-        document.body.appendChild(video);
-        video.type = info.type;
-        video.src = info.src;
-        wtu.startPlayingAndWaitForVideo(video, runTest);
-    }
 
     var init = function()
     {
@@ -93,42 +56,58 @@ function generateTest(pixelFormat, pixelType, prologue) {
             return;
         }
 
-        var program = wtu.setupTexturedQuad(gl);
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
-        textureLoc = gl.getUniformLocation(program, "tex");
-        runNextVideo();
+        runTest();
     }
 
-    function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottomColor)
+    function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottomColor, program, bindingTarget)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY);
+              ' with flipY=' + flipY + ' bindingTarget=' +
+              (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Disable any writes to the alpha channel
         gl.colorMask(1, 1, 1, 0);
         var texture = gl.createTexture();
         // Bind the texture to texture unit 0
-        gl.bindTexture(gl.TEXTURE_2D, texture);
+        gl.bindTexture(bindingTarget, texture);
         // Set up texture parameters
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        var targets = [gl.TEXTURE_2D];
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
+        }
         // Upload the videoElement into the texture
-        if (useTexSubImage2D) {
+        for (var tt = 0; tt < targets.length; ++tt) {
             // Initialize the texture to black first
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat],
-                          videoElement.videoWidth, videoElement.videoHeight, 0,
-                          gl[pixelFormat], gl[pixelType], null);
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl[pixelFormat], gl[pixelType], videoElement);
-        } else {
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], videoElement);
+            if (useTexSubImage2D) {
+                var width = videoElement.videoWidth;
+                var height = videoElement.videoHeight;
+                if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                    // cube map texture must be square.
+                    width = Math.max(width, height);
+                    height = width;
+                }
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat],
+                              width, height, 0,
+                              gl[pixelFormat], gl[pixelType], null);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], videoElement);
+            } else {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], videoElement);
+            }
         }
 
         var c = document.createElement("canvas");
@@ -139,33 +118,104 @@ function generateTest(pixelFormat, pixelType, prologue) {
         ctx.drawImage(videoElement, 0, 0, 16, 16);
         document.body.appendChild(c);
 
-        // Point the uniform sampler to texture unit 0
-        gl.uniform1i(textureLoc, 0);
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-        // Check a few pixels near the top and bottom and make sure they have
-        // the right color.
-        var tolerance = 5;
-        debug("Checking lower left corner");
-        wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
-                            "shouldBe " + bottomColor, tolerance);
-        debug("Checking upper left corner");
-        wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
-                            "shouldBe " + topColor, tolerance);
+        var loc;
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            loc = gl.getUniformLocation(program, "face");
+        }
+
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                gl.uniform1i(loc, targets[tt]);
+            }
+            // Draw the triangles
+            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+            // Check a few pixels near the top and bottom and make sure they have
+            // the right color.
+            var tolerance = 5;
+            debug("Checking lower left corner");
+            wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
+                                "shouldBe " + bottomColor, tolerance);
+            debug("Checking upper left corner");
+            wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor,
+                                "shouldBe " + topColor, tolerance);
+        }
     }
 
     function runTest(videoElement)
     {
         var red = [255, 0, 0];
         var green = [0, 255, 0];
-        runOneIteration(videoElement, false, true, red, green);
-        runOneIteration(videoElement, false, false, green, red);
-        runOneIteration(videoElement, true, true, red, green);
-        runOneIteration(videoElement, true, false, green, red);
+        var cases = [
+            { sub: false, flipY: true, topColor: red, bottomColor: green },
+            { sub: false, flipY: false, topColor: green, bottomColor: red },
+            { sub: true, flipY: true, topColor: red, bottomColor: green },
+            { sub: true, flipY: false, topColor: green, bottomColor: red },
+        ];
 
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+        function runTexImageTest(bindingTarget) {
+            var program;
+            if (bindingTarget == gl.TEXTURE_2D) {
+                program = wtu.setupTexturedQuad(gl);
+            } else {
+                program = wtu.setupTexturedQuadWithCubeMap(gl);
+            }
 
-        runNextVideo();
+            return new Promise(function(resolve, reject) {
+                var videoNdx = 0;
+                var video;
+                function runNextVideo() {
+                    if (video) {
+                        video.pause();
+                    }
+
+                    if (videoNdx == videos.length) {
+                        resolve("SUCCESS");
+                        return;
+                    }
+
+                    var info = videos[videoNdx++];
+                    debug("");
+                    debug("testing: " + info.type);
+                    video = document.createElement("video");
+                    var canPlay = true;
+                    if (!video.canPlayType) {
+                      testFailed("video.canPlayType required method missing");
+                      runNextVideo();
+                      return;
+                    }
+
+                    if(!video.canPlayType(info.type).replace(/no/, '')) {
+                      debug(info.type + " unsupported");
+                      runNextVideo();
+                      return;
+                    };
+
+                    document.body.appendChild(video);
+                    video.type = info.type;
+                    video.src = info.src;
+                    wtu.startPlayingAndWaitForVideo(video, runTest);
+                }
+                function runTest() {
+                    for (var i in cases) {
+                        // cube map texture must be square but video is not square.
+                        if (bindingTarget == gl.TEXTURE_2D || cases[i].sub == true) {
+                            runOneIteration(video, cases[i].sub, cases[i].flipY,
+                                            cases[i].topColor, cases[i].bottomColor,
+                                            program, bindingTarget);
+                        }
+                    }
+                    runNextVideo();
+                }
+                runNextVideo();
+            });
+        }
+
+        runTexImageTest(gl.TEXTURE_2D).then(function(val) {
+            runTexImageTest(gl.TEXTURE_CUBE_MAP).then(function(val) {
+                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+                finishTest();
+            });
+        })
     }
 
     return init;

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -37,8 +37,6 @@ function generateTest(pixelFormat, pixelType, prologue) {
             return;
         }
 
-        var program = wtu.setupTexturedQuad(gl);
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -62,33 +60,85 @@ function generateTest(pixelFormat, pixelType, prologue) {
       ctx.disable(ctx.SCISSOR_TEST);
     }
 
-    function setCanvasTo257x257(ctx) {
+    function setCanvasTo257x257(ctx, bindingTarget) {
       ctx.canvas.width = 257;
       ctx.canvas.height = 257;
       setCanvasToRedGreen(ctx);
     }
 
-    function setCanvasTo1x2(ctx) {
-      ctx.canvas.width = 1;
+    function setCanvasToMin(ctx, bindingTarget) {
+      if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+        // cube map texture must be square.
+        ctx.canvas.width = 2;
+      } else {
+        ctx.canvas.width = 1;
+      }
       ctx.canvas.height = 2;
       setCanvasToRedGreen(ctx);
     }
 
-    function runOneIteration(canvas, useTexSubImage2D, flipY, opt_texture)
+    function initCubeMapProgram() {
+        var vshader = [
+            'attribute vec4 vPosition;',
+            'attribute vec2 texCoord0;',
+            'varying vec2 texCoord;',
+            'void main() {',
+            '    gl_Position = vPosition;',
+            '    texCoord = texCoord0;',
+            '}'
+        ].join('\n');
+
+        var fshader = [
+            'precision mediump float;',
+            'uniform samplerCube tex;',
+            'uniform int face;',
+            'varying vec2 texCoord;',
+            'void main() {',
+            // Transform [0, 1] -> [-1, 1]
+            '    vec2 texC2 = (texCoord * 2.) - 1.;',
+            // Transform 2d tex coord. to each face of TEXTURE_CUBE_MAP coord.
+            '    vec3 texCube = vec3(0., 0., 0.);',
+            '    if (face == ' + gl.TEXTURE_CUBE_MAP_POSITIVE_X + ") {",
+            '        texCube = vec3(1., -texC2.y, -texC2.x);',
+            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_NEGATIVE_X + ") {",
+            '        texCube = vec3(-1., -texC2.y, texC2.x);',
+            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_POSITIVE_Y + ") {",
+            '        texCube = vec3(texC2.x, 1., texC2.y);',
+            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_NEGATIVE_Y + ") {",
+            '        texCube = vec3(texC2.x, -1., -texC2.y);',
+            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_POSITIVE_Z + ") {",
+            '        texCube = vec3(texC2.x, -texC2.y, 1.);',
+            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_NEGATIVE_Z + ") {",
+            '        texCube = vec3(-texC2.x, -texC2.y, -1.);',
+            '    }',
+            '    gl_FragColor = textureCube(tex, texCube);',
+            '}'
+        ].join('\n');
+
+        var program = wtu.setupProgram(gl, [vshader, fshader], ['vPosition', 'texCoord0'], [0, 1]);
+        if (!program) {
+            testFailed("failed to create cube map program");
+        }
+        var loc = gl.getUniformLocation(program, "tex");
+        gl.uniform1i(loc, 0)
+        return program;
+    }
+
+    function runOneIteration(canvas, useTexSubImage2D, flipY, program, bindingTarget, opt_texture)
     {
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' canvas size: ' + canvas.width + 'x' + canvas.height +
-              ' with red-green');
+        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') + ' with flipY=' +
+              flipY + ' bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP') +
+              ' canvas size: ' + canvas.width + 'x' + canvas.height + ' with red-green');
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         if (!opt_texture) {
             var texture = gl.createTexture();
             // Bind the texture to texture unit 0
-            gl.bindTexture(gl.TEXTURE_2D, texture);
+            gl.bindTexture(bindingTarget, texture);
             // Set up texture parameters
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
         } else {
             var texture = opt_texture;
         }
@@ -96,18 +146,26 @@ function generateTest(pixelFormat, pixelType, prologue) {
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
         gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
-        // Upload the image into the texture
-        if (useTexSubImage2D) {
-            // Initialize the texture to black first
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], canvas.width, canvas.height, 0,
-                          gl[pixelFormat], gl[pixelType], null);
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl[pixelFormat], gl[pixelType], canvas);
-        } else {
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], canvas);
+        var targets = [gl.TEXTURE_2D];
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
         }
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 255, 0, 255]);
+        // Upload the image into the texture
+        for (var tt = 0; tt < targets.length; ++tt) {
+            // Initialize the texture to black first
+            if (useTexSubImage2D) {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], canvas.width, canvas.height, 0,
+                              gl[pixelFormat], gl[pixelType], null);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], canvas);
+            } else {
+                gl.texImage2D(targets[tt], 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], canvas);
+            }
+        }
 
         var width = gl.canvas.width;
         var height = gl.canvas.height;
@@ -115,15 +173,28 @@ function generateTest(pixelFormat, pixelType, prologue) {
         var top = flipY ? (height - halfHeight) : 0;
         var bottom = flipY ? 0 : (height - halfHeight);
 
-        // Check the top and bottom halves and make sure they have the right color.
         var red = [255, 0, 0];
         var green = [0, 255, 0];
-        debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, red,
-                            "shouldBe " + red);
-        debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, 0, top, width, halfHeight, green,
-                            "shouldBe " + green);
+        var loc;
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            loc = gl.getUniformLocation(program, "face");
+        }
+
+        for (var tt = 0; tt < targets.length; ++tt) {
+            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                gl.uniform1i(loc, targets[tt]);
+            }
+            // Draw the triangles
+            wtu.clearAndDrawUnitQuad(gl, [0, 255, 0, 255]);
+
+            // Check the top and bottom halves and make sure they have the right color.
+            debug("Checking " + (flipY ? "top" : "bottom"));
+            wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, red,
+                    "shouldBe " + red);
+            debug("Checking " + (flipY ? "bottom" : "top"));
+            wtu.checkCanvasRect(gl, 0, top, width, halfHeight, green,
+                    "shouldBe " + green);
+        }
 
         if (false) {
           var ma = wtu.makeImageFromCanvas(canvas);
@@ -142,11 +213,8 @@ function generateTest(pixelFormat, pixelType, prologue) {
         var ctx = wtu.create3DContext();
         var canvas = ctx.canvas;
 
-        var count = 4;
-        var caseNdx = 0;
-
         var cases = [
-            { sub: false, flipY: true, init: setCanvasTo1x2 },
+            { sub: false, flipY: true, init: setCanvasToMin },
             { sub: false, flipY: false },
             { sub: true,  flipY: true },
             { sub: true,  flipY: false },
@@ -156,30 +224,49 @@ function generateTest(pixelFormat, pixelType, prologue) {
             { sub: true,  flipY: false },
         ];
 
-        var texture;
-        function runNextTest() {
-            var c = cases[caseNdx];
-            if (c.init) {
-              c.init(ctx);
+        function runTexImageTest(bindingTarget) {
+            var program;
+            if (bindingTarget == gl.TEXTURE_2D) {
+                program = wtu.setupTexturedQuad(gl);
+            } else {
+                program = initCubeMapProgram();
             }
-            texture = runOneIteration(canvas, c.sub, c.flipY, texture);
-            // for the first 2 iterations always make a new texture.
-            if (count > 2) {
-              texture = undefined;
-            }
-            ++caseNdx;
-            if (caseNdx == cases.length) {
-                caseNdx = 0;
-                --count;
-                if (!count) {
-                    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-                    finishTest();
-                    return;
+
+            return new Promise(function(resolve, reject) {
+                var count = 4;
+                var caseNdx = 0;
+                var texture = undefined;
+                function runNextTest() {
+                    var c = cases[caseNdx];
+                    if (c.init) {
+                      c.init(ctx, bindingTarget);
+                    }
+                    texture = runOneIteration(canvas, c.sub, c.flipY, program, bindingTarget, texture);
+                    // for the first 2 iterations always make a new texture.
+                    if (count > 2) {
+                      texture = undefined;
+                    }
+                    ++caseNdx;
+                    if (caseNdx == cases.length) {
+                        caseNdx = 0;
+                        --count;
+                        if (!count) {
+                            resolve("SUCCESS");
+                            return;
+                        }
+                    }
+                    wtu.waitForComposite(runNextTest);
                 }
-            }
-            wtu.waitForComposite(runNextTest);
+                runNextTest();
+            });
         }
-        runNextTest();
+
+        runTexImageTest(gl.TEXTURE_2D).then(function(val) {
+            runTexImageTest(gl.TEXTURE_CUBE_MAP).then(function(val) {
+                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+                finishTest();
+            });
+        })
     }
 
     return init;

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -77,53 +77,6 @@ function generateTest(pixelFormat, pixelType, prologue) {
       setCanvasToRedGreen(ctx);
     }
 
-    function initCubeMapProgram() {
-        var vshader = [
-            'attribute vec4 vPosition;',
-            'attribute vec2 texCoord0;',
-            'varying vec2 texCoord;',
-            'void main() {',
-            '    gl_Position = vPosition;',
-            '    texCoord = texCoord0;',
-            '}'
-        ].join('\n');
-
-        var fshader = [
-            'precision mediump float;',
-            'uniform samplerCube tex;',
-            'uniform int face;',
-            'varying vec2 texCoord;',
-            'void main() {',
-            // Transform [0, 1] -> [-1, 1]
-            '    vec2 texC2 = (texCoord * 2.) - 1.;',
-            // Transform 2d tex coord. to each face of TEXTURE_CUBE_MAP coord.
-            '    vec3 texCube = vec3(0., 0., 0.);',
-            '    if (face == ' + gl.TEXTURE_CUBE_MAP_POSITIVE_X + ") {",
-            '        texCube = vec3(1., -texC2.y, -texC2.x);',
-            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_NEGATIVE_X + ") {",
-            '        texCube = vec3(-1., -texC2.y, texC2.x);',
-            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_POSITIVE_Y + ") {",
-            '        texCube = vec3(texC2.x, 1., texC2.y);',
-            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_NEGATIVE_Y + ") {",
-            '        texCube = vec3(texC2.x, -1., -texC2.y);',
-            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_POSITIVE_Z + ") {",
-            '        texCube = vec3(texC2.x, -texC2.y, 1.);',
-            '    } else if (face == ' + gl.TEXTURE_CUBE_MAP_NEGATIVE_Z + ") {",
-            '        texCube = vec3(-texC2.x, -texC2.y, -1.);',
-            '    }',
-            '    gl_FragColor = textureCube(tex, texCube);',
-            '}'
-        ].join('\n');
-
-        var program = wtu.setupProgram(gl, [vshader, fshader], ['vPosition', 'texCoord0'], [0, 1]);
-        if (!program) {
-            testFailed("failed to create cube map program");
-        }
-        var loc = gl.getUniformLocation(program, "tex");
-        gl.uniform1i(loc, 0)
-        return program;
-    }
-
     function runOneIteration(canvas, useTexSubImage2D, flipY, program, bindingTarget, opt_texture)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') + ' with flipY=' +
@@ -229,7 +182,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
             if (bindingTarget == gl.TEXTURE_2D) {
                 program = wtu.setupTexturedQuad(gl);
             } else {
-                program = initCubeMapProgram();
+                program = wtu.setupTexturedQuadWithCubeMap(gl);
             }
 
             return new Promise(function(resolve, reject) {

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -131,6 +131,36 @@ var simpleTextureFragmentShader = [
   '}'].join('\n');
 
 /**
+ * A fragment shader for a single cube map texture.
+ * @type {string}
+ */
+var simpleCubeMapTextureFragmentShader = [
+  'precision mediump float;',
+  'uniform samplerCube tex;',
+  'uniform int face;',
+  'varying vec2 texCoord;',
+  'void main() {',
+  // Transform [0, 1] -> [-1, 1]
+  '    vec2 texC2 = (texCoord * 2.) - 1.;',
+  // Transform 2d tex coord. to each face of TEXTURE_CUBE_MAP coord.
+  '    vec3 texCube = vec3(0., 0., 0.);',
+  '    if (face == 34069) {',         // TEXTURE_CUBE_MAP_POSITIVE_X
+  '        texCube = vec3(1., -texC2.y, -texC2.x);',
+  '    } else if (face == 34070) {',  // TEXTURE_CUBE_MAP_NEGATIVE_X
+  '        texCube = vec3(-1., -texC2.y, texC2.x);',
+  '    } else if (face == 34071) {',  // TEXTURE_CUBE_MAP_POSITIVE_Y
+  '        texCube = vec3(texC2.x, 1., texC2.y);',
+  '    } else if (face == 34072) {',  // TEXTURE_CUBE_MAP_NEGATIVE_Y
+  '        texCube = vec3(texC2.x, -1., -texC2.y);',
+  '    } else if (face == 34073) {',  // TEXTURE_CUBE_MAP_POSITIVE_Z
+  '        texCube = vec3(texC2.x, -texC2.y, 1.);',
+  '    } else if (face == 34074) {',  // TEXTURE_CUBE_MAP_NEGATIVE_Z
+  '        texCube = vec3(-texC2.x, -texC2.y, -1.);',
+  '    }',
+  '    gl_FragData[0] = textureCube(tex, texCube);',
+  '}'].join('\n');
+
+/**
  * A vertex shader for a single texture.
  * @type {string}
  */
@@ -204,6 +234,16 @@ var setupSimpleTextureVertexShader = function(gl) {
 var setupSimpleTextureFragmentShader = function(gl) {
     return loadShader(
         gl, simpleTextureFragmentShader, gl.FRAGMENT_SHADER);
+};
+
+/**
+ * Creates a simple cube map texture fragment shader.
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @return {!WebGLShader}
+ */
+var setupSimpleCubeMapTextureFragmentShader = function(gl) {
+    return loadShader(
+        gl, simpleCubeMapTextureFragmentShader, gl.FRAGMENT_SHADER);
 };
 
 /**
@@ -359,6 +399,35 @@ var setupSimpleTextureProgram = function(
   opt_texcoordLocation = opt_texcoordLocation || 1;
   var vs = setupSimpleTextureVertexShader(gl);
   var fs = setupSimpleTextureFragmentShader(gl);
+  if (!vs || !fs) {
+    return null;
+  }
+  var program = setupProgram(
+      gl,
+      [vs, fs],
+      ['vPosition', 'texCoord0'],
+      [opt_positionLocation, opt_texcoordLocation]);
+  if (!program) {
+    gl.deleteShader(fs);
+    gl.deleteShader(vs);
+  }
+  gl.useProgram(program);
+  return program;
+};
+
+/**
+ * Creates a simple cube map texture program.
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number} opt_positionLocation The attrib location for position.
+ * @param {number} opt_texcoordLocation The attrib location for texture coords.
+ * @return {WebGLProgram}
+ */
+var setupSimpleCubeMapTextureProgram = function(
+    gl, opt_positionLocation, opt_texcoordLocation) {
+  opt_positionLocation = opt_positionLocation || 0;
+  opt_texcoordLocation = opt_texcoordLocation || 1;
+  var vs = setupSimpleTextureVertexShader(gl);
+  var fs = setupSimpleCubeMapTextureFragmentShader(gl);
   if (!vs || !fs) {
     return null;
   }
@@ -570,6 +639,24 @@ var setupTexturedQuadWithTexCoords = function(
       gl, opt_positionLocation, opt_texcoordLocation);
   setupUnitQuadWithTexCoords(gl, lowerLeftTexCoords, upperRightTexCoords,
                              opt_positionLocation, opt_texcoordLocation);
+  return program;
+};
+
+/**
+ * Creates a program and buffers for rendering a textured quad with
+ * a cube map texture.
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number} opt_positionLocation The attrib location for
+ *        position. Default = 0.
+ * @param {number} opt_texcoordLocation The attrib location for
+ *        texture coords. Default = 1.
+ * @return {!WebGLProgram}
+ */
+var setupTexturedQuadWithCubeMap = function(
+    gl, opt_positionLocation, opt_texcoordLocation) {
+  var program = setupSimpleCubeMapTextureProgram(
+      gl, opt_positionLocation, opt_texcoordLocation);
+  setupUnitQuad(gl, opt_positionLocation, opt_texcoordLocation);
   return program;
 };
 
@@ -2721,7 +2808,9 @@ return {
   setupSimpleColorVertexShader: setupSimpleColorVertexShader,
   setupSimpleColorProgram: setupSimpleColorProgram,
   setupSimpleTextureFragmentShader: setupSimpleTextureFragmentShader,
+  setupSimpleCubeMapTextureFragmentShader: setupSimpleCubeMapTextureFragmentShader,
   setupSimpleTextureProgram: setupSimpleTextureProgram,
+  setupSimpleCubeMapTextureProgram: setupSimpleCubeMapTextureProgram,
   setupSimpleTextureVertexShader: setupSimpleTextureVertexShader,
   setupSimpleVertexColorFragmentShader: setupSimpleVertexColorFragmentShader,
   setupSimpleVertexColorProgram: setupSimpleVertexColorProgram,
@@ -2730,6 +2819,7 @@ return {
   setupNoTexCoordTextureVertexShader: setupNoTexCoordTextureVertexShader,
   setupTexturedQuad: setupTexturedQuad,
   setupTexturedQuadWithTexCoords: setupTexturedQuadWithTexCoords,
+  setupTexturedQuadWithCubeMap: setupTexturedQuadWithCubeMap,
   setupUnitQuad: setupUnitQuad,
   setupUnitQuadWithTexCoords: setupUnitQuadWithTexCoords,
   setFloatDrawColor: setFloatDrawColor,

--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html
@@ -42,9 +42,6 @@
 description('Verifies texImage2D and texSubImage2D code paths taking ArrayBufferView');
 
 var wtu = WebGLTestUtils;
-var gl = null;
-var textureLoc = null;
-var successfullyParsed = false;
 
 function roundUpToAlignment(value, alignment) {
   return Math.floor((value + alignment - 1) / alignment) * alignment;
@@ -113,12 +110,14 @@ function typeToString(type)
     return 'Unknown type ' + type;
 }
 
-function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premultiplyAlpha, topColor, bottomColor, extraColor)
+function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premultiplyAlpha,
+                         topColor, bottomColor, extraColor, bindingTarget, program)
 {
     debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
           ' with type=' + typeToString(type) +
           ', unpackAlignment=' + unpackAlignment +
-          ', flipY=' + flipY + ', premultiplyAlpha=' + premultiplyAlpha);
+          ', flipY=' + flipY + ', premultiplyAlpha=' + premultiplyAlpha +
+          ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
     gl.colorMask(true, true, true, true);
     gl.clearColor(0, 0, 0, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -126,12 +125,12 @@ function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premult
     gl.colorMask(true, true, true, false);
     var texture = gl.createTexture();
     // Bind the texture to texture unit 0
-    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.bindTexture(bindingTarget, texture);
     // Set up texture parameters
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     // Set up pixel store parameters
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, unpackAlignment);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
@@ -140,74 +139,118 @@ function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premult
     var sourceData = [ 255,   0,   0, 255,
                        0,   255,   0,   0 ];
     var texWidth = 5;   // this must be mod 4 + 1 to test unpackAlignment
+    // cube map texture must be square.
+    if (bindingTarget == gl.TEXTURE_CUBE_MAP)
+        texWidth = 16;
     var texHeight = 16;
     var data = generateRGBAData(type, unpackAlignment, sourceData, texWidth, texHeight);
     if (gl.getError() != gl.NO_ERROR)
         testFailed("GL error before texture upload");
+    var targets = [gl.TEXTURE_2D];
+    if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+        targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                   gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                   gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                   gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                   gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                   gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
+    }
     // Upload the image into the texture
-    if (useTexSubImage2D) {
-        // Initialize the texture to black first
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, texWidth, texHeight, 0,
-                      gl.RGBA, type, null);
-        if (gl.getError() != gl.NO_ERROR)
-            testFailed("GL error after texImage2D(null)");
-        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, texWidth, texHeight, gl.RGBA, type, data);
-        if (gl.getError() != gl.NO_ERROR)
-            testFailed("GL error after texSubImage2D");
-    } else {
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, texWidth, texHeight, 0, gl.RGBA, type, data);
-        if (gl.getError() != gl.NO_ERROR)
-            testFailed("GL error after texImage2D");
+    for (var tt = 0; tt < targets.length; ++tt) {
+        if (useTexSubImage2D) {
+            // Initialize the texture to black first
+            gl.texImage2D(targets[tt], 0, gl.RGBA, texWidth, texHeight, 0,
+                          gl.RGBA, type, null);
+            if (gl.getError() != gl.NO_ERROR)
+                testFailed("GL error after texImage2D(null)");
+            gl.texSubImage2D(targets[tt], 0, 0, 0, texWidth, texHeight, gl.RGBA, type, data);
+            if (gl.getError() != gl.NO_ERROR)
+                testFailed("GL error after texSubImage2D");
+        } else {
+            gl.texImage2D(targets[tt], 0, gl.RGBA, texWidth, texHeight, 0, gl.RGBA, type, data);
+            if (gl.getError() != gl.NO_ERROR)
+                testFailed("GL error after texImage2D");
+        }
     }
 
-    // Point the uniform sampler to texture unit 0
-    gl.uniform1i(textureLoc, 0);
-    // Draw the triangles
-    wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-    // Check the top pixel and bottom pixel and make sure they have
-    // the right color.
     var testWidth  = gl.drawingBufferWidth;
     var testHeight = gl.drawingBufferHeight / 2;
-    wtu.checkCanvasRect(gl, 0, 0, testWidth, testHeight, bottomColor, "bottom pixel should be " + bottomColor);
-    wtu.checkCanvasRect(gl, 0, testHeight, testWidth, testHeight, topColor, "top pixel should be " + topColor);
+
+    var loc;
+    if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+        loc = gl.getUniformLocation(program, "face");
+    }
+
+    for (var tt = 0; tt < targets.length; ++tt) {
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            gl.uniform1i(loc, targets[tt]);
+        }
+
+        // Draw the triangles
+        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+
+        // Check the top pixel and bottom pixel and make sure they have
+        // the right color.
+        wtu.checkCanvasRect(gl, 0, 0, testWidth, testHeight, bottomColor, "bottom pixel should be " + bottomColor);
+        wtu.checkCanvasRect(gl, 0, testHeight, testWidth, testHeight, topColor, "top pixel should be " + topColor);
+    }
 
     // Change part of the texture.
-    var partWidth = 8;
+    var partWidth = 16;
     var partHeight = 16;
     // make texture double res of part.
     var data = generateRGBAData(type, unpackAlignment, sourceData, partWidth * 2, partHeight * 2);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, partWidth * 2, partHeight * 2, 0, gl.RGBA, type, data);
+    for (var tt = 0; tt < targets.length; ++tt) {
+        gl.texImage2D(targets[tt], 0, gl.RGBA, partWidth * 2, partHeight * 2, 0, gl.RGBA, type, data);
+    }
     // set part.
     var extraData = [
       255,   0,   0, 255,
         0,   0, 255,   0
     ];
     var data = generateRGBAData(type, unpackAlignment, extraData, partWidth, partHeight);
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, partWidth, partHeight, gl.RGBA, type, data);
-    wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+    for (var tt = 0; tt < targets.length; ++tt) {
+        gl.texSubImage2D(targets[tt], 0, 0, 0, partWidth, partHeight, gl.RGBA, type, data);
+    }
     var halfWidth  = gl.drawingBufferWidth / 2;
     var halfHeight = gl.drawingBufferHeight / 2;
     var quarterHeight = gl.drawingBufferHeight / 4;
     var red = [255, 0, 0, 255];
     var tcolor0 = flipY ? extraColor : red;
     var tcolor1 = flipY ? red : extraColor;
-    wtu.checkCanvasRect(gl, 0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0);
-    wtu.checkCanvasRect(gl, 0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1);
-    wtu.checkCanvasRect(gl, halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom right pixels should be " + bottomColor);
-    wtu.checkCanvasRect(gl, 0, halfHeight, testWidth, halfHeight, topColor, "top pixels should be " + topColor);
+
+    for (var tt = 0; tt < targets.length; ++tt) {
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            gl.uniform1i(loc, targets[tt]);
+        }
+
+        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+        wtu.checkCanvasRect(gl, 0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0);
+        wtu.checkCanvasRect(gl, 0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1);
+        wtu.checkCanvasRect(gl, halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom right pixels should be " + bottomColor);
+        wtu.checkCanvasRect(gl, 0, halfHeight, testWidth, halfHeight, topColor, "top pixels should be " + topColor);
+    }
+
     // set far corner.
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, partWidth, partHeight, partWidth, partHeight, gl.RGBA, type, data);
-    wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-    wtu.checkCanvasRect(gl, 0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0);
-    wtu.checkCanvasRect(gl, 0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1);
-    wtu.checkCanvasRect(gl, halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom left pixels should be " + bottomColor);
-    wtu.checkCanvasRect(gl, 0, halfHeight, halfWidth, halfHeight, topColor, "top right pixels should be " + topColor);
-    wtu.checkCanvasRect(gl, halfWidth, halfHeight, halfWidth, quarterHeight, tcolor0, "top right bottom pixels should be " + tcolor0);
-    wtu.checkCanvasRect(gl, halfWidth, halfHeight + quarterHeight, halfWidth, quarterHeight, tcolor1, "top right top pixels should be " + tcolor1);
+    for (var tt = 0; tt < targets.length; ++tt) {
+        gl.texSubImage2D(targets[tt], 0, partWidth, partHeight, partWidth, partHeight, gl.RGBA, type, data);
+    }
+    for (var tt = 0; tt < targets.length; ++tt) {
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            gl.uniform1i(loc, targets[tt]);
+        }
+
+        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+        wtu.checkCanvasRect(gl, 0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0);
+        wtu.checkCanvasRect(gl, 0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1);
+        wtu.checkCanvasRect(gl, halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom left pixels should be " + bottomColor);
+        wtu.checkCanvasRect(gl, 0, halfHeight, halfWidth, halfHeight, topColor, "top right pixels should be " + topColor);
+        wtu.checkCanvasRect(gl, halfWidth, halfHeight, halfWidth, quarterHeight, tcolor0, "top right bottom pixels should be " + tcolor0);
+        wtu.checkCanvasRect(gl, halfWidth, halfHeight + quarterHeight, halfWidth, quarterHeight, tcolor1, "top right top pixels should be " + tcolor1);
+    }
 }
 
-function runTest()
+function runTest(bindingTarget, program)
 {
     var red = [255, 0, 0, 255];
     var green = [0, 255, 0, 255];
@@ -219,37 +262,35 @@ function runTest()
     var types = [ gl.UNSIGNED_BYTE, gl.UNSIGNED_SHORT_5_5_5_1, gl.UNSIGNED_SHORT_4_4_4_4 ];
     var unpackAlignments = [ 1, 2, 4, 8 ];
 
-    for (var i = 0; i < types.length; ++i) {
-        var type = types[i];
-        for (var j = 0; j < unpackAlignments.length; ++j) {
-            var unpackAlignment = unpackAlignments[j];
-            runOneIteration(false, type, unpackAlignment, true, false,
-                            red, green, blue);
-            runOneIteration(false, type, unpackAlignment, false, false,
-                            green, red, blue);
-            runOneIteration(false, type, unpackAlignment, true, true,
-                            redPremultiplyAlpha, greenPremultiplyAlpha, bluePremultiplyAlpha);
-            runOneIteration(false, type, unpackAlignment, false, true,
-                            greenPremultiplyAlpha, redPremultiplyAlpha, bluePremultiplyAlpha);
-            runOneIteration(true, type, unpackAlignment, true, false,
-                            red, green, blue);
-            runOneIteration(true, type, unpackAlignment, false, false,
-                            green, red, blue);
-            runOneIteration(true, type, unpackAlignment, true, true,
-                            redPremultiplyAlpha, greenPremultiplyAlpha, bluePremultiplyAlpha);
-            runOneIteration(true, type, unpackAlignment, false, true,
-                            greenPremultiplyAlpha, redPremultiplyAlpha, bluePremultiplyAlpha);
+    var cases = [
+        { sub: false, flipY: true, premultiplyAlpha: false, topColor: red, bottomColor: green, extraColor: blue },
+        { sub: false, flipY: false, premultiplyAlpha: false, topColor: green, bottomColor: red, extraColor: blue },
+        { sub: false, flipY: true, premultiplyAlpha: true, topColor: redPremultiplyAlpha, bottomColor: greenPremultiplyAlpha, extraColor: bluePremultiplyAlpha },
+        { sub: false, flipY: false, premultiplyAlpha: true, topColor: greenPremultiplyAlpha, bottomColor: redPremultiplyAlpha, extraColor: bluePremultiplyAlpha },
+        { sub: true, flipY: true, premultiplyAlpha: false, topColor: red, bottomColor: green, extraColor: blue },
+        { sub: true, flipY: false, premultiplyAlpha: false, topColor: green, bottomColor: red, extraColor: blue },
+        { sub: true, flipY: true, premultiplyAlpha: true, topColor: redPremultiplyAlpha, bottomColor: greenPremultiplyAlpha, extraColor: bluePremultiplyAlpha },
+        { sub: true, flipY: false, premultiplyAlpha: true, topColor: greenPremultiplyAlpha, bottomColor: redPremultiplyAlpha, extraColor: bluePremultiplyAlpha },
+    ];
+
+    for (var i in types) {
+        for (var j in unpackAlignments) {
+            for (var k in cases) {
+                runOneIteration(cases[k].sub, types[i], unpackAlignments[j], cases[k].flipY, cases[k].premultiplyAlpha,
+                                cases[k].topColor, cases[k].bottomColor, cases[k].extraColor, bindingTarget, program);
+            }
         }
     }
 
 }
 
 var gl = wtu.create3DContext("example");
+
 var program = wtu.setupTexturedQuad(gl);
+runTest(gl.TEXTURE_2D, program);
+program = wtu.setupTexturedQuadWithCubeMap(gl);
+runTest(gl.TEXTURE_CUBE_MAP, program);
 
-textureLoc = gl.getUniformLocation(program, "tex");
-
-runTest();
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
 var successfullyParsed = true;
 </script>


### PR DESCRIPTION
Make tex-image-and-sub-image-2d-with-webgl-canvas-* cover TEXTURE_CUBE_MAP.

Improve tex-image-and-sub-image-2d-with-webgl-canvas-* to check http://crrev.com/735623003/
Change from setCanvasTo1x2 to setCanvasTo2x2 because cube map allows only square source.