### PR TITLE
getBufferSubData should accept null param for returnedData.

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 12 March 2015</h2>
+    <h2 class="no-toc">Editor's Draft 1 April 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -681,7 +681,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   // MapBufferRange, in particular its read-only and write-only modes,
   // can not be exposed safely to JavaScript. GetBufferSubData
   // replaces it for the purpose of fetching data back from the GPU.
-  void getBufferSubData(GLenum target, GLintptr offset, ArrayBuffer returnedData);
+  void getBufferSubData(GLenum target, GLintptr offset, ArrayBuffer? returnedData);
 
   /* Framebuffer objects */
   void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -314,7 +314,7 @@ interface WebGL2RenderingContextBase
   // MapBufferRange, in particular its read-only and write-only modes,
   // can not be exposed safely to JavaScript. GetBufferSubData
   // replaces it for the purpose of fetching data back from the GPU.
-  void getBufferSubData(GLenum target, GLintptr offset, ArrayBuffer returnedData);
+  void getBufferSubData(GLenum target, GLintptr offset, ArrayBuffer? returnedData);
 
   /* Framebuffer objects */
   void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,


### PR DESCRIPTION
https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.2 says for `getBufferSubData()`:

> If returnedData is null then an INVALID_VALUE error is generated.

The current webidl doesn't allow null. Instead, in FF for example, a TypeError is caused:
```javascript
var data = null;
gl.getBufferSubData(gl.ARRAY_BUFFER, 0, data);
```
results in

```
TypeError: Argument 3 is not valid for any of the 3-argument overloads of WebGL2RenderingContext.getBufferSubData.
```

PS: I hope I updated the correct date.