### PR TITLE
framebuffer-bindings-...-to-data-url does not report completeness to test harness

### DIFF
--- a/sdk/tests/conformance/canvas/framebuffer-bindings-affected-by-to-data-url.html
+++ b/sdk/tests/conformance/canvas/framebuffer-bindings-affected-by-to-data-url.html
@@ -90,5 +90,6 @@ test();
 
 var successfullyParsed = true;
 </script>
+<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The framebuffer-bindings-affected-by-to-data-url test needs to report completeness back to
the test harness. Otherwise, the test harness will timeout the test.

To fix this we add js-test-post.js to the end of the test.