### PR TITLE
reject WEBGL_texture_from_depth_video

### DIFF
--- a/extensions/rejected/WEBGL_texture_from_depth_video/extension.xml
+++ b/extensions/rejected/WEBGL_texture_from_depth_video/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<proposal href="proposals/WEBGL_texture_from_depth_video/">
+<rejected href="rejected/WEBGL_texture_from_depth_video/">
   <name>WEBGL_texture_from_depth_video</name>
 
   <contact><a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -101,5 +101,8 @@ if (ext) {
     <revision date="2014/11/03">
       <change>Initial revision.</change>
     </revision>
+    <revision date="2015/01/24">
+      <change>Moved to rejected on the grounds that it can be done without an extension.</change>
+    </revision>
   </history>
-</proposal>
+</rejected>


### PR DESCRIPTION
Proposing to reject WEBGL_texture_from_depth video because it's not required to do it as an extension.