### PR TITLE
Add a difference between ES3 and WebGL 2.

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 06 February 2015</h2>
+    <h2 class="no-toc">Editor's Draft 11 February 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -2486,8 +2486,8 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
     <h3>Queries should fail on a program that failed to link</h3>
 
     <p>
-        OpenGL ES 3.0 allows application to enumerate and query properties of
-        active variables and interface blocks of a speicied program even if
+        OpenGL ES 3.0 allows applications to enumerate and query properties of
+        active variables and interface blocks of a specified program even if
         that program failed to link <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-2.11.3">OpenGL ES 3.0.3 &sect;2.11.3</a>)</span>. The returned information is implementation
         dependent and may be incomplete. For the behaviors to be consistent
         across all platforms, in WebGL, these commands will always generate an

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -2483,6 +2483,18 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         WebGL 2.0.
     </p>
 
+    <h3>Queries should fail on a program that failed to link</h3>
+
+    <p>
+        OpenGL ES 3.0 allows application to enumerate and query properties of
+        active variables and interface blocks of a speicied program even if
+        that program failed to link <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-2.11.3">OpenGL ES 3.0.3 &sect;2.11.3</a>)</span>. The returned information is implementation
+        dependent and may be incomplete. For the behaviors to be consistent
+        across all platforms, in WebGL, these commands will always generate an
+        INVALID_OPERATION error on a program that failed to link, and no
+        information is returned.
+    </p>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>


### PR DESCRIPTION
On a program that failed to link, queries to that program's active variables and interface blocks should always generate an INVALID_OPERATION.