### PR TITLE
add getVersion to get current WebGL rendering context version

### DIFF
--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1326,6 +1326,13 @@ var getUrlOptions = function() {
 };
 
 /**
+ * By default, the contextVersion is 1. If webgl rendering context 2.x (or 3.x
+ * or higher) is created by create3DContext, contextVersion should be changed
+ * accordingly to record the major version number.
+ */
+var contextVersion = 1;
+
+/**
  * Creates a webgl context.
  * @param {!Canvas|string} opt_canvas The canvas tag to get
  *     context from. If one is not passed in one will be
@@ -1355,7 +1362,9 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
   var names;
   switch (opt_version) {
     case 2:
-      names = ["webgl2", "experimental-webgl2"]; break;
+      names = ["webgl2", "experimental-webgl2"];
+      contextVersion = 2;
+      break;
     default:
       names = ["webgl", "experimental-webgl"]; break;
   }
@@ -1373,6 +1382,14 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
     testFailed("Unable to fetch WebGL rendering context for Canvas");
   }
   return context;
+}
+
+/**
+ * Return current WebGL rendering context version.
+ * @return {function} Current rendering context version.
+ */
+var getVersion = function() {
+  return contextVersion;
 }
 
 /**
@@ -2774,6 +2791,7 @@ return {
   getUrlOptions: getUrlOptions,
   getAttribMap: getAttribMap,
   getUniformMap: getUniformMap,
+  getVersion: getVersion,
   glEnumToString: glEnumToString,
   glErrorShouldBe: glErrorShouldBe,
   glTypeToTypedArrayType: glTypeToTypedArrayType,


### PR DESCRIPTION
separate from https://github.com/Richard-Yunchao/WebGL/tree/Conformance_fixBugsInGettersForWebGL2. This small change is standalone. Then my work can go on.