### PR TITLE
update getBufferParameter for WebGL 2.0

### DIFF
--- a/sdk/tests/conformance/resources/gl-object-get-calls.js
+++ b/sdk/tests/conformance/resources/gl-object-get-calls.js
@@ -78,6 +78,9 @@ debug("");
 debug("test getBufferParameter");
 // Test getBufferParameter
 var bufferTypes = [gl.ARRAY_BUFFER, gl.ELEMENT_ARRAY_BUFFER];
+if (contextVersion > 1) {
+  bufferTypes += [gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, gl.PIXEL_PACK_BUFFER, gl.PIXEL_UNPACK_BUFFER, gl.TRANSFORM_FEEDBACK_BUFFER, gl.UNIFORM_BUFFER];
+}
 for (var bb = 0; bb < bufferTypes.length; ++bb) {
   var bufferType = bufferTypes[bb];
   var buffer = gl.createBuffer();


### PR DESCRIPTION
rebase #898. I should rebase and update the original pull request... 

@kenrussell , The code refactoring is OK for me. It is clear. Differences of GL state getters between WebGLRenderingContext and WebGL2RenderingContext can be distinguished by contextVersion. And If a big change is needed, I can implement a new function for that getter to override the old one for WebGL2RenderingContext, and execute different ones according to contextVersion.