### PR TITLE
Remove illegal constructs from deqp tests used for WebGL 1

### DIFF
--- a/sdk/tests/deqp/data/gles2/shaders/functions.test
+++ b/sdk/tests/deqp/data/gles2/shaders/functions.test
@@ -2368,15 +2368,14 @@ group control_flow "Control Flow In Functions"
 
 			float func (float a)
 			{
-				int i;
-				for (i = 0; i < 6; i++) // negate a
+				for (int i = 0; i < 6; i++) // negate a
 				{
 					a = -a;
 					if (i == 4)
 						a = -a;
 				}
 
-				for (; i < 10; i++) // keep a
+				for (int i = 6; i < 10; i++) // keep a
 				{
 					if (i == 8)
 						continue;
@@ -2410,8 +2409,7 @@ group control_flow "Control Flow In Functions"
 
 			float func (float a)
 			{
-				int i;
-				for (i = 0; i < 6; i++)
+				for (int i = 0; i < 6; i++)
 				{
 					if (i == 0)
 						continue;

--- a/sdk/tests/deqp/data/gles2/shaders/scoping.test
+++ b/sdk/tests/deqp/data/gles2/shaders/scoping.test
@@ -104,33 +104,6 @@ group valid "Valid scoping and name redeclaration cases"
 		""
 	end
 
-	case while_condition_variable_hides_local_variable
-		version 100 es
-		values
-		{
-			input int in0 = [ 1 | 2 | 3 ];
-			output int out0 = [ 1 | 2 | 3 ];
-		}
-
-		both ""
-			#version 100
-			precision mediump float;
-			${DECLARATIONS}
-			void main()
-			{
-				${SETUP}
-				int a = in0;
-				int i = 0;
-				while (bool a = (i < 1))
-				{
-					i++;
-				}
-				out0 = a;
-				${OUTPUT}
-			}
-		""
-	end
-
 	case for_init_statement_variable_hides_global_variable
 		version 100 es
 		values
@@ -151,35 +124,6 @@ group valid "Valid scoping and name redeclaration cases"
 				${SETUP}
 				for (int a = 0; a < 10; a++)
 				{
-				}
-				out0 = in0 + a - 5;
-				${OUTPUT}
-			}
-		""
-	end
-
-	case while_condition_variable_hides_global_variable
-		version 100 es
-		values
-		{
-			input int in0 = [ 1 | 2 | 3 ];
-			output int out0 = [ 1 | 2 | 3 ];
-		}
-
-		both ""
-			#version 100
-			precision mediump float;
-			${DECLARATIONS}
-
-			int a = 5;
-
-			void main()
-			{
-				${SETUP}
-				int i = 0;
-				while (bool a = (i < 1))
-				{
-					i++;
 				}
 				out0 = in0 + a - 5;
 				${OUTPUT}


### PR DESCRIPTION
Remove shader functionality that's not supported according to the
restrictions in Appendix A of the OpenGL ES Shading Language 1.00 spec.