### PR TITLE
Add simple ESSL3 tests for array assignment and equality

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -1,2 +1,4 @@
+array-assign.html
+array-equality.html
 misplaced-version-directive.html
 shader-linking.html

--- a/sdk/tests/conformance2/glsl3/array-assign.html
+++ b/sdk/tests/conformance2/glsl3/array-assign.html
@@ -1,0 +1,133 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL array assignment test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../conformance/resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="64" height="64"> </canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+
+void main() {
+    gl_Position = vec4(aPosition, 1);
+}
+</script>
+<script id="fshaderSimple" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform int uCount;
+
+out vec4 my_FragColor;
+
+void main() {
+    // This simple test uses the ESSL1 style array initialization in order
+    // to be able to test array assignment independently of array constructors.
+    int a[3];
+    int b[3];
+    for (int i = 0; i < 3; ++i) {
+        a[i] = 0;
+        b[i] = i;
+    }
+    a = b;
+    bool fail = false;
+    for (int i = 0; i < 3; ++i) {
+        if (a[i] != i) {
+            fail = true;
+        }
+    }
+    my_FragColor = vec4(0.0, (fail ? 0.0 : 1.0), 0.0, 1.0);
+}
+</script>
+<script id="fshaderArrayOfStructs" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform int uCount;
+
+out vec4 my_FragColor;
+
+struct S {
+    int foo;
+};
+
+void main() {
+    // This simple test uses the ESSL1 style array initialization in order
+    // to be able to test array assignment independently of array constructors.
+    S a[3];
+    S b[3];
+    for (int i = 0; i < 3; ++i) {
+        a[i].foo = 0;
+        b[i].foo = i;
+    }
+    a = b;
+    bool fail = false;
+    for (int i = 0; i < 3; ++i) {
+        if (a[i].foo != i) {
+            fail = true;
+        }
+    }
+    my_FragColor = vec4(0.0, (fail ? 0.0 : 1.0), 0.0, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Assigning arrays should work.");
+debug("");
+var wtu = WebGLTestUtils;
+function test() {
+  var gl = wtu.create3DContext("canvas", undefined, 2);
+  if (!gl) {
+    testFailed("WebGL 2 context does not exist");
+    return;
+  }
+  wtu.setupUnitQuad(gl);
+
+  debug("Testing with arrays of integers");
+  wtu.setupProgram(gl, ["vshader", "fshaderSimple"], ["aPosition"], undefined, true);
+  wtu.drawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+
+  debug("");
+  debug("Testing with arrays of structs");
+  wtu.setupProgram(gl, ["vshader", "fshaderArrayOfStructs"], ["aPosition"], undefined, true);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+};
+
+test();
+var successfullyParsed = true;
+finishTest();
+</script>
+</body>
+</html>
+

--- a/sdk/tests/conformance2/glsl3/array-equality.html
+++ b/sdk/tests/conformance2/glsl3/array-equality.html
@@ -1,0 +1,125 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL array equality test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../conformance/resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="64" height="64"> </canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+
+void main() {
+    gl_Position = vec4(aPosition, 1);
+}
+</script>
+<script id="fshaderSimple" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform int uCount;
+
+out vec4 my_FragColor;
+
+void main() {
+    // This simple test uses the ESSL1 style array initialization in order
+    // to be able to test array equality independently of array constructors.
+    int a[3];
+    int b[3];
+    int c[3];
+    for (int i = 0; i < 3; ++i) {
+        a[i] = i;
+        b[i] = i;
+        c[i] = i + 1;
+    }
+    bool success = (a == b) && (a != c);
+    my_FragColor = vec4(0.0, (success ? 1.0 : 0.0), 0.0, 1.0);
+}
+</script>
+<script id="fshaderArrayOfStructs" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform int uCount;
+
+out vec4 my_FragColor;
+
+struct S {
+    int foo;
+};
+
+void main() {
+    // This simple test uses the ESSL1 style array initialization in order
+    // to be able to test array equality independently of array constructors.
+    S a[3];
+    S b[3];
+    S c[3];
+    for (int i = 0; i < 3; ++i) {
+        a[i].foo = i;
+        b[i].foo = i;
+        c[i].foo = i + 1;
+    }
+    bool success = (a == b) && (a != c);
+    my_FragColor = vec4(0.0, (success ? 1.0 : 0.0), 0.0, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Comparing arrays should work.");
+debug("");
+var wtu = WebGLTestUtils;
+function test() {
+  var gl = wtu.create3DContext("canvas", undefined, 2);
+  if (!gl) {
+    testFailed("WebGL 2 context does not exist");
+    return;
+  }
+  wtu.setupUnitQuad(gl);
+
+  debug("Testing with arrays of integers");
+  wtu.setupProgram(gl, ["vshader", "fshaderSimple"], ["aPosition"], undefined, true);
+  wtu.drawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+
+  debug("");
+  debug("Testing with arrays of structs");
+  wtu.setupProgram(gl, ["vshader", "fshaderArrayOfStructs"], ["aPosition"], undefined, true);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+};
+
+test();
+var successfullyParsed = true;
+finishTest();
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
Test ESSL3 array assignment and equality operators with arrays of ints
and arrays of structs. These use ESSL1-compatible code for array
initialization, which helps with developing these features independently
of array constructors. This complements dEQP array tests, which require
constructors to be supported.