### PR TITLE
Built-ins can be active uniforms

### DIFF
--- a/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
+++ b/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
@@ -500,6 +500,8 @@ function drawWithProgram(program, programInfo, test) {
   // Check for unset uniforms
   for (var name in uniforms) {
     var uniform = uniforms[name];
+    if (name.indexOf("gl_") == 0)
+      continue;
     if (!uniform.used) {
       testFailed("uniform " + name + " never set");
     }

--- a/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
+++ b/conformance-suites/1.0.2/conformance/ogles/ogles-utils.js
@@ -500,8 +500,9 @@ function drawWithProgram(program, programInfo, test) {
   // Check for unset uniforms
   for (var name in uniforms) {
     var uniform = uniforms[name];
-    if (name.indexOf("gl_") == 0)
+    if (name.indexOf("gl_") == 0) {
       continue;
+    }
     if (!uniform.used) {
       testFailed("uniform " + name + " never set");
     }

--- a/conformance-suites/1.0.3/conformance/ogles/ogles-utils.js
+++ b/conformance-suites/1.0.3/conformance/ogles/ogles-utils.js
@@ -500,6 +500,8 @@ function drawWithProgram(program, programInfo, test) {
   // Check for unset uniforms
   for (var name in uniforms) {
     var uniform = uniforms[name];
+    if (name.indexOf("gl_") == 0)
+      continue;
     if (!uniform.used) {
       testFailed("uniform " + name + " never set");
     }

--- a/conformance-suites/1.0.3/conformance/ogles/ogles-utils.js
+++ b/conformance-suites/1.0.3/conformance/ogles/ogles-utils.js
@@ -500,8 +500,9 @@ function drawWithProgram(program, programInfo, test) {
   // Check for unset uniforms
   for (var name in uniforms) {
     var uniform = uniforms[name];
-    if (name.indexOf("gl_") == 0)
+    if (name.indexOf("gl_") == 0) {
       continue;
+    }
     if (!uniform.used) {
       testFailed("uniform " + name + " never set");
     }

--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -500,9 +500,9 @@ function drawWithProgram(program, programInfo, test) {
   // Check for unset uniforms
   for (var name in uniforms) {
     var uniform = uniforms[name];
-    if (name.indexOf("gl_") == 0)
+    if (name.indexOf("gl_") == 0) {
       continue;
-
+    }
     if (!uniform.used) {
       testFailed("uniform " + name + " never set");
     }

--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -500,6 +500,9 @@ function drawWithProgram(program, programInfo, test) {
   // Check for unset uniforms
   for (var name in uniforms) {
     var uniform = uniforms[name];
+    if (name.indexOf("gl_") == 0)
+      continue;
+
     if (!uniform.used) {
       testFailed("uniform " + name + " never set");
     }


### PR DESCRIPTION
At least two tests (biuDepthRange_001_to_001 and gl_FragCoord_001_to_003) check that there are no active uniforms they didn't request, but since they use gl_DepthRange.far and .near, these count as active uniforms. (GLES 2.0.25 p36: "The returned uniform name can be the name of a built-in uniform state as well")

NB: The test also uses gl_DepthRange.diff, but does not return this as an active uniform. The compiler likely emits `far - near` instead of using a separate value for `diff`, thus it does not consider `diff` to be an active uniform. Whether or not this is spec-compliant is beyond the scope of this bug.