### PR TITLE
Buffer calls to console.log to reduce amount of debugging output.

### DIFF
--- a/sdk/tests/conformance/resources/glsl-conformance-test.js
+++ b/sdk/tests/conformance/resources/glsl-conformance-test.js
@@ -40,9 +40,7 @@ var defaultFragmentShader = [
 ].join('\n');
 
 function log(msg) {
-  if (window.console && window.console.log) {
-    window.console.log(msg);
-  }
+  bufferedLogToConsole(msg);
 }
 
 var vShaderDB = {};

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-video.js
@@ -28,7 +28,7 @@ initTestingHarness();
 
 var old = debug;
 var debug = function(msg) {
-  console.log(msg);
+  bufferedLogToConsole(msg);
   old(msg);
 };
 

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -28,9 +28,7 @@ var WebGLTestUtils = (function() {
  * @param {string} msg The message to log.
  */
 var log = function(msg) {
-  if (window.console && window.console.log) {
-    window.console.log(msg);
-  }
+  bufferedLogToConsole(msg);
 };
 
 /**
@@ -38,14 +36,10 @@ var log = function(msg) {
  * @param {string} msg The message to log.
  */
 var error = function(msg) {
-  if (window.console) {
-    if (window.console.error) {
-      window.console.error(msg);
-    }
-    else if (window.console.log) {
-      window.console.log(msg);
-    }
-  }
+  // For the time being, diverting this to window.console.log rather
+  // than window.console.error. If anyone cares enough they can
+  // generalize the mechanism in js-test-pre.js.
+  log(msg);
 };
 
 /**
@@ -2583,10 +2577,12 @@ var waitForComposite = function(callback) {
   var frames = 5;
   var countDown = function() {
     if (frames == 0) {
-      log("waitForComposite: callback");
+      // TODO(kbr): unify with js-test-pre.js and enable these with
+      // verbose logging.
+      // log("waitForComposite: callback");
       callback();
     } else {
-      log("waitForComposite: countdown(" + frames + ")");
+      // log("waitForComposite: countdown(" + frames + ")");
       --frames;
       requestAnimFrame.call(window, countDown);
     }

--- a/sdk/tests/resources/js-test-post.js
+++ b/sdk/tests/resources/js-test-post.js
@@ -24,6 +24,6 @@
 shouldBeTrue("successfullyParsed");
 _addSpan('<br /><span class="pass">TEST COMPLETE</span>');
 if (_jsTestPreVerboseLogging) {
-    _logToConsole('TEST COMPLETE');
+    _bufferedLogToConsole('TEST COMPLETE');
 }
 notifyFinishedToHarness()

--- a/sdk/tests/resources/js-test-pre.js
+++ b/sdk/tests/resources/js-test-pre.js
@@ -86,10 +86,34 @@ function notifyFinishedToHarness() {
   }
 }
 
-function _logToConsole(msg)
+var _bufferedConsoleLogs = [];
+
+function _bufferedLogToConsole(msg)
 {
-    if (window.console)
-      window.console.log(msg);
+  if (_bufferedConsoleLogs) {
+    _bufferedConsoleLogs.push(msg);
+  } else if (window.console) {
+    window.console.log(msg);
+  }
+}
+
+// Public entry point exposed to many other files.
+function bufferedLogToConsole(msg)
+{
+  _bufferedLogToConsole(msg);
+}
+
+// Called implicitly by testFailed().
+function _flushBufferedLogsToConsole()
+{
+  if (_bufferedConsoleLogs) {
+    if (window.console) {
+      for (var ii = 0; ii < _bufferedConsoleLogs.length; ++ii) {
+        window.console.log(_bufferedConsoleLogs[ii]);
+      }
+    }
+    _bufferedConsoleLogs = null;
+  }
 }
 
 var _jsTestPreVerboseLogging = false;
@@ -114,7 +138,7 @@ function description(msg)
     else
         description.appendChild(span);
     if (_jsTestPreVerboseLogging) {
-        _logToConsole(msg);
+        _bufferedLogToConsole(msg);
     }
 }
 
@@ -129,7 +153,7 @@ function debug(msg)
 {
     _addSpan(msg);
     if (_jsTestPreVerboseLogging) {
-	_logToConsole(msg);
+	_bufferedLogToConsole(msg);
     }
 }
 
@@ -143,7 +167,7 @@ function testPassed(msg)
     reportTestResultsToHarness(true, msg);
     _addSpan('<span><span class="pass">PASS</span> ' + escapeHTML(msg) + '</span>');
     if (_jsTestPreVerboseLogging) {
-	_logToConsole('PASS ' + msg);
+	_bufferedLogToConsole('PASS ' + msg);
     }
 }
 
@@ -151,7 +175,8 @@ function testFailed(msg)
 {
     reportTestResultsToHarness(false, msg);
     _addSpan('<span><span class="fail">FAIL</span> ' + escapeHTML(msg) + '</span>');
-    _logToConsole('FAIL ' + msg);
+    _bufferedLogToConsole('FAIL ' + msg);
+    _flushBufferedLogsToConsole();
 }
 
 function areArraysEqual(_a, _b)


### PR DESCRIPTION
Only output the buffered logs if the test fails -- i.e., calls testFailed().

This reduces the amount of debugging output for a typical run of the
conformance suite, while still remaining debuggable in case of errors.

Tested by injecting a synthetic failure in a test which previously had
debugging output; verified that the output was printed, and only then.