### PR TITLE
Disable webgl-draw-buffers-max-draw-buffers.html on WebGL 2.0.

### DIFF
--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -30,6 +30,6 @@ webgl-debug-shaders.html
 --min-version 1.0.3 webgl-compressed-texture-size-limit.html
 --min-version 1.0.2 --max-version 1.9.9 webgl-depth-texture.html
 --min-version 1.0.3 --max-version 1.9.9 webgl-draw-buffers.html
---min-version 1.0.4 webgl-draw-buffers-max-draw-buffers.html
+--min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-max-draw-buffers.html
 --min-version 1.0.3 webgl-shared-resources.html
 


### PR DESCRIPTION
Following up to #906, if the WEBGL_draw_buffers test is disabled in WebGL 2.0, this one should be too.