### PR TITLE
Fix broken links in specs

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 29 January 2015</h2>
+    <h2 class="no-toc">Editor's Draft 12 February 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -3768,7 +3768,7 @@ extensions.
     <dl>
 
         <dt id="refsCANVAS">[CANVAS]</dt>
-        <dd><cite><a href="http://www.w3.org/TR/html5/the-canvas-element.html">
+        <dd><cite><a href="http://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
             HTML5: The Canvas Element</a></cite>,
             World Wide Web Consortium (W3C).
         </dd>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 11 February 2015</h2>
+    <h2 class="no-toc">Editor's Draft 12 February 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -947,7 +947,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       </dt>
       <dd>
         Copy part of the data of the buffer bound to <em>readTarget</em> to the buffer bound to <em>writeTarget</em>.
-        See <a href="COPYING_BUFFERS">Copying Buffers</a> for restrictions imposed by the WebGL 2 API.
+        See <a href="#COPYING_BUFFERS">Copying Buffers</a> for restrictions imposed by the WebGL 2 API.
       </dd>
       <dt>
         <p class="idl-code">void getBufferSubData(GLenum target, GLintptr offset, ArrayBufferData returnedData)
@@ -2505,6 +2505,16 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <dd><cite><a href="http://www.khronos.org/registry/webgl/specs/1.0/">
             WebGL Specification 1.0.2</a></cite>,
             C. Marrin 2013.
+        </dd>
+        <dt id="refsCANVAS">[CANVAS]</dt>
+        <dd><cite><a href="http://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
+            HTML5: The Canvas Element</a></cite>,
+            World Wide Web Consortium (W3C).
+        </dd>
+        <dt id="refsCANVASCONTEXTS">[CANVASCONTEXTS]</dt>
+        <dd><cite><a href="http://wiki.whatwg.org/wiki/CanvasContexts">
+            Canvas Context Registry</a></cite>,
+            WHATWG.
         </dd>
         <dt id="refsGLES30">[GLES30]</dt>
         <dd><cite><a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf">


### PR DESCRIPTION
The WebGL 1 spec had a link to a W3C page that has moved, and the WebGL 2
spec had some missing references and one broken internal link.