### PR TITLE
Add conformance test for deferred shader compilations with extensions.

### DIFF
--- a/sdk/tests/conformance/extensions/ext-frag-depth.html
+++ b/sdk/tests/conformance/extensions/ext-frag-depth.html
@@ -116,6 +116,9 @@ gl = wtu.create3DContext();
 ext = null;
 runAllTests();
 
+// Run deferred link tests.
+runDeferredLinkTests();
+
 function runAllTests() {
     if (!gl) {
         testFailed("WebGL context does not exist");
@@ -242,6 +245,66 @@ function runUniqueObjectTest()
     gl.getExtension("EXT_frag_depth").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("EXT_frag_depth").myProperty', '2');
+}
+
+function runDeferredLinkTests() {
+    debug("");
+    debug("Testing deferred shader compilation tests.");
+
+    // Test for compilation failures that are caused by missing extensions
+    // do not succeed if extensions are enabled during linking. This would
+    // only happen for deferred shader compilations.
+
+    var vertex_element = document.getElementById("goodVertexShader");
+    var fragment_element = document.getElementById("macroFragmentShader");
+    if (!vertex_element || !fragment_element) {
+        testFailed("Could not find shader elements.");
+        return;
+    }
+
+    var err;
+
+    var gl_deferred = wtu.create3DContext();
+
+    var vertex_shader = gl_deferred.createShader(gl_deferred.VERTEX_SHADER);
+    var fragment_shader = gl_deferred.createShader(gl_deferred.FRAGMENT_SHADER);
+    if (vertex_shader == null || fragment_shader == null) {
+        testFailed("Could not create shaders.");
+        return;
+    }
+
+    gl_deferred.shaderSource(vertex_shader, vertex_element.text);
+    err = gl_deferred.getError();
+    if (err != gl_deferred.NO_ERROR) {
+        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
+        return;
+    }
+
+    gl_deferred.shaderSource(fragment_shader, fragment_element.text);
+    err = gl_deferred.getError();
+    if (err != gl_deferred.NO_ERROR) {
+        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
+        return;
+    }
+
+    gl_deferred.compileShader(vertex_shader);
+    gl_deferred.compileShader(fragment_shader);
+
+    // Shader compilations should have failed due to extensions not enabled.
+    gl_deferred.getExtension("EXT_frag_depth");
+
+    var program = gl_deferred.createProgram();
+    gl_deferred.attachShader(program, vertex_shader);
+    gl_deferred.attachShader(program, fragment_shader);
+    gl_deferred.linkProgram(program);
+
+    var linked = gl_deferred.getProgramParameter(program, gl_deferred.LINK_STATUS);
+    if (linked) {
+        testFailed("Compilation with extension disabled then linking with extension enabled caused successful compile.");
+        return;
+    }
+
+    testPassed("Compilation with extension disabled then linking with extension enabled.");
 }
 
 debug("");

--- a/sdk/tests/conformance/extensions/ext-frag-depth.html
+++ b/sdk/tests/conformance/extensions/ext-frag-depth.html
@@ -116,9 +116,6 @@ gl = wtu.create3DContext();
 ext = null;
 runAllTests();
 
-// Run deferred link tests.
-runDeferredLinkTests();
-
 function runAllTests() {
     if (!gl) {
         testFailed("WebGL context does not exist");
@@ -143,6 +140,9 @@ function runAllTests() {
             runUniqueObjectTest();
         }
     }
+
+    // Run deferred link tests.
+    runDeferredLinkTests();
 }
 
 function runSupportedTest(extensionEnabled) {
@@ -255,52 +255,48 @@ function runDeferredLinkTests() {
     // do not succeed if extensions are enabled during linking. This would
     // only happen for deferred shader compilations.
 
-    var vertex_element = document.getElementById("goodVertexShader");
-    var fragment_element = document.getElementById("macroFragmentShader");
-    if (!vertex_element || !fragment_element) {
-        testFailed("Could not find shader elements.");
+    // First test if link succeeds with extension enabled.
+    var glEnabled = wtu.create3DContext();
+    var extEnabled = glEnabled.getExtension("EXT_frag_depth");
+
+    var vertexShader = wtu.loadShaderFromScript(glEnabled, "goodVertexShader");
+    var fragmentShader = wtu.loadShaderFromScript(glEnabled, "macroFragmentShader");
+
+    if (!vertexShader || !fragmentShader) {
+        testFailed("Could not create good shaders.");
         return;
     }
 
-    var err;
+    var program = wtu.setupProgram(glEnabled, [vertexShader, fragmentShader]);
 
-    var gl_deferred = wtu.create3DContext();
+    if (extEnabled) {
+        if (!program) {
+            testFailed("Compilation with extension enabled failed.");
+            return;
+        }
+    } else {
+        if (program) {
+            testFailed("Compilation with extension disabled succeeded.");
+            return;
+        }
+    }
 
-    var vertex_shader = gl_deferred.createShader(gl_deferred.VERTEX_SHADER);
-    var fragment_shader = gl_deferred.createShader(gl_deferred.FRAGMENT_SHADER);
-    if (vertex_shader == null || fragment_shader == null) {
+    // Create new context to test link failure without extension enabled.
+    var glDeferred = wtu.create3DContext();
+
+    var vertexShader = wtu.loadShaderFromScript(glDeferred, "goodVertexShader", glDeferred.VERTEX_SHADER, undefined, undefined, true);
+    var fragmentShader = wtu.loadShaderFromScript(glDeferred, "macroFragmentShader", glDeferred.FRAGMENT_SHADER, undefined, undefined, true);
+
+    if (vertexShader == null || fragmentShader == null) {
         testFailed("Could not create shaders.");
         return;
     }
 
-    gl_deferred.shaderSource(vertex_shader, vertex_element.text);
-    err = gl_deferred.getError();
-    if (err != gl_deferred.NO_ERROR) {
-        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
-        return;
-    }
-
-    gl_deferred.shaderSource(fragment_shader, fragment_element.text);
-    err = gl_deferred.getError();
-    if (err != gl_deferred.NO_ERROR) {
-        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
-        return;
-    }
-
-    gl_deferred.compileShader(vertex_shader);
-    gl_deferred.compileShader(fragment_shader);
-
     // Shader compilations should have failed due to extensions not enabled.
-    gl_deferred.getExtension("EXT_frag_depth");
-
-    var program = gl_deferred.createProgram();
-    gl_deferred.attachShader(program, vertex_shader);
-    gl_deferred.attachShader(program, fragment_shader);
-    gl_deferred.linkProgram(program);
-
-    var linked = gl_deferred.getProgramParameter(program, gl_deferred.LINK_STATUS);
-    if (linked) {
-        testFailed("Compilation with extension disabled then linking with extension enabled caused successful compile.");
+    glDeferred.getExtension("EXT_frag_depth");
+    var program = wtu.setupProgram(glDeferred, [vertexShader, fragmentShader]);
+    if (program) {
+        testFailed("Compilation with extension disabled then linking with extension enabled should have failed.");
         return;
     }
 

--- a/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
+++ b/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
@@ -133,6 +133,9 @@ gl = wtu.create3DContext(canvas2);
 ext = null;
 runAllTests();
 
+// Run deferred link tests.
+runDeferredLinkTests();
+
 function runAllTests() {
     if (!gl) {
         testFailed("WebGL context does not exist");
@@ -294,6 +297,66 @@ function runReferenceCycleTest()
 
     // create a self-cycle on the extension object
     ext.ext = ext;
+}
+
+function runDeferredLinkTests() {
+    debug("");
+    debug("Testing deferred shader compilation tests.");
+
+    // Test for compilation failures that are caused by missing extensions
+    // do not succeed if extensions are enabled during linking. This would
+    // only happen for deferred shader compilations.
+
+    var vertex_element = document.getElementById("goodVertexShader");
+    var fragment_element = document.getElementById("macroFragmentShader");
+    if (!vertex_element || !fragment_element) {
+        testFailed("Could not find shader elements.");
+        return;
+    }
+
+    var err;
+
+    var gl_deferred = wtu.create3DContext();
+
+    var vertex_shader = gl_deferred.createShader(gl_deferred.VERTEX_SHADER);
+    var fragment_shader = gl_deferred.createShader(gl_deferred.FRAGMENT_SHADER);
+    if (vertex_shader == null || fragment_shader == null) {
+        testFailed("Could not create shaders.");
+        return;
+    }
+
+    gl_deferred.shaderSource(vertex_shader, vertex_element.text);
+    err = gl_deferred.getError();
+    if (err != gl_deferred.NO_ERROR) {
+        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
+        return;
+    }
+
+    gl_deferred.shaderSource(fragment_shader, fragment_element.text);
+    err = gl_deferred.getError();
+    if (err != gl_deferred.NO_ERROR) {
+        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
+        return;
+    }
+
+    gl_deferred.compileShader(vertex_shader);
+    gl_deferred.compileShader(fragment_shader);
+
+    // Shader compilations should have failed due to extensions not enabled.
+    gl_deferred.getExtension("EXT_shader_texture_lod");
+
+    var program = gl_deferred.createProgram();
+    gl_deferred.attachShader(program, vertex_shader);
+    gl_deferred.attachShader(program, fragment_shader);
+    gl_deferred.linkProgram(program);
+
+    var linked = gl_deferred.getProgramParameter(program, gl_deferred.LINK_STATUS);
+    if (linked) {
+        testFailed("Compilation with extension disabled then linking with extension enabled caused successful compile.");
+        return;
+    }
+
+    testPassed("Compilation with extension disabled then linking with extension enabled.");
 }
 
 debug("");

--- a/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
+++ b/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
@@ -133,9 +133,6 @@ gl = wtu.create3DContext(canvas2);
 ext = null;
 runAllTests();
 
-// Run deferred link tests.
-runDeferredLinkTests();
-
 function runAllTests() {
     if (!gl) {
         testFailed("WebGL context does not exist");
@@ -162,6 +159,9 @@ function runAllTests() {
             runReferenceCycleTest();
         }
     }
+
+    // Run deferred link tests.
+    runDeferredLinkTests();
 }
 
 function runSupportedTest(extensionEnabled) {
@@ -307,52 +307,48 @@ function runDeferredLinkTests() {
     // do not succeed if extensions are enabled during linking. This would
     // only happen for deferred shader compilations.
 
-    var vertex_element = document.getElementById("goodVertexShader");
-    var fragment_element = document.getElementById("macroFragmentShader");
-    if (!vertex_element || !fragment_element) {
-        testFailed("Could not find shader elements.");
+    // First test if link succeeds with extension enabled.
+    var glEnabled = wtu.create3DContext();
+    var extEnabled = glEnabled.getExtension("EXT_shader_texture_lod");
+
+    var vertexShader = wtu.loadShaderFromScript(glEnabled, "goodVertexShader");
+    var fragmentShader = wtu.loadShaderFromScript(glEnabled, "macroFragmentShader");
+
+    if (!vertexShader || !fragmentShader) {
+        testFailed("Could not create good shaders.");
         return;
     }
 
-    var err;
+    var program = wtu.setupProgram(glEnabled, [vertexShader, fragmentShader]);
 
-    var gl_deferred = wtu.create3DContext();
+    if (extEnabled) {
+        if (!program) {
+            testFailed("Compilation with extension enabled failed.");
+            return;
+        }
+    } else {
+        if (program) {
+            testFailed("Compilation with extension disabled succeeded.");
+            return;
+        }
+    }
 
-    var vertex_shader = gl_deferred.createShader(gl_deferred.VERTEX_SHADER);
-    var fragment_shader = gl_deferred.createShader(gl_deferred.FRAGMENT_SHADER);
-    if (vertex_shader == null || fragment_shader == null) {
+    // Create new context to test link failure without extension enabled.
+    var glDeferred = wtu.create3DContext();
+
+    var vertexShader = wtu.loadShaderFromScript(glDeferred, "goodVertexShader", glDeferred.VERTEX_SHADER, undefined, undefined, true);
+    var fragmentShader = wtu.loadShaderFromScript(glDeferred, "macroFragmentShader", glDeferred.FRAGMENT_SHADER, undefined, undefined, true);
+
+    if (vertexShader == null || fragmentShader == null) {
         testFailed("Could not create shaders.");
         return;
     }
 
-    gl_deferred.shaderSource(vertex_shader, vertex_element.text);
-    err = gl_deferred.getError();
-    if (err != gl_deferred.NO_ERROR) {
-        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
-        return;
-    }
-
-    gl_deferred.shaderSource(fragment_shader, fragment_element.text);
-    err = gl_deferred.getError();
-    if (err != gl_deferred.NO_ERROR) {
-        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
-        return;
-    }
-
-    gl_deferred.compileShader(vertex_shader);
-    gl_deferred.compileShader(fragment_shader);
-
     // Shader compilations should have failed due to extensions not enabled.
-    gl_deferred.getExtension("EXT_shader_texture_lod");
-
-    var program = gl_deferred.createProgram();
-    gl_deferred.attachShader(program, vertex_shader);
-    gl_deferred.attachShader(program, fragment_shader);
-    gl_deferred.linkProgram(program);
-
-    var linked = gl_deferred.getProgramParameter(program, gl_deferred.LINK_STATUS);
-    if (linked) {
-        testFailed("Compilation with extension disabled then linking with extension enabled caused successful compile.");
+    glDeferred.getExtension("EXT_shader_texture_lod");
+    var program = wtu.setupProgram(glDeferred, [vertexShader, fragmentShader]);
+    if (program) {
+        testFailed("Compilation with extension disabled then linking with extension enabled should have failed.");
         return;
     }
 

--- a/sdk/tests/conformance/extensions/oes-standard-derivatives.html
+++ b/sdk/tests/conformance/extensions/oes-standard-derivatives.html
@@ -128,6 +128,9 @@ gl = wtu.create3DContext();
 ext = null;
 runAllTests();
 
+// Run deferred link tests.
+runDeferredLinkTests();
+
 function runAllTests() {
     if (!gl) {
         testFailed("WebGL context does not exist");
@@ -353,6 +356,66 @@ function runUniqueObjectTest()
     gl.getExtension("OES_standard_derivatives").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("OES_standard_derivatives").myProperty', '2');
+}
+
+function runDeferredLinkTests() {
+    debug("");
+    debug("Testing deferred shader compilation tests.");
+
+    // Test for compilation failures that are caused by missing extensions
+    // do not succeed if extensions are enabled during linking. This would
+    // only happen for deferred shader compilations.
+
+    var vertex_element = document.getElementById("goodVertexShader");
+    var fragment_element = document.getElementById("macroFragmentShader");
+    if (!vertex_element || !fragment_element) {
+        testFailed("Could not find shader elements.");
+        return;
+    }
+
+    var err;
+
+    var gl_deferred = wtu.create3DContext();
+
+    var vertex_shader = gl_deferred.createShader(gl_deferred.VERTEX_SHADER);
+    var fragment_shader = gl_deferred.createShader(gl_deferred.FRAGMENT_SHADER);
+    if (vertex_shader == null || fragment_shader == null) {
+        testFailed("Could not create shaders.");
+        return;
+    }
+
+    gl_deferred.shaderSource(vertex_shader, vertex_element.text);
+    err = gl_deferred.getError();
+    if (err != gl_deferred.NO_ERROR) {
+        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
+        return;
+    }
+
+    gl_deferred.shaderSource(fragment_shader, fragment_element.text);
+    err = gl_deferred.getError();
+    if (err != gl_deferred.NO_ERROR) {
+        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
+        return;
+    }
+
+    gl_deferred.compileShader(vertex_shader);
+    gl_deferred.compileShader(fragment_shader);
+
+    // Shader compilations should have failed due to extensions not enabled.
+    gl_deferred.getExtension("OES_standard_derivatives");
+
+    var program = gl_deferred.createProgram();
+    gl_deferred.attachShader(program, vertex_shader);
+    gl_deferred.attachShader(program, fragment_shader);
+    gl_deferred.linkProgram(program);
+
+    var linked = gl_deferred.getProgramParameter(program, gl_deferred.LINK_STATUS);
+    if (linked) {
+        testFailed("Compilation with extension disabled then linking with extension enabled caused successful compile.");
+        return;
+    }
+
+    testPassed("Compilation with extension disabled then linking with extension enabled.");
 }
 
 debug("");

--- a/sdk/tests/conformance/extensions/oes-standard-derivatives.html
+++ b/sdk/tests/conformance/extensions/oes-standard-derivatives.html
@@ -128,9 +128,6 @@ gl = wtu.create3DContext();
 ext = null;
 runAllTests();
 
-// Run deferred link tests.
-runDeferredLinkTests();
-
 function runAllTests() {
     if (!gl) {
         testFailed("WebGL context does not exist");
@@ -158,6 +155,9 @@ function runAllTests() {
             runUniqueObjectTest();
         }
     }
+
+    // Run deferred link tests.
+    runDeferredLinkTests();
 }
 
 function runSupportedTest(extensionEnabled) {
@@ -366,52 +366,48 @@ function runDeferredLinkTests() {
     // do not succeed if extensions are enabled during linking. This would
     // only happen for deferred shader compilations.
 
-    var vertex_element = document.getElementById("goodVertexShader");
-    var fragment_element = document.getElementById("macroFragmentShader");
-    if (!vertex_element || !fragment_element) {
-        testFailed("Could not find shader elements.");
+    // First test if link succeeds with extension enabled.
+    var glEnabled = wtu.create3DContext();
+    var extEnabled = glEnabled.getExtension("OES_standard_derivatives");
+
+    var vertexShader = wtu.loadShaderFromScript(glEnabled, "goodVertexShader");
+    var fragmentShader = wtu.loadShaderFromScript(glEnabled, "macroFragmentShader");
+
+    if (!vertexShader || !fragmentShader) {
+        testFailed("Could not create good shaders.");
         return;
     }
 
-    var err;
+    var program = wtu.setupProgram(glEnabled, [vertexShader, fragmentShader]);
 
-    var gl_deferred = wtu.create3DContext();
+    if (extEnabled) {
+        if (!program) {
+            testFailed("Compilation with extension enabled failed.");
+            return;
+        }
+    } else {
+        if (program) {
+            testFailed("Compilation with extension disabled succeeded.");
+            return;
+        }
+    }
 
-    var vertex_shader = gl_deferred.createShader(gl_deferred.VERTEX_SHADER);
-    var fragment_shader = gl_deferred.createShader(gl_deferred.FRAGMENT_SHADER);
-    if (vertex_shader == null || fragment_shader == null) {
+    // Create new context to test link failure without extension enabled.
+    var glDeferred = wtu.create3DContext();
+
+    var vertexShader = wtu.loadShaderFromScript(glDeferred, "goodVertexShader", glDeferred.VERTEX_SHADER, undefined, undefined, true);
+    var fragmentShader = wtu.loadShaderFromScript(glDeferred, "macroFragmentShader", glDeferred.FRAGMENT_SHADER, undefined, undefined, true);
+
+    if (vertexShader == null || fragmentShader == null) {
         testFailed("Could not create shaders.");
         return;
     }
 
-    gl_deferred.shaderSource(vertex_shader, vertex_element.text);
-    err = gl_deferred.getError();
-    if (err != gl_deferred.NO_ERROR) {
-        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
-        return;
-    }
-
-    gl_deferred.shaderSource(fragment_shader, fragment_element.text);
-    err = gl_deferred.getError();
-    if (err != gl_deferred.NO_ERROR) {
-        testFailed("Could not load vertex shader: " + wtu.glEnumToString(gl_deferred, err));
-        return;
-    }
-
-    gl_deferred.compileShader(vertex_shader);
-    gl_deferred.compileShader(fragment_shader);
-
     // Shader compilations should have failed due to extensions not enabled.
-    gl_deferred.getExtension("OES_standard_derivatives");
-
-    var program = gl_deferred.createProgram();
-    gl_deferred.attachShader(program, vertex_shader);
-    gl_deferred.attachShader(program, fragment_shader);
-    gl_deferred.linkProgram(program);
-
-    var linked = gl_deferred.getProgramParameter(program, gl_deferred.LINK_STATUS);
-    if (linked) {
-        testFailed("Compilation with extension disabled then linking with extension enabled caused successful compile.");
+    glDeferred.getExtension("OES_standard_derivatives");
+    var program = wtu.setupProgram(glDeferred, [vertexShader, fragmentShader]);
+    if (program) {
+        testFailed("Compilation with extension disabled then linking with extension enabled should have failed.");
         return;
     }
 

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1696,11 +1696,12 @@ var readFileList = function(url) {
  * @param {string} opt_url URL from where the shader source was loaded from.
  *     If opt_logShaders is set, then a link to the source file will also be
  *     added.
+ * @param {boolean} Skip compilation status check. Default = false.
  * @return {!WebGLShader} The created shader.
  */
 var loadShader = function(
     gl, shaderSource, shaderType, opt_errorCallback, opt_logShaders,
-    opt_shaderLabel, opt_url) {
+    opt_shaderLabel, opt_url, opt_skipCompileStatus) {
   var errFn = opt_errorCallback || error;
   // Create the shader object
   var shader = gl.createShader(shaderType);
@@ -1730,13 +1731,15 @@ var loadShader = function(
   }
 
   // Check the compile status
-  var compiled = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
-  if (!compiled) {
-    // Something went wrong during compilation; get the error
-    lastError = gl.getShaderInfoLog(shader);
-    errFn("*** Error compiling " + glEnumToString(gl, shaderType) + " '" + shader + "':" + lastError);
-    gl.deleteShader(shader);
-    return null;
+  if (!opt_skipCompileStatus) {
+    var compiled = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
+    if (!compiled) {
+      // Something went wrong during compilation; get the error
+      lastError = gl.getShaderInfoLog(shader);
+      errFn("*** Error compiling " + glEnumToString(gl, shaderType) + " '" + shader + "':" + lastError);
+      gl.deleteShader(shader);
+      return null;
+    }
   }
 
   return shader;
@@ -1749,13 +1752,14 @@ var loadShader = function(
  * @param {number} type The type of shader.
  * @param {function(string): void) opt_errorCallback callback for errors. 
  * @param {boolean} opt_logShaders Whether to log shader source.
+ * @param {boolean} Skip compilation status check. Default = false.
  * @return {!WebGLShader} The created shader.
  */
 var loadShaderFromFile = function(
-    gl, file, type, opt_errorCallback, opt_logShaders) {
+    gl, file, type, opt_errorCallback, opt_logShaders, opt_skipCompileStatus) {
   var shaderSource = readFile(file);
   return loadShader(gl, shaderSource, type, opt_errorCallback,
-      opt_logShaders, undefined, file);
+      opt_logShaders, undefined, file, opt_skipCompileStatus);
 };
 
 /**
@@ -1779,10 +1783,11 @@ var getScript = function(scriptId) {
  *     be derived from the type of the script tag.
  * @param {function(string): void) opt_errorCallback callback for errors. 
  * @param {boolean} opt_logShaders Whether to log shader source.
+ * @param {boolean} Skip compilation status check. Default = false.
  * @return {!WebGLShader} The created shader.
  */
 var loadShaderFromScript = function(
-    gl, scriptId, opt_shaderType, opt_errorCallback, opt_logShaders) {
+    gl, scriptId, opt_shaderType, opt_errorCallback, opt_logShaders, opt_skipCompileStatus) {
   var shaderSource = "";
   var shaderScript = document.getElementById(scriptId);
   if (!shaderScript) {
@@ -1802,7 +1807,7 @@ var loadShaderFromScript = function(
   }
 
   return loadShader(gl, shaderSource, opt_shaderType, opt_errorCallback,
-      opt_logShaders);
+      opt_logShaders, undefined, undefined, opt_skipCompileStatus);
 };
 
 var loadStandardProgram = function(gl) {


### PR DESCRIPTION
Add conformance test for deferred shader compilations with extensions.

If shader compilation is deferred until the link time, a test has been added to be sure the shader compiler uses its state as seen during the compilation request, not the link request. The added conformance test does the following to test this:

1. Create a new GL context which does not have the tested extension enabled.
2. Compile the vertex and fragment shaders which would fail if the extension were disabled.
3. Enable the extension by querying if the extension is supported.
4. Link the shader and check the link status, this should fail since at the time of the compilation the extension was disabled.