### PR TITLE
Backported fixes to tex-image-with-invalid-data to 1.0.1, 1.0.2, and 1.0...

### DIFF
--- a/conformance-suites/1.0.1/conformance/textures/tex-image-with-invalid-data.html
+++ b/conformance-suites/1.0.1/conformance/textures/tex-image-with-invalid-data.html
@@ -25,7 +25,7 @@ var tex;
 
 function setup() {
     tex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, bug32619_tests.tex);
+    gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 64, 64, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 }
 
@@ -53,6 +53,21 @@ function test(desc, func, expected) {
 	}
     }
 }
+
+test("Calling texImage2D with no WebGLTexture bound generates INVALID_OPERATION",
+     function () {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 64, 64, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+     },
+     gl.INVALID_OPERATION);
+
+test("Calling texSubImage2D with no WebGLTexture bound generates INVALID_OPERATION",
+     function () {
+        var buffer = new Uint8Array(4);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buffer);
+     },
+     gl.INVALID_OPERATION);
+
+setup();
 
 test("Passing a buffer not large enough to texImage2D should generate an INVALID_OPERATION",
      function () {
@@ -91,8 +106,10 @@ test("Passing texSubImage2D parameter data of String type should throw a TypeErr
      },
      "exception");
 
+teardown();
+
 debug("");
-successfullyParsed = true;
+var successfullyParsed = true;
 </script>
 <script src="../../resources/js-test-post.js"></script>
 

--- a/conformance-suites/1.0.2/conformance/textures/tex-image-with-invalid-data.html
+++ b/conformance-suites/1.0.2/conformance/textures/tex-image-with-invalid-data.html
@@ -53,7 +53,7 @@ var tex;
 
 function setup() {
     tex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, bug32619_tests.tex);
+    gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 64, 64, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 }
 
@@ -81,6 +81,21 @@ function test(desc, func, expected) {
         }
     }
 }
+
+test("Calling texImage2D with no WebGLTexture bound generates INVALID_OPERATION",
+     function () {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 64, 64, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+     },
+     gl.INVALID_OPERATION);
+
+test("Calling texSubImage2D with no WebGLTexture bound generates INVALID_OPERATION",
+     function () {
+        var buffer = new Uint8Array(4);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buffer);
+     },
+     gl.INVALID_OPERATION);
+
+setup();
 
 test("Passing a buffer not large enough to texImage2D should generate an INVALID_OPERATION",
      function () {
@@ -118,6 +133,8 @@ test("Passing texSubImage2D parameter data of String type should throw a TypeErr
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, "not a buffer");
      },
      "exception");
+
+teardown();
 
 debug("");
 var successfullyParsed = true;

--- a/conformance-suites/1.0.3/conformance/textures/tex-image-with-invalid-data.html
+++ b/conformance-suites/1.0.3/conformance/textures/tex-image-with-invalid-data.html
@@ -52,7 +52,7 @@ var tex;
 
 function setup() {
     tex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, bug32619_tests.tex);
+    gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 64, 64, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 }
 
@@ -80,6 +80,21 @@ function test(desc, func, expected) {
         }
     }
 }
+
+test("Calling texImage2D with no WebGLTexture bound generates INVALID_OPERATION",
+     function () {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 64, 64, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+     },
+     gl.INVALID_OPERATION);
+
+test("Calling texSubImage2D with no WebGLTexture bound generates INVALID_OPERATION",
+     function () {
+        var buffer = new Uint8Array(4);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buffer);
+     },
+     gl.INVALID_OPERATION);
+
+setup();
 
 test("Passing a buffer not large enough to texImage2D should generate an INVALID_OPERATION",
      function () {
@@ -117,6 +132,8 @@ test("Passing texSubImage2D parameter data of String type should throw a TypeErr
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 64, 64, gl.RGBA, gl.UNSIGNED_BYTE, "not a buffer");
      },
      "exception");
+
+teardown();
 
 debug("");
 var successfullyParsed = true;


### PR DESCRIPTION
....3 conformance suites.

https://github.com/KhronosGroup/WebGL/pull/853
https://github.com/KhronosGroup/WebGL/pull/869

Thanks to Roger Fong for pointing out the need for these fixes.

Verified all three backports manually.