### PR TITLE
Angle-instanced-arrays calls notifyFinishedToHarness multiple times

### DIFF
--- a/conformance-suites/1.0.3/conformance/extensions/angle-instanced-arrays.html
+++ b/conformance-suites/1.0.3/conformance/extensions/angle-instanced-arrays.html
@@ -77,6 +77,7 @@ var program;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
+    finishTest();
 } else {
     testPassed("WebGL context exists");
 
@@ -88,6 +89,7 @@ if (!gl) {
         testPassed("No ANGLE_instanced_arrays support -- this is legal");
 
         runSupportedTest(false);
+        finishTest();
     } else {
         testPassed("Successfully enabled ANGLE_instanced_arrays extension");
 
@@ -413,10 +415,6 @@ function runANGLECorruptionTest()
 
     cycleAndTest();
 }
-
-var successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
-
 </body>
 </html>

--- a/sdk/tests/conformance/extensions/angle-instanced-arrays.html
+++ b/sdk/tests/conformance/extensions/angle-instanced-arrays.html
@@ -77,6 +77,7 @@ var program;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
+    finishTest();
 } else {
     testPassed("WebGL context exists");
 
@@ -88,6 +89,7 @@ if (!gl) {
         testPassed("No ANGLE_instanced_arrays support -- this is legal");
 
         runSupportedTest(false);
+        finishTest();
     } else {
         testPassed("Successfully enabled ANGLE_instanced_arrays extension");
 
@@ -413,10 +415,6 @@ function runANGLECorruptionTest()
 
     cycleAndTest();
 }
-
-var successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
-
 </body>
 </html>


### PR DESCRIPTION
Conformance tests notify the harness of completeness one of two ways:
1) Manually include "var successfullyParsed = true;" and
    js-test-post.js at the end of the test. js-test-post.js calls notifyFinishedToHarness
2) Call finishTest at the of the test. FinishTest performs the first method programatically.

Angle-instanced-arrays does both of these things. The "TEST COMPLETED" message shows
up twice in the final output.

Since finishTest is called as part of multiple setTimeout callbacks, we end up
notifying the harness of completeness (through the manually inserted script tag)
before the test actually finishes.

The fix is to delete js-test-post.js from the end of the test and rely on finishTest exclusively.