### PR TITLE
Mark WEBGL_depth_texture as removed in WebGL 2.0 instead of in core.

### DIFF
--- a/extensions/WEBGL_depth_texture/extension.xml
+++ b/extensions/WEBGL_depth_texture/extension.xml
@@ -16,7 +16,7 @@
   <number>9</number>
   <depends>
     <api version="1.0"/>
-    <core version="2.0" />
+    <removed version="2.0" />
   </depends>
   <overview>
     <p>This extension exposes the


### PR DESCRIPTION
Following up to #903, this extension's limitations have been removed in WebGL 2.0 so the extension should probably be marked as removed.