### PR TITLE
Add tests disallowing operators on certain types of structs

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -99,6 +99,7 @@ uniform-location-length-limits.html
 --min-version 1.0.2 shader-with-global-variable-precision-mismatch.html
 --min-version 1.0.2 large-loop-compile.html
 --min-version 1.0.3 struct-equals.html
+--min-version 1.0.4 struct-assign.html
 --min-version 1.0.3 struct-mixed-array-declarators.html
 --min-version 1.0.3 struct-nesting-of-variable-names.html
 --min-version 1.0.3 struct-specifiers-in-uniforms.html

--- a/sdk/tests/conformance/glsl/misc/struct-assign.html
+++ b/sdk/tests/conformance/glsl/misc/struct-assign.html
@@ -1,0 +1,234 @@
+<!--
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL Structure Assignment Test</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"> </script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+
+<script id="simple-vs" type="x-shader/x-vertex">
+attribute vec4 a_position;
+void main(void) {
+    gl_Position = a_position;
+}
+</script>
+<script id="simple-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+struct my_struct {
+  float f;
+};
+
+my_struct a = my_struct(0.0);
+my_struct b = my_struct(1.0);
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    a = b;
+    if (a.f == 1.0) {
+        gl_FragColor.y = 1.0;
+    }
+}
+</script>
+<script id="vec-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+struct my_struct {
+  vec3 v;
+};
+
+my_struct a = my_struct(vec3(0.0, 0.0, 0.0));
+my_struct b = my_struct(vec3(1.0, 2.0, 3.0));
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    a = b;
+    if (a.v.x == 1.0) {
+        gl_FragColor.y = 1.0;
+    }
+}
+</script>
+<script id="nested-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+
+struct s1
+{
+  float f;
+};
+
+struct s2
+{
+  s1 s;
+};
+
+s2 a = s2(s1(0.0));
+s2 b = s2(s1(1.0));
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    a = b;
+    if (a.s.f == 1.0) {
+        gl_FragColor.y = 1.0;
+    }
+}
+</script>
+<script id="nested-vec-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+
+struct s1
+{
+  vec3 v;
+};
+
+struct s2
+{
+  s1 s;
+};
+
+s2 a = s2(s1(vec3(0.0, 0.0, 0.0)));
+s2 b = s2(s1(vec3(1.0, 2.0, 3.0)));
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    a = b;
+    if (a.s.v.x == 1.0) {
+        gl_FragColor.y = 1.0;
+    }
+}
+</script>
+<script id="array-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+
+struct my_struct
+{
+  float f[3];
+};
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    my_struct a;
+    my_struct b;
+    for (int i = 0; i < 3; ++i) {
+        a.f[i] = 0.0;
+        b.f[i] = float(i);
+    }
+
+    a = b;
+    if (a.f[1] == 1.0 && a.f[2] == 2.0) {
+      gl_FragColor.y = 1.0;
+    }
+}
+</script>
+<script id="sampler-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+
+struct my_struct
+{
+  sampler2D s;
+};
+
+uniform my_struct a;
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    my_struct b;
+    b = a;
+}
+</script>
+</head>
+<body>
+<canvas id="canvas" width="50" height="50"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Testing struct assignment");
+
+var wtu = WebGLTestUtils;
+GLSLConformanceTester.runTests([
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "simple-struct-fs",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Simple struct with one float",
+  },
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "vec-struct-fs",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Simple struct with a vector",
+  },
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "nested-struct-fs",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Nested struct with a float",
+  },
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "nested-vec-struct-fs",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Nested struct with a vector",
+  },
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "array-struct-fs",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Assigning a struct containing an array should not compile",
+  },
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "sampler-struct-fs",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Assigning a struct containing a sampler should not compile",
+  }
+]);
+debug("");
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>
+

--- a/sdk/tests/conformance/glsl/misc/struct-equals.html
+++ b/sdk/tests/conformance/glsl/misc/struct-equals.html
@@ -125,6 +125,47 @@ void main(void) {
     }
 }
 </script>
+<script id="array-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+
+struct my_struct
+{
+  float f[3];
+};
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+    my_struct a;
+    my_struct b;
+    for (int i = 0; i < 3; ++i) {
+        a.f[i] = 0.0;
+        b.f[i] = 1.0;
+    }
+
+    if (a == b) {
+      gl_FragColor.x = 1.0;
+    }
+}
+</script>
+<script id="sampler-struct-fs" type="x-shader/x-fragment">
+precision mediump float;
+
+struct my_struct
+{
+    sampler2D s;
+};
+
+uniform my_struct a;
+uniform my_struct b;
+
+void main(void) {
+    gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+
+    if (a == b) {
+      gl_FragColor.x = 1.0;
+    }
+}
+</script>
 </head>
 <body>
 <canvas id="canvas" width="50" height="50"></canvas>
@@ -135,13 +176,14 @@ void main(void) {
 description("Testing struct equals");
 
 var wtu = WebGLTestUtils;
-GLSLConformanceTester.runRenderTests([
+GLSLConformanceTester.runTests([
   {
     vShaderId: "simple-vs",
     vShaderSuccess: true,
     fShaderId: "simple-struct-fs",
     fShaderSuccess: true,
     linkSuccess: true,
+    render: true,
     passMsg: "Simple struct with one float",
   },
   {
@@ -150,6 +192,7 @@ GLSLConformanceTester.runRenderTests([
     fShaderId: "vec-struct-fs",
     fShaderSuccess: true,
     linkSuccess: true,
+    render: true,
     passMsg: "Simple struct with a vector",
   },
   {
@@ -158,6 +201,7 @@ GLSLConformanceTester.runRenderTests([
     fShaderId: "nested-struct-fs",
     fShaderSuccess: true,
     linkSuccess: true,
+    render: true,
     passMsg: "Nested struct with a float",
   },
   {
@@ -166,8 +210,25 @@ GLSLConformanceTester.runRenderTests([
     fShaderId: "nested-vec-struct-fs",
     fShaderSuccess: true,
     linkSuccess: true,
+    render: true,
     passMsg: "Nested struct with a vector",
   },
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "array-struct-fs",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Comparing a struct containing an array should not compile",
+  },
+  {
+    vShaderId: "simple-vs",
+    vShaderSuccess: true,
+    fShaderId: "sampler-struct-fs",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Comparing a struct containing a sampler should not compile",
+  }
 ]);
 debug("");
 


### PR DESCRIPTION
Comparing or assigning structs that contain arrays or samplers is "not
defined" in ESSL 1.00 (spec section 5.7). In addition the spec
mentions in section 5.8 that

"structures containing arrays may be passed to parameters declared as out
or inout but may not be used as the target of an assignment."

and in section 5.9:

"The equality operators equal (==), and not equal (!=) operate on all
types except arrays, structures containing arrays, sampler types and
structures containing sampler types"

It is also not allowed to use samplers as l-values, so it makes sense
that using structs containing samplers as l-values would be disallowed as
well.

Add tests to enforce that equality and assignment of structs containing
arrays or samplers are disallowed in WebGL. Spec clarification doesn't
seem necessary as the ESSL spec is already pretty clear on this.

On many platforms shaders that contain these operations are already
failing compilation:

1. Equality comparison of structs containing arrays or samplers is
failing on at least Linux/NVIDIA/Chrome, Windows/Intel/IE and
Windows/Intel/Firefox.

2. Assignment of structs containing arrays is failing on at least
Windows/Intel/IE.

3. Assignment of structs containing samplers is failing on at least
Linux/NVIDIA/Chrome, Windows/Intel/IE and Windows/Intel/Firefox.