### PR TITLE
Use undefined instead of null for optional arg omission.

### DIFF
--- a/conformance-suites/1.0.2/conformance/typedarrays/resources/typed-array-worker.js
+++ b/conformance-suites/1.0.2/conformance/typedarrays/resources/typed-array-worker.js
@@ -74,7 +74,7 @@ onmessage = function(event) {
     } else {
       valueToSend = view.buffer;
     }
-    var transferablesToSend = null;
+    var transferablesToSend = undefined;
     if (message.command == 'transfer' ||
         message.command == 'transferBuffer') {
       transferablesToSend = [ view.buffer ];

--- a/conformance-suites/1.0.3/conformance/typedarrays/resources/typed-array-worker.js
+++ b/conformance-suites/1.0.3/conformance/typedarrays/resources/typed-array-worker.js
@@ -74,7 +74,7 @@ onmessage = function(event) {
     } else {
       valueToSend = view.buffer;
     }
-    var transferablesToSend = null;
+    var transferablesToSend = undefined;
     if (message.command == 'transfer' ||
         message.command == 'transferBuffer') {
       transferablesToSend = [ view.buffer ];

--- a/sdk/tests/conformance/typedarrays/resources/typed-array-worker.js
+++ b/sdk/tests/conformance/typedarrays/resources/typed-array-worker.js
@@ -74,7 +74,7 @@ onmessage = function(event) {
     } else {
       valueToSend = view.buffer;
     }
-    var transferablesToSend = null;
+    var transferablesToSend = undefined;
     if (message.command == 'transfer' ||
         message.command == 'transferBuffer') {
       transferablesToSend = [ view.buffer ];


### PR DESCRIPTION
This was https://github.com/KhronosGroup/WebGL/pull/886, but with the summary line fixed.