### PR TITLE
rejected EXT_color_buffer_half_float and WEBGL_color_buffer_float

### DIFF
--- a/extensions/rejected/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/rejected/EXT_color_buffer_half_float/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension href="EXT_color_buffer_half_float/">
+<rejected href="rejected/EXT_color_buffer_half_float/">
   <name>EXT_color_buffer_half_float</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list">WebGL
@@ -134,5 +134,9 @@ interface EXT_color_buffer_half_float {
     <revision date="2014/11/24">
       <change>Move to community approved.</change>
     </revision>
+    
+    <revision date="2015/01/31">
+      <change>Move to rejected. Implementation difficulties emerged and support is dropped.</change>
+    </revision>
   </history>
-</extension>
+</rejected>

--- a/extensions/rejected/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/rejected/WEBGL_color_buffer_float/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension href="WEBGL_color_buffer_float/">
+<rejected href="rejected/WEBGL_color_buffer_float/">
   <name>WEBGL_color_buffer_float</name>
 
   <contact><a href="https://www.khronos.org/webgl/public-mailing-list">WebGL
@@ -120,5 +120,9 @@ interface WEBGL_color_buffer_float {
     <revision date="2014/11/24">
       <change>Move to community approved.</change>
     </revision>
+    
+    <revision date="2015/01/31">
+      <change>Move to rejected. Implementation difficulties emerged and support is dropped.</change>
+    </revision>
   </history>
-</extension>
+</rejected>


### PR DESCRIPTION
Due to implementation difficulties I propose to reject these extensions.

Google has stated that these extensions will not be implemented by chrome. Mozilla has withdrawn their initial implementation.