### PR TITLE
Fix mistakes in WebGL 2.0 getParameter enum list

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 26 January 2015</h2>
+    <h2 class="no-toc">Editor's Draft 29 January 2015</h2>
     <dl>
         <dt>This version:
             <dd>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -846,11 +846,9 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
                 <tr><th>pname</th><th>returned type</th></tr>
                 <tr><td>COPY_READ_BUFFER_BINDING</td><td>WebGLBuffer</td></tr>
                 <tr><td>COPY_WRITE_BUFFER_BINDING</td><td>WebGLBuffer</td></tr>
-                <tr><td>DRAW_BINDING</td><td>GLenum</td></tr>
+                <tr><td>DRAW_BUFFER<em>i</em></td><td>GLenum</td></tr>
                 <tr><td>DRAW_FRAMEBUFFER_BINDING</td><td>WebGLFramebuffer</td></tr>
                 <tr><td>FRAGMENT_SHADER_DERIVATIVE_HINT</td><td>GLenum</td></tr>
-                <tr><td>IMPLEMENTATION_COLOR_READ_FORMAT</td><td>GLenum</td></tr>
-                <tr><td>IMPLEMENTATION_COLOR_READ_TYPE</td><td>GLenum</td></tr>
                 <tr><td>MAX_3D_TEXTURE_SIZE</td><td>GLint</td></tr>
                 <tr><td>MAX_ARRAY_TEXTURE_LAYERS</td><td>GLint</td></tr>
                 <tr><td>MAX_COLOR_ATTACHMENTS</td><td>GLint</td></tr>
@@ -878,9 +876,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
                 <tr><td>MAX_VERTEX_UNIFORM_BLOCKS</td><td>GLint</td></tr>
                 <tr><td>MAX_VERTEX_UNIFORM_COMPONENTS</td><td>GLint</td></tr>
                 <tr><td>MIN_PROGRAM_TEXEL_OFFSET</td><td>GLint</td></tr>
-                <tr><td>PACK_IMAGE_HEIGHT</td><td>GLint</td></tr>
                 <tr><td>PACK_ROW_LENGTH</td><td>GLint</td></tr>
-                <tr><td>PACK_SKIP_IMAGES</td><td>GLint</td></tr>
                 <tr><td>PACK_SKIP_PIXELS</td><td>GLint</td></tr>
                 <tr><td>PACK_SKIP_ROWS</td><td>GLint</td></tr>
                 <tr><td>PIXEL_PACK_BUFFER_BINDING</td><td>WebGLBuffer</td></tr>


### PR DESCRIPTION
DRAW_BINDING was incorrect, it should have been DRAW_BUFFER<i>.
PACK_IMAGE_HEIGHT and PACK_SKIP_IMAGES were removed in GLES3.0.1 (see spec
section E.4), so they should not be in WebGL 2.0 either.

IMPLEMENTATION_COLOR_READ_FORMAT and IMPLEMENTATION_COLOR_READ_TYPE are not
new in WebGL 2.0 any more, since they were added to WebGL 1.0, so remove them
from the table that should only list the new enums.