### PR TITLE
update getBufferParameter for WebGL 2

### DIFF
--- a/sdk/tests/conformance/state/gl-object-get-calls.html
+++ b/sdk/tests/conformance/state/gl-object-get-calls.html
@@ -90,7 +90,11 @@ function testInvalidArgument(funcName, argumentName, validArgumentArray, func) {
 debug("");
 debug("test getBufferParameter");
 // Test getBufferParameter
+var version = wtu.getVersion();
 var bufferTypes = [gl.ARRAY_BUFFER, gl.ELEMENT_ARRAY_BUFFER];
+if (version > 1) {
+  bufferTypes += [gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, gl.PIXEL_PACK_BUFFER, gl.PIXEL_UNPACK_BUFFER, gl.TRANSFORM_FEEDBACK_BUFFER, gl.UNIFORM_BUFFER];
+}
 for (var bb = 0; bb < bufferTypes.length; ++bb) {
   var bufferType = bufferTypes[bb];
   var buffer = gl.createBuffer();


### PR DESCRIPTION
For simple change to GL state getter, I prefer to add it directly into sdk/tests/conformance/, instead of sdk/tests/conformance2/. WDYT? 

I prefer to make my changes small at the very beginning. It is easy to review. This small patch depends on this one: https://github.com/Richard-Yunchao/WebGL/tree/Conformance_addAPIToGetWebGLVersion/. 