### PR TITLE
Backport gl_Position assignment from test.

### DIFF
--- a/conformance-suites/1.0.2/conformance/glsl/literals/float_literal.vert.html
+++ b/conformance-suites/1.0.2/conformance/glsl/literals/float_literal.vert.html
@@ -60,6 +60,7 @@ void main() {
   highp float negInRange = -4611686018427387903.;
   highp float negOutRange = -4611686018427387905.;
   highp float negHuge = 1E100;
+  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
 }
 </script>
 <script>


### PR DESCRIPTION
1.0.3 has this, but 1.0.2 does not. The GLSL spec requires it.

It looks like this was missed when this test was updated. (Note that 1.0.3 has -1E100 for negHuge, which is obviously a bug with 1.0.2. That said, it's not hurting anything, so there's no reason to change it, according to our rules for backporting fixes)