### PR TITLE
Fix bugs in extensions for WebGL 2, they are promoted to core or removed 

### DIFF
--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -1,35 +1,35 @@
---min-version 1.0.3 angle-instanced-arrays.html
---min-version 1.0.3 angle-instanced-arrays-out-of-bounds.html
---min-version 1.0.3 ext-blend-minmax.html
---min-version 1.0.3 ext-frag-depth.html
---min-version 1.0.3 ext-shader-texture-lod.html
---min-version 1.0.3 ext-sRGB.html
+--min-version 1.0.3 --max-version 1.9.9 angle-instanced-arrays.html
+--min-version 1.0.3 --max-version 1.9.9 angle-instanced-arrays-out-of-bounds.html
+--min-version 1.0.3 --max-version 1.9.9 ext-blend-minmax.html
+--min-version 1.0.3 --max-version 1.9.9 ext-frag-depth.html
+--min-version 1.0.3 --max-version 1.9.9 ext-shader-texture-lod.html
+--min-version 1.0.3 --max-version 1.9.9 ext-sRGB.html
 --min-version 1.0.2 ext-texture-filter-anisotropic.html
 --min-version 1.0.2 get-extension.html
 --max-version 1.9.9 oes-standard-derivatives.html
-oes-texture-float-with-canvas.html
-oes-texture-float-with-image-data.html
-oes-texture-float-with-image.html
-oes-texture-float-with-video.html
-oes-texture-float.html
-oes-vertex-array-object.html
---min-version 1.0.3 oes-vertex-array-object-bufferData.html
---min-version 1.0.3 oes-texture-half-float.html
+--max-version 1.9.9 oes-texture-float-with-canvas.html
+--max-version 1.9.9 oes-texture-float-with-image-data.html
+--max-version 1.9.9 oes-texture-float-with-image.html
+--max-version 1.9.9 oes-texture-float-with-video.html
+--max-version 1.9.9 oes-texture-float.html
+--max-version 1.9.9 oes-vertex-array-object.html
+--min-version 1.0.3 --max-version 1.9.9 oes-vertex-array-object-bufferData.html
+--min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float.html
 --min-version 1.0.3 oes-texture-float-linear.html
---min-version 1.0.3 oes-texture-half-float-linear.html
---min-version 1.0.3 oes-texture-half-float-with-canvas.html
---min-version 1.0.3 oes-texture-half-float-with-image-data.html
---min-version 1.0.3 oes-texture-half-float-with-image.html
---min-version 1.0.3 oes-texture-half-float-with-video.html
---min-version 1.0.2 oes-element-index-uint.html
+--min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float-linear.html
+--min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float-with-canvas.html
+--min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float-with-image-data.html
+--min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float-with-image.html
+--min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float-with-video.html
+--min-version 1.0.2 --max-version 1.9.9 oes-element-index-uint.html
 webgl-debug-renderer-info.html
 webgl-debug-shaders.html
 --min-version 1.0.3 webgl-compressed-texture-atc.html
 --min-version 1.0.3 webgl-compressed-texture-pvrtc.html
 --min-version 1.0.2 webgl-compressed-texture-s3tc.html
 --min-version 1.0.3 webgl-compressed-texture-size-limit.html
---min-version 1.0.2 webgl-depth-texture.html
---min-version 1.0.3 webgl-draw-buffers.html
+--min-version 1.0.2 --max-version 1.9.9 webgl-depth-texture.html
+--min-version 1.0.3 --max-version 1.9.9 webgl-draw-buffers.html
 --min-version 1.0.4 webgl-draw-buffers-max-draw-buffers.html
 --min-version 1.0.3 webgl-shared-resources.html
 

--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -6,7 +6,7 @@
 --min-version 1.0.3 ext-sRGB.html
 --min-version 1.0.2 ext-texture-filter-anisotropic.html
 --min-version 1.0.2 get-extension.html
-oes-standard-derivatives.html
+--max-version 1.9.9 oes-standard-derivatives.html
 oes-texture-float-with-canvas.html
 oes-texture-float-with-image-data.html
 oes-texture-float-with-image.html


### PR DESCRIPTION
This change comes from #897. It skips extensions those have been promoted or removed in WebGL 2.0 by adding max-version for them.

I go through all GL extensions in WebGL Extension Registry webpage(https://www.khronos.org/registry/webgl/extensions/) , these extensions are promoted into core in WebGL 2.0:
ANGLE_instanced_arrays, 
OES_element_index_uint, 
OES_standard_derivatives,
OES_vertex_array_object,
WebGL_draw_buffers,
EXT_blend_minmax,
EXT_frag_depth,
EXT_sRGB,
EXT_shader_texture_lod. 

Aligned with #903 , WEBGL_depth_texture is also promoted into core. 
And these extensions are removed in WebGL 2.0:
OES_texture_float
OES_texture_half_float
OES_texture_half_float_linear.

Please have a look. Thanks a lot!