### PR TITLE
Don't print error messages from removed properties twice

### DIFF
--- a/sdk/tests/conformance/context/constants-and-properties.html
+++ b/sdk/tests/conformance/context/constants-and-properties.html
@@ -544,7 +544,7 @@ for (var i in gl) {
   } else if (otherProperties[i] !== undefined &&
              (otherProperties[i] == "implementation-dependent" || typeof gl[i] == otherProperties[i])) {
     // OK; known property of known type
-  } else if (typeof gl[i] != "function") {
+  } else if (typeof gl[i] != "function" && removedConstants[i] === undefined) {
     if (!extended) {
       extended = true;
       testFailed("Also found the following extra properties:");

--- a/sdk/tests/conformance2/context/constants-and-properties-2.html
+++ b/sdk/tests/conformance2/context/constants-and-properties-2.html
@@ -842,7 +842,7 @@ for (var i in gl) {
   } else if (otherProperties[i] !== undefined &&
              (otherProperties[i] == "implementation-dependent" || typeof gl[i] == otherProperties[i])) {
     // OK; known property of known type
-  } else if (typeof gl[i] != "function") {
+  } else if (typeof gl[i] != "function" && removedConstants[i] === undefined) {
     if (!extended) {
       extended = true;
       testFailed("Also found the following extra properties:");


### PR DESCRIPTION
There's code to write error messages specifically for the removed constants, they don't need to be handled later when the code is looking for extra constants.