### PR TITLE
Use null instead of undefined for optional arg omission.

### DIFF
--- a/conformance-suites/1.0.2/conformance/typedarrays/resources/typed-array-worker.js
+++ b/conformance-suites/1.0.2/conformance/typedarrays/resources/typed-array-worker.js
@@ -74,7 +74,7 @@ onmessage = function(event) {
     } else {
       valueToSend = view.buffer;
     }
-    var transferablesToSend = null;
+    var transferablesToSend = undefined;
     if (message.command == 'transfer' ||
         message.command == 'transferBuffer') {
       transferablesToSend = [ view.buffer ];

--- a/conformance-suites/1.0.3/conformance/typedarrays/resources/typed-array-worker.js
+++ b/conformance-suites/1.0.3/conformance/typedarrays/resources/typed-array-worker.js
@@ -74,7 +74,7 @@ onmessage = function(event) {
     } else {
       valueToSend = view.buffer;
     }
-    var transferablesToSend = null;
+    var transferablesToSend = undefined;
     if (message.command == 'transfer' ||
         message.command == 'transferBuffer') {
       transferablesToSend = [ view.buffer ];

--- a/sdk/tests/conformance/typedarrays/resources/typed-array-worker.js
+++ b/sdk/tests/conformance/typedarrays/resources/typed-array-worker.js
@@ -74,7 +74,7 @@ onmessage = function(event) {
     } else {
       valueToSend = view.buffer;
     }
-    var transferablesToSend = null;
+    var transferablesToSend = undefined;
     if (message.command == 'transfer' ||
         message.command == 'transferBuffer') {
       transferablesToSend = [ view.buffer ];


### PR DESCRIPTION
This appears to be a bug in other browsers, since postMessage's second arg is `optional Sequence<foo>`, which null can't be converted to.

We appear to still have a bug in Firefox, but with this fix we get further in the test.