### PR TITLE
Added documentation about implementing draft extensions behind run-time ...

### DIFF
--- a/extensions/registry.html
+++ b/extensions/registry.html
@@ -110,31 +110,32 @@ ul li+li {
         If an extension cannot advance through the extension process it can be <em>rejected</em>.
     </p>
     <ul>
-        <li> <em>Rejected</em> extensions should never be implemented.
-        An extension enters <em>rejected</em> status because consensus on it could not be reached at the <em>proposal</em> stage
-        or technical difficulties arise during implementation at the <em>draft</em> stage.
-        A <em>community approved</em> extension can only be rejected in extraordinary circumstances.
-        A <em>Khronos ratified</em> extension cannot be rejected.
-
         <li> <em>Proposed</em> extensions are intended for discussion on the public WebGL mailing
         list, in order to move to <em>draft</em> status; they should not be implemented, even under
         a vendor prefix. If consensus is reached in the community, the extension can be moved
         to <em>draft</em> status.
 
-        <li> <em>Draft</em> extensions may be implemented under a vendor prefix for experimentation
-        purposes, in order to gain experience with the extension before finalizing it. Once
-        consensus is reached in the community, the extension can be moved to <em>community approved</em>
-        status.
+        <li> <em>Draft</em> extensions may be implemented under a vendor prefix or behind a run-time
+        option for experimentation purposes, in order to gain experience with the extension before
+        finalizing it. Draft extensions should not be exposed by default by WebGL implementations.
+        Once consensus is reached in the community, the extension can be moved to <em>community
+        approved</em> status.
 
         <li> <em>Community approved</em> extensions should be implemented without a vendor
         prefix. When a draft extension moves to community approved status, any existing
-        implementation should immediately remove support for the vendor-prefixed extension
+        implementation should immediately remove support for any vendor-prefixed extension
         name. Once implemented by a vendor, support should not be removed unless there is a serious
         issue with the extension, such as a security flaw.
 
         <li> <em>Khronos ratified</em> extensions are those community approved extensions which have
         been voted upon by the Khronos Board of Promoters.
 
+        <li> <em>Rejected</em> extensions should never be implemented.  An extension
+        enters <em>rejected</em> status because consensus on it could not be reached at
+        the <em>proposal</em> stage or technical difficulties arise during implementation at
+        the <em>draft</em> stage.
+        A <em>community approved</em> extension can only be rejected in extraordinary circumstances.
+        A <em>Khronos ratified</em> extension cannot be rejected.
     </ul>
 
     <h2 class="no-toc">Khronos ratified WebGL Extensions</h2>


### PR DESCRIPTION
...option.

Slight change of wording about vendor prefixes when moving an extension to community approved.

Moved documentation of rejected status to the last bullet point.