### PR TITLE
moved WEBGL_color_buffer_float and EXT_color_buffer_half_float to draft

### DIFF
--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension href="EXT_color_buffer_half_float/">
+<draft href="EXT_color_buffer_half_float/">
   <name>EXT_color_buffer_half_float</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list">WebGL
@@ -134,5 +134,9 @@ interface EXT_color_buffer_half_float {
     <revision date="2014/11/24">
       <change>Move to community approved.</change>
     </revision>
+    
+    <revision date="2015/02/07">
+      <change>Moved back to draft because of technical difficulties.</change>
+    </revision>
   </history>
-</extension>
+</draft>

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extension href="WEBGL_color_buffer_float/">
+<draft href="WEBGL_color_buffer_float/">
   <name>WEBGL_color_buffer_float</name>
 
   <contact><a href="https://www.khronos.org/webgl/public-mailing-list">WebGL
@@ -120,5 +120,9 @@ interface WEBGL_color_buffer_float {
     <revision date="2014/11/24">
       <change>Move to community approved.</change>
     </revision>
+    
+    <revision date="2015/02/07">
+      <change>Moved back to draft because of technical difficulties.</change>
+    </revision>
   </history>
-</extension>
+</draft>


### PR DESCRIPTION
Rejection of these extensions has proven impossible on objections to rejection. Implementation has proven impossible because of vendor objections. Ratification will prove impossible because of a lack of implementations. These extensions should move back to draft.