### PR TITLE
Small improvements in the deqp test framework

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsShaderLibrary.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderLibrary.js
@@ -984,7 +984,7 @@ define(["framework/common/tcuTestCase", "./glsShaderLibraryCase", "framework/ope
 /**
  * Parse the test file and execute the test cases
  * @param {string} testName Name of the test file (without extension)
- * @param {string} filter Optional filter
+ * @param {string} filter Optional filter. Common substring of the names of the tests that should be run.
  */
 var run = function(testName, filter) {
     WebGLTestUtils.loadTextFileAsync(testName + '.test', function(success, content) {

--- a/sdk/tests/resources/js-test-pre.js
+++ b/sdk/tests/resources/js-test-pre.js
@@ -218,7 +218,7 @@ function testPassedOptions(msg, addSpan)
 {
     if (addSpan)
 	{
-        reportTestResultsToHarness(true, msg);
+        reportTestResultsToHarness(true, _currentTestName + ": " + msg);
         _addSpan('<span><span class="pass">PASS</span> ' + escapeHTML(_currentTestName) + ": " + escapeHTML(msg) + '</span>');
 	}
     if (_jsTestPreVerboseLogging) {
@@ -233,7 +233,7 @@ function testPassedOptions(msg, addSpan)
  */
 function testFailedOptions(msg, exthrow)
 {
-    reportTestResultsToHarness(false, msg);
+    reportTestResultsToHarness(false, _currentTestName + ": " + msg);
     _addSpan('<span><span class="fail">FAIL</span> ' + escapeHTML(_currentTestName) + ": " + escapeHTML(msg) + '</span>');
     _bufferedLogToConsole('FAIL ' + msg);
     _flushBufferedLogsToConsole();


### PR DESCRIPTION
Include the name of the failed/passed test when reporting the results
back to the test runner, and add a bit of documentation for the filter
parameter.