### PR TITLE
uniformMatrixBadArgs test: allow 1 shade of tolerance in framebuffer value

### DIFF
--- a/conformance-suites/1.0.3/conformance/more/functions/uniformMatrixBadArgs.html
+++ b/conformance-suites/1.0.3/conformance/more/functions/uniformMatrixBadArgs.html
@@ -120,7 +120,7 @@ Tests.testUniformf = function(gl, unwrappedGL) {
   });
   var d = new Uint8Array(4);
   gl.readPixels(0,0,1,1,gl.RGBA, gl.UNSIGNED_BYTE, d);
-  assertArrayEquals([1,2,3,8], d);
+  assertArrayEqualsWithEpsilon([1,2,3,8], d, [1,1,1,1]);
   sh.destroy();
 }
 

--- a/conformance-suites/1.0.3/conformance/more/unit.js
+++ b/conformance-suites/1.0.3/conformance/more/unit.js
@@ -391,6 +391,38 @@ function assertArrayEquals(name, v, p) {
   return true;
 }
 
+function assertArrayEqualsWithEpsilon(name, v, p, l) {
+  if (l == null) { l = p; p = v; v = name; name = null; }
+  if (!v) {
+    testFailed("assertArrayEqualsWithEpsilon: first array undefined", name, v, p);
+    return false;
+  }
+  if (!p) {
+    testFailed("assertArrayEqualsWithEpsilon: second array undefined", name, v, p);
+    return false;
+  }
+  if (!l) {
+    testFailed("assertArrayEqualsWithEpsilon: limit array undefined", name, v, p);
+    return false;
+  }
+  if (v.length != p.length) {
+    testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+    return false;
+  }
+  if (v.length != l.length) {
+    testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+    return false;
+  }
+  for (var ii = 0; ii < v.length; ++ii) {
+    if (Math.abs(v[ii]- p[ii])>l[ii]) {
+      testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+      return false;
+    }
+  }
+  testPassed("assertArrayEqualsWithEpsilon", name, v, p, l);
+  return true;
+}
+
 function assertNotEquals(name, v, p) {
   if (p == null) { p = v; v = name; name = null; }
   if (compare(v, p)) {


### PR DESCRIPTION
The uniformMatrixBadArgs test culminates with a call to glReadPixels and expects to get an exact result of [1,2,3,8].

The fragment shader output color is calculated like this:
gl_FragColor = vec4(fm4[0][0]/256.0, fm4[1][1]/256.0, fm4[2][2]/256.0, fm4[3][3]*texCoord0.z/256.0);

While the vertex position is calculated like this:
gl_Position = vec4(Vertex, 1.0 + d * 0.0001);

The framebuffer value therefore depends on an iterated texture coordinate (texCoord0.z) which has been subject to perspective projection by a non 1.0f vertex W-value. These operations may introduce small errors on some implementations, along with the usual float-to-unorm rounding issues.

As such, we propose that the test allows 1 shade of tolerance in the framebuffer value, as is typical in GLES Conformance tests. We have added a utility function assertArrayEqualsWithEpsilon() for this purpose.

Thanks, 
Jonathan Putsman
(Imagination Technologies)