### PR TITLE
Revert "Backport gl_Position assignment from test."

### DIFF
--- a/conformance-suites/1.0.2/conformance/glsl/literals/float_literal.vert.html
+++ b/conformance-suites/1.0.2/conformance/glsl/literals/float_literal.vert.html
@@ -60,7 +60,6 @@ void main() {
   highp float negInRange = -4611686018427387903.;
   highp float negOutRange = -4611686018427387905.;
   highp float negHuge = 1E100;
-  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
 }
 </script>
 <script>


### PR DESCRIPTION
This reverts commit 78f9793a4f327d0e2427836ee20c386d8174cfd1.

Writing gl_Position is not required by the spec (see OpenGL ES Shading
Language 1.00 section 10.13) so the patch being reverted did not fix a
bug as it was intended, but reduced test coverage in the 1.0.2 suite.