### PR TITLE
Pass -no-remote option to Firefox in test runner

### DIFF
--- a/other/test-runner/config.json
+++ b/other/test-runner/config.json
@@ -145,7 +145,8 @@
             },
 
             "args": [
-                "-silent"
+                "-silent",
+                "-no-remote"
             ]
         },
 
@@ -167,7 +168,8 @@
             },
 
             "args": [
-                "-silent"
+                "-silent",
+                "-no-remote"
             ]
         },
 


### PR DESCRIPTION
This makes sure that a new instance of the browser is opened with newer
versions of Firefox.