### PR TITLE
Fixed conformance tests

### DIFF
--- a/sdk/tests/conformance/extensions/ext-frag-depth.html
+++ b/sdk/tests/conformance/extensions/ext-frag-depth.html
@@ -112,8 +112,7 @@ runAllTests();
 // Run all tests against with a new context to test for any cache issues.
 debug("");
 debug("Testing new context to catch cache errors");
-var canvas2 = document.getElementById("canvas2");
-gl = wtu.create3DContext(canvas2);
+gl = wtu.create3DContext();
 ext = null;
 runAllTests();
 

--- a/sdk/tests/conformance/extensions/ext-frag-depth.html
+++ b/sdk/tests/conformance/extensions/ext-frag-depth.html
@@ -106,27 +106,40 @@ var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
 var ext = null;
 
-if (!gl) {
-    testFailed("WebGL context does not exist");
-} else {
-    testPassed("WebGL context exists");
+// Run all tests once.
+runAllTests();
 
-    runShaderTests(false);
+// Run all tests against with a new context to test for any cache issues.
+debug("");
+debug("Testing new context to catch cache errors");
+var canvas2 = document.getElementById("canvas2");
+gl = wtu.create3DContext(canvas2);
+ext = null;
+runAllTests();
 
-    // Query the extension and store globally so shouldBe can access it
-    ext = wtu.getExtensionWithKnownPrefixes(gl, "EXT_frag_depth");
-    if (!ext) {
-        testPassed("No EXT_frag_depth support -- this is legal");
-
-        runSupportedTest(false);
+function runAllTests() {
+    if (!gl) {
+        testFailed("WebGL context does not exist");
     } else {
-        testPassed("Successfully enabled EXT_frag_depth extension");
+        testPassed("WebGL context exists");
 
-        runSupportedTest(true);
+        runShaderTests(false);
 
-        runShaderTests(true);
-        runOutputTests();
-        runUniqueObjectTest();
+        // Query the extension and store globally so shouldBe can access it
+        ext = wtu.getExtensionWithKnownPrefixes(gl, "EXT_frag_depth");
+        if (!ext) {
+            testPassed("No EXT_frag_depth support -- this is legal");
+
+            runSupportedTest(false);
+        } else {
+            testPassed("Successfully enabled EXT_frag_depth extension");
+
+            runSupportedTest(true);
+
+            runShaderTests(true);
+            runOutputTests();
+            runUniqueObjectTest();
+        }
     }
 }
 

--- a/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
+++ b/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
@@ -36,7 +36,8 @@
 </head>
 <body>
 <div id="description"></div>
-<canvas id="canvas" style="width: 50px; height: 50px;"> </canvas>
+<canvas id="canvas" style="width: 256px; height: 256px;"> </canvas>
+<canvas id="canvas2" style="width: 256px; height: 256px;"> </canvas>
 <div id="console"></div>
 <!-- Shaders for testing texture LOD functions -->
 
@@ -44,9 +45,11 @@
 <script id="missingPragmaFragmentShader" type="x-shader/x-fragment">
 precision mediump float;
 varying vec2 texCoord0v;
+uniform float lod;
+uniform sampler2D tex;
 void main() {
     vec4 color = texture2DLodEXT(tex, texCoord0v, lod);
-    gl_FragColor = vec4(dx, dy, w, 1.0);
+    gl_FragColor = color;
 }
 </script>
 
@@ -116,34 +119,45 @@ debug("");
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
-canvas.width = 256; canvas.height = 256;
-
 var gl = wtu.create3DContext(canvas);
 var ext = null;
 
-if (!gl) {
-    testFailed("WebGL context does not exist");
-} else {
-    testPassed("WebGL context exists");
+// Run all tests once.
+runAllTests();
 
-    // Run tests with extension disabled
-    runShaderTests(false);
+// Run all tests against with a new context to test for any cache issues.
+debug("");
+debug("Testing new context to catch cache errors");
+var canvas2 = document.getElementById("canvas2");
+gl = wtu.create3DContext(canvas2);
+ext = null;
+runAllTests();
 
-    // Query the extension and store globally so shouldBe can access it
-    ext = gl.getExtension("EXT_shader_texture_lod");
-    if (!ext) {
-        testPassed("No EXT_shader_texture_lod support -- this is legal");
-
-        runSupportedTest(false);
+function runAllTests() {
+    if (!gl) {
+        testFailed("WebGL context does not exist");
     } else {
-        testPassed("Successfully enabled EXT_shader_texture_lod extension");
+        testPassed("WebGL context exists");
 
-        runSupportedTest(true);
+        // Run tests with extension disabled
+        runShaderTests(false);
 
-        runShaderTests(true);
-        runOutputTests();
-        runUniqueObjectTest();
-        runReferenceCycleTest();
+        // Query the extension and store globally so shouldBe can access it
+        ext = gl.getExtension("EXT_shader_texture_lod");
+        if (!ext) {
+            testPassed("No EXT_shader_texture_lod support -- this is legal");
+
+            runSupportedTest(false);
+        } else {
+            testPassed("Successfully enabled EXT_shader_texture_lod extension");
+
+            runSupportedTest(true);
+
+            runShaderTests(true);
+            runOutputTests();
+            runUniqueObjectTest();
+            runReferenceCycleTest();
+        }
     }
 }
 

--- a/sdk/tests/conformance/extensions/oes-standard-derivatives.html
+++ b/sdk/tests/conformance/extensions/oes-standard-derivatives.html
@@ -124,8 +124,7 @@ runAllTests();
 // Run all tests against with a new context to test for any cache issues.
 debug("");
 debug("Testing new context to catch cache errors");
-var canvas2 = document.getElementById("canvas2");
-gl = wtu.create3DContext(canvas2);
+gl = wtu.create3DContext();
 ext = null;
 runAllTests();
 

--- a/sdk/tests/conformance/extensions/oes-standard-derivatives.html
+++ b/sdk/tests/conformance/extensions/oes-standard-derivatives.html
@@ -118,30 +118,43 @@ var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
 var ext = null;
 
-if (!gl) {
-    testFailed("WebGL context does not exist");
-} else {
-    testPassed("WebGL context exists");
+// Run all tests once.
+runAllTests();
 
-    // Run tests with extension disabled
-    runHintTestDisabled();
-    runShaderTests(false);
+// Run all tests against with a new context to test for any cache issues.
+debug("");
+debug("Testing new context to catch cache errors");
+var canvas2 = document.getElementById("canvas2");
+gl = wtu.create3DContext(canvas2);
+ext = null;
+runAllTests();
 
-    // Query the extension and store globally so shouldBe can access it
-    ext = gl.getExtension("OES_standard_derivatives");
-    if (!ext) {
-        testPassed("No OES_standard_derivatives support -- this is legal");
-
-        runSupportedTest(false);
+function runAllTests() {
+    if (!gl) {
+        testFailed("WebGL context does not exist");
     } else {
-        testPassed("Successfully enabled OES_standard_derivatives extension");
+        testPassed("WebGL context exists");
 
-        runSupportedTest(true);
+        // Run tests with extension disabled
+        runHintTestDisabled();
+        runShaderTests(false);
 
-        runHintTestEnabled();
-        runShaderTests(true);
-        runOutputTests();
-        runUniqueObjectTest();
+        // Query the extension and store globally so shouldBe can access it
+        ext = gl.getExtension("OES_standard_derivatives");
+        if (!ext) {
+            testPassed("No OES_standard_derivatives support -- this is legal");
+
+            runSupportedTest(false);
+        } else {
+            testPassed("Successfully enabled OES_standard_derivatives extension");
+
+            runSupportedTest(true);
+
+            runHintTestEnabled();
+            runShaderTests(true);
+            runOutputTests();
+            runUniqueObjectTest();
+        }
     }
 }
 

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -732,8 +732,7 @@ function runEndTests() {
   // Create new context and verify shader tests with no extension still succeeds.
   debug("");
   debug("Testing new context with no extension");
-  var canvas2 = document.getElementById("canvas2");
-  gl = wtu.create3DContext(canvas2);
+  gl = wtu.create3DContext();
   if (!gl) {
     testFailed("New WebGL context does not exist");
   } else {

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -724,8 +724,26 @@ function runPreserveTests() {
     wtu.checkCanvas(gl, [0, 0, 0, 0], "should be clear");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 
-    finishTest();
+    runEndTests();
   });
+}
+
+function runEndTests() {
+  // Create new context and verify shader tests with no extension still succeeds.
+  debug("");
+  debug("Testing new context with no extension");
+  var canvas2 = document.getElementById("canvas2");
+  gl = wtu.create3DContext(canvas2);
+  if (!gl) {
+    testFailed("New WebGL context does not exist");
+  } else {
+    testPassed("New WebGL context exists");
+    runEnumTestDisabled();
+    runShadersTestDisabled();
+    runAttachmentTestDisabled();
+  }
+
+  finishTest();
 }
 </script>
 </body>


### PR DESCRIPTION
Add conformance tests to check that cached shaders take into account extensions.

Due to the complexity of caching shaders with global extensions that affect shader compilations,
it is necessary to test for these special conditions by running these shader tests twice. The tests
for the following extensions have been modified to catch cache problems:

GL_OES_standard_derivatives
GL_EXT_frag_depth
GL_EXT_draw_buffers
GL_EXT_shader_texture_lod

Additionally, an issue with the "missingPragmaFragmentShader shader" inside of
ext-shader-texture-lod.html has been fixed. This shader was not properly catching pragma
errors because the shader itself was invalid with other errors such as undeclared variables.
This has been fixed now so the only error is that the pragma extension is missing.