### PR TITLE
Modified biuDepthRange_001_to_002.html and gl_FragCoord_001_to_003.html ...

### DIFF
--- a/sdk/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
+++ b/sdk/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
@@ -58,14 +58,22 @@ OpenGLESTestRunner.run({
               1.0
             ]
           }
-        }, 
+        },
         "fragmentShader": "../default/expected.frag"
       }, 
       "name": "DepthRange_frag.test.html", 
       "pattern": "compare", 
       "testProgram": {
         "vertexShader": "../default/default.vert", 
-        "fragmentShader": "DepthRange_frag.frag"
+        "fragmentShader": "DepthRange_frag.frag",
+        "builtin_uniforms": {
+          "min_required": 2,
+          "valid_values": [
+            "gl_DepthRange.near",
+            "gl_DepthRange.far",
+            "gl_DepthRange.diff"
+          ],
+        }
       }, 
       "state": {
         "depthrange": {
@@ -90,6 +98,14 @@ OpenGLESTestRunner.run({
             ]
           }
         }, 
+        "builtin_uniforms": {
+          "min_required": 2,
+          "valid_values": [
+            "gl_DepthRange.near",
+            "gl_DepthRange.far",
+            "gl_DepthRange.diff"
+          ],
+        },
         "fragmentShader": "../default/expected.frag"
       }, 
       "name": "DepthRange_vert.test.html", 

--- a/sdk/tests/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
+++ b/sdk/tests/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
@@ -60,7 +60,15 @@ OpenGLESTestRunner.run({
     {
       "referenceProgram": {
         "vertexShader": "gl_FragCoord_z_frag_ref.vert", 
-        "fragmentShader": "gl_FragCoord_z_frag_ref.frag"
+        "fragmentShader": "gl_FragCoord_z_frag_ref.frag",
+        "builtin_uniforms": {
+          "min_required": 2,
+          "valid_values": [
+            "gl_DepthRange.near",
+            "gl_DepthRange.far",
+            "gl_DepthRange.diff"
+          ],
+        }
       }, 
       "model": null, 
       "testProgram": {

--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -497,13 +497,29 @@ function drawWithProgram(program, programInfo, test) {
     }
   }
 
+  // Filter out specified built-in uniforms
+  if (programInfo.builtin_uniforms) {
+    var num_builtins_found = 0;
+    var valid_values = programInfo.builtin_uniforms.valid_values;
+    for (var index in valid_values) {
+      var uniform = uniforms[valid_values[index]];
+      if (uniform) {
+        ++num_builtins_found;
+        uniform.builtin = true;
+      }
+    }
+
+    var min_required = programInfo.builtin_uniforms.min_required;
+    if (num_builtins_found < min_required) {
+      testFailed("only found " + num_builtins_found + " of " + min_required +
+		 " required built-in uniforms: " + valid_values);
+    }
+  }
+
   // Check for unset uniforms
   for (var name in uniforms) {
     var uniform = uniforms[name];
-    if (name.indexOf("gl_") == 0) {
-      continue;
-    }
-    if (!uniform.used) {
+    if (!uniform.used && !uniform.builtin) {
       testFailed("uniform " + name + " never set");
     }
   }


### PR DESCRIPTION
...tests imported from OpenGL ES 2.0 conformance suite to require the presence of some of the gl_DepthRange built-in uniforms' components. Some browsers currently expose these uniforms and some don't; it's important that the behavior be consistent across implementations.