### PR TITLE
Propose WEBGL_render_to_float.

### DIFF
--- a/extensions/proposals/WEBGL_render_to_float/extension.xml
+++ b/extensions/proposals/WEBGL_render_to_float/extension.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proposal href="WEBGL_render_to_float/">
+  <name>WEBGL_render_to_float</name>
+
+  <contact>
+    <a href="https://www.khronos.org/webgl/public-mailing-list">WebGL working
+    group</a> (public_webgl 'at' khronos.org)
+  </contact>
+
+  <contributors>
+    <contributor>Jeff Gilbert, Mozilla Corporation</contributor>
+
+    <contributor>Members of the WebGL working group</contributor>
+  </contributors>
+
+  <number>unassigned</number>
+
+  <depends>
+    <api version="1.0"/>
+
+    <ext name="OES_texture_float"/>
+    <ext name="OES_texture_half_float"/>
+  </depends>
+
+  <overview>
+    <p>Adds support for rendering to floating-point color buffers.</p>
+
+    <features>
+      <feature>
+        <p>
+          Textures created with <code>format = RGBA</code> and
+          <code>type = FLOAT</code> or <code>type = HALF_FLOAT_OES</code>, as
+          specified in <a
+          href="http://www.khronos.org/registry/webgl/extensions/OES_texture_float/">
+          OES_texture_float</a> and <a
+          href="http://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/">
+          OES_texture_half_float</a>, can be attached to framebuffer object
+          color attachments for rendering.
+        </p>
+      </feature>
+
+      <feature>
+        <p>
+          <span style="color: red">NOTE:</span> fragment shaders outputs
+          gl_FragColor and gl_FragData[0] will only be clamped and converted
+          when the color buffer is fixed-point and <code>blendColor()</code> and
+          <code>clearColor()</code> will continue to clamp their parameter
+          values on input. Clamping will be applied as necessary at draw time
+          according to the type of color buffer in use.
+        </p>
+      </feature>
+
+      <feature>
+        <p>
+          If any active draw buffer is a floating-point color buffer:
+          <ul>
+            <li>Drawing with <code>BLEND</code> enabled will generate an
+                <code>INVALID_OPERATION</code> error.</li>
+            <li><code>clear()</code> will generate an
+                <code>INVALID_OPERATION</code> error.</li>
+          </ul>
+        </p>
+      </feature>
+
+      <feature>
+        <p>
+          The format and type combination <code>RGBA</code> and
+          <code>FLOAT</code> becomes valid for reading from a floating-point
+          rendering buffer. Note: <code>RGBA</code> and
+          <code>UNSIGNED_BYTE</code> cannot be used for reading from a
+          floating-point rendering buffer.
+        </p>
+      </feature>
+
+      <feature>
+        <p>
+          The component types of framebuffer object attachments can be queried.
+        </p>
+      </feature>
+    </features>
+  </overview>
+
+  <idl xml:space="preserve">
+[NoInterfaceObject]
+interface WEBGL_render_to_float {
+  const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
+  const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
+}; // interface WEBGL_render_to_float
+  </idl>
+
+  <newtok>
+    <function name="getParameter" type="any">
+      <param name="pname" type="GLenum"/>
+      <code>FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT</code> is accepted as the
+      <code>pname</code> parameter of <code>getParameter()</code>.
+    </function>
+  </newtok>
+
+  <additions>
+    <p>
+      The behavioral changes for drawing to and reading from floating-point color
+      buffers specified in <a
+      href="http://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/">
+      EXT_color_buffer_half_float</a> are incorporated into WebGL except for the
+      new color-renderable formats for <code>RenderbufferStorage</code>, and
+      sections regarding <code>BlendColor</code> and <code>ClearColor</code>.
+    </p>
+  </additions>
+
+  <history>
+    <revision date="2015/02/17">
+      <change>Initial revision.</change>
+    </revision>
+  </history>
+</extension>


### PR DESCRIPTION
This might be a more portable way to allow render-to-float behavior in WebGL. It's more restricted than WEBGL_color_buffer_float or EXT_color_buffer_half_float. It's implementable everywhere that supports render-to-float, including D3D9.

BLEND with floating-point is disallowed because of lack of support. EXT_color_buffer_float does not allow blending with float32s, and D3D9 only supports normalized uint8 glBlendColor-equivalent. 

clear() is disallowed because many implementations clamp clearColor, (driver bugs) and/or limit clearColor to normalized uint8 values. (D3D9. Notably, 0.5f is not representable in normalized uint8) WebGL implementations can work around this by doing a full-screen blit, but this is much more expensive, and current best-practice is to no longer hide performance caveats.

For textures, the initial contents can be set at upload-time. If there is strong support for floating-point clears on drivers that can't support the full WEBGL_color_buffer_float/EXT_color_buffer_half_float extensions, we can add an extension just for floating-point clears. (similar in nature to OES_texture_float_linear)

We could split this into WEBGL_render_to_float and WEBGL_render_to_half_float, but we should only do so if there are platforms or configurations which require this differentiation. (That is, FLOAT and HALF_FLOAT_OES textures are supported, but only one of the two is renderable)