### PR TITLE
Removed imageSize from compressedTex{Sub}Image3D

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -711,10 +711,10 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
                          GLint x, GLint y, GLsizei width, GLsizei height);
   void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat,
                             GLsizei width, GLsizei height, GLsizei depth,
-                            GLint border, GLsizei imageSize, ArrayBufferView data);
+                            GLint border, ArrayBufferView data);
   void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                                GLsizei width, GLsizei height, GLsizei depth,
-                               GLenum format, GLsizei imageSize, ArrayBufferView data);
+                               GLenum format, ArrayBufferView data);
 
   /* Programs and shaders */
   [WebGLHandlesContextLoss] GLint getFragDataLocation(WebGLProgram? program, DOMString name);
@@ -1302,7 +1302,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         Framebuffer</a>. <br><br>
       </dd>
       <dt>
-        <p class="idl-code">void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, ArrayBufferView data)
+        <p class="idl-code">void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, ArrayBufferView data)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.3 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexImage3D.xhtml" class="nonnormative">man page</a>)
@@ -1310,7 +1310,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         </p>
       </dt>
       <dt>
-        <p class="idl-code">void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, ArrayBufferView data)
+        <p class="idl-code">void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, ArrayBufferView data)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.3.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.3 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexSubImage3D.xhtml" class="nonnormative">man page</a>)

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -283,12 +283,6 @@ interface WebGL2RenderingContextBase
   const GLenum ANY_SAMPLES_PASSED_CONSERVATIVE               = 0x8D6A;
   const GLenum SAMPLER_BINDING                               = 0x8919;
   const GLenum RGB10_A2UI                                    = 0x906F;
-  const GLenum TEXTURE_SWIZZLE_R                             = 0x8E42;
-  const GLenum TEXTURE_SWIZZLE_G                             = 0x8E43;
-  const GLenum TEXTURE_SWIZZLE_B                             = 0x8E44;
-  const GLenum TEXTURE_SWIZZLE_A                             = 0x8E45;
-  const GLenum GREEN                                         = 0x1904;
-  const GLenum BLUE                                          = 0x1905;
   const GLenum INT_2_10_10_10_REV                            = 0x8D9F;
   const GLenum TRANSFORM_FEEDBACK                            = 0x8E22;
   const GLenum TRANSFORM_FEEDBACK_PAUSED                     = 0x8E23;
@@ -350,10 +344,10 @@ interface WebGL2RenderingContextBase
                          GLint x, GLint y, GLsizei width, GLsizei height);
   void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat,
                             GLsizei width, GLsizei height, GLsizei depth,
-                            GLint border, GLsizei imageSize, ArrayBufferView data);
+                            GLint border, ArrayBufferView data);
   void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                                GLsizei width, GLsizei height, GLsizei depth,
-                               GLenum format, GLsizei imageSize, ArrayBufferView data);
+                               GLenum format, ArrayBufferView data);
 
   /* Programs and shaders */
   [WebGLHandlesContextLoss] GLint getFragDataLocation(WebGLProgram? program, DOMString name);


### PR DESCRIPTION
Size should be implied by the ArrayBufferView size, which is consistent with compressedTex{Sub}Image2D.