### PR TITLE
uniformMatrixBadArgs test: allow 1 shade of tolerance in framebuffer value (1.0.1 and 1.0.2)

### DIFF
--- a/conformance-suites/1.0.1/conformance/more/functions/uniformMatrixBadArgs.html
+++ b/conformance-suites/1.0.1/conformance/more/functions/uniformMatrixBadArgs.html
@@ -93,7 +93,7 @@ Tests.testUniformf = function(gl, unwrappedGL) {
   });
   var d = new Uint8Array(4);
   gl.readPixels(0,0,1,1,gl.RGBA, gl.UNSIGNED_BYTE, d);
-  assertArrayEquals([1,2,3,8], d);
+  assertArrayEqualsWithEpsilon([1,2,3,8], d, [1,1,1,1]);
   sh.destroy();
 }
 

--- a/conformance-suites/1.0.1/conformance/more/unit.js
+++ b/conformance-suites/1.0.1/conformance/more/unit.js
@@ -360,6 +360,38 @@ function assertArrayEquals(name, v, p) {
   return true;
 }
 
+function assertArrayEqualsWithEpsilon(name, v, p, l) {
+  if (l == null) { l = p; p = v; v = name; name = null; }
+  if (!v) {
+    testFailed("assertArrayEqualsWithEpsilon: first array undefined", name, v, p);
+    return false;
+  }
+  if (!p) {
+    testFailed("assertArrayEqualsWithEpsilon: second array undefined", name, v, p);
+    return false;
+  }
+  if (!l) {
+    testFailed("assertArrayEqualsWithEpsilon: limit array undefined", name, v, p);
+    return false;
+  }
+  if (v.length != p.length) {
+    testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+    return false;
+  }
+  if (v.length != l.length) {
+    testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+    return false;
+  }
+  for (var ii = 0; ii < v.length; ++ii) {
+    if (Math.abs(v[ii]- p[ii])>l[ii]) {
+      testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+      return false;
+    }
+  }
+  testPassed("assertArrayEqualsWithEpsilon", name, v, p, l);
+  return true;
+}
+
 function assertNotEquals(name, v, p) {
   if (p == null) { p = v; v = name; name = null; }
   if (compare(v, p)) {

--- a/conformance-suites/1.0.2/conformance/more/functions/uniformMatrixBadArgs.html
+++ b/conformance-suites/1.0.2/conformance/more/functions/uniformMatrixBadArgs.html
@@ -120,7 +120,7 @@ Tests.testUniformf = function(gl, unwrappedGL) {
   });
   var d = new Uint8Array(4);
   gl.readPixels(0,0,1,1,gl.RGBA, gl.UNSIGNED_BYTE, d);
-  assertArrayEquals([1,2,3,8], d);
+  assertArrayEqualsWithEpsilon([1,2,3,8], d, [1,1,1,1]);
   sh.destroy();
 }
 

--- a/conformance-suites/1.0.2/conformance/more/unit.js
+++ b/conformance-suites/1.0.2/conformance/more/unit.js
@@ -390,6 +390,38 @@ function assertArrayEquals(name, v, p) {
   return true;
 }
 
+function assertArrayEqualsWithEpsilon(name, v, p, l) {
+if (l == null) { l = p; p = v; v = name; name = null; }
+if (!v) {
+testFailed("assertArrayEqualsWithEpsilon: first array undefined", name, v, p);
+return false;
+}
+if (!p) {
+testFailed("assertArrayEqualsWithEpsilon: second array undefined", name, v, p);
+return false;
+}
+if (!l) {
+testFailed("assertArrayEqualsWithEpsilon: limit array undefined", name, v, p);
+return false;
+}
+if (v.length != p.length) {
+testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+return false;
+}
+if (v.length != l.length) {
+testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+return false;
+}
+for (var ii = 0; ii < v.length; ++ii) {
+if (Math.abs(v[ii]- p[ii])>l[ii]) {
+testFailed("assertArrayEqualsWithEpsilon", name, v, p, l);
+return false;
+}
+}
+testPassed("assertArrayEqualsWithEpsilon", name, v, p, l);
+return true;
+}
+
 function assertNotEquals(name, v, p) {
   if (p == null) { p = v; v = name; name = null; }
   if (compare(v, p)) {


### PR DESCRIPTION
As discussed in pull request #849, apply change to uniformMatrixBadArgs test to 1.0.1 and 1.0.2 WebGL Conformance suites.