### PR TITLE
rejecting WEBGL_draw_elements_no_range_check

### DIFF
--- a/extensions/rejected/WEBGL_draw_elements_no_range_check/extension.xml
+++ b/extensions/rejected/WEBGL_draw_elements_no_range_check/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<proposal href="proposals/WEBGL_draw_elements_no_range_check/">
+<rejected href="rejected/WEBGL_draw_elements_no_range_check/">
   <name>WEBGL_draw_elements_no_range_check</name>
 
   <contact><a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -76,5 +76,8 @@ interface WEBGL_draw_elements_no_range_check {
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
     </revision>
+    <revision date="2015/01/24">
+      <change>Moved to rejected.</change>
+    </revision>
   </history>
-</proposal>
+</rejected>


### PR DESCRIPTION
Olli indicated that this extension might be best dropped.