### PR TITLE
Added Closure externs file for WebGL 2.0 under sdk/tests/deqp/webgl2.js ...

### DIFF
--- a/sdk/tests/deqp/temp_externs/chrome.js
+++ b/sdk/tests/deqp/temp_externs/chrome.js
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2013 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for globals in Chrome.  This file describes the
+ * externs API for the chrome.* object when running in a normal browser
+ * context.  For APIs available in Chrome Extensions, see chrome_extensions.js
+ * in this directory.
+ * @externs
+ */
+
+
+/**
+ * namespace
+ * @const
+ */
+var chrome = {};
+
+
+
+/**
+ * Returns an object representing current load times. Note that the properties
+ * on the object do not change and the function must be called again to get
+ * up-to-date data.
+ *
+ * @see http://goto.google.com/chromeloadtimesextension
+ *
+ * @return {!ChromeLoadTimes}
+ */
+chrome.loadTimes = function() {};
+
+
+
+/**
+ * The data object given by chrome.loadTimes().
+ * @constructor
+ */
+function ChromeLoadTimes() {}
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.requestTime;
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.startLoadTime;
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.commitLoadTime;
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.finishDocumentLoadTime;
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.finishLoadTime;
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.firstPaintTime;
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.firstPaintAfterLoadTime;
+
+
+/** @type {number} */
+ChromeLoadTimes.prototype.navigationType;
+
+
+/**
+ * True iff the resource was fetched over SPDY.
+ * @type {boolean}
+ */
+ChromeLoadTimes.prototype.wasFetchedViaSpdy;
+
+
+/** @type {boolean} */
+ChromeLoadTimes.prototype.wasNpnNegotiated;
+
+
+/** @type {string} */
+ChromeLoadTimes.prototype.npnNegotiatedProtocol;
+
+
+/** @type {boolean} */
+ChromeLoadTimes.prototype.wasAlternateProtocolAvailable;
+
+
+/** @type {string} */
+ChromeLoadTimes.prototype.connectionInfo;
+
+
+/**
+ * Returns an object containing timing information.
+ * @return {!ChromeCsiInfo}
+ */
+chrome.csi = function() {};
+
+
+
+/**
+ * The data object given by chrome.csi().
+ * @constructor
+ */
+function ChromeCsiInfo() {}
+
+
+/**
+ * Same as chrome.loadTimes().requestTime, if defined.
+ * Otherwise, gives the same value as chrome.loadTimes().startLoadTime.
+ * In milliseconds, truncated.
+ * @type {number}
+ */
+ChromeCsiInfo.prototype.startE;
+
+
+/**
+ * Same as chrome.loadTimes().finishDocumentLoadTime but in milliseconds and
+ * truncated.
+ * @type {number}
+ */
+ChromeCsiInfo.prototype.onloadT;
+
+
+/**
+ * The time since startE in milliseconds.
+ * @type {number}
+ */
+ChromeCsiInfo.prototype.pageT;
+
+
+/** @type {number} */
+ChromeCsiInfo.prototype.tran;
+
+
+/**
+ * @param {string|!ArrayBuffer|!Object} message
+ * @see https://developers.google.com/native-client/devguide/tutorial
+ */
+HTMLEmbedElement.prototype.postMessage = function(message) {};

--- a/sdk/tests/deqp/temp_externs/deprecated.js
+++ b/sdk/tests/deqp/temp_externs/deprecated.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview JavaScript Built-Ins that are not
+ * part of any specifications but are
+ * still needed in some project's build.
+ * @externs
+ *
+ */
+
+// Do we need an opera.js?
+var opera;
+Window.prototype.opera;
+Window.prototype.opera.postError;
+
+/** @constructor */ function XSLTProcessor() {}
+/**
+ * @param {*=} opt_text
+ * @param {*=} opt_value
+ * @param {*=} opt_defaultSelected
+ * @param {*=} opt_selected
+ * @constructor
+ * @extends {Element}
+ */
+function Option(opt_text, opt_value, opt_defaultSelected, opt_selected) {}
+
+
+// The "methods" object is a place to hang arbitrary external
+// properties. It is a throwback to pre-typed days, and should
+// not be used for any new definitions; it exists only to bridge
+// the gap between the old way and the new way.
+var methods = {};

--- a/sdk/tests/deqp/temp_externs/es3.js
+++ b/sdk/tests/deqp/temp_externs/es3.js
@@ -1,0 +1,2236 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview ECMAScript 3 Built-Ins. This include common extensions so this
+ * is actually ES3+Reality.
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ * @author nicksantos@google.com (Nick Santos)
+ * @author arv@google.com (Erik Arvidsson)
+ * @author johnlenz@google.com (John Lenz)
+ */
+
+
+// These built-ins are still needed for compilation.
+
+/**
+ * @constructor
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Functions_and_function_scope/arguments
+ */
+function Arguments() {}
+
+/**
+ * @type {Function}
+ * @see http://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Functions_and_function_scope/arguments/callee
+ */
+Arguments.prototype.callee;
+
+/**
+ * Use the non-standard {@see Function.prototype.caller} property of a function
+ * object instead.
+ * @type {Function}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Functions/arguments/caller
+ * @deprecated
+ */
+Arguments.prototype.caller;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Functions_and_function_scope/arguments/length
+ */
+Arguments.prototype.length;
+
+/**
+ * @type {!Arguments}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Functions_and_function_scope/arguments
+ */
+var arguments;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Properties/Infinity
+ * @const
+ */
+var Infinity;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Properties/NaN
+ * @const
+ */
+var NaN;
+
+/**
+ * @type {undefined}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Properties/undefined
+ * @const
+ */
+var undefined;
+
+/**
+ * @param {string} uri
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/decodeURI
+ */
+function decodeURI(uri) {}
+
+/**
+ * @param {string} uri
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/decodeURIComponent
+ */
+function decodeURIComponent(uri) {}
+
+/**
+ * @param {string} uri
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/encodeURI
+ */
+function encodeURI(uri) {}
+
+/**
+ * @param {string} uri
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/encodeURIComponent
+ */
+function encodeURIComponent(uri) {}
+
+/**
+ * Should only be used in browsers where encode/decodeURIComponent
+ * are not present, as the latter handle fancy Unicode characters.
+ * @param {string} str
+ * @return {string}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Guide/Predefined_Functions/escape_and_unescape_Functions
+ */
+function escape(str) {}
+
+/**
+ * Should only be used in browsers where encode/decodeURIComponent
+ * are not present, as the latter handle fancy Unicode characters.
+ * @param {string} str
+ * @return {string}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Guide/Predefined_Functions/escape_and_unescape_Functions
+ */
+function unescape(str) {}
+
+/**
+ * @param {*} num
+ * @return {boolean}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/isFinite
+ */
+function isFinite(num) {}
+
+/**
+ * @param {*} num
+ * @return {boolean}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/isNaN
+ */
+function isNaN(num) {}
+
+/**
+ * @param {*} num
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/parseFloat
+ */
+function parseFloat(num) {}
+
+/**
+ * Parse an integer. Use of {@code parseInt} without {@code base} is strictly
+ * banned in Google. If you really want to parse octal or hex based on the
+ * leader, then pass {@code undefined} as the base.
+ *
+ * @param {*} num
+ * @param {number|undefined} base
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/parseInt
+ */
+function parseInt(num, base) {}
+
+/**
+ * @param {string} code
+ * @return {*}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Functions/eval
+ */
+function eval(code) {}
+
+/**
+ * @constructor
+ * @param {*=} opt_value
+ * @return {!Object}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object
+ */
+function Object(opt_value) {}
+
+/**
+ * The constructor of the current object.
+ * @type {Function}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/constructor
+ */
+Object.prototype.constructor = function() {};
+
+/**
+ * Binds an object's property to a function to be called when that property is
+ * looked up.
+ * Mozilla-only.
+ *
+ * @param {string} sprop
+ * @param {Function} fun
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/defineGetter
+ */
+Object.prototype.__defineGetter__ = function(sprop, fun) {};
+
+/**
+ * Binds an object's property to a function to be called when an attempt is made
+ * to set that property.
+ * Mozilla-only.
+ *
+ * @param {string} sprop
+ * @param {Function} fun
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/defineSetter
+ */
+Object.prototype.__defineSetter__ = function(sprop, fun) {};
+
+/**
+ * Returns whether the object has a property with the specified name.
+ *
+ * @param {*} propertyName Implicitly cast to a string.
+ * @return {boolean}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/hasOwnProperty
+ */
+Object.prototype.hasOwnProperty = function(propertyName) {};
+
+/**
+ * Returns whether an object exists in another object's prototype chain.
+ *
+ * @param {Object} other
+ * @return {boolean}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/isPrototypeOf
+ */
+Object.prototype.isPrototypeOf = function(other) {};
+
+/**
+ * Return the function bound as a getter to the specified property.
+ * Mozilla-only.
+ *
+ * @param {string} sprop a string containing the name of the property whose
+ * getter should be returned
+ * @return {Function}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/lookupGetter
+ */
+Object.prototype.__lookupGetter__ = function(sprop) {};
+
+/**
+ * Return the function bound as a setter to the specified property.
+ * Mozilla-only.
+ *
+ * @param {string} sprop a string containing the name of the property whose
+ *     setter should be returned.
+ * @return {Function}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/lookupSetter
+ */
+Object.prototype.__lookupSetter__ = function(sprop) {};
+
+/**
+ * Executes a function when a non-existent method is called on an object.
+ * Mozilla-only.
+ *
+ * @param {Function} fun
+ * @return {*}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/noSuchMethod
+ */
+Object.prototype.__noSuchMethod__ = function(fun) {};
+
+/**
+ * Points to an object's context.  For top-level objects, this is the e.g. window.
+ * Mozilla-only.
+ *
+ * @type {Object}
+ * @deprecated
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/parent
+ */
+Object.prototype.__parent__;
+
+/**
+ * Points to the object which was used as prototype when the object was instantiated.
+ * Mozilla-only.
+ *
+ * Will be null on Object.prototype.
+ *
+ * @type {Object}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/proto
+ */
+Object.prototype.__proto__;
+
+/**
+ * Determine whether the specified property in an object can be enumerated by a
+ * for..in loop, with the exception of properties inherited through the
+ * prototype chain.
+ *
+ * @param {string} propertyName
+ * @return {boolean}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/propertyIsEnumerable
+ */
+Object.prototype.propertyIsEnumerable = function(propertyName) {};
+
+/**
+ * Returns a localized string representing the object.
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/toLocaleString
+ */
+Object.prototype.toLocaleString = function() {};
+
+/**
+ * Returns a string representing the source code of the object.
+ * Mozilla-only.
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/toSource
+ */
+Object.prototype.toSource = function() {};
+
+/**
+ * Returns a string representing the object.
+ * @this {*}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/toString
+ */
+Object.prototype.toString = function() {};
+
+/**
+ * Removes a watchpoint set with the {@see Object.prototype.watch} method.
+ * Mozilla-only.
+ * @param {string} prop The name of a property of the object.
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/unwatch
+ */
+Object.prototype.unwatch = function(prop) {};
+
+/**
+ * Returns the object's {@code this} value.
+ * @return {*}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/valueOf
+ */
+Object.prototype.valueOf = function() {};
+
+/**
+ * Sets a watchpoint method.
+ * Mozilla-only.
+ * @param {string} prop The name of a property of the object.
+ * @param {Function} handler A function to call.
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Object/watch
+ */
+Object.prototype.watch = function(prop, handler) {};
+
+
+/**
+ * @constructor
+ * @param {...*} var_args
+ * @nosideeffects
+ * @throws {Error}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Function
+ */
+function Function(var_args) {}
+
+/**
+ * @param {...*} var_args
+ * @return {*}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Function/call
+ */
+Function.prototype.call = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ * @return {*}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Function/apply
+ */
+Function.prototype.apply = function(var_args) {};
+
+Function.prototype.arguments;
+
+/**
+ * @type {number}
+ * @deprecated
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Function/arity
+ */
+Function.prototype.arity;
+
+/**
+ * Nonstandard; Mozilla and JScript only.
+ * @type {Function}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Function/caller
+ */
+Function.prototype.caller;
+
+/**
+ * Nonstandard.
+ * @type {?}
+ * @see http://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/displayName
+ */
+Function.prototype.displayName;
+
+/**
+ * Expected number of arguments.
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Function/length
+ */
+Function.prototype.length;
+
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Function/name
+ */
+Function.prototype.name;
+
+/**
+ * @this {Function}
+ * @return {string}
+ * @nosideeffects
+ * @override
+ */
+Function.prototype.toString = function() {};
+
+
+/**
+ * @constructor
+ * @param {...*} var_args
+ * @return {!Array.<?>}
+ * @nosideeffects
+ * @template T
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array
+ */
+function Array(var_args) {}
+
+// Functions:
+
+/**
+ * Returns a new array comprised of this array joined with other array(s)
+ * and/or value(s).
+ *
+ * @param {...*} var_args
+ * @return {!Array.<?>}
+ * @this {*}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/concat
+ */
+Array.prototype.concat = function(var_args) {};
+
+/**
+ * Joins all elements of an array into a string.
+ *
+ * @param {*=} opt_separator Specifies a string to separate each element of the
+ *     array. The separator is converted to a string if necessary. If omitted,
+ *     the array elements are separated with a comma.
+ * @return {string}
+ * @this {{length: number}|string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/join
+ */
+Array.prototype.join = function(opt_separator) {};
+
+/**
+ * Removes the last element from an array and returns that element.
+ *
+ * @return {T}
+ * @this {{length: number}|Array.<T>}
+ * @modifies {this}
+ * @template T
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/pop
+ */
+Array.prototype.pop = function() {};
+
+/**
+ * Mutates an array by appending the given elements and returning the new
+ * length of the array.
+ *
+ * @param {...T} var_args
+ * @return {number} The new length of the array.
+ * @this {{length: number}|Array.<T>}
+ * @template T
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/push
+ */
+Array.prototype.push = function(var_args) {};
+
+/**
+ * Transposes the elements of an array in place: the first array element becomes the
+ * last and the last becomes the first.
+ *
+ * @this {{length: number}}
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/reverse
+ */
+Array.prototype.reverse = function() {};
+
+/**
+ * Removes the first element from an array and returns that element. This
+ * method changes the length of the array.
+ *
+ * @this {{length: number}|Array.<T>}
+ * @modifies {this}
+ * @return {T}
+ * @template T
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/shift
+ */
+Array.prototype.shift = function() {};
+
+/**
+ * Extracts a section of an array and returns a new array.
+ *
+ * @param {*=} opt_begin Zero-based index at which to begin extraction.  A
+ *     non-number type will be auto-cast by the browser to a number.
+ * @param {*=} opt_end Zero-based index at which to end extraction.  slice
+ *     extracts up to but not including end.
+ * @return {!Array.<T>}
+ * @this {{length: number}|Array.<T>|string}
+ * @template T
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/slice
+ */
+Array.prototype.slice = function(opt_begin, opt_end) {};
+
+/**
+ * Sorts the elements of an array in place.
+ *
+ * @param {function(T,T):number=} opt_compareFunction Specifies a function that
+ *     defines the sort order.
+ * @this {{length: number}|Array.<T>}
+ * @template T
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/sort
+ */
+Array.prototype.sort = function(opt_compareFunction) {};
+
+/**
+ * Changes the content of an array, adding new elements while removing old
+ * elements.
+ *
+ * @param {*=} opt_index Index at which to start changing the array. If negative,
+ *     will begin that many elements from the end.  A non-number type will be
+ *     auto-cast by the browser to a number.
+ * @param {*=} opt_howMany An integer indicating the number of old array elements
+ *     to remove.
+ * @param {...T} var_args
+ * @return {!Array.<T>}
+ * @this {{length: number}|Array.<T>}
+ * @modifies {this}
+ * @template T
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/splice
+ */
+Array.prototype.splice = function(opt_index, opt_howMany, var_args) {};
+
+/**
+ * @return {string}
+ * @this {Object}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/toSource
+ */
+Array.prototype.toSource;
+
+/**
+ * @this {Array.<?>}
+ * @return {string}
+ * @nosideeffects
+ * @override
+ */
+Array.prototype.toString = function() {};
+
+/**
+ * Adds one or more elements to the beginning of an array and returns the new
+ * length of the array.
+ *
+ * @param {...*} var_args
+ * @return {number} The new length of the array
+ * @this {{length: number}}
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/unshift
+ */
+Array.prototype.unshift = function(var_args) {};
+
+/**
+ * Apply a function simultaneously against two values of the array (from
+ * left-to-right) as to reduce it to a single value.
+ *
+ * @param {?function(?, T, number, !Array.<T>) : R} callback
+ * @param {*=} opt_initialValue
+ * @return {R}
+ * @this {{length: number}|Array.<T>|string}
+ * @template T,R
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/reduce
+ */
+Array.prototype.reduce = function(callback, opt_initialValue) {};
+
+/**
+ * Apply a function simultaneously against two values of the array (from
+ * right-to-left) as to reduce it to a single value.
+ *
+ * @param {?function(?, T, number, !Array.<T>) : R} callback
+ * @param {*=} opt_initialValue
+ * @return {R}
+ * @this {{length: number}|Array.<T>|string}
+ * @template T,R
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/reduceRight
+ */
+Array.prototype.reduceRight = function(callback, opt_initialValue) {};
+
+/**
+ * Available in ECMAScript 5, Mozilla 1.6+.
+ * @param {?function(this:S, T, number, !Array.<T>): ?} callback
+ * @param {S=} opt_thisobj
+ * @return {boolean}
+ * @this {{length: number}|Array.<T>|string}
+ * @template T,S
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/every
+ */
+Array.prototype.every = function(callback, opt_thisobj) {};
+
+/**
+ * Available in ECMAScript 5, Mozilla 1.6+.
+ * @param {?function(this:S, T, number, !Array.<T>): ?} callback
+ * @param {S=} opt_thisobj
+ * @return {!Array.<T>}
+ * @this {{length: number}|Array.<T>|string}
+ * @template T,S
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/filter
+ */
+Array.prototype.filter = function(callback, opt_thisobj) {};
+
+/**
+ * Available in ECMAScript 5, Mozilla 1.6+.
+ * @param {?function(this:S, T, number, !Array.<T>): ?} callback
+ * @param {S=} opt_thisobj
+ * @this {{length: number}|Array.<T>|string}
+ * @template T,S
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/forEach
+ */
+Array.prototype.forEach = function(callback, opt_thisobj) {};
+
+/**
+ * Available in ECMAScript 5, Mozilla 1.6+.
+ * @param {T} obj
+ * @param {number=} opt_fromIndex
+ * @return {number}
+ * @this {{length: number}|Array.<T>|string}
+ * @nosideeffects
+ * @template T
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/indexOf
+ */
+Array.prototype.indexOf = function(obj, opt_fromIndex) {};
+
+/**
+ * Available in ECMAScript 5, Mozilla 1.6+.
+ * @param {T} obj
+ * @param {number=} opt_fromIndex
+ * @return {number}
+ * @this {{length: number}|Array.<T>|string}
+ * @nosideeffects
+ * @template T
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/lastIndexOf
+ */
+Array.prototype.lastIndexOf = function(obj, opt_fromIndex) {};
+
+/**
+ * Available in ECMAScript 5, Mozilla 1.6+.
+ * @param {?function(this:S, T, number, !Array.<T>): R} callback
+ * @param {S=} opt_thisobj
+ * @return {!Array.<R>}
+ * @this {{length: number}|Array.<T>|string}
+ * @template T,S,R
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/map
+ */
+Array.prototype.map = function(callback, opt_thisobj) {};
+
+/**
+ * Available in ECMAScript 5, Mozilla 1.6+.
+ * @param {?function(this:S, T, number, !Array.<T>): ?} callback
+ * @param {S=} opt_thisobj
+ * @return {boolean}
+ * @this {{length: number}|Array.<T>|string}
+ * @template T,S
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/some
+ */
+Array.prototype.some = function(callback, opt_thisobj) {};
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/index
+ */
+Array.prototype.index;
+
+/**
+ * @type {?string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/input
+ */
+Array.prototype.input;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/length
+ */
+Array.prototype.length;
+
+/**
+ * @param {{length: number}|Array.<T>} arr
+ * @param {?function(this:S, T, number, ?) : ?} callback
+ * @param {S=} opt_context
+ * @return {boolean}
+ * @template T,S
+ */
+Array.every = function(arr, callback, opt_context) {};
+
+/**
+ * @param {{length: number}|Array.<T>} arr
+ * @param {?function(this:S, T, number, ?) : ?} callback
+ * @param {S=} opt_context
+ * @return {!Array.<T>}
+ * @template T,S
+ */
+Array.filter = function(arr, callback, opt_context) {};
+
+/**
+ * @param {{length: number}|Array.<T>} arr
+ * @param {?function(this:S, T, number, ?) : ?} callback
+ * @param {S=} opt_context
+ * @template T,S
+ */
+Array.forEach = function(arr, callback, opt_context) {};
+
+/**
+ * Mozilla 1.6+ only.
+ * @param {{length: number}|Array.<T>} arr
+ * @param {T} obj
+ * @param {number=} opt_fromIndex
+ * @return {number}
+ * @template T
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/indexOf
+ */
+Array.indexOf = function(arr, obj, opt_fromIndex) {};
+
+/**
+ * Mozilla 1.6+ only.
+ * @param {{length: number}|Array.<T>} arr
+ * @param {T} obj
+ * @param {number=} opt_fromIndex
+ * @return {number}
+ * @template T
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/lastIndexOf
+ */
+Array.lastIndexOf = function(arr, obj, opt_fromIndex) {};
+
+/**
+ * @param {{length: number}|Array.<T>} arr
+ * @param {?function(this:S, T, number, !Array.<T>): R} callback
+ * @param {S=} opt_context
+ * @return {!Array.<R>}
+ * @template T,S,R
+ */
+Array.map = function(arr, callback, opt_context) {};
+
+/**
+ * @param {{length: number}|Array.<T>} arr
+ * @param {?function(this:S, T, number, ?) : ?} callback
+ * @param {S=} opt_context
+ * @return {boolean}
+ * @template T,S
+ */
+Array.some = function(arr, callback, opt_context) {};
+
+/**
+ * Introduced in 1.8.5.
+ * @param {*} arr
+ * @return {boolean}
+ * @see http://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/isArray
+ */
+Array.isArray = function(arr) {};
+
+/**
+ * @constructor
+ * @param {*=} opt_value
+ * @return {boolean}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Boolean
+ */
+function Boolean(opt_value) {}
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Boolean/toSource
+ * @override
+ */
+Boolean.prototype.toSource = function() {};
+
+/**
+ * @this {boolean|Boolean}
+ * @return {string}
+ * @nosideeffects
+ * @override
+ */
+Boolean.prototype.toString = function() {};
+
+/**
+ * @constructor
+ * @param {*=} opt_value
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number
+ */
+function Number(opt_value) {}
+
+/**
+ * @this {Number|number}
+ * @param {number=} opt_fractionDigits
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/toExponential
+ */
+Number.prototype.toExponential = function(opt_fractionDigits) {};
+
+/**
+ * @this {Number|number}
+ * @param {*=} opt_digits
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/toFixed
+ */
+Number.prototype.toFixed = function(opt_digits) {};
+
+/**
+ * @this {Number|number}
+ * @param {number=} opt_precision
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/toPrecision
+ */
+Number.prototype.toPrecision = function(opt_precision) {};
+
+/**
+ * Returns a string representing the number.
+ * @this {Number|number}
+ * @param {(number|Number)=} opt_radix An optional radix.
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/toString
+ * @override
+ */
+Number.prototype.toString = function(opt_radix) {};
+
+// Properties.
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/MAX_VALUE
+ */
+Number.MAX_VALUE;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/MIN_VALUE
+ */
+Number.MIN_VALUE;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/NaN
+ */
+Number.NaN;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/NEGATIVE_INFINITY
+ */
+Number.NEGATIVE_INFINITY;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Number/POSITIVE_INFINITY
+ */
+Number.POSITIVE_INFINITY;
+
+
+/**
+ * @const
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math
+ */
+var Math = {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/abs
+ */
+Math.abs = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/acos
+ */
+Math.acos = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/asin
+ */
+Math.asin = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/atan
+ */
+Math.atan = function(x) {};
+
+/**
+ * @param {*} y
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/atan2
+ */
+Math.atan2 = function(y, x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/ceil
+ */
+Math.ceil = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/cos
+ */
+Math.cos = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/exp
+ */
+Math.exp = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/floor
+ */
+Math.floor = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/log
+ */
+Math.log = function(x) {};
+
+/**
+ * @param {...*} var_args
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/max
+ */
+Math.max = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/min
+ */
+Math.min = function(var_args) {};
+
+/**
+ * @param {*} x
+ * @param {*} y
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/pow
+ */
+Math.pow = function(x, y) {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/random
+ */
+Math.random = function() {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/round
+ */
+Math.round = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/sin
+ */
+Math.sin = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/sqrt
+ */
+Math.sqrt = function(x) {};
+
+/**
+ * @param {*} x
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/tan
+ */
+Math.tan = function(x) {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/toSource
+ */
+Math.toSource = function() {};
+
+// Properties:
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/E
+ */
+Math.E;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/LN2
+ */
+Math.LN2;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/LN10
+ */
+Math.LN10;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/LOG2E
+ */
+Math.LOG2E;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/LOG10E
+ */
+Math.LOG10E;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/PI
+ */
+Math.PI;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/SQRT1_2
+ */
+Math.SQRT1_2;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Math/SQRT2
+ */
+Math.SQRT2;
+
+
+/**
+ * @param {?=} opt_yr_num
+ * @param {?=} opt_mo_num
+ * @param {?=} opt_day_num
+ * @param {?=} opt_hr_num
+ * @param {?=} opt_min_num
+ * @param {?=} opt_sec_num
+ * @param {?=} opt_ms_num
+ * @constructor
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date
+ */
+function Date(opt_yr_num, opt_mo_num, opt_day_num, opt_hr_num, opt_min_num,
+    opt_sec_num, opt_ms_num) {}
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/now
+ */
+Date.now = function() {};
+
+/**
+ * Parses a string representation of a date, and returns the number
+ * of milliseconds since January 1, 1970, 00:00:00, local time.
+ * @param {*} date
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/parse
+ */
+Date.parse = function(date) {};
+
+/**
+ * @param {number} year
+ * @param {number} month
+ * @param {number=} opt_date
+ * @param {number=} opt_hours
+ * @param {number=} opt_minute
+ * @param {number=} opt_second
+ * @param {number=} opt_ms
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/UTC
+ */
+Date.UTC = function(year, month,
+                    opt_date, opt_hours, opt_minute, opt_second, opt_ms) {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getDate
+ */
+Date.prototype.getDate = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getDay
+ */
+Date.prototype.getDay = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getMonth
+ */
+Date.prototype.getMonth = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getFullYear
+ */
+Date.prototype.getFullYear = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getYear
+ */
+Date.prototype.getYear = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getHours
+ */
+Date.prototype.getHours = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getMinutes
+ */
+Date.prototype.getMinutes = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getSeconds
+ */
+Date.prototype.getSeconds = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getMilliseconds
+ */
+Date.prototype.getMilliseconds = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getTime
+ */
+Date.prototype.getTime = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getTimezoneOffset
+ */
+Date.prototype.getTimezoneOffset = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCDate
+ */
+Date.prototype.getUTCDate = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCDay
+ */
+Date.prototype.getUTCDay = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCMonth
+ */
+Date.prototype.getUTCMonth = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCFullYear
+ */
+Date.prototype.getUTCFullYear = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCHours
+ */
+Date.prototype.getUTCHours = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCMinutes
+ */
+Date.prototype.getUTCMinutes = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCSeconds
+ */
+Date.prototype.getUTCSeconds = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/getUTCMilliseconds
+ */
+Date.prototype.getUTCMilliseconds = function() {};
+
+/**
+ * Sets the day of the month for a specified date according to local time.
+ *
+ * @param {number} dayValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setDate
+ */
+Date.prototype.setDate = function(dayValue) {};
+
+/**
+ * Set the month for a specified date according to local time.
+ *
+ * @param {number} monthValue
+ * @param {number=} opt_dayValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setMonth
+ */
+Date.prototype.setMonth = function(monthValue, opt_dayValue) {};
+
+/**
+ * Sets the full year for a specified date according to local time.
+ *
+ * @param {number} yearValue
+ * @param {number=} opt_monthValue
+ * @param {number=} opt_dayValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setFullYear
+ */
+Date.prototype.setFullYear =
+    function(yearValue, opt_monthValue, opt_dayValue) {};
+
+/**
+ * Sets the year for a specified date according to local time.
+ *
+ * @param {number} yearValue
+ * @deprecated
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setYear
+ */
+Date.prototype.setYear = function(yearValue) {};
+
+/**
+ * Sets the hours for a specified date according to local time.
+ *
+ * @param {number} hoursValue
+ * @param {number=} opt_minutesValue
+ * @param {number=} opt_secondsValue
+ * @param {number=} opt_msValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setHours
+ */
+Date.prototype.setHours = function(hoursValue, opt_minutesValue,
+                                   opt_secondsValue, opt_msValue) {};
+
+/**
+ * Sets the minutes for a specified date according to local time.
+ *
+ * @param {number} minutesValue
+ * @param {number=} opt_secondsValue
+ * @param {number=} opt_msValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setMinutes
+ */
+Date.prototype.setMinutes =
+    function(minutesValue, opt_secondsValue, opt_msValue) {};
+
+/**
+ * Sets the seconds for a specified date according to local time.
+ *
+ * @param {number} secondsValue
+ * @param {number=} opt_msValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setSeconds
+ */
+Date.prototype.setSeconds = function(secondsValue, opt_msValue) {};
+
+/**
+ * Sets the milliseconds for a specified date according to local time.
+ *
+ * @param {number} millisecondsValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setMilliseconds
+ */
+Date.prototype.setMilliseconds = function(millisecondsValue) {};
+
+/**
+ * Sets the Date object to the time represented by a number of milliseconds
+ * since January 1, 1970, 00:00:00 UTC.
+ *
+ * @param {number} timeValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setTime
+ */
+Date.prototype.setTime = function(timeValue) {};
+
+/**
+ * Sets the day of the month for a specified date according to universal time.
+ *
+ * @param {number} dayValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setUTCDate
+ */
+Date.prototype.setUTCDate = function(dayValue) {};
+
+/**
+ * Sets the month for a specified date according to universal time.
+ *
+ * @param {number} monthValue
+ * @param {number=} opt_dayValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setUTCMonth
+ */
+Date.prototype.setUTCMonth = function(monthValue, opt_dayValue) {};
+
+/**
+ * Sets the full year for a specified date according to universal time.
+ *
+ * @param {number} yearValue
+ * @param {number=} opt_monthValue
+ * @param {number=} opt_dayValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setUTCFullYear
+ */
+Date.prototype.setUTCFullYear = function(yearValue, opt_monthValue,
+                                         opt_dayValue) {};
+
+/**
+ * Sets the hour for a specified date according to universal time.
+ *
+ * @param {number} hoursValue
+ * @param {number=} opt_minutesValue
+ * @param {number=} opt_secondsValue
+ * @param {number=} opt_msValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setUTCHours
+ */
+Date.prototype.setUTCHours = function(hoursValue, opt_minutesValue,
+                                      opt_secondsValue, opt_msValue) {};
+
+/**
+ * Sets the minutes for a specified date according to universal time.
+ *
+ * @param {number} minutesValue
+ * @param {number=} opt_secondsValue
+ * @param {number=} opt_msValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setUTCMinutes
+ */
+Date.prototype.setUTCMinutes = function(minutesValue, opt_secondsValue,
+                                        opt_msValue) {};
+
+
+/**
+ * Sets the seconds for a specified date according to universal time.
+ *
+ * @param {number} secondsValue
+ * @param {number=} opt_msValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setUTCSeconds
+ */
+Date.prototype.setUTCSeconds = function(secondsValue, opt_msValue) {};
+
+/**
+ * Sets the milliseconds for a specified date according to universal time.
+ *
+ * @param {number} millisecondsValue
+ * @modifies {this}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/setUTCMilliseconds
+ */
+Date.prototype.setUTCMilliseconds = function(millisecondsValue) {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toSource
+ * @override
+ */
+Date.prototype.toSource = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/toDateString
+ */
+Date.prototype.toDateString = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toGMTString
+ */
+Date.prototype.toGMTString = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toTimeString
+ */
+Date.prototype.toTimeString = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toUTCString
+ */
+Date.prototype.toUTCString = function() {};
+
+/**
+ * @param {(string|Array.<string>)=} opt_locales
+ * @param {Object=} opt_options
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toLocaleDateString
+ */
+Date.prototype.toLocaleDateString = function(opt_locales, opt_options) {};
+
+/**
+ * @param {string} formatString
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toLocaleFormat
+ */
+Date.prototype.toLocaleFormat = function(formatString) {};
+
+/**
+ * @param {string|Array.<string>=} opt_locales
+ * @param {Object=} opt_options
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toLocaleString
+ * @see http://www.ecma-international.org/ecma-402/1.0/#sec-13.3.1
+ * @override
+ */
+Date.prototype.toLocaleString = function(opt_locales, opt_options) {};
+
+/**
+ * @param {(string|Array.<string>)=} opt_locales
+ * @param {Object=} opt_options
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/toLocaleTimeString
+ */
+Date.prototype.toLocaleTimeString = function(opt_locales, opt_options) {};
+
+/**
+ * @this {Date}
+ * @return {string}
+ * @nosideeffects
+ * @override
+ */
+Date.prototype.toString = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Date/valueOf
+ */
+Date.prototype.valueOf;
+
+/**
+ * @constructor
+ * @param {*=} opt_str
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String
+ */
+function String(opt_str) {}
+// Functions:
+
+/**
+ * @param {...number} var_args
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/fromCharCode
+ */
+String.fromCharCode = function(var_args) {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/anchor
+ */
+String.prototype.anchor = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/big
+ */
+String.prototype.big = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/blink
+ */
+String.prototype.blink = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/bold
+ */
+String.prototype.bold = function() {};
+
+/**
+ * Returns the specified character from a string.
+ *
+ * @this {String|string}
+ * @param {number} index
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/charAt
+ */
+String.prototype.charAt = function(index) {};
+
+/**
+ * Returns a number indicating the Unicode value of the character at the given
+ * index.
+ *
+ * @this {String|string}
+ * @param {number=} opt_index
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/charCodeAt
+ */
+String.prototype.charCodeAt = function(opt_index) {};
+
+/**
+ * Combines the text of two or more strings and returns a new string.
+ *
+ * @this {String|string}
+ * @param {...*} var_args
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/concat
+ */
+String.prototype.concat = function(var_args) {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/fixed
+ */
+String.prototype.fixed = function() {};
+
+/**
+ * @this {String|string}
+ * @param {string} color
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/fontcolor
+ */
+String.prototype.fontcolor = function(color) {};
+
+/**
+ * @this {String|string}
+ * @param {number} size
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/fontsize
+ */
+String.prototype.fontsize = function(size) {};
+
+/**
+ * Returns the index within the calling String object of the first occurrence
+ * of the specified value, starting the search at fromIndex, returns -1 if the
+ * value is not found.
+ *
+ * @this {String|string}
+ * @param {string|null} searchValue
+ * @param {(number|null)=} opt_fromIndex
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/indexOf
+ */
+String.prototype.indexOf = function(searchValue, opt_fromIndex) {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/italics
+ */
+String.prototype.italics = function() {};
+
+/**
+ * Returns the index within the calling String object of the last occurrence of
+ * the specified value, or -1 if not found. The calling string is searched
+ * backward, starting at fromIndex.
+ *
+ * @this {String|string}
+ * @param {string|null} searchValue
+ * @param {(number|null)=} opt_fromIndex
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/lastIndexOf
+ */
+String.prototype.lastIndexOf = function(searchValue, opt_fromIndex) {};
+
+/**
+ * @this {String|string}
+ * @param {string} hrefAttribute
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/link
+ */
+String.prototype.link = function(hrefAttribute) {};
+
+/**
+ * Returns a number indicating whether a reference string comes before or after
+ * or is the same as the given string in sort order.
+ *
+ * @this {*}
+ * @param {?string} compareString
+ * @param {string|Array.<string>=} locales
+ * @param {Object=} options
+ * @return {number}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/En/Core_JavaScript_1.5_Reference/Objects/String/localeCompare
+ * @see http://www.ecma-international.org/ecma-402/1.0/#sec-13.1.1
+ */
+String.prototype.localeCompare = function(compareString, locales, options) {};
+
+/**
+ * Used to retrieve the matches when matching a string against a regular
+ * expression.
+ *
+ * @this {String|string}
+ * @param {*} regexp
+ * @return {Array.<string>} This should really return an Array with a few
+ *     special properties, but we do not have a good way to model this in
+ *     our type system. Also see Regexp.prototype.exec.
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/match
+ */
+String.prototype.match = function(regexp) {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/quote
+ */
+String.prototype.quote = function() {};
+
+/**
+ * Finds a match between a regular expression and a string, and replaces the
+ * matched substring with a new substring.
+ *
+ * This may have side-effects if the replacement function has side-effects.
+ *
+ * @this {String|string}
+ * @param {RegExp|string} regex
+ * @param {string|Function} str
+ * @param {string=} opt_flags
+ * @return {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/replace
+ */
+String.prototype.replace = function(regex, str, opt_flags) {};
+
+/**
+ * Executes the search for a match between a regular expression and this String
+ * object.
+ *
+ * @this {String|string}
+ * @param {RegExp|string} regexp
+ * @return {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/search
+ */
+String.prototype.search = function(regexp) {};
+
+/**
+ * @this {String|string}
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/slice
+ */
+String.prototype.slice = function(begin, opt_end) {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/small
+ */
+String.prototype.small = function() {};
+
+/**
+ * @this {String|string}
+ * @param {*=} opt_separator
+ * @param {number=} opt_limit
+ * @return {!Array.<string>}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/split
+ */
+String.prototype.split = function(opt_separator, opt_limit) {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/strike
+ */
+String.prototype.strike = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/sub
+ */
+String.prototype.sub = function() {};
+
+/**
+ * @this {String|string}
+ * @param {number} start
+ * @param {number=} opt_length
+ * @return {string} The specified substring.
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/substr
+ */
+String.prototype.substr = function(start, opt_length) {};
+
+/**
+ * @this {String|string}
+ * @param {number} start
+ * @param {number=} opt_end
+ * @return {string} The specified substring.
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/substring
+ */
+String.prototype.substring = function(start, opt_end) {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/sup
+ */
+String.prototype.sup = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/toLocaleUpperCase
+ */
+String.prototype.toLocaleUpperCase = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/toLocaleLowerCase
+ */
+String.prototype.toLocaleLowerCase = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/toLowerCase
+ */
+String.prototype.toLowerCase = function() {};
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/toUpperCase
+ */
+String.prototype.toUpperCase = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/toSource
+ * @override
+ */
+String.prototype.toSource = function() {};
+
+/**
+ * @this {string|String}
+ * @return {string}
+ * @nosideeffects
+ * @override
+ */
+String.prototype.toString = function() {};
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/valueOf
+ */
+String.prototype.valueOf;
+
+/**
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/String/length
+ */
+String.prototype.length;
+
+/**
+ * @constructor
+ * @param {*=} opt_pattern
+ * @param {*=} opt_flags
+ * @return {!RegExp}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+function RegExp(opt_pattern, opt_flags) {}
+
+/**
+ * @param {*} pattern
+ * @param {*=} opt_flags
+ * @return {void}
+ * @modifies {this}
+ * @deprecated
+ * @see http://msdn.microsoft.com/en-us/library/x9cswe0z(v=VS.85).aspx
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/compile
+ */
+RegExp.prototype.compile = function(pattern, opt_flags) {};
+
+/**
+ * @param {*} str The string to search.
+ * @return {Array.<string>} This should really return an Array with a few
+ *     special properties, but we do not have a good way to model this in
+ *     our type system. Also see String.prototype.match.
+ * @see http://msdn.microsoft.com/en-us/library/z908hy33(VS.85).aspx
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/exec
+ */
+RegExp.prototype.exec = function(str) {};
+
+/**
+ * @param {*} str The string to search.
+ * @return {boolean} Whether the string was matched.
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/test
+ */
+RegExp.prototype.test = function(str) {};
+
+/**
+ * @this {RegExp}
+ * @return {string}
+ * @nosideeffects
+ * @override
+ */
+RegExp.prototype.toString = function() {};
+
+// Constructor properties:
+
+/**
+ * The string against which the last regexp was matched.
+ * @type {string}
+ * @see http://www.devguru.com/Technologies/Ecmascript/Quickref/regexp_input.html
+ */
+RegExp.input;
+
+/**
+ * The last matched characters.
+ * @type {string}
+ * @see http://www.devguru.com/Technologies/Ecmascript/Quickref/regexp_lastMatch.html
+ */
+RegExp.lastMatch;
+
+/**
+ * The last matched parenthesized substring, if any.
+ * @type {string}
+ * @see http://www.devguru.com/Technologies/Ecmascript/Quickref/regexp_lastParen.html
+ */
+RegExp.lastParen;
+
+/**
+ * The substring of the input up to the characters most recently matched.
+ * @type {string}
+ * @see http://www.devguru.com/Technologies/Ecmascript/Quickref/regexp_leftContext.html
+ */
+RegExp.leftContext;
+
+/**
+ * The substring of the input after the characters most recently matched.
+ * @type {string}
+ * @see http://www.devguru.com/Technologies/Ecmascript/Quickref/regexp_rightContext.html
+ */
+RegExp.rightContext;
+
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$1;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$2;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$3;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$4;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$5;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$6;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$7;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$8;
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp
+ */
+RegExp.$9;
+
+// Prototype properties:
+
+/**
+ * Whether to test the regular expression against all possible matches
+ * in a string, or only against the first.
+ * @type {boolean}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/global
+ */
+RegExp.prototype.global;
+
+/**
+ * Whether to ignore case while attempting a match in a string.
+ * @type {boolean}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/ignoreCase
+ */
+RegExp.prototype.ignoreCase;
+
+/**
+ * The index at which to start the next match.
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/lastIndex
+ */
+RegExp.prototype.lastIndex;
+
+/**
+ * Whether or not to search in strings across multiple lines.
+ * @type {boolean}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/multiline
+ */
+RegExp.prototype.multiline;
+
+/**
+ * The text of the pattern.
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RegExp/source
+ */
+RegExp.prototype.source;
+
+
+/**
+ * @constructor
+ * @param {*=} opt_message
+ * @param {*=} opt_file
+ * @param {*=} opt_line
+ * @return {!Error}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Error
+ */
+function Error(opt_message, opt_file, opt_line) {}
+
+
+/**
+ * Chrome/v8 specific, altering the maximum depth of the stack trace
+ * (10 by default).
+ * @type {number}
+ * @see http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
+ */
+Error.stackTraceLimit;
+
+
+/**
+ * Chrome/v8 specific, adds a stack trace to the error object. The optional
+ * constructorOpt parameter allows you to pass in a function value. When
+ * collecting the stack trace all frames above the topmost call to this
+ * function, including that call, will be left out of the stack trace.
+ * @param {Object} error The object to add the stack trace to.
+ * @param {Function=} opt_constructor A function in the stack trace
+ * @see http://code.google.com/p/v8/wiki/JavaScriptStackTraceApi
+ */
+Error.captureStackTrace = function(error, opt_constructor){};
+
+
+/**
+ * IE-only.
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/2w6a45b5.aspx
+ */
+Error.prototype.description;
+
+
+/**
+ * Mozilla-only.
+ * @type {number}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Error/lineNumber
+ */
+Error.prototype.lineNumber;
+
+/**
+ * Mozilla-only
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Error/fileName
+ */
+Error.prototype.fileName;
+
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Error/name
+ */
+Error.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Error/message
+ */
+Error.prototype.message;
+
+/**
+ * Doesn't seem to exist, but closure/debug.js references it.
+ */
+Error.prototype.sourceURL;
+
+/** @type {string} */
+Error.prototype.stack;
+
+
+/**
+ * @constructor
+ * @extends {Error}
+ * @param {*=} opt_message
+ * @param {*=} opt_file
+ * @param {*=} opt_line
+ * @return {!EvalError}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/EvalError
+ */
+function EvalError(opt_message, opt_file, opt_line) {}
+
+/**
+ * @constructor
+ * @extends {Error}
+ * @param {*=} opt_message
+ * @param {*=} opt_file
+ * @param {*=} opt_line
+ * @return {!RangeError}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/RangeError
+ */
+function RangeError(opt_message, opt_file, opt_line) {}
+
+/**
+ * @constructor
+ * @extends {Error}
+ * @param {*=} opt_message
+ * @param {*=} opt_file
+ * @param {*=} opt_line
+ * @return {!ReferenceError}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/ReferenceError
+ */
+function ReferenceError(opt_message, opt_file, opt_line) {}
+
+/**
+ * @constructor
+ * @extends {Error}
+ * @param {*=} opt_message
+ * @param {*=} opt_file
+ * @param {*=} opt_line
+ * @return {!SyntaxError}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/SyntaxError
+ */
+function SyntaxError(opt_message, opt_file, opt_line) {}
+
+/**
+ * @constructor
+ * @extends {Error}
+ * @param {*=} opt_message
+ * @param {*=} opt_file
+ * @param {*=} opt_line
+ * @return {!TypeError}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/TypeError
+ */
+function TypeError(opt_message, opt_file, opt_line) {}
+
+/**
+ * @constructor
+ * @extends {Error}
+ * @param {*=} opt_message
+ * @param {*=} opt_file
+ * @param {*=} opt_line
+ * @return {!URIError}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/URIError
+ */
+function URIError(opt_message, opt_file, opt_line) {}
+
+
+// JScript extensions.
+// @see http://msdn.microsoft.com/en-us/library/894hfyb4(VS.80).aspx
+
+/**
+ * @param {string} progId
+ * @param {string=} opt_location
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/7sw4ddf8.aspx
+ */
+function ActiveXObject(progId, opt_location) {}
+
+/**
+ * @return {string}
+ * @nosideeffects
+ * @see http://msdn.microsoft.com/en-us/library/9k34bww2(VS.80).aspx
+ */
+function ScriptEngine() {}
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://msdn.microsoft.com/en-us/library/yf25ky07(VS.80).aspx
+ */
+function ScriptEngineMajorVersion() {}
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://msdn.microsoft.com/en-us/library/wx3812cz(VS.80).aspx
+ */
+function ScriptEngineMinorVersion() {}
+
+/**
+ * @return {number}
+ * @nosideeffects
+ * @see http://msdn.microsoft.com/en-us/library/e98hsk2f(VS.80).aspx
+ */
+function ScriptEngineBuildVersion() {}

--- a/sdk/tests/deqp/temp_externs/es5.js
+++ b/sdk/tests/deqp/temp_externs/es5.js
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2009 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for ECMAScript 5.
+ * @see http://www.ecma-international.org/publications/files/drafts/tc39-2009-025.pdf
+ * @externs
+ */
+
+
+/**
+ * @param {Object|undefined} selfObj Specifies the object to which |this| should
+ *     point when the function is run. If the value is null or undefined, it
+ *     will default to the global object.
+ * @param {...*} var_args Additional arguments that are partially
+ *     applied to fn.
+ * @return {!Function} A partially-applied form of the Function on which
+ *     bind() was invoked as a method.
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/bind
+ */
+Function.prototype.bind = function(selfObj, var_args) {};
+
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/String/Trim
+ */
+String.prototype.trim = function() {};
+
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/String/TrimLeft
+ */
+String.prototype.trimLeft = function() {};
+
+
+/**
+ * @this {String|string}
+ * @return {string}
+ * @nosideeffects
+ * @see http://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/String/TrimRight
+ */
+String.prototype.trimRight = function() {};
+
+
+/**
+ * A object property descriptor used by Object.create, Object.defineProperty,
+ * Object.defineProperties, Object.getOwnPropertyDescriptor.
+ *
+ * Note: not a real constructor.
+ * @constructor
+ */
+var ObjectPropertyDescriptor = function(){};
+
+/** @type {*} */
+ObjectPropertyDescriptor.prototype.value;
+
+/** @type {(function():?)||undefined} */
+ObjectPropertyDescriptor.prototype.get;
+
+/** @type {(function(?):void)||undefined} */
+ObjectPropertyDescriptor.prototype.set;
+
+/** @type {boolean|undefined} */
+ObjectPropertyDescriptor.prototype.writable;
+
+/** @type {boolean|undefined} */
+ObjectPropertyDescriptor.prototype.enumerable;
+
+/** @type {boolean|undefined} */
+ObjectPropertyDescriptor.prototype.configurable;
+
+
+/**
+ * @param {Object} proto
+ * @param {Object=} opt_properties  A map of ObjectPropertyDescriptors.
+ * @return {!Object}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/create
+ */
+Object.create = function(proto, opt_properties) {};
+
+
+/**
+ * @param {!Object} obj
+ * @param {string} prop
+ * @param {!Object} descriptor A ObjectPropertyDescriptor.
+ * @return {!Object}
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineProperty
+ */
+Object.defineProperty = function(obj, prop, descriptor) {};
+
+
+/**
+ * @param {!Object} obj
+ * @param {!Object} props A map of ObjectPropertyDescriptors.
+ * @return {!Object}
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/defineProperties
+ */
+Object.defineProperties = function(obj, props) {};
+
+
+/**
+ * @param {!Object} obj
+ * @param {string} prop
+ * @return {!ObjectPropertyDescriptor|undefined}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
+ */
+Object.getOwnPropertyDescriptor = function(obj, prop) {};
+
+
+/**
+ * @param {!Object} obj
+ * @return {!Array.<string>}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/keys
+ */
+Object.keys = function(obj) {};
+
+
+/**
+ * @param {!Object} obj
+ * @return {!Array.<string>}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames
+ */
+Object.getOwnPropertyNames = function(obj) {};
+
+
+/**
+ * @param {!Object} obj
+ * @return {Object}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/GetPrototypeOf
+ */
+Object.getPrototypeOf = function(obj) {};
+
+
+/**
+ * @param {T} obj
+ * @return {T}
+ * @template T
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/preventExtensions
+ */
+Object.preventExtensions = function(obj) {};
+
+
+/**
+ * @param {T} obj
+ * @return {T}
+ * @template T
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/seal
+ */
+Object.seal = function(obj) {};
+
+
+/**
+ * @param {T} obj
+ * @return {T}
+ * @template T
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/freeze
+ */
+Object.freeze = function(obj) {};
+
+
+/**
+ * @param {!Object} obj
+ * @return {boolean}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/isExtensible
+ */
+Object.isExtensible = function(obj) {};
+
+
+/**
+ * @param {!Object} obj
+ * @return {boolean}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/isSealed
+ */
+Object.isSealed = function(obj) {};
+
+
+/**
+ * @param {!Object} obj
+ * @return {boolean}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Object/isFrozen
+ */
+Object.isFrozen = function(obj) {};
+
+
+/**
+ * As per ECMAScript 5, 15.12.3.
+ * @param {string=} opt_key The JSON key for this object.
+ * @return {*} The serializable representation of this object. Note that this
+ *     need not be a string. See http://goo.gl/PEUvs.
+ */
+Object.prototype.toJSON = function(opt_key) {};
+
+
+/**
+ * @see https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/toISOString
+ * @return {string}
+ */
+Date.prototype.toISOString = function() {};
+
+
+/**
+ * @param {*=} opt_ignoredKey
+ * @return {string}
+ * @override
+ */
+Date.prototype.toJSON = function(opt_ignoredKey) {};
+
+
+/**
+ * A fake type to model the JSON object.
+ * @constructor
+ */
+var JSONType = function() {};
+
+
+/**
+ * @param {string} jsonStr The string to parse.
+ * @param {(function(string, *) : *)=} opt_reviver
+ * @return {*} The JSON object.
+ * @throws {Error}
+ * @nosideeffects
+ */
+JSONType.prototype.parse = function(jsonStr, opt_reviver) {};
+
+
+/**
+ * @param {*} jsonObj Input object.
+ * @param {(Array.<string>|(function(string, *) : *)|null)=} opt_replacer
+ * @param {(number|string)=} opt_space
+ * @return {string} JSON string which represents jsonObj.
+ * @throws {Error}
+ * @nosideeffects
+ */
+JSONType.prototype.stringify = function(jsonObj, opt_replacer, opt_space) {};
+
+
+/**
+ * @type {!JSONType}
+ * @suppress {duplicate}
+ */
+var JSON;

--- a/sdk/tests/deqp/temp_externs/es6.js
+++ b/sdk/tests/deqp/temp_externs/es6.js
@@ -1,0 +1,856 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for ECMAScript 6.
+ * @see http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts
+ * @see https://www.khronos.org/registry/typedarray/specs/latest/
+ * @externs
+ */
+
+// TODO(johnlenz): symbol should be a primitive type.
+/** @typedef {?} */
+var symbol;
+
+/**
+ * @param {string} description
+ * @return {symbol}
+ */
+function Symbol(description) {}
+
+/** @const {symbol} */
+Symbol.iterator;
+
+
+/**
+ * @interface
+ * @template VALUE
+ */
+function Iterable() {}
+
+// TODO(johnlenz): remove this when the compiler understands "symbol" natively
+/**
+ * @return {Iterator.<VALUE>}
+ * @suppress {externsValidation}
+ */
+Iterable.prototype[Symbol.iterator] = function() {};
+
+
+
+// TODO(johnlenz): Iterator should be a templated record type.
+/**
+ * @interface
+ * @template VALUE
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol
+ */
+function Iterator() {}
+
+/**
+ * @param {VALUE=} value
+ * @return {{value:VALUE, done:boolean}}
+ */
+Iterator.prototype.next;
+
+
+/**
+ * @constructor
+ * @see http://people.mozilla.org/~jorendorff/es6-draft.html#sec-generator-objects
+ * @implements {Iterator<VALUE>}
+ * @template VALUE
+ */
+var Generator = function() {};
+
+/**
+ * @param {?=} opt_value
+ * @return {{value:VALUE, done:boolean}}
+ * @override
+ */
+Generator.prototype.next = function(opt_value) {};
+
+/**
+ * @param {VALUE} value
+ * @return {{value:VALUE, done:boolean}}
+ */
+Generator.prototype.return = function(value) {};
+
+/**
+ * @param {?} exception
+ * @return {{value:VALUE, done:boolean}}
+ */
+Generator.prototype.throw = function(exception) {};
+
+
+// TODO(johnlenz): Array should be Iterable.
+
+
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.log10 = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.log2 = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.log1p = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.expm1 = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.cosh = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.sinh = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.tanh = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.acosh = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.asinh = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.atanh = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.trunc = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.sign = function(value) {};
+
+/**
+ * @param {number} value
+ * @return {number}
+ * @nosideeffects
+ */
+Math.cbrt = function(value) {};
+
+/**
+ * @param {number} value1
+ * @param {...number} var_args
+ * @return {number}
+ * @nosideeffects
+ * @see http://people.mozilla.org/~jorendorff/es6-draft.html#sec-math.hypot
+ */
+Math.hypot = function(value1, var_args) {};
+
+
+/**
+ * @param {*} a
+ * @param {*} b
+ * @return {boolean}
+ * @see http://people.mozilla.org/~jorendorff/es6-draft.html#sec-object.is
+ */
+Object.is;
+
+
+/**
+ * Returns a language-sensitive string representation of this number.
+ * @param {(string|!Array<string>)=} opt_locales
+ * @param {Object=} opt_options
+ * @return {string}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
+ * @see http://www.ecma-international.org/ecma-402/1.0/#sec-13.2.1
+ * @override
+ */
+Number.prototype.toLocaleString = function(opt_locales, opt_options) {};
+
+
+/**
+ * @see http://dev.w3.org/html5/postmsg/
+ * @interface
+ */
+function Transferable() {}
+
+/**
+ * @param {number} length The length in bytes
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @nosideeffects
+ * @implements {Transferable}
+ */
+function ArrayBuffer(length) {}
+
+/** @type {number} */
+ArrayBuffer.prototype.byteLength;
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!ArrayBuffer}
+ * @nosideeffects
+ */
+ArrayBuffer.prototype.slice = function(begin, opt_end) {};
+
+
+/**
+ * @constructor
+ * @noalias
+ */
+function ArrayBufferView() {}
+
+/** @type {!ArrayBuffer} */
+ArrayBufferView.prototype.buffer;
+
+/** @type {number} */
+ArrayBufferView.prototype.byteOffset;
+
+/** @type {number} */
+ArrayBufferView.prototype.byteLength;
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments} If the user passes a backing array, then indexed
+ *     accesses will modify the backing array. JSCompiler does not model
+ *     this well. In other words, if you have:
+ *     <code>
+ *     var x = new ArrayBuffer(1);
+ *     var y = new Int8Array(x);
+ *     y[0] = 2;
+ *     </code>
+ *     JSCompiler will not recognize that the last assignment modifies x.
+ *     We workaround this by marking all these arrays as @modifies {arguments},
+ *     to introduce the possibility that x aliases y.
+ */
+function Int8Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Int8Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Int8Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Int8Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Int8Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Int8Array}
+ * @nosideeffects
+ */
+Int8Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Uint8Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Uint8Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint8Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint8Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Uint8Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Uint8Array}
+ * @nosideeffects
+ */
+Uint8Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Uint8ClampedArray(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Uint8ClampedArray.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint8ClampedArray.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint8ClampedArray.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Uint8ClampedArray.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Uint8ClampedArray}
+ * @nosideeffects
+ */
+Uint8ClampedArray.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @typedef {Uint8ClampedArray}
+ * @deprecated CanvasPixelArray has been replaced by Uint8ClampedArray
+ *     in the latest spec.
+ * @see http://www.w3.org/TR/2dcontext/#imagedata
+ */
+var CanvasPixelArray;
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Int16Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Int16Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Int16Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Int16Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Int16Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Int16Array}
+ * @nosideeffects
+ */
+Int16Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Uint16Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Uint16Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint16Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint16Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Uint16Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Uint16Array}
+ * @nosideeffects
+ */
+Uint16Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Int32Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Int32Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Int32Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Int32Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Int32Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Int32Array}
+ * @nosideeffects
+ */
+Int32Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Uint32Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Uint32Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint32Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Uint32Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Uint32Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Uint32Array}
+ * @nosideeffects
+ */
+Uint32Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Float32Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Float32Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Float32Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Float32Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Float32Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Float32Array}
+ * @nosideeffects
+ */
+Float32Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {number|ArrayBufferView|Array.<number>|ArrayBuffer} length or array
+ *     or buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_length
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @modifies {arguments}
+ */
+function Float64Array(length, opt_byteOffset, opt_length) {}
+
+/** @type {number} */
+Float64Array.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Float64Array.prototype.BYTES_PER_ELEMENT;
+
+/** @type {number} */
+Float64Array.prototype.length;
+
+/**
+ * @param {ArrayBufferView|Array.<number>} array
+ * @param {number=} opt_offset
+ */
+Float64Array.prototype.set = function(array, opt_offset) {};
+
+/**
+ * @param {number} begin
+ * @param {number=} opt_end
+ * @return {!Float64Array}
+ * @nosideeffects
+ */
+Float64Array.prototype.subarray = function(begin, opt_end) {};
+
+
+/**
+ * @param {ArrayBuffer} buffer
+ * @param {number=} opt_byteOffset
+ * @param {number=} opt_byteLength
+ * @extends {ArrayBufferView}
+ * @constructor
+ * @noalias
+ * @throws {Error}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays/DataView
+ */
+function DataView(buffer, opt_byteOffset, opt_byteLength) {}
+
+/**
+ * @param {number} byteOffset
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getInt8 = function(byteOffset) {};
+
+/**
+ * @param {number} byteOffset
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getUint8 = function(byteOffset) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {boolean=} opt_littleEndian
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getInt16 = function(byteOffset, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {boolean=} opt_littleEndian
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getUint16 = function(byteOffset, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {boolean=} opt_littleEndian
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getInt32 = function(byteOffset, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {boolean=} opt_littleEndian
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getUint32 = function(byteOffset, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {boolean=} opt_littleEndian
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getFloat32 = function(byteOffset, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {boolean=} opt_littleEndian
+ * @return {number}
+ * @throws {Error}
+ * @nosideeffects
+ */
+DataView.prototype.getFloat64 = function(byteOffset, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @throws {Error}
+ */
+DataView.prototype.setInt8 = function(byteOffset, value) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @throws {Error}
+ */
+DataView.prototype.setUint8 = function(byteOffset, value) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @param {boolean=} opt_littleEndian
+ * @throws {Error}
+ */
+DataView.prototype.setInt16 = function(byteOffset, value, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @param {boolean=} opt_littleEndian
+ * @throws {Error}
+ */
+DataView.prototype.setUint16 = function(byteOffset, value, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @param {boolean=} opt_littleEndian
+ * @throws {Error}
+ */
+DataView.prototype.setInt32 = function(byteOffset, value, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @param {boolean=} opt_littleEndian
+ * @throws {Error}
+ */
+DataView.prototype.setUint32 = function(byteOffset, value, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @param {boolean=} opt_littleEndian
+ * @throws {Error}
+ */
+DataView.prototype.setFloat32 = function(
+    byteOffset, value, opt_littleEndian) {};
+
+/**
+ * @param {number} byteOffset
+ * @param {number} value
+ * @param {boolean=} opt_littleEndian
+ * @throws {Error}
+ */
+DataView.prototype.setFloat64 = function(
+    byteOffset, value, opt_littleEndian) {};
+
+
+/**
+ * @see https://github.com/promises-aplus/promises-spec
+ * @typedef {{then: !Function}}
+ */
+var Thenable;
+
+
+/**
+ * This is not an official DOM interface. It is used to add generic typing
+ * and respective type inference where available.
+ * {@see goog.Thenable} inherits from this making all promises
+ * interoperate.
+ * @interface
+ * @template TYPE
+ */
+var IThenable = function() {};
+
+
+/**
+ * @param {?(function(TYPE):
+ *             (RESULT|IThenable.<RESULT>|Thenable))=} opt_onFulfilled
+ * @param {?(function(*): *)=} opt_onRejected
+ * @return {!IThenable.<RESULT>}
+ * @template RESULT
+ */
+IThenable.prototype.then = function(opt_onFulfilled, opt_onRejected) {};
+
+
+/**
+ * @see https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects
+ * @param {function(
+ *             function((TYPE|IThenable.<TYPE>|Thenable|null)=),
+ *             function(*=))} resolver
+ * @constructor
+ * @implements {IThenable.<TYPE>}
+ * @template TYPE
+ */
+var Promise = function(resolver) {};
+
+
+/**
+ * @param {(TYPE|IThenable.<TYPE>)=} opt_value
+ * @return {!Promise.<TYPE>}
+ * @template TYPE
+ */
+Promise.resolve = function(opt_value) {};
+
+
+/**
+ * @param {*=} opt_error
+ * @return {!Promise.<?>}
+ */
+Promise.reject = function(opt_error) {};
+
+
+/**
+ * @template T
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+ * @param {!Array<T|!Promise<T>>} iterable
+ * @return {!Promise<!Array<T>>}
+ */
+Promise.all = function(iterable) {};
+
+
+/**
+ * @template T
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+ * @param {!Array.<T>} iterable
+ * @return {!Promise.<T>}
+ */
+Promise.race = function(iterable) {};
+
+
+/**
+ * @param {?(function(TYPE):
+ *             (RESULT|IThenable.<RESULT>|Thenable))=} opt_onFulfilled
+ * @param {?(function(*): *)=} opt_onRejected
+ * @return {!Promise.<RESULT>}
+ * @template RESULT
+ * @override
+ */
+Promise.prototype.then = function(opt_onFulfilled, opt_onRejected) {};
+
+
+/**
+ * @param {function(*): RESULT} onRejected
+ * @return {!Promise.<RESULT>}
+ * @template RESULT
+ */
+Promise.prototype.catch = function(onRejected) {};

--- a/sdk/tests/deqp/temp_externs/es6_collections.js
+++ b/sdk/tests/deqp/temp_externs/es6_collections.js
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2014 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for ECMAScript 6.
+ * @see http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts
+ * @externs
+ */
+
+// TODO(johnlenz): Use Tuples for the Map and Set iterators where appropriate.
+
+/**
+ * @constructor
+ * @param {Iterable.<!Array.<KEY|VALUE>>|!Array.<!Array.<KEY|VALUE>>=} opt_iterable
+ * @implements {Iterable.<!Array.<KEY|VALUE>>}
+ * @template KEY, VALUE
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+ */
+function Map(opt_iterable) {}
+
+/** @return {void} */
+Map.prototype.clear;
+
+/**
+ * @param {KEY} key
+ * @return {boolean}
+ */
+Map.prototype.delete;
+
+/**
+ * @return {!Iterator.<!Array.<KEY|VALUE>>}
+ * @nosideeffects
+ */
+Map.prototype.entries;
+
+/**
+ * @param {function(this:THIS, VALUE, KEY, MAP):void} callback
+ * @param {THIS} thisArg
+ * @this {MAP}
+ * @template MAP,THIS
+ */
+Map.prototype.forEach;
+
+/**
+ * @param {KEY} key
+ * @return {VALUE|undefined}
+ * @nosideeffects
+ */
+Map.prototype.get;
+
+/**
+ * @param {KEY} key
+ * @return {boolean}
+ * @nosideeffects
+ */
+Map.prototype.has;
+
+/**
+ * @return {!Iterator.<KEY>}
+ */
+Map.prototype.keys;
+
+/**
+ * @param {KEY} key
+ * @param {VALUE} value
+ * @return {THIS}
+ * @this {THIS}
+ * @template THIS
+ */
+Map.prototype.set;
+
+/**
+ * @type {number}
+ * (readonly)
+ */
+Map.prototype.size;
+
+/**
+ * @return {!Iterator.<VALUE>}
+ * @nosideeffects
+ */
+Map.prototype.values;
+
+/**
+ * @return {!Iterator.<!Array.<KEY|VALUE>>}
+ */
+Map.prototype[Symbol.iterator] = function() {};
+
+
+/**
+ * @constructor
+ * @param {Iterable.<!Array.<KEY|VALUE>>|!Array.<!Array.<KEY|VALUE>>=} opt_iterable
+ * @template KEY, VALUE
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
+ */
+function WeakMap(opt_iterable) {}
+
+/** @return {void} */
+WeakMap.prototype.clear;
+
+/**
+ * @param {KEY} key
+ * @return {boolean}
+ */
+WeakMap.prototype.delete;
+
+/**
+ * @param {KEY} key
+ * @return {VALUE|undefined}
+ * @nosideeffects
+ */
+WeakMap.prototype.get;
+
+/**
+ * @param {KEY} key
+ * @return {boolean}
+ * @nosideeffects
+ */
+WeakMap.prototype.has;
+
+/**
+ * @param {KEY} key
+ * @param {VALUE} value
+ * @return {THIS}
+ * @this {THIS}
+ * @template THIS
+ */
+WeakMap.prototype.set;
+
+
+
+/**
+ * @constructor
+ * @param {Iterable.<VALUE>|Array.<VALUE>=} opt_iterable
+ * @implements {Iterable.<VALUE>}
+ * @template VALUE
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+ */
+function Set(opt_iterable) {}
+
+/**
+ * @param {VALUE} value
+ * @return {THIS}
+ * @this {THIS}
+ * @template THIS
+ */
+Set.prototype.add;
+
+/**
+ * @return {void}
+ */
+Set.prototype.clear;
+
+/**
+ * @param {VALUE} value
+ * @return {boolean}
+ */
+Set.prototype.delete;
+
+/**
+ * @return {!Iterator.<!Array.<VALUE>>} Where each array has two entries:
+ *     [value, value]
+ * @nosideeffects
+ */
+Set.prototype.entries;
+
+/**
+ * @param {function(VALUE, VALUE, SET)} callback
+ * @param {THIS} thisArg
+ * @this {SET}
+ * @template SET,THIS
+ */
+Set.prototype.forEach;
+
+/**
+ * @param {VALUE} value
+ * @return {boolean}
+ * @nosideeffects
+ */
+Set.prototype.has;
+
+/**
+ * @type {number} (readonly)
+ */
+Set.prototype.size;
+
+/**
+ * @return {!Iterator.<VALUE>}
+ * @nosideeffects
+ */
+Set.prototype.keys;
+
+/**
+ * @return {!Iterator.<VALUE>}
+ * @nosideeffects
+ */
+Set.prototype.values;
+
+/**
+ * @return {!Iterator.<VALUE>}
+ */
+Set.prototype[Symbol.iterator] = function() {};
+
+
+
+/**
+ * @constructor
+ * @param {Iterable.<VALUE>|Array.<VALUE>=} opt_iterable
+ * @template VALUE
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+ */
+function WeakSet(opt_iterable) {}
+
+/**
+ * @param {VALUE} value
+ * @return {THIS}
+ * @this {THIS}
+ * @template THIS
+ */
+WeakSet.prototype.add;
+
+/**
+ * @return {void}
+ */
+WeakSet.prototype.clear;
+
+/**
+ * @param {VALUE} value
+ * @return {boolean}
+ */
+WeakSet.prototype.delete;
+
+/**
+ * @param {VALUE} value
+ * @return {boolean}
+ * @nosideeffects
+ */
+WeakSet.prototype.has;
+
+

--- a/sdk/tests/deqp/temp_externs/fileapi.js
+++ b/sdk/tests/deqp/temp_externs/fileapi.js
@@ -1,0 +1,961 @@
+/*
+ * Copyright 2010 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for objects in the File API, File Writer API, and
+ * File System API. Details of the API are at:
+ * http://www.w3.org/TR/FileAPI/
+ * http://www.w3.org/TR/file-writer-api/
+ * http://www.w3.org/TR/file-system-api/
+ *
+ * @externs
+ * @author dbk@google.com (David Barrett-Kahn)
+ */
+
+
+/**
+ * @see http://dev.w3.org/2006/webapi/FileAPI/#dfn-Blob
+ * @param {Array.<ArrayBufferView|Blob|string>=} opt_blobParts
+ * @param {Object=} opt_options
+ * @constructor
+ * @nosideeffects
+ */
+function Blob(opt_blobParts, opt_options) {}
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-size
+ * @type {number}
+ */
+Blob.prototype.size;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-type
+ * @type {string}
+ */
+Blob.prototype.type;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-slice
+ * @param {number} start
+ * @param {number} length
+ * @return {!Blob}
+ * @nosideeffects
+ */
+Blob.prototype.slice = function(start, length) {};
+
+/**
+ * This replaces Blob.slice in Chrome since WebKit revision 84005.
+ * @see http://lists.w3.org/Archives/Public/public-webapps/2011AprJun/0222.html
+ * @param {number} start
+ * @param {number} end
+ * @return {!Blob}
+ * @nosideeffects
+ */
+Blob.prototype.webkitSlice = function(start, end) {};
+
+/**
+ * This replaces Blob.slice in Firefox.
+ * @see http://lists.w3.org/Archives/Public/public-webapps/2011AprJun/0222.html
+ * @param {number} start
+ * @param {number} end
+ * @return {!Blob}
+ * @nosideeffects
+ */
+Blob.prototype.mozSlice = function(start, end) {};
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#the-blobbuilder-interface
+ * @constructor
+ */
+function BlobBuilder() {}
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-append0
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-append1
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-append2
+ * @param {string|Blob|ArrayBuffer} data
+ * @param {string=} endings
+ */
+BlobBuilder.prototype.append = function(data, endings) {};
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-getBlob
+ * @param {string=} contentType
+ * @return {!Blob}
+ */
+BlobBuilder.prototype.getBlob = function(contentType) {};
+
+/**
+ * This has replaced BlobBuilder in Chrome since WebKit revision 84008.
+ * @see http://lists.w3.org/Archives/Public/public-webapps/2011AprJun/0222.html
+ * @constructor
+ */
+function WebKitBlobBuilder() {}
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-append0
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-append1
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-append2
+ * @param {string|Blob|ArrayBuffer} data
+ * @param {string=} endings
+ */
+WebKitBlobBuilder.prototype.append = function(data, endings) {};
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-BlobBuilder-getBlob
+ * @param {string=} contentType
+ * @return {!Blob}
+ */
+WebKitBlobBuilder.prototype.getBlob = function(contentType) {};
+
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#the-directoryentry-interface
+ * @constructor
+ * @extends {Entry}
+ */
+function DirectoryEntry() {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-DirectoryEntry-createReader
+ * @return {!DirectoryReader}
+ */
+DirectoryEntry.prototype.createReader = function() {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-DirectoryEntry-getFile
+ * @param {string} path
+ * @param {Object=} options
+ * @param {function(!FileEntry)=} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+DirectoryEntry.prototype.getFile = function(path, options, successCallback,
+    errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-DirectoryEntry-getDirectory
+ * @param {string} path
+ * @param {Object=} options
+ * @param {function(!DirectoryEntry)=} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+DirectoryEntry.prototype.getDirectory = function(path, options, successCallback,
+    errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-DirectoryEntry-removeRecursively
+ * @param {function()} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+DirectoryEntry.prototype.removeRecursively = function(successCallback,
+    errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#the-directoryreader-interface
+ * @constructor
+ */
+function DirectoryReader() {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-DirectoryReader-readEntries
+ * @param {function(!Array.<!Entry>)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+DirectoryReader.prototype.readEntries = function(successCallback,
+    errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#the-entry-interface
+ * @constructor
+ */
+function Entry() {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-isFile
+ * @type {boolean}
+ */
+Entry.prototype.isFile;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-isDirectory
+ * @type {boolean}
+ */
+Entry.prototype.isDirectory;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-name
+ * @type {string}
+ */
+Entry.prototype.name;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-fullPath
+ * @type {string}
+ */
+Entry.prototype.fullPath;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-filesystem
+ * @type {!FileSystem}
+ */
+Entry.prototype.filesystem;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-moveTo
+ * @param {!DirectoryEntry} parent
+ * @param {string=} newName
+ * @param {function(!Entry)=} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Entry.prototype.moveTo = function(parent, newName, successCallback,
+    errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-copyTo
+ * @param {!DirectoryEntry} parent
+ * @param {string=} newName
+ * @param {function(!Entry)=} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Entry.prototype.copyTo = function(parent, newName, successCallback,
+    errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-toURL
+ * @param {string=} mimeType
+ * @return {string}
+ */
+Entry.prototype.toURL = function(mimeType) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-remove
+ * @param {function()} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Entry.prototype.remove = function(successCallback, errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-getMetadata
+ * @param {function(!Metadata)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Entry.prototype.getMetadata = function(successCallback, errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Entry-getParent
+ * @param {function(!Entry)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Entry.prototype.getParent = function(successCallback, errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-file
+ * @constructor
+ * @extends {Blob}
+ */
+function File() {}
+
+/**
+ * Chrome uses this instead of name.
+ * @deprecated Use name instead.
+ * @type {string}
+ */
+File.prototype.fileName;
+
+/**
+ * Chrome uses this instead of size.
+ * @deprecated Use size instead.
+ * @type {string}
+ */
+File.prototype.fileSize;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-name
+ * @type {string}
+ */
+File.prototype.name;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-lastModifiedDate
+ * @type {Date}
+ */
+File.prototype.lastModifiedDate;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#the-fileentry-interface
+ * @constructor
+ * @extends {Entry}
+ */
+function FileEntry() {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileEntry-createWriter
+ * @param {function(!FileWriter)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+FileEntry.prototype.createWriter = function(successCallback, errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileEntry-file
+ * @param {function(!File)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+FileEntry.prototype.file = function(successCallback, errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#FileErrorInterface
+ * @constructor
+ * @extends {DOMError}
+ */
+function FileError() {}
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-NOT_FOUND_ERR
+ * @type {number}
+ */
+FileError.prototype.NOT_FOUND_ERR = 1;
+
+/** @type {number} */
+FileError.NOT_FOUND_ERR = 1;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-SECURITY_ERR
+ * @type {number}
+ */
+FileError.prototype.SECURITY_ERR = 2;
+
+/** @type {number} */
+FileError.SECURITY_ERR = 2;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-ABORT_ERR
+ * @type {number}
+ */
+FileError.prototype.ABORT_ERR = 3;
+
+/** @type {number} */
+FileError.ABORT_ERR = 3;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-NOT_READABLE_ERR
+ * @type {number}
+ */
+FileError.prototype.NOT_READABLE_ERR = 4;
+
+/** @type {number} */
+FileError.NOT_READABLE_ERR = 4;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-ENCODING_ERR
+ * @type {number}
+ */
+FileError.prototype.ENCODING_ERR = 5;
+
+/** @type {number} */
+FileError.ENCODING_ERR = 5;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileError-NO_MODIFICATION_ALLOWED_ERR
+ * @type {number}
+ */
+FileError.prototype.NO_MODIFICATION_ALLOWED_ERR = 6;
+
+/** @type {number} */
+FileError.NO_MODIFICATION_ALLOWED_ERR = 6;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileException-INVALID_STATE_ERR
+ * @type {number}
+ */
+FileError.prototype.INVALID_STATE_ERR = 7;
+
+/** @type {number} */
+FileError.INVALID_STATE_ERR = 7;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileException-SYNTAX_ERR
+ * @type {number}
+ */
+FileError.prototype.SYNTAX_ERR = 8;
+
+/** @type {number} */
+FileError.SYNTAX_ERR = 8;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileError-INVALID_MODIFICATION_ERR
+ * @type {number}
+ */
+FileError.prototype.INVALID_MODIFICATION_ERR = 9;
+
+/** @type {number} */
+FileError.INVALID_MODIFICATION_ERR = 9;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileError-QUOTA_EXCEEDED_ERR
+ * @type {number}
+ */
+FileError.prototype.QUOTA_EXCEEDED_ERR = 10;
+
+/** @type {number} */
+FileError.QUOTA_EXCEEDED_ERR = 10;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileException-TYPE_MISMATCH_ERR
+ * @type {number}
+ */
+FileError.prototype.TYPE_MISMATCH_ERR = 11;
+
+/** @type {number} */
+FileError.TYPE_MISMATCH_ERR = 11;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileException-PATH_EXISTS_ERR
+ * @type {number}
+ */
+FileError.prototype.PATH_EXISTS_ERR = 12;
+
+/** @type {number} */
+FileError.PATH_EXISTS_ERR = 12;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-code-exception
+ * @type {number}
+ * @deprecated Use the 'name' or 'message' attributes of DOMError rather than
+ * 'code'
+ */
+FileError.prototype.code;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-filereader
+ * @constructor
+ * @implements {EventTarget}
+ */
+function FileReader() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+FileReader.prototype.addEventListener = function(type, listener, opt_useCapture)
+    {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+FileReader.prototype.removeEventListener = function(type, listener,
+    opt_useCapture) {};
+
+/** @override */
+FileReader.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-readAsArrayBuffer
+ * @param {!Blob} blob
+ */
+FileReader.prototype.readAsArrayBuffer = function(blob) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-readAsBinaryStringAsync
+ * @param {!Blob} blob
+ */
+FileReader.prototype.readAsBinaryString = function(blob) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-readAsText
+ * @param {!Blob} blob
+ * @param {string=} encoding
+ */
+FileReader.prototype.readAsText = function(blob, encoding) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-readAsDataURL
+ * @param {!Blob} blob
+ */
+FileReader.prototype.readAsDataURL = function(blob) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-abort
+ */
+FileReader.prototype.abort = function() {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-empty
+ * @type {number}
+ */
+FileReader.prototype.EMPTY = 0;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-loading
+ * @type {number}
+ */
+FileReader.prototype.LOADING = 1;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-done
+ * @type {number}
+ */
+FileReader.prototype.DONE = 2;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-readystate
+ * @type {number}
+ */
+FileReader.prototype.readyState;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-result
+ * @type {string|Blob|ArrayBuffer}
+ */
+FileReader.prototype.result;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-error
+ * @type {FileError}
+ */
+FileReader.prototype.error;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-onloadstart
+ * @type {?function(!ProgressEvent)}
+ */
+FileReader.prototype.onloadstart;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-onprogress
+ * @type {?function(!ProgressEvent)}
+ */
+FileReader.prototype.onprogress;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-onload
+ * @type {?function(!ProgressEvent)}
+ */
+FileReader.prototype.onload;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-onabort
+ * @type {?function(!ProgressEvent)}
+ */
+FileReader.prototype.onabort;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-onerror
+ * @type {?function(!ProgressEvent)}
+ */
+FileReader.prototype.onerror;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-onloadend
+ * @type {?function(!ProgressEvent)}
+ */
+FileReader.prototype.onloadend;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#idl-def-FileSaver
+ * @constructor
+ */
+function FileSaver() {};
+
+/** @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-abort */
+FileSaver.prototype.abort = function() {};
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-INIT
+ * @type {number}
+ */
+FileSaver.prototype.INIT = 0;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-WRITING
+ * @type {number}
+ */
+FileSaver.prototype.WRITING = 1;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-DONE
+ * @type {number}
+ */
+FileSaver.prototype.DONE = 2;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-readyState
+ * @type {number}
+ */
+FileSaver.prototype.readyState;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-error
+ * @type {FileError}
+ */
+FileSaver.prototype.error;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-onwritestart
+ * @type {?function(!ProgressEvent)}
+ */
+FileSaver.prototype.onwritestart;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-onprogress
+ * @type {?function(!ProgressEvent)}
+ */
+FileSaver.prototype.onprogress;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-onwrite
+ * @type {?function(!ProgressEvent)}
+ */
+FileSaver.prototype.onwrite;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-onabort
+ * @type {?function(!ProgressEvent)}
+ */
+FileSaver.prototype.onabort;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-onerror
+ * @type {?function(!ProgressEvent)}
+ */
+FileSaver.prototype.onerror;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileSaver-onwriteend
+ * @type {?function(!ProgressEvent)}
+ */
+FileSaver.prototype.onwriteend;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#the-filesystem-interface
+ * @constructor
+ */
+function FileSystem() {}
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileSystem-name
+ * @type {string}
+ */
+FileSystem.prototype.name;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-FileSystem-root
+ * @type {!DirectoryEntry}
+ */
+FileSystem.prototype.root;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#idl-def-FileWriter
+ * @constructor
+ * @extends {FileSaver}
+ */
+function FileWriter() {}
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileWriter-position
+ * @type {number}
+ */
+FileWriter.prototype.position;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileWriter-length
+ * @type {number}
+ */
+FileWriter.prototype.length;
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileWriter-write
+ * @param {!Blob} blob
+ */
+FileWriter.prototype.write = function(blob) {};
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileWriter-seek
+ * @param {number} offset
+ */
+FileWriter.prototype.seek = function(offset) {};
+
+/**
+ * @see http://www.w3.org/TR/file-writer-api/#widl-FileWriter-truncate
+ * @param {number} size
+ */
+FileWriter.prototype.truncate = function(size) {};
+
+/**
+ * LocalFileSystem interface, implemented by Window and WorkerGlobalScope.
+ * @see http://www.w3.org/TR/file-system-api/#idl-def-LocalFileSystem
+ * @constructor
+ */
+function LocalFileSystem() {}
+
+/**
+ * Metadata interface.
+ * @see http://www.w3.org/TR/file-system-api/#idl-def-Metadata
+ * @constructor
+ */
+function Metadata() {}
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Metadata-modificationTime
+ * @type {!Date}
+ */
+Metadata.prototype.modificationTime;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-Metadata-size
+ * @type {number}
+ */
+Metadata.prototype.size;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-TEMPORARY
+ * @type {number}
+*/
+Window.prototype.TEMPORARY = 0;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-PERSISTENT
+ * @type {number}
+*/
+Window.prototype.PERSISTENT = 1;
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-requestFileSystem
+ * @param {number} type
+ * @param {number} size
+ * @param {function(!FileSystem)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+function requestFileSystem(type, size, successCallback, errorCallback) {}
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-requestFileSystem
+ * @param {number} type
+ * @param {number} size
+ * @param {function(!FileSystem)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Window.prototype.requestFileSystem = function(type, size, successCallback,
+    errorCallback) {};
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-resolveLocalFileSystemURI
+ * @param {string} uri
+ * @param {function(!Entry)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+function resolveLocalFileSystemURI(uri, successCallback, errorCallback) {}
+
+/**
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-resolveLocalFileSystemURI
+ * @param {string} uri
+ * @param {function(!Entry)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Window.prototype.resolveLocalFileSystemURI = function(uri, successCallback,
+    errorCallback) {}
+
+/**
+ * This has replaced requestFileSystem in Chrome since WebKit revision 84224.
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-requestFileSystem
+ * @param {number} type
+ * @param {number} size
+ * @param {function(!FileSystem)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+function webkitRequestFileSystem(type, size, successCallback, errorCallback) {}
+
+/**
+ * This has replaced requestFileSystem in Chrome since WebKit revision 84224.
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-requestFileSystem
+ * @param {number} type
+ * @param {number} size
+ * @param {function(!FileSystem)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Window.prototype.webkitRequestFileSystem = function(type, size, successCallback,
+    errorCallback) {};
+
+/**
+ * This has replaced resolveLocalFileSystemURI in Chrome since WebKit revision
+ * 84224.
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-resolveLocalFileSystemURI
+ * @param {string} uri
+ * @param {function(!Entry)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+function webkitResolveLocalFileSystemURI(uri, successCallback, errorCallback) {}
+
+/**
+ * This has replaced resolveLocalFileSystemURI in Chrome since WebKit revision
+ * 84224.
+ * @see http://www.w3.org/TR/file-system-api/#widl-LocalFileSystem-resolveLocalFileSystemURI
+ * @param {string} uri
+ * @param {function(!Entry)} successCallback
+ * @param {function(!FileError)=} errorCallback
+ */
+Window.prototype.webkitResolveLocalFileSystemURI = function(uri, successCallback,
+    errorCallback) {}
+
+// WindowBlobURIMethods interface, implemented by Window and WorkerGlobalScope.
+// There are three APIs for this: the old specced API, the new specced API, and
+// the webkit-prefixed API.
+// @see http://www.w3.org/TR/FileAPI/#creating-revoking
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-createObjectURL
+ * @param {!Object} obj
+ * @return {string}
+ */
+function createObjectURL(obj) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-createObjectURL
+ * @param {!Object} obj
+ * @return {string}
+ */
+Window.prototype.createObjectURL = function(obj) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-revokeObjectURL
+ * @param {string} url
+ */
+function revokeObjectURL(url) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-revokeObjectURL
+ * @param {string} url
+ */
+Window.prototype.revokeObjectURL = function(url) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#URL-object
+ * @constructor
+ */
+function DOMURL() {}
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#
+ * @constructor
+ * @param {string} urlString
+ * @param {string=} opt_base
+ * @extends {DOMURL}
+ */
+function URL(urlString, opt_base) {}
+
+/** @type {string} */
+URL.prototype.protocol;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-createObjectURL
+ * @param {!File|!Blob|!MediaSource|!MediaStream} obj
+ * @return {string}
+ */
+URL.createObjectURL = function(obj) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-revokeObjectURL
+ * @param {string} url
+ */
+URL.revokeObjectURL = function(url) {};
+
+/**
+ * This has been replaced by URL in Chrome since WebKit revision 75739.
+ * @constructor
+ * @param {string} urlString
+ * @param {string=} opt_base
+ * @extends {DOMURL}
+ */
+function webkitURL(urlString, opt_base) {}
+
+/** @constructor */
+window.webkitURL = webkitURL;
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-createObjectURL
+ * @param {!Object} obj
+ * @return {string}
+ */
+webkitURL.createObjectURL = function(obj) {};
+
+/**
+ * @see http://www.w3.org/TR/FileAPI/#dfn-revokeObjectURL
+ * @param {string} url
+ */
+webkitURL.revokeObjectURL = function(url) {};
+
+/**
+ * @see https://developers.google.com/chrome/whitepapers/storage
+ * @constructor
+ */
+function StorageInfo() {}
+
+/**
+ * @see https://developers.google.com/chrome/whitepapers/storage
+ * @type {number}
+ * */
+StorageInfo.prototype.TEMPORARY = 0;
+
+/**
+ * @see https://developers.google.com/chrome/whitepapers/storage
+ * @type {number}
+ */
+StorageInfo.prototype.PERSISTENT = 1;
+
+/**
+ * @see https://developers.google.com/chrome/whitepapers/storage#requestQuota
+ * @param {number} type
+ * @param {number} size
+ * @param {function(number)} successCallback
+ * @param {function(!DOMException)=} errorCallback
+ */
+StorageInfo.prototype.requestQuota = function(type, size, successCallback,
+    errorCallback) {};
+
+/**
+ * @see https://developers.google.com/chrome/whitepapers/storage#queryUsageAndQuota
+ * @param {number} type
+ * @param {function(number, number)} successCallback
+ * @param {function(!DOMException)=} errorCallback
+ */
+StorageInfo.prototype.queryUsageAndQuota = function(type, successCallback,
+    errorCallback) {};
+
+/**
+ * @see https://developers.google.com/chrome/whitepapers/storage
+ * @type {!StorageInfo}
+ */
+Window.prototype.webkitStorageInfo;
+
+/**
+ * @see https://dvcs.w3.org/hg/quota/raw-file/tip/Overview.html#storagequota-interface.
+ * @constructor
+ */
+function StorageQuota() {}
+
+/**
+ * @param {number} size
+ * @param {function(number)=} opt_successCallback
+ * @param {function(!DOMException)=} opt_errorCallback
+ */
+StorageQuota.prototype.requestQuota = function(size, opt_successCallback,
+    opt_errorCallback) {};
+
+/**
+ * @param {function(number, number)} successCallback
+ * @param {function(!DOMException)=} opt_errorCallback
+ */
+StorageQuota.prototype.queryUsageAndQuota = function(successCallback,
+    opt_errorCallback) {};

--- a/sdk/tests/deqp/temp_externs/flash.js
+++ b/sdk/tests/deqp/temp_externs/flash.js
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for all the Flash Object JavaScript methods. This
+ * file depends on w3c_dom2.js.
+ * Created from
+ * http://www.adobe.com/support/flash/publishexport/scriptingwithflash/scriptingwithflash_03.html
+ *
+ * @externs
+ */
+
+
+// Standard Methods.
+
+/**
+ * Call a Flash function exported by ExternalInterface.
+ * @param {string} xmlString The XML string passed to Flash. The outer element
+ *     should be {@code <invoke>}. A sample invocation string:
+ *     {@code <invoke name="function_name" returntype="javascript">
+ *     <string>test</string></invoke>}
+ * @return {string} The serialized return value from Flash that you can eval.
+ */
+HTMLObjectElement.prototype.CallFunction = function(xmlString) {};
+
+/**
+ * Returns the value of the Flash variable specified by varName or null if the
+ * variable does not exist.
+ * @param {string} varName The variable name.
+ * @return {string?} The variable value.
+ */
+HTMLObjectElement.prototype.GetVariable = function(varName) {};
+
+/**
+ * Activates the frame number specified by {@code frameNumber} in the current
+ * movie.
+ * @param {number} frameNumber A non-negative integer frame number.
+ */
+HTMLObjectElement.prototype.GotoFrame = function(frameNumber) {};
+
+/**
+ * @return {boolean} Whether the movie is currently playing.
+ */
+HTMLObjectElement.prototype.IsPlaying = function() {};
+
+/**
+ * Loads the movie identified by {@code url} to the layer specified by {@code
+ * layerNumber}.
+ * @param {number} layerNumber The layer number.
+ * @param {string} url The movie URL.
+ */
+HTMLObjectElement.prototype.LoadMovie = function(layerNumber, url) {};
+
+/**
+ * Pans a zoomed-in movie to the coordinates specified by x and y. Use mode to
+ * specify whether the values for x and y are pixels or a percent of the window.
+ * When mode is 0, the coordinates are pixels; when mode is 1, the coordinates
+ * are percent of the window.
+ * @param {number} x The x-coordinate.
+ * @param {number} y The y-coordinate.
+ * @param {number} mode The mode.
+ */
+HTMLObjectElement.prototype.Pan = function(x, y, mode) {};
+
+/**
+ * @return {number} The percent of the Flash Player movie that has streamed
+ *     into the browser so far; Possible values are from 0 to 100.
+ */
+HTMLObjectElement.prototype.PercentLoaded = function() {};
+
+/**
+ * Starts playing the movie.
+ */
+HTMLObjectElement.prototype.Play = function() {};
+
+/**
+ * Goes to the first frame.
+ */
+HTMLObjectElement.prototype.Rewind = function() {};
+
+/**
+ * Sets the value of the flash variable.
+ * @param {string} variableName The variable name.
+ * @param {string} value The value.
+ */
+HTMLObjectElement.prototype.SetVariable = function(variableName, value) {};
+
+/**
+ * Zooms in on a rectangular area of the movie. The units of the coordinates
+ * are in twips (1440 units per inch).
+ * @param {number} left The left coordinate.
+ * @param {number} top The top coordinate.
+ * @param {number} right The right coordinate.
+ * @param {number} bottom The bottom coordinate.
+ */
+HTMLObjectElement.prototype.SetZoomRect = function(left, top, right, bottom) {};
+
+/**
+ * Stops playing the movie.
+ */
+HTMLObjectElement.prototype.StopPlay = function() {};
+
+/**
+ * @return {number} The total number of frames in the movie.
+ */
+HTMLObjectElement.prototype.TotalFrames = function() {};
+
+/**
+ * Zooms the view by a relative scale factor.
+ * @param {number} percent The percentage scale factor, should be an integer.
+ */
+HTMLObjectElement.prototype.Zoom = function(percent) {};
+
+
+// TellTarget Methods.
+
+/**
+ * Executes the action in the timeline specified by {@code target} in the
+ * specified frame.
+ * @param {string} target The timeline.
+ * @param {number} frameNumber The frame number.
+ */
+HTMLObjectElement.prototype.TCallFrame = function(target, frameNumber) {};
+
+/**
+ * Executes the action in the timeline specified by {@code target} in the
+ * specified frame.
+ * @param {string} target The timeline.
+ * @param {string} label The frame label.
+ */
+HTMLObjectElement.prototype.TCallLabel = function(target, label) {};
+
+/**
+ * Returns the number of the current frame for the specified timeline.
+ * @param {string} target The timeline.
+ * @return {number} The number of the current frame.
+ */
+HTMLObjectElement.prototype.TCurentFrame = function(target) {};
+
+/**
+ * Returns the label of the current frame for the specified timeline.
+ * @param {string} target The timeline.
+ * @return {string} The label of the current frame, empty string if no
+ *     current frame.
+ */
+HTMLObjectElement.prototype.TCurrentLabel = function(target) {};
+
+/**
+ * Returns a string indicating the value of the property in the
+ * specified timeline.
+ * @param {string} target The timeline.
+ * @param {number} property The integer corresponding to the desired property.
+ * @return {string} The value of the property.
+ */
+HTMLObjectElement.prototype.TGetProperty = function(target, property) {};
+
+/**
+ * Returns a number indicating the value of the property in the specified
+ * timeline.
+ * @param {string} target The timeline.
+ * @param {number} property The integer corresponding to the desired property.
+ * @return {number} A number indicating the value of the property.
+ */
+HTMLObjectElement.prototype.TGetPropertyAsNumber = function(target, property) {};
+
+/**
+ * Goes to the specified frame number in the specified timeline.
+ * @param {string} target The timeline.
+ * @param {number} frameNumber The frame number.
+ */
+HTMLObjectElement.prototype.TGotoFrame = function(target, frameNumber) {};
+
+/**
+ * Goes to the specified frame label in the specified timeline.
+ * @param {string} target The timeline.
+ * @param {string} label The framelabel.
+ */
+HTMLObjectElement.prototype.TGotoLabel = function(target, label) {};
+
+/**
+ * Plays the specified timeline.
+ * @param {number} target The timeline.
+ */
+HTMLObjectElement.prototype.TPlay = function(target) {};
+
+/**
+ * Sets the value of the property in the specified timeline.
+ * @param {number} target The timeline.
+ * @param {number} property The integer corresponding to the desired property.
+ * @param {string|number} value The value.
+ */
+HTMLObjectElement.prototype.TSetProperty = function(target, property, value) {};
+
+/**
+ * Stops the specified timeline.
+ * @param {number} target The timeline.
+ */
+HTMLObjectElement.prototype.TStopPlay = function(target) {};

--- a/sdk/tests/deqp/temp_externs/gecko_css.js
+++ b/sdk/tests/deqp/temp_externs/gecko_css.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for Gecko's custom CSS properties. Copied from:
+ * http://mxr.mozilla.org/mozilla2.0/source/dom/interfaces/css/nsIDOMCSS2Properties.idl
+ *
+ * @externs
+ * @author nicksantos@google.com (Nick Santos)
+ */
+
+
+/** @type {string} */ CSSProperties.prototype.MozAppearance;
+/** @type {string} */ CSSProperties.prototype.MozBackfaceVisibility;
+/** @type {string} */ CSSProperties.prototype.MozBackgroundClip;
+/** @type {string} */ CSSProperties.prototype.MozBackgroundInlinePolicy;
+/** @type {string} */ CSSProperties.prototype.MozBackgroundOrigin;
+/** @type {string} */ CSSProperties.prototype.MozBinding;
+/** @type {string} */ CSSProperties.prototype.MozBorderBottomColors;
+/** @type {string} */ CSSProperties.prototype.MozBorderEnd;
+/** @type {string} */ CSSProperties.prototype.MozBorderEndColor;
+/** @type {string} */ CSSProperties.prototype.MozBorderEndStyle;
+/** @type {string} */ CSSProperties.prototype.MozBorderEndWidth;
+/** @type {string} */ CSSProperties.prototype.MozBorderImage;
+/** @type {string} */ CSSProperties.prototype.MozBorderLeftColors;
+/** @type {string} */ CSSProperties.prototype.MozBorderRadius;
+/** @type {string} */ CSSProperties.prototype.MozBorderRadiusTopleft;
+/** @type {string} */ CSSProperties.prototype.MozBorderRadiusTopright;
+/** @type {string} */ CSSProperties.prototype.MozBorderRadiusBottomleft;
+/** @type {string} */ CSSProperties.prototype.MozBorderRadiusBottomright;
+/** @type {string} */ CSSProperties.prototype.MozBorderRightColors;
+/** @type {string} */ CSSProperties.prototype.MozBorderStart;
+/** @type {string} */ CSSProperties.prototype.MozBorderStartColor;
+/** @type {string} */ CSSProperties.prototype.MozBorderStartStyle;
+/** @type {string} */ CSSProperties.prototype.MozBorderStartWidth;
+/** @type {string} */ CSSProperties.prototype.MozBorderTopColors;
+/** @type {string} */ CSSProperties.prototype.MozBoxAlign;
+/** @type {string} */ CSSProperties.prototype.MozBoxDirection;
+/** @type {string} */ CSSProperties.prototype.MozBoxFlex;
+/** @type {string} */ CSSProperties.prototype.MozBoxOrdinalGroup;
+/** @type {string} */ CSSProperties.prototype.MozBoxOrient;
+/** @type {string} */ CSSProperties.prototype.MozBoxPack;
+/** @type {string} */ CSSProperties.prototype.MozBoxSizing;
+/** @type {string} */ CSSProperties.prototype.MozBoxShadow;
+/** @type {string} */ CSSProperties.prototype.MozColumnCount;
+/** @type {string} */ CSSProperties.prototype.MozColumnGap;
+/** @type {string} */ CSSProperties.prototype.MozColumnRule;
+/** @type {string} */ CSSProperties.prototype.MozColumnRuleColor;
+/** @type {string} */ CSSProperties.prototype.MozColumnRuleStyle;
+/** @type {string} */ CSSProperties.prototype.MozColumnRuleWidth;
+/** @type {string} */ CSSProperties.prototype.MozColumnWidth;
+/** @type {string} */ CSSProperties.prototype.MozFloatEdge;
+/** @type {string} */ CSSProperties.prototype.MozFontFeatureSettings;
+/** @type {string} */ CSSProperties.prototype.MozFontLanguageOverride;
+/** @type {string} */ CSSProperties.prototype.MozForceBrokenImageIcon;
+/** @type {string} */ CSSProperties.prototype.MozImageRegion;
+/** @type {string} */ CSSProperties.prototype.MozMarginEnd;
+/** @type {string} */ CSSProperties.prototype.MozMarginStart;
+/** @type {number|string} */ CSSProperties.prototype.MozOpacity;
+/** @type {string} */ CSSProperties.prototype.MozOutline;
+/** @type {string} */ CSSProperties.prototype.MozOutlineColor;
+/** @type {string} */ CSSProperties.prototype.MozOutlineOffset;
+/** @type {string} */ CSSProperties.prototype.MozOutlineRadius;
+/** @type {string} */ CSSProperties.prototype.MozOutlineRadiusBottomleft;
+/** @type {string} */ CSSProperties.prototype.MozOutlineRadiusBottomright;
+/** @type {string} */ CSSProperties.prototype.MozOutlineRadiusTopleft;
+/** @type {string} */ CSSProperties.prototype.MozOutlineRadiusTopright;
+/** @type {string} */ CSSProperties.prototype.MozOutlineStyle;
+/** @type {string} */ CSSProperties.prototype.MozOutlineWidth;
+/** @type {string} */ CSSProperties.prototype.MozPaddingEnd;
+/** @type {string} */ CSSProperties.prototype.MozPaddingStart;
+/** @type {string} */ CSSProperties.prototype.MozPerspective;
+/** @type {string} */ CSSProperties.prototype.MozStackSizing;
+/** @type {string} */ CSSProperties.prototype.MozTabSize;
+/** @type {string} */ CSSProperties.prototype.MozTransform;
+/** @type {string} */ CSSProperties.prototype.MozTransformOrigin;
+/** @type {string} */ CSSProperties.prototype.MozTransition;
+/** @type {string} */ CSSProperties.prototype.MozTransitionDelay;
+/** @type {string} */ CSSProperties.prototype.MozTransitionDuration;
+/** @type {string} */ CSSProperties.prototype.MozTransitionProperty;
+/** @type {string} */ CSSProperties.prototype.MozTransitionTimingFunction;
+/** @type {string} */ CSSProperties.prototype.MozUserFocus;
+/** @type {string} */ CSSProperties.prototype.MozUserInput;
+/** @type {string} */ CSSProperties.prototype.MozUserModify;
+/** @type {string} */ CSSProperties.prototype.MozUserSelect;
+/** @type {string} */ CSSProperties.prototype.MozWindowShadow;
+
+
+// These are non-standard Gecko CSSOM properties on Window.prototype.screen.
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/En/DOM/window.screen.availTop
+ */
+Screen.prototype.availTop;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/En/DOM/window.screen.availLeft
+ */
+Screen.prototype.availLeft;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/En/DOM/window.screen.left
+ */
+Screen.prototype.left;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/En/DOM/window.screen.top
+ */
+Screen.prototype.top;

--- a/sdk/tests/deqp/temp_externs/gecko_dom.js
+++ b/sdk/tests/deqp/temp_externs/gecko_dom.js
@@ -1,0 +1,1120 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for all the extensions over
+ *  W3C's DOM specification by Gecko. This file depends on
+ *  w3c_dom2.js.
+ *
+ * When a non-standard extension appears in both Gecko and IE, we put
+ * it in gecko_dom.js
+ *
+ * @externs
+ */
+
+// TODO: Almost all of it has not been annotated with types.
+
+// Gecko DOM;
+
+/**
+ * Mozilla only???
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLSpanElement() {}
+
+/**
+ * @see https://developer.mozilla.org/en/Components_object
+ */
+Window.prototype.Components;
+
+/**
+ * @type Window
+ * @see https://developer.mozilla.org/en/DOM/window.content
+ */
+Window.prototype.content;
+
+/**
+ * @type {boolean}
+ * @see https://developer.mozilla.org/en/DOM/window.closed
+ */
+Window.prototype.closed;
+
+/** @see https://developer.mozilla.org/en/DOM/window.controllers */
+Window.prototype.controllers;
+
+/** @see https://developer.mozilla.org/en/DOM/window.crypto */
+Window.prototype.crypto;
+
+/**
+ * Gets/sets the status bar text for the given window.
+ * @type {string}
+ * @see https://developer.mozilla.org/en/DOM/window.defaultStatus
+ */
+Window.prototype.defaultStatus;
+
+/** @see https://developer.mozilla.org/en/DOM/window.dialogArguments */
+Window.prototype.dialogArguments;
+
+/** @see https://developer.mozilla.org/en/DOM/window.directories */
+Window.prototype.directories;
+
+/**
+ * @type {HTMLObjectElement|HTMLIFrameElement|null}
+ * @see https://developer.mozilla.org/en/DOM/window.frameElement
+ */
+Window.prototype.frameElement;
+
+/**
+ * Allows lookup of frames by index or by name.
+ * @type {?Object}
+ * @see https://developer.mozilla.org/en/DOM/window.frames
+ */
+Window.prototype.frames;
+
+/**
+ * @type {boolean}
+ * @see https://developer.mozilla.org/en/DOM/window.fullScreen
+ */
+Window.prototype.fullScreen;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/Storage#globalStorage
+ */
+Window.prototype.globalStorage;
+
+/**
+ * @type {!History}
+ * @see https://developer.mozilla.org/en/DOM/window.history
+ */
+Window.prototype.history;
+
+/**
+ * Returns the number of frames (either frame or iframe elements) in the
+ * window.
+ *
+ * @type {number}
+ * @see https://developer.mozilla.org/en/DOM/window.length
+ */
+Window.prototype.length;
+
+/**
+ * @type {!Location}
+ * @implicitCast
+ * @see https://developer.mozilla.org/en/DOM/window.location
+ */
+Window.prototype.location;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/window.locationbar
+ */
+Window.prototype.locationbar;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/window.menubar
+ */
+Window.prototype.menubar;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/DOM/window.name
+ */
+Window.prototype.name;
+
+/**
+ * @type {Navigator}
+ * @see https://developer.mozilla.org/en/DOM/window.navigator
+ */
+Window.prototype.navigator;
+
+/**
+ * @type {?Window}
+ * @see https://developer.mozilla.org/en/DOM/window.opener
+ */
+Window.prototype.opener;
+
+/**
+ * @type {!Window}
+ * @see https://developer.mozilla.org/en/DOM/window.parent
+ */
+Window.prototype.parent;
+
+/** @see https://developer.mozilla.org/en/DOM/window.personalbar */
+Window.prototype.personalbar;
+
+/** @see https://developer.mozilla.org/en/DOM/window.pkcs11 */
+Window.prototype.pkcs11;
+
+/** @see https://developer.mozilla.org/en/DOM/window */
+Window.prototype.returnValue;
+
+/** @see https://developer.mozilla.org/en/DOM/window.scrollbars */
+Window.prototype.scrollbars;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/En/DOM/window.scrollMaxX
+ */
+Window.prototype.scrollMaxX;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/En/DOM/window.scrollMaxY
+ */
+Window.prototype.scrollMaxY;
+
+/**
+ * @type {!Window}
+ * @see https://developer.mozilla.org/en/DOM/window.self
+ */
+Window.prototype.self;
+
+/** @see https://developer.mozilla.org/en/DOM/Storage#sessionStorage */
+Window.prototype.sessionStorage;
+
+/** @see https://developer.mozilla.org/en/DOM/window.sidebar */
+Window.prototype.sidebar;
+
+/**
+ * @type {?string}
+ * @see https://developer.mozilla.org/en/DOM/window.status
+ */
+Window.prototype.status;
+
+/** @see https://developer.mozilla.org/en/DOM/window.statusbar */
+Window.prototype.statusbar;
+
+/** @see https://developer.mozilla.org/en/DOM/window.toolbar */
+Window.prototype.toolbar;
+
+/**
+ * @type {!Window}
+ * @see https://developer.mozilla.org/en/DOM/window.self
+ */
+Window.prototype.top;
+
+/**
+ * @type {!Window}
+ * @see https://developer.mozilla.org/en/DOM/window.self
+ */
+Window.prototype.window;
+
+/**
+ * @param {*} message
+ * @see https://developer.mozilla.org/en/DOM/window.alert
+ */
+Window.prototype.alert = function(message) {};
+
+/**
+ * Decodes a string of data which has been encoded using base-64 encoding.
+ *
+ * @param {string} encodedData
+ * @return {string}
+ * @see https://developer.mozilla.org/en/DOM/window.atob
+ * @nosideeffects
+ */
+function atob(encodedData) {}
+
+/** @see https://developer.mozilla.org/en/DOM/window.back */
+Window.prototype.back = function() {};
+
+/** @see https://developer.mozilla.org/en/DOM/window.blur */
+Window.prototype.blur = function() {};
+
+/**
+ * @param {string} stringToEncode
+ * @return {string}
+ * @see https://developer.mozilla.org/en/DOM/window.btoa
+ * @nosideeffects
+ */
+function btoa(stringToEncode) {}
+
+/** @deprecated */
+Window.prototype.captureEvents;
+
+/** @see https://developer.mozilla.org/en/DOM/window.close */
+Window.prototype.close = function() {};
+
+/** @see https://developer.mozilla.org/en/DOM/window.find */
+Window.prototype.find;
+
+/** @see https://developer.mozilla.org/en/DOM/window.focus */
+Window.prototype.focus = function() {};
+
+/** @see https://developer.mozilla.org/en/DOM/window.forward */
+Window.prototype.forward = function() {};
+
+/** @see https://developer.mozilla.org/en/DOM/window.getAttention */
+Window.prototype.getAttention = function() {};
+
+/**
+ * @return {Selection}
+ * @see https://developer.mozilla.org/en/DOM/window.getSelection
+ * @nosideeffects
+ */
+Window.prototype.getSelection = function() {};
+
+/** @see https://developer.mozilla.org/en/DOM/window.home */
+Window.prototype.home = function() {};
+
+Window.prototype.openDialog;
+Window.prototype.releaseEvents;
+Window.prototype.scrollByLines;
+Window.prototype.scrollByPages;
+
+/**
+ * @param {string} uri
+ * @param {?=} opt_arguments
+ * @param {string=} opt_options
+ * @see https://developer.mozilla.org/en/DOM/window.showModalDialog
+ */
+Window.prototype.showModalDialog;
+
+Window.prototype.sizeToContent;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536769(VS.85).aspx
+ */
+Window.prototype.stop = function() {};
+
+Window.prototype.updateCommands;
+
+// properties of Document
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.alinkColor
+ * @type {string}
+ */
+Document.prototype.alinkColor;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.anchors
+ * @type {HTMLCollection}
+ */
+Document.prototype.anchors;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.applets
+ * @type {HTMLCollection}
+ */
+Document.prototype.applets;
+/** @type {boolean} */ Document.prototype.async;
+/** @type {string?} */ Document.prototype.baseURI;
+Document.prototype.baseURIObject;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.bgColor
+ * @type {string}
+ */
+Document.prototype.bgColor;
+
+/** @type {HTMLBodyElement} */ Document.prototype.body;
+Document.prototype.characterSet;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.compatMode
+ * @type {string}
+ */
+Document.prototype.compatMode;
+
+Document.prototype.contentType;
+/** @type {string} */ Document.prototype.cookie;
+Document.prototype.defaultView;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.designMode
+ * @type {string}
+ */
+Document.prototype.designMode;
+
+Document.prototype.documentURIObject;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.domain
+ * @type {string}
+ */
+Document.prototype.domain;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.embeds
+ * @type {HTMLCollection}
+ */
+Document.prototype.embeds;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.fgColor
+ * @type {string}
+ */
+Document.prototype.fgColor;
+
+/** @type {Element} */ Document.prototype.firstChild;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.forms
+ * @type {HTMLCollection}
+ */
+Document.prototype.forms;
+
+/** @type {number} */ Document.prototype.height;
+/** @type {HTMLCollection} */ Document.prototype.images;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/DOM/document.lastModified
+ */
+Document.prototype.lastModified;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/DOM/document.linkColor
+ */
+Document.prototype.linkColor;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.links
+ * @type {HTMLCollection}
+ */
+Document.prototype.links;
+
+/**
+ * @type {!Location}
+ * @implicitCast
+ */
+Document.prototype.location;
+
+Document.prototype.namespaceURI;
+Document.prototype.nodePrincipal;
+Document.prototype.plugins;
+Document.prototype.popupNode;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/DOM/document.referrer
+ */
+Document.prototype.referrer;
+
+/**
+ * @type {StyleSheetList}
+ * @see https://developer.mozilla.org/en/DOM/document.styleSheets
+ */
+Document.prototype.styleSheets;
+
+/** @type {?string} */ Document.prototype.title;
+Document.prototype.tooltipNode;
+/** @type {string} */ Document.prototype.URL;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/DOM/document.vlinkColor
+ */
+Document.prototype.vlinkColor;
+
+/** @type {number} */ Document.prototype.width;
+
+// Methods of Document
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.clear
+ */
+Document.prototype.clear = function() {};
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.close
+ */
+Document.prototype.close;
+
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/document.createElementNS
+ * @see http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-instantiate
+ * @param {?string} namespaceURI
+ * @param {string} qualifiedName
+ * @param {string=} opt_typeExtension
+ * @return {!Element}
+ */
+Document.prototype.createElementNS =
+    function(namespaceURI, qualifiedName, opt_typeExtension) {};
+
+/**
+ * @param {string} type
+ * @return {Event}
+ */
+Document.prototype.createEvent = function(type) {};
+Document.prototype.createNSResolver;
+/** @return {Range} */ Document.prototype.createRange = function() {};
+Document.prototype.createTreeWalker;
+
+Document.prototype.evaluate;
+
+/**
+ * @param {string} commandName
+ * @param {?boolean=} opt_showUi
+ * @param {*=} opt_value
+ * @see https://developer.mozilla.org/en/Rich-Text_Editing_in_Mozilla#Executing_Commands
+ */
+Document.prototype.execCommand;
+
+/**
+ * @param {string} s id.
+ * @return {HTMLElement}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/DOM/document.getElementById
+ */
+Document.prototype.getElementById = function(s) {};
+
+/**
+ * @param {string} name
+ * @return {!NodeList}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/DOM/document.getElementsByClassName
+ */
+Document.prototype.getElementsByClassName = function(name) {};
+
+/**
+ * @param {string} name
+ * @return {!NodeList}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/DOM/document.getElementsByName
+ */
+Document.prototype.getElementsByName = function(name) {};
+
+/**
+ * @param {string} namespace
+ * @param {string} name
+ * @return {!NodeList}
+ * @nosideeffects
+ * @see https://developer.mozilla.org/en/DOM/document.getElementsByTagNameNS
+ */
+Document.prototype.getElementsByTagNameNS = function(namespace, name) {};
+
+/**
+ * @param {Node} externalNode
+ * @param {boolean} deep
+ * @return {Node}
+ */
+Document.prototype.importNode = function(externalNode, deep) {};
+
+/** @param {string} uri */
+Document.prototype.load = function(uri) {};
+Document.prototype.loadOverlay;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.open
+ */
+Document.prototype.open;
+
+/**
+ * @see https://developer.mozilla.org/en/Midas
+ * @see http://msdn.microsoft.com/en-us/library/ms536676(VS.85).aspx
+ */
+Document.prototype.queryCommandEnabled;
+
+/**
+ * @see https://developer.mozilla.org/en/Midas
+ * @see http://msdn.microsoft.com/en-us/library/ms536678(VS.85).aspx
+ */
+Document.prototype.queryCommandIndeterm;
+
+/**
+ * @see https://developer.mozilla.org/en/Midas
+ * @see http://msdn.microsoft.com/en-us/library/ms536679(VS.85).aspx
+ */
+Document.prototype.queryCommandState;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.queryCommandSupported
+ * @see http://msdn.microsoft.com/en-us/library/ms536681(VS.85).aspx
+ * @param {string} command
+ * @return {?} Implementation-specific.
+ */
+Document.prototype.queryCommandSupported;
+
+/**
+ * @see https://developer.mozilla.org/en/Midas
+ * @see http://msdn.microsoft.com/en-us/library/ms536683(VS.85).aspx
+ */
+Document.prototype.queryCommandValue;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.write
+ * @param {string} text
+ */
+Document.prototype.write = function(text) {};
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/document.writeln
+ * @param {string} text
+ */
+Document.prototype.writeln = function(text) {};
+
+Document.prototype.ononline;
+Document.prototype.onoffline;
+
+// XUL
+/**
+ * @see http://developer.mozilla.org/en/DOM/document.getBoxObjectFor
+ * @return {BoxObject}
+ * @nosideeffects
+ */
+Document.prototype.getBoxObjectFor = function(element) {};
+
+// From:
+// http://lxr.mozilla.org/mozilla1.8/source/dom/public/idl/range/nsIDOMNSRange.idl
+
+/**
+ * @param {string} tag
+ * @return {DocumentFragment}
+ */
+Range.prototype.createContextualFragment;
+
+/**
+ * @param {Node} parent
+ * @param {number} offset
+ * @return {boolean}
+ * @nosideeffects
+ */
+Range.prototype.isPointInRange;
+
+/**
+ * @param {Node} parent
+ * @param {number} offset
+ * @return {number}
+ * @nosideeffects
+ */
+Range.prototype.comparePoint;
+
+/**
+ * @param {Node} n
+ * @return {boolean}
+ * @nosideeffects
+ */
+Range.prototype.intersectsNode;
+
+/**
+ * @param {Node} n
+ * @return {number}
+ * @nosideeffects
+ */
+Range.prototype.compareNode;
+
+
+/** @constructor */
+function Selection() {}
+
+/**
+ * @type {Node}
+ * @see https://developer.mozilla.org/en/DOM/Selection/anchorNode
+ */
+Selection.prototype.anchorNode;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/en/DOM/Selection/anchorOffset
+ */
+Selection.prototype.anchorOffset;
+
+/**
+ * @type {Node}
+ * @see https://developer.mozilla.org/en/DOM/Selection/focusNode
+ */
+Selection.prototype.focusNode;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/en/DOM/Selection/focusOffset
+ */
+Selection.prototype.focusOffset;
+
+/**
+ * @type {boolean}
+ * @see https://developer.mozilla.org/en/DOM/Selection/isCollapsed
+ */
+Selection.prototype.isCollapsed;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/en/DOM/Selection/rangeCount
+ */
+Selection.prototype.rangeCount;
+
+/**
+ * @param {Range} range
+ * @return {undefined}
+ * @see https://developer.mozilla.org/en/DOM/Selection/addRange
+ */
+Selection.prototype.addRange = function(range) {};
+
+/**
+ * @param {number} index
+ * @return {Range}
+ * @see https://developer.mozilla.org/en/DOM/Selection/getRangeAt
+ * @nosideeffects
+ */
+Selection.prototype.getRangeAt = function(index) {};
+
+/**
+ * @param {Node} node
+ * @param {number} index
+ * @return {undefined}
+ * @see https://developer.mozilla.org/en/DOM/Selection/collapse
+ */
+Selection.prototype.collapse = function(node, index) {};
+
+/**
+ * @return {undefined}
+ * @see https://developer.mozilla.org/en/DOM/Selection/collapseToEnd
+ */
+Selection.prototype.collapseToEnd = function() {};
+
+/**
+ * @return {undefined}
+ * @see https://developer.mozilla.org/en/DOM/Selection/collapseToStart
+ */
+Selection.prototype.collapseToStart = function() {};
+
+/**
+ * @param {Node} node
+ * @param {boolean} partlyContained
+ * @return {boolean}
+ * @see https://developer.mozilla.org/en/DOM/Selection/containsNode
+ * @nosideeffects
+ */
+Selection.prototype.containsNode = function(node, partlyContained) {};
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/Selection/deleteFromDocument
+ */
+Selection.prototype.deleteFromDocument = function() {};
+
+/**
+ * @param {Node} parentNode
+ * @param {number} offset
+ * @see https://developer.mozilla.org/en/DOM/Selection/extend
+ */
+Selection.prototype.extend = function(parentNode, offset) {};
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/Selection/removeAllRanges
+ */
+Selection.prototype.removeAllRanges = function() {};
+
+/**
+ * @param {Range} range
+ * @see https://developer.mozilla.org/en/DOM/Selection/removeRange
+ */
+Selection.prototype.removeRange = function(range) {};
+
+/**
+ * @param {Node} parentNode
+ * @see https://developer.mozilla.org/en/DOM/Selection/selectAllChildren
+ */
+Selection.prototype.selectAllChildren;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/Selection/selectionLanguageChange
+ */
+Selection.prototype.selectionLanguageChange;
+
+/** @type {NamedNodeMap} */ Element.prototype.attributes;
+Element.prototype.baseURIObject;
+/** @type {!NodeList} */ Element.prototype.childNodes;
+
+/**
+ * @type {!NodeList}
+ * @see https://developer.mozilla.org/en/DOM/element.children
+ */
+Element.prototype.children;
+
+/**
+ * @type {string}
+ * @implicitCast
+ */
+Element.prototype.className;
+/** @type {string} */ Element.prototype.dir;
+
+/**
+ * Firebug sets this property on elements it is inserting into the DOM.
+ * @type {boolean}
+ */
+Element.prototype.firebugIgnore;
+
+/** @type {Node} */ Element.prototype.firstChild;
+/**
+ * @type {string}
+ * @implicitCast
+ */
+Element.prototype.id;
+/**
+ * @type {string}
+ * @implicitCast
+ */
+Element.prototype.innerHTML;
+/** @type {string} */ Element.prototype.lang;
+/** @type {Node} */ Element.prototype.lastChild;
+Element.prototype.localName;
+Element.prototype.name;
+Element.prototype.namespaceURI;
+/** @type {Node} */ Element.prototype.nextSibling;
+Element.prototype.nodeName;
+Element.prototype.nodePrincipal;
+/** @type {number} */ Element.prototype.nodeType;
+Element.prototype.nodeValue;
+/** @type {Document} */ Element.prototype.ownerDocument;
+/** @type {Node} */ Element.prototype.parentNode;
+Element.prototype.prefix;
+/** @type {Node} */ Element.prototype.previousSibling;
+/** @type {!CSSStyleDeclaration} */ Element.prototype.style;
+/**
+ * @type {number}
+ * @implicitCast
+ */
+Element.prototype.tabIndex;
+
+/**
+ * @type {string}
+ * @implicitCast
+ */
+Element.prototype.textContent;
+/** @type {string} */ Element.prototype.title;
+
+/**
+ * @param {Node} child
+ * @return {Node} appendedElement.
+ * @override
+ */
+Element.prototype.appendChild = function(child) {};
+
+/**
+ * @override
+ * @return {!Element}
+ */
+Element.prototype.cloneNode = function(deep) {};
+
+/** @override */
+Element.prototype.dispatchEvent = function(event) {};
+
+/** @return {undefined} */
+Element.prototype.blur = function() {};
+
+/** @return {undefined} */
+Element.prototype.click = function() {};
+
+/** @return {undefined} */
+Element.prototype.focus = function() {};
+
+/**
+ * @return {boolean}
+ * @override
+ * @nosideeffects
+ */
+Element.prototype.hasAttributes = function() {};
+
+/**
+ * @return {boolean}
+ * @override
+ * @nosideeffects
+ */
+Element.prototype.hasChildNodes = function() {};
+
+/** @override */
+Element.prototype.insertBefore = function(insertedNode, adjacentNode) {};
+
+/**
+ * @return {undefined}
+ * @override
+ */
+Element.prototype.normalize = function() {};
+
+/**
+ * @param {Node} removedNode
+ * @return {!Node}
+ * @override
+ */
+Element.prototype.removeChild = function(removedNode) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Element.prototype.removeEventListener = function(type, handler, opt_useCapture)
+    {};
+
+/** @override */
+Element.prototype.replaceChild = function(insertedNode, replacedNode) {};
+
+/** @type {number} */
+HTMLInputElement.prototype.selectionStart;
+
+/** @type {number} */
+HTMLInputElement.prototype.selectionEnd;
+
+/**
+ * @param {number} selectionStart
+ * @param {number} selectionEnd
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#dom-textarea/input-setselectionrange
+ */
+HTMLInputElement.prototype.setSelectionRange =
+    function(selectionStart, selectionEnd) {};
+
+/** @type {number} */
+HTMLTextAreaElement.prototype.selectionStart;
+
+/** @type {number} */
+HTMLTextAreaElement.prototype.selectionEnd;
+
+/**
+ * @param {number} selectionStart
+ * @param {number} selectionEnd
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#dom-textarea/input-setselectionrange
+ */
+HTMLTextAreaElement.prototype.setSelectionRange =
+    function(selectionStart, selectionEnd) {};
+
+/** @constructor */
+function Navigator() {}
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.appCodeName
+ */
+Navigator.prototype.appCodeName;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.appVersion
+ */
+Navigator.prototype.appName;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.appVersion
+ */
+Navigator.prototype.appVersion;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.buildID
+ */
+Navigator.prototype.buildID;
+
+/**
+ * @type {boolean}
+ * @see https://developer.mozilla.org/en/Navigator.cookieEnabled
+ */
+Navigator.prototype.cookieEnabled;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.language
+ */
+Navigator.prototype.language;
+
+/**
+ * @type {MimeTypeArray}
+ * @see https://developer.mozilla.org/en/Navigator.mimeTypes
+ */
+Navigator.prototype.mimeTypes;
+
+/**
+ * @type {boolean}
+ * @see https://developer.mozilla.org/en/Navigator.onLine
+ */
+Navigator.prototype.onLine;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.oscpu
+ */
+Navigator.prototype.oscpu;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.platform
+ */
+Navigator.prototype.platform;
+
+/**
+ * @type {PluginArray}
+ * @see https://developer.mozilla.org/en/Navigator.plugins
+ */
+Navigator.prototype.plugins;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.product
+ */
+Navigator.prototype.product;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.productSub
+ */
+Navigator.prototype.productSub;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.securityPolicy
+ */
+Navigator.prototype.securityPolicy;
+
+/**
+ * @param {string} url
+ * @param {ArrayBufferView|Blob|string|FormData=} opt_data
+ * @return {boolean}
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/navigator.sendBeacon
+ */
+Navigator.prototype.sendBeacon = function(url, opt_data) {};
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.userAgent
+ */
+Navigator.prototype.userAgent;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.vendor
+ */
+Navigator.prototype.vendor;
+
+/**
+ * @type {string}
+ * @see https://developer.mozilla.org/en/Navigator.vendorSub
+ */
+Navigator.prototype.vendorSub;
+
+/**
+ * @type {function(): boolean}
+ * @see https://developer.mozilla.org/en/Navigator.javaEnabled
+ * @nosideeffects
+ */
+Navigator.prototype.javaEnabled = function() {};
+
+/**
+ * @constructor
+ * @see https://developer.mozilla.org/en/DOM/PluginArray
+ */
+function PluginArray() {}
+
+/** @type {number} */
+PluginArray.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {Plugin}
+ */
+PluginArray.prototype.item = function(index) {};
+
+/**
+ * @param {string} name
+ * @return {Plugin}
+ */
+PluginArray.prototype.namedItem = function(name) {};
+
+/** @param {boolean=} reloadDocuments */
+PluginArray.prototype.refresh = function(reloadDocuments) {};
+
+/** @constructor */
+function MimeTypeArray() {}
+
+/**
+ * @param {number} index
+ * @return {MimeType}
+ */
+MimeTypeArray.prototype.item = function(index) {};
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/en/DOM/window.navigator.mimeTypes
+ */
+MimeTypeArray.prototype.length;
+
+/**
+ * @param {string} name
+ * @return {MimeType}
+ */
+MimeTypeArray.prototype.namedItem = function(name) {};
+
+/** @constructor */
+function MimeType() {}
+
+/** @type {string} */
+MimeType.prototype.description;
+
+/** @type {Plugin} */
+MimeType.prototype.enabledPlugin;
+
+/** @type {string} */
+MimeType.prototype.suffixes;
+
+/** @type {string} */
+MimeType.prototype.type;
+
+/** @constructor */
+function Plugin() {}
+
+/** @type {string} */
+Plugin.prototype.description;
+
+/** @type {string} */
+Plugin.prototype.filename;
+
+/** @type {number} */
+Plugin.prototype.length;
+
+/** @type {string} */
+Plugin.prototype.name;
+
+/** @constructor */
+function BoxObject() {}
+
+/** @type {Element} */
+BoxObject.prototype.element;
+
+/** @type {number} */
+BoxObject.prototype.screenX;
+
+/** @type {number} */
+BoxObject.prototype.screenY;
+
+/** @type {number} */
+BoxObject.prototype.x;
+
+/** @type {number} */
+BoxObject.prototype.y;
+
+/** @type {number} */
+BoxObject.prototype.width;
+
+
+/**
+ * @type {number}
+ * @see http://www.google.com/codesearch/p?hl=en#eksvcKKj5Ng/mozilla/dom/public/idl/html/nsIDOMNSHTMLImageElement.idl&q=naturalWidth
+ */
+HTMLImageElement.prototype.naturalWidth;
+
+/**
+ * @type {number}
+ * @see http://www.google.com/codesearch/p?hl=en#eksvcKKj5Ng/mozilla/dom/public/idl/html/nsIDOMNSHTMLImageElement.idl&q=naturalHeight
+ */
+HTMLImageElement.prototype.naturalHeight;
+
+
+/**
+ * @param {Element} element
+ * @param {?string=} pseudoElt
+ * @return {CSSStyleDeclaration}
+ * @nosideeffects
+ */
+function getComputedStyle(element, pseudoElt) {}

--- a/sdk/tests/deqp/temp_externs/gecko_event.js
+++ b/sdk/tests/deqp/temp_externs/gecko_event.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for all the extensions over
+ *  W3C's event specification by Gecko. This file depends on
+ *  w3c_event.js.
+ *
+ * @externs
+ */
+
+// TODO: Almost all of it has not been annotated with types.
+
+/** @type {number} */ Event.prototype.HORIZONTAL_AXIS;
+/** @type {number} */ Event.prototype.VERTICAL_AXIS;
+/** @type {boolean} */ Event.prototype.altKey;
+/** @type {number} */ Event.prototype.axis;
+/** @type {number} */ Event.prototype.button;
+/** @type {boolean} */ Event.prototype.cancelBubble;
+/** @type {number} */ Event.prototype.charCode;
+/** @type {number} */ Event.prototype.clientX;
+/** @type {number} */ Event.prototype.clientY;
+/** @type {boolean} */ Event.prototype.ctrlKey;
+/** @type {EventTarget} */ Event.prototype.explicitOriginalTarget;
+/** @type {boolean} */ Event.prototype.isChar;
+/** @type {number} */ Event.prototype.keyCode;
+/** @type {number} */ Event.prototype.layerX;
+/** @type {number} */ Event.prototype.layerY;
+/** @type {boolean} */ Event.prototype.metaKey;
+/** @type {EventTarget} */ Event.prototype.originalTarget;
+/** @type {number} */ Event.prototype.pageX;
+/** @type {number} */ Event.prototype.pageY;
+/** @type {EventTarget} */ Event.prototype.relatedTarget;
+/** @type {number} */ Event.prototype.screenX;
+/** @type {number} */ Event.prototype.screenY;
+/** @type {boolean} */ Event.prototype.shiftKey;
+/** @type {Window} */ Event.prototype.view;
+/** @type {number} */ Event.prototype.which;
+
+/** @constructor */ function nsIDOMPageTransitionEvent() {}
+/** @type {boolean} */ nsIDOMPageTransitionEvent.prototype.persisted;
+
+//Methods
+Event.prototype.initKeyEvent;
+Event.prototype.initMouseEvent;
+Event.prototype.initUIEvent;
+Event.prototype.initMessageEvent;
+Event.prototype.preventBubble;
+Event.prototype.preventCapture;

--- a/sdk/tests/deqp/temp_externs/gecko_xml.js
+++ b/sdk/tests/deqp/temp_externs/gecko_xml.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for all the extensions over some of the
+ *  W3C's XML specifications by Gecko. This file depends on
+ *  w3c_xml.js. The whole file has been fully type annotated.
+ *
+ * @externs
+ */
+
+/**
+ * XMLSerializer can be used to convert DOM subtree or DOM document into text.
+ * XMLSerializer is available to unprivileged scripts.
+ *
+ * XMLSerializer is mainly useful for applications and extensions based on
+ * Mozilla platform. While it's available to web pages, it's not part of any
+ * standard and level of support in other browsers is unknown.
+ *
+ * @constructor
+ */
+function XMLSerializer() {}
+
+/**
+ * Returns the serialized subtree in the form of a string
+ * @param {Node} subtree
+ * @return {string}
+ */
+XMLSerializer.prototype.serializeToString = function(subtree) {};
+
+/**
+ * The subtree rooted by the specified element is serialized to a byte stream
+ * using the character set specified.
+ *
+ * @param {Node} subtree
+ * @return {Object}
+ */
+XMLSerializer.prototype.serializeToStream = function(subtree) {};
+
+/**
+ * DOMParser is mainly useful for applications and extensions based on Mozilla
+ * platform. While it's available to web pages, it's not part of any standard and
+ * level of support in other browsers is unknown.
+ *
+ * @constructor
+ */
+function DOMParser() {}
+
+/**
+ * The string passed in is parsed into a DOM document.
+ *
+ * Example:
+ *  var parser = new DOMParser();
+ *  var doc = parser.parseFromString(aStr, "text/xml");
+ *
+ * @param {string} src The UTF16 string to be parsed.
+ * @param {string} type The content type of the string.
+ * @return {Document}
+ */
+DOMParser.prototype.parseFromString = function(src, type) {};

--- a/sdk/tests/deqp/temp_externs/google.js
+++ b/sdk/tests/deqp/temp_externs/google.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2010 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Declaration of the type level google namespace.
+ * @externs
+ * @author nicksantos@google.com (Nick Santos)
+ */
+
+/**
+ * Suppresses the compiler warning when multiple externs files declare the
+ * google namespace.
+ * @suppress {duplicate}
+ * @noalias
+ */
+// TODO(nicksantos): Consolidate to one google namespace declaration.
+var google = {};

--- a/sdk/tests/deqp/temp_externs/html5.js
+++ b/sdk/tests/deqp/temp_externs/html5.js
@@ -1,0 +1,3241 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for all the extensions over the
+ *  W3C's DOM3 specification in HTML5. This file depends on
+ *  w3c_dom3.js. The whole file has been fully type annotated.
+ *
+ *  @see http://www.whatwg.org/specs/web-apps/current-work/multipage/index.html
+ *  @see http://dev.w3.org/html5/spec/Overview.html
+ *
+ *  This also includes Typed Array definitions from
+ *  http://www.khronos.org/registry/typedarray/specs/latest/
+ *
+ *  This relies on w3c_event.js being included first.
+ *
+ * @externs
+ */
+
+
+/**
+ * Note: In IE, the contains() method only exists on Elements, not Nodes.
+ * Therefore, it is recommended that you use the Conformance framework to
+ * prevent calling this on Nodes which are not Elements.
+ * @see https://connect.microsoft.com/IE/feedback/details/780874/node-contains-is-incorrect
+ *
+ * @param {Node} n The node to check
+ * @return {boolean} If 'n' is this Node, or is contained within this Node.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Node.contains
+ * @nosideeffects
+ */
+Node.prototype.contains = function(n) {};
+
+
+/**
+ * @constructor
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#the-canvas-element
+ * @extends {HTMLElement}
+ */
+function HTMLCanvasElement() {}
+
+/** @type {number} */
+HTMLCanvasElement.prototype.width;
+
+/** @type {number} */
+HTMLCanvasElement.prototype.height;
+
+/**
+ * @param {string=} opt_type
+ * @param {...*} var_args
+ * @return {string}
+ * @throws {Error}
+ * @nosideeffects
+ */
+HTMLCanvasElement.prototype.toDataURL = function(opt_type, var_args) {};
+
+/**
+ * @param {string} contextId
+ * @param {Object=} opt_args
+ * @return {Object}
+ */
+HTMLCanvasElement.prototype.getContext = function(contextId, opt_args) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/2dcontext/#canvasrenderingcontext2d
+ */
+function CanvasRenderingContext2D() {}
+
+/** @type {HTMLCanvasElement} */
+CanvasRenderingContext2D.prototype.canvas;
+
+/**
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.save = function() {};
+
+/**
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.restore = function() {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.scale = function(x, y) {};
+
+/**
+ * @param {number} angle
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.rotate = function(angle) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.translate = function(x, y) {};
+
+/**
+ * @param {number} m11
+ * @param {number} m12
+ * @param {number} m21
+ * @param {number} m22
+ * @param {number} dx
+ * @param {number} dy
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.transform = function(
+    m11, m12, m21, m22, dx, dy) {};
+
+/**
+ * @param {number} m11
+ * @param {number} m12
+ * @param {number} m21
+ * @param {number} m22
+ * @param {number} dx
+ * @param {number} dy
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.setTransform = function(
+    m11, m12, m21, m22, dx, dy) {};
+
+/**
+ * @param {number} x0
+ * @param {number} y0
+ * @param {number} x1
+ * @param {number} y1
+ * @return {CanvasGradient}
+ * @throws {Error}
+ * @nosideeffects
+ */
+CanvasRenderingContext2D.prototype.createLinearGradient = function(
+    x0, y0, x1, y1) {};
+
+/**
+ * @param {number} x0
+ * @param {number} y0
+ * @param {number} r0
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} r1
+ * @return {CanvasGradient}
+ * @throws {Error}
+ * @nosideeffects
+ */
+CanvasRenderingContext2D.prototype.createRadialGradient = function(
+    x0, y0, r0, x1, y1, r1) {};
+
+/**
+ * @param {HTMLImageElement|HTMLCanvasElement} image
+ * @param {string} repetition
+ * @return {CanvasPattern}
+ * @throws {Error}
+ * @nosideeffects
+ */
+CanvasRenderingContext2D.prototype.createPattern = function(
+    image, repetition) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.clearRect = function(x, y, w, h) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.fillRect = function(x, y, w, h) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.strokeRect = function(x, y, w, h) {};
+
+/**
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.beginPath = function() {};
+
+/**
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.closePath = function() {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.moveTo = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.lineTo = function(x, y) {};
+
+/**
+ * @param {number} cpx
+ * @param {number} cpy
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.quadraticCurveTo = function(
+    cpx, cpy, x, y) {};
+
+/**
+ * @param {number} cp1x
+ * @param {number} cp1y
+ * @param {number} cp2x
+ * @param {number} cp2y
+ * @param {number} x
+ * @param {number} y
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.bezierCurveTo = function(
+    cp1x, cp1y, cp2x, cp2y, x, y) {};
+
+/**
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @param {number} radius
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.arcTo = function(x1, y1, x2, y2, radius) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} w
+ * @param {number} h
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.rect = function(x, y, w, h) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} radius
+ * @param {number} startAngle
+ * @param {number} endAngle
+ * @param {boolean=} opt_anticlockwise
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.arc = function(
+    x, y, radius, startAngle, endAngle, opt_anticlockwise) {};
+
+/**
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.fill = function() {};
+
+/**
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.stroke = function() {};
+
+/**
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.clip = function() {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {boolean}
+ * @nosideeffects
+ */
+CanvasRenderingContext2D.prototype.isPointInPath = function(x, y) {};
+
+/**
+ * @param {string} text
+ * @param {number} x
+ * @param {number} y
+ * @param {number=} opt_maxWidth
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.fillText = function(
+    text, x, y, opt_maxWidth) {};
+
+/**
+ * @param {string} text
+ * @param {number} x
+ * @param {number} y
+ * @param {number=} opt_maxWidth
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.strokeText = function(
+    text, x, y, opt_maxWidth) {};
+
+/**
+ * @param {string} text
+ * @return {TextMetrics}
+ * @nosideeffects
+ */
+CanvasRenderingContext2D.prototype.measureText = function(text) {};
+
+/**
+ * @param {HTMLImageElement|HTMLCanvasElement|Image|HTMLVideoElement} image
+ * @param {number} dx Destination x coordinate.
+ * @param {number} dy Destination y coordinate.
+ * @param {number=} opt_dw Destination box width.  Defaults to the image width.
+ * @param {number=} opt_dh Destination box height.
+ *     Defaults to the image height.
+ * @param {number=} opt_sx Source box x coordinate.  Used to select a portion of
+ *     the source image to draw.  Defaults to 0.
+ * @param {number=} opt_sy Source box y coordinate.  Used to select a portion of
+ *     the source image to draw.  Defaults to 0.
+ * @param {number=} opt_sw Source box width.  Used to select a portion of
+ *     the source image to draw.  Defaults to the full image width.
+ * @param {number=} opt_sh Source box height.  Used to select a portion of
+ *     the source image to draw.  Defaults to the full image height.
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.drawImage = function(
+    image, dx, dy, opt_dw, opt_dh, opt_sx, opt_sy, opt_sw, opt_sh) {};
+
+/**
+ * @param {number} sw
+ * @param {number} sh
+ * @return {ImageData}
+ * @nosideeffects
+ */
+CanvasRenderingContext2D.prototype.createImageData = function(sw, sh) {};
+
+/**
+ * @param {number} sx
+ * @param {number} sy
+ * @param {number} sw
+ * @param {number} sh
+ * @return {ImageData}
+ * @throws {Error}
+ * @nosideeffects
+ */
+CanvasRenderingContext2D.prototype.getImageData = function(sx, sy, sw, sh) {};
+
+/**
+ * @param {ImageData} imagedata
+ * @param {number} dx
+ * @param {number} dy
+ * @param {number=} opt_dirtyX
+ * @param {number=} opt_dirtyY
+ * @param {number=} opt_dirtyWidth
+ * @param {number=} opt_dirtyHeight
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.putImageData = function(imagedata, dx, dy,
+    opt_dirtyX, opt_dirtyY, opt_dirtyWidth, opt_dirtyHeight) {};
+
+/**
+ * Note: WebKit only
+ * @param {number|string=} opt_a
+ * @param {number=} opt_b
+ * @param {number=} opt_c
+ * @param {number=} opt_d
+ * @param {number=} opt_e
+ * @see http://developer.apple.com/library/safari/#documentation/appleapplications/reference/WebKitDOMRef/CanvasRenderingContext2D_idl/Classes/CanvasRenderingContext2D/index.html
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.setFillColor;
+
+/**
+ * Note: WebKit only
+ * @param {number|string=} opt_a
+ * @param {number=} opt_b
+ * @param {number=} opt_c
+ * @param {number=} opt_d
+ * @param {number=} opt_e
+ * @see http://developer.apple.com/library/safari/#documentation/appleapplications/reference/WebKitDOMRef/CanvasRenderingContext2D_idl/Classes/CanvasRenderingContext2D/index.html
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.setStrokeColor;
+
+/**
+ * @return {Array.<number>}
+ */
+CanvasRenderingContext2D.prototype.getLineDash;
+
+/**
+ * @param {Array.<number>} segments
+ * @return {undefined}
+ */
+CanvasRenderingContext2D.prototype.setLineDash;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.fillColor;
+
+/**
+ * @type {string}
+ * @implicitCast
+ */
+CanvasRenderingContext2D.prototype.fillStyle;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.font;
+
+/** @type {number} */
+CanvasRenderingContext2D.prototype.globalAlpha;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.globalCompositeOperation;
+
+/** @type {number} */
+CanvasRenderingContext2D.prototype.lineWidth;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.lineCap;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.lineJoin;
+
+/** @type {number} */
+CanvasRenderingContext2D.prototype.miterLimit;
+
+/** @type {number} */
+CanvasRenderingContext2D.prototype.shadowBlur;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.shadowColor;
+
+/** @type {number} */
+CanvasRenderingContext2D.prototype.shadowOffsetX;
+
+/** @type {number} */
+CanvasRenderingContext2D.prototype.shadowOffsetY;
+
+/**
+ * @type {string}
+ * @implicitCast
+ */
+CanvasRenderingContext2D.prototype.strokeStyle;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.strokeColor;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.textAlign;
+
+/** @type {string} */
+CanvasRenderingContext2D.prototype.textBaseline;
+
+/**
+ * @constructor
+ */
+function CanvasGradient() {}
+
+/**
+ * @param {number} offset
+ * @param {string} color
+ * @return {undefined}
+ */
+CanvasGradient.prototype.addColorStop = function(offset, color) {};
+
+/**
+ * @constructor
+ */
+function CanvasPattern() {}
+
+/**
+ * @constructor
+ */
+function TextMetrics() {}
+
+/** @type {number} */
+TextMetrics.prototype.width;
+
+/**
+ * @constructor
+ */
+function ImageData() {}
+
+/** @type {Uint8ClampedArray} */
+ImageData.prototype.data;
+
+/** @type {number} */
+ImageData.prototype.width;
+
+/** @type {number} */
+ImageData.prototype.height;
+
+/**
+ * @constructor
+ */
+function ClientInformation() {}
+
+/** @type {boolean} */
+ClientInformation.prototype.onLine;
+
+/**
+ * @param {string} protocol
+ * @param {string} uri
+ * @param {string} title
+ * @return {undefined}
+ */
+ClientInformation.prototype.registerProtocolHandler = function(
+    protocol, uri, title) {};
+
+/**
+ * @param {string} mimeType
+ * @param {string} uri
+ * @param {string} title
+ * @return {undefined}
+ */
+ClientInformation.prototype.registerContentHandler = function(
+    mimeType, uri, title) {};
+
+// HTML5 Database objects
+/**
+ * @constructor
+ */
+function Database() {}
+
+/**
+ * @type {string}
+ */
+Database.prototype.version;
+
+/**
+ * @param {function(!SQLTransaction) : void} callback
+ * @param {(function(!SQLError) : void)=} opt_errorCallback
+ * @param {Function=} opt_Callback
+ */
+Database.prototype.transaction = function(
+    callback, opt_errorCallback, opt_Callback) {};
+
+/**
+ * @param {function(!SQLTransaction) : void} callback
+ * @param {(function(!SQLError) : void)=} opt_errorCallback
+ * @param {Function=} opt_Callback
+ */
+Database.prototype.readTransaction = function(
+    callback, opt_errorCallback, opt_Callback) {};
+
+/**
+ * @param {string} oldVersion
+ * @param {string} newVersion
+ * @param {function(!SQLTransaction) : void} callback
+ * @param {function(!SQLError) : void} errorCallback
+ * @param {Function} successCallback
+ */
+Database.prototype.changeVersion = function(
+    oldVersion, newVersion, callback, errorCallback, successCallback) {};
+
+/**
+ * @interface
+ */
+function DatabaseCallback() {}
+
+/**
+ * @param {!Database} db
+ * @return {undefined}
+ */
+DatabaseCallback.prototype.handleEvent = function(db) {};
+
+/**
+ * @constructor
+ */
+function SQLError() {}
+
+/**
+ * @type {number}
+ */
+SQLError.prototype.code;
+
+/**
+ * @type {string}
+ */
+SQLError.prototype.message;
+
+/**
+ * @constructor
+ */
+function SQLTransaction() {}
+
+/**
+ * @param {string} sqlStatement
+ * @param {Array.<*>=} opt_queryArgs
+ * @param {SQLStatementCallback=} opt_callback
+ * @param {(function(!SQLTransaction, !SQLError) : (boolean|void))=}
+ *     opt_errorCallback
+ */
+SQLTransaction.prototype.executeSql = function(
+    sqlStatement, opt_queryArgs, opt_callback, opt_errorCallback) {};
+
+/**
+ * @typedef {(function(!SQLTransaction, !SQLResultSet) : void)}
+ */
+var SQLStatementCallback;
+
+/**
+ * @constructor
+ */
+function SQLResultSet() {}
+
+/**
+ * @type {number}
+ */
+SQLResultSet.prototype.insertId;
+
+/**
+ * @type {number}
+ */
+SQLResultSet.prototype.rowsAffected;
+
+/**
+ * @type {SQLResultSetRowList}
+ */
+SQLResultSet.prototype.rows;
+
+/**
+ * @constructor
+ */
+function SQLResultSetRowList() {}
+
+/**
+ * @type {number}
+ */
+SQLResultSetRowList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {Object}
+ * @nosideeffects
+ */
+SQLResultSetRowList.prototype.item = function(index) {};
+
+/**
+ * @param {string} name
+ * @param {string} version
+ * @param {string} description
+ * @param {number} size
+ * @param {(DatabaseCallback|function(Database))=} opt_callback
+ * @return {Database}
+ */
+function openDatabase(name, version, description, size, opt_callback) {}
+
+/**
+ * @param {string} name
+ * @param {string} version
+ * @param {string} description
+ * @param {number} size
+ * @param {(DatabaseCallback|function(Database))=} opt_callback
+ * @return {Database}
+ */
+Window.prototype.openDatabase =
+    function(name, version, description, size, opt_callback) {};
+
+/**
+ * @type {boolean}
+ */
+HTMLImageElement.prototype.complete;
+
+/**
+ * @type {string}
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/embedded-content-1.html#attr-img-crossorigin
+ */
+HTMLImageElement.prototype.crossOrigin;
+
+/**
+ * This is a superposition of the Window and Worker postMessage methods.
+ * @param {*} message
+ * @param {(string|!Array.<!Transferable>)=} opt_targetOriginOrTransfer
+ * @param {(string|!Array.<!MessagePort>|!Array.<!Transferable>)=}
+ *     opt_targetOriginOrPortsOrTransfer
+ * @return {void}
+ */
+function postMessage(message, opt_targetOriginOrTransfer,
+    opt_targetOriginOrPortsOrTransfer) {}
+
+/**
+ * The postMessage method (as implemented in Opera).
+ * @param {string} message
+ */
+Document.prototype.postMessage = function(message) {};
+
+/**
+ * Document head accessor.
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/dom.html#the-head-element-0
+ * @type {HTMLHeadElement}
+ */
+Document.prototype.head;
+
+/**
+ * @see https://developer.apple.com/webapps/docs/documentation/AppleApplications/Reference/SafariJSRef/DOMApplicationCache/DOMApplicationCache.html
+ * @constructor
+ * @implements {EventTarget}
+ */
+function DOMApplicationCache() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+DOMApplicationCache.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+DOMApplicationCache.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+DOMApplicationCache.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * The object isn't associated with an application cache. This can occur if the
+ * update process fails and there is no previous cache to revert to, or if there
+ * is no manifest file.
+ * @type {number}
+ */
+DOMApplicationCache.prototype.UNCACHED = 0;
+
+/**
+ * The cache is idle.
+ * @type {number}
+ */
+DOMApplicationCache.prototype.IDLE = 1;
+
+/**
+ * The update has started but the resources are not downloaded yet - for
+ * example, this can happen when the manifest file is fetched.
+ * @type {number}
+ */
+DOMApplicationCache.prototype.CHECKING = 2;
+
+/**
+ * The resources are being downloaded into the cache.
+ * @type {number}
+ */
+DOMApplicationCache.prototype.DOWNLOADING = 3;
+
+/**
+ * Resources have finished downloading and the new cache is ready to be used.
+ * @type {number}
+ */
+DOMApplicationCache.prototype.UPDATEREADY = 4;
+
+/**
+ * The cache is obsolete.
+ * @type {number}
+ */
+DOMApplicationCache.prototype.OBSOLETE = 5;
+
+/**
+ * The current status of the application cache.
+ * @type {number}
+ */
+DOMApplicationCache.prototype.status;
+
+/**
+ * Sent when the update process finishes for the first time; that is, the first
+ * time an application cache is saved.
+ * @type {?function(!Event)}
+ */
+DOMApplicationCache.prototype.oncached;
+
+/**
+ * Sent when the cache update process begins.
+ * @type {?function(!Event)}
+ */
+DOMApplicationCache.prototype.onchecking;
+
+/**
+ * Sent when the update process begins downloading resources in the manifest
+ * file.
+ * @type {?function(!Event)}
+ */
+DOMApplicationCache.prototype.ondownloading;
+
+/**
+ * Sent when an error occurs.
+ * @type {?function(!Event)}
+ */
+DOMApplicationCache.prototype.onerror;
+
+/**
+ * Sent when the update process finishes but the manifest file does not change.
+ * @type {?function(!Event)}
+ */
+DOMApplicationCache.prototype.onnoupdate;
+
+/**
+ * Sent when each resource in the manifest file begins to download.
+ * @type {?function(!Event)}
+ */
+DOMApplicationCache.prototype.onprogress;
+
+/**
+ * Sent when there is an existing application cache, the update process
+ * finishes, and there is a new application cache ready for use.
+ * @type {?function(!Event)}
+ */
+DOMApplicationCache.prototype.onupdateready;
+
+/**
+ * Replaces the active cache with the latest version.
+ * @throws {DOMException}
+ */
+DOMApplicationCache.prototype.swapCache = function() {};
+
+/**
+ * Manually triggers the update process.
+ * @throws {DOMException}
+ */
+DOMApplicationCache.prototype.update = function() {};
+
+/** @type {DOMApplicationCache} */
+var applicationCache;
+
+/** @type {DOMApplicationCache} */
+Window.prototype.applicationCache;
+
+/**
+ * @see https://developer.mozilla.org/En/DOM/Worker/Functions_available_to_workers
+ * @param {...string} var_args
+ */
+Window.prototype.importScripts = function(var_args) {};
+
+/**
+ * @see https://developer.mozilla.org/En/DOM/Worker/Functions_available_to_workers
+ * @param {...string} var_args
+ */
+var importScripts = function(var_args) {};
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @constructor
+ * @implements {EventTarget}
+ */
+function WebWorker() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+WebWorker.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+WebWorker.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+WebWorker.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * Stops the worker process
+ */
+WebWorker.prototype.terminate = function() {};
+
+/**
+ * Posts a message to the worker thread.
+ * @param {string} message
+ */
+WebWorker.prototype.postMessage = function(message) {};
+
+/**
+ * Sent when the worker thread posts a message to its creator.
+ * @type {?function(!MessageEvent.<*>)}
+ */
+WebWorker.prototype.onmessage;
+
+/**
+ * Sent when the worker thread encounters an error.
+ * TODO(tbreisacher): Should this change to function(!ErrorEvent)?
+ * @type {?function(!Event)}
+ */
+WebWorker.prototype.onerror;
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @constructor
+ * @implements {EventTarget}
+ */
+function Worker(opt_arg0) {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Worker.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Worker.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+Worker.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * Stops the worker process
+ */
+Worker.prototype.terminate = function() {};
+
+/**
+ * Posts a message to the worker thread.
+ * @param {*} message
+ * @param {Array.<!Transferable>=} opt_transfer
+ */
+Worker.prototype.postMessage = function(message, opt_transfer) {};
+
+/**
+ * Posts a message to the worker thread.
+ * @param {*} message
+ * @param {Array.<!Transferable>=} opt_transfer
+ */
+Worker.prototype.webkitPostMessage = function(message, opt_transfer) {};
+
+/**
+ * Sent when the worker thread posts a message to its creator.
+ * @type {?function(!MessageEvent.<*>)}
+ */
+Worker.prototype.onmessage;
+
+/**
+ * Sent when the worker thread encounters an error.
+ * TODO(tbreisacher): Should this change to function(!ErrorEvent)?
+ * @type {?function(!Event)}
+ */
+Worker.prototype.onerror;
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @param {string} scriptURL The URL of the script to run in the SharedWorker.
+ * @param {string=} opt_name A name that can later be used to obtain a
+ *     reference to the same SharedWorker.
+ * @constructor
+ * @implements {EventTarget}
+ */
+function SharedWorker(scriptURL, opt_name) {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+SharedWorker.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+SharedWorker.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+SharedWorker.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * @type {!MessagePort}
+ */
+SharedWorker.prototype.port;
+
+/**
+ * Called on network errors for loading the initial script.
+ * TODO(tbreisacher): Should this change to function(!ErrorEvent)?
+ * @type {?function(!Event)}
+ */
+SharedWorker.prototype.onerror;
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @interface
+ */
+function WorkerLocation() {}
+
+/** @type {string} */
+WorkerLocation.prototype.protocol;
+
+/** @type {string} */
+WorkerLocation.prototype.host;
+
+/** @type {string} */
+WorkerLocation.prototype.hostname;
+
+/** @type {string} */
+WorkerLocation.prototype.port;
+
+/** @type {string} */
+WorkerLocation.prototype.pathname;
+
+/** @type {string} */
+WorkerLocation.prototype.search;
+
+/** @type {string} */
+WorkerLocation.prototype.hash;
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @interface
+ * @extends {EventTarget}
+ */
+function WorkerGlobalScope() {}
+
+/** @type {WorkerGlobalScope} */
+WorkerGlobalScope.prototype.self;
+
+/** @type {WorkerLocation} */
+WorkerGlobalScope.prototype.location;
+
+/**
+ * Closes the worker represented by this WorkerGlobalScope.
+ */
+WorkerGlobalScope.prototype.close = function() {};
+
+/**
+ * Sent when the worker encounters an error.
+ * @type {?function(!Event)}
+ */
+WorkerGlobalScope.prototype.onerror;
+
+/**
+ * Sent when the worker goes offline.
+ * @type {?function(!Event)}
+ */
+WorkerGlobalScope.prototype.onoffline;
+
+/**
+ * Sent when the worker goes online.
+ * @type {?function(!Event)}
+ */
+WorkerGlobalScope.prototype.ononline;
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @interface
+ * @extends {WorkerGlobalScope}
+ */
+function DedicatedWorkerGlobalScope() {}
+
+/**
+ * Posts a message to creator of this worker.
+ * @param {*} message
+ * @param {Array.<!Transferable>=} opt_transfer
+ */
+DedicatedWorkerGlobalScope.prototype.postMessage =
+    function(message, opt_transfer) {};
+
+/**
+ * Posts a message to creator of this worker.
+ * @param {*} message
+ * @param {Array.<!Transferable>=} opt_transfer
+ */
+DedicatedWorkerGlobalScope.prototype.webkitPostMessage =
+    function(message, opt_transfer) {};
+
+/**
+ * Sent when the creator posts a message to this worker.
+ * @type {?function(!MessageEvent.<*>)}
+ */
+DedicatedWorkerGlobalScope.prototype.onmessage;
+
+/**
+ * @see http://dev.w3.org/html5/workers/
+ * @interface
+ * @extends {WorkerGlobalScope}
+ */
+function SharedWorkerGlobalScope() {}
+
+/** @type {string} */
+SharedWorkerGlobalScope.prototype.name;
+
+/**
+ * Sent when a connection to this worker is opened.
+ * @type {?function(!Event)}
+ */
+SharedWorkerGlobalScope.prototype.onconnect;
+
+/** @type {Element} */
+HTMLElement.prototype.contextMenu;
+
+/** @type {boolean} */
+HTMLElement.prototype.draggable;
+
+/**
+ * This is actually a DOMSettableTokenList property. However since that
+ * interface isn't currently defined and no known browsers implement this
+ * feature, just define the property for now.
+ *
+ * @const
+ * @type {Object}
+ */
+HTMLElement.prototype.dropzone;
+
+/**
+ * @see http://www.w3.org/TR/html5/dom.html#dom-getelementsbyclassname
+ * @param {string} classNames
+ * @return {!NodeList}
+ * @nosideeffects
+ */
+HTMLElement.prototype.getElementsByClassName = function(classNames) {};
+// NOTE: Document.prototype.getElementsByClassName is in gecko_dom.js
+
+/** @type {boolean} */
+HTMLElement.prototype.hidden;
+
+/** @type {boolean} */
+HTMLElement.prototype.spellcheck;
+
+/**
+ * @see http://www.w3.org/TR/components-intro/
+ * @return {!ShadowRoot}
+ */
+HTMLElement.prototype.createShadowRoot;
+
+/**
+ * @see http://www.w3.org/TR/components-intro/
+ * @return {!ShadowRoot}
+ */
+HTMLElement.prototype.webkitCreateShadowRoot;
+
+/**
+ * @see http://www.w3.org/TR/shadow-dom/
+ * @type {ShadowRoot}
+ */
+HTMLElement.prototype.shadowRoot;
+
+/**
+ * @see http://www.w3.org/TR/shadow-dom/
+ * @return {!NodeList}
+ */
+HTMLElement.prototype.getDestinationInsertionPoints = function() {};
+
+/**
+ * @see http://www.w3.org/TR/components-intro/
+ * @type {function()}
+ */
+HTMLElement.prototype.createdCallback;
+
+/**
+ * @see http://w3c.github.io/webcomponents/explainer/#lifecycle-callbacks
+ * @type {function()}
+ */
+HTMLElement.prototype.attachedCallback;
+
+/**
+ * @see http://w3c.github.io/webcomponents/explainer/#lifecycle-callbacks
+ * @type {function()}
+ */
+HTMLElement.prototype.detachedCallback;
+
+/** @type {string} */
+HTMLAnchorElement.prototype.hash;
+
+/** @type {string} */
+HTMLAnchorElement.prototype.host;
+
+/** @type {string} */
+HTMLAnchorElement.prototype.hostname;
+
+/** @type {string} */
+HTMLAnchorElement.prototype.pathname;
+
+/**
+ * The 'ping' attribute is known to be supported in recent versions (as of
+ * mid-2014) of Chrome, Safari, and Firefox, and is not supported in any
+ * current version of Internet Explorer.
+ *
+ * @type {string}
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#hyperlink-auditing
+ */
+HTMLAnchorElement.prototype.ping;
+
+/** @type {string} */
+HTMLAnchorElement.prototype.port;
+
+/** @type {string} */
+HTMLAnchorElement.prototype.protocol;
+
+/** @type {string} */
+HTMLAnchorElement.prototype.search;
+
+/**
+ * @type {string}
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#hyperlink-auditing
+ */
+HTMLAreaElement.prototype.ping;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html-markup/iframe.html#iframe.attrs.srcdoc
+ */
+HTMLIFrameElement.prototype.srcdoc;
+
+/** @type {string} */
+HTMLInputElement.prototype.autocomplete;
+
+/** @type {string} */
+HTMLInputElement.prototype.dirname;
+
+/** @type {FileList} */
+HTMLInputElement.prototype.files;
+
+/** @type {string} */
+HTMLInputElement.prototype.list;
+
+/** @type {string} */
+HTMLInputElement.prototype.max;
+
+/** @type {string} */
+HTMLInputElement.prototype.min;
+
+/** @type {string} */
+HTMLInputElement.prototype.pattern;
+
+/** @type {boolean} */
+HTMLInputElement.prototype.multiple;
+
+/** @type {string} */
+HTMLInputElement.prototype.placeholder;
+
+/** @type {boolean} */
+HTMLInputElement.prototype.required;
+
+/** @type {string} */
+HTMLInputElement.prototype.step;
+
+/** @type {Date} */
+HTMLInputElement.prototype.valueAsDate;
+
+/** @type {number} */
+HTMLInputElement.prototype.valueAsNumber;
+
+/**
+ * Changes the form control's value by the value given in the step attribute
+ * multiplied by opt_n.
+ * @param {number=} opt_n step multiplier.  Defaults to 1.
+ */
+HTMLInputElement.prototype.stepDown = function(opt_n) {};
+
+/**
+ * Changes the form control's value by the value given in the step attribute
+ * multiplied by opt_n.
+ * @param {number=} opt_n step multiplier.  Defaults to 1.
+ */
+HTMLInputElement.prototype.stepUp = function(opt_n) {};
+
+
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement
+ */
+function HTMLMediaElement() {}
+
+/**
+ * @type {number}
+ * @const
+ */
+HTMLMediaElement.HAVE_NOTHING;  // = 0
+
+/**
+ * @type {number}
+ * @const
+ */
+HTMLMediaElement.HAVE_METADATA;  // = 1
+
+/**
+ * @type {number}
+ * @const
+ */
+HTMLMediaElement.HAVE_CURRENT_DATA;  // = 2
+
+/**
+ * @type {number}
+ * @const
+ */
+HTMLMediaElement.HAVE_FUTURE_DATA;  // = 3
+
+/**
+ * @type {number}
+ * @const
+ */
+HTMLMediaElement.HAVE_ENOUGH_DATA;  // = 4
+
+/** @type {MediaError} */
+HTMLMediaElement.prototype.error;
+
+/** @type {string} */
+HTMLMediaElement.prototype.src;
+
+/** @type {string} */
+HTMLMediaElement.prototype.currentSrc;
+
+/** @type {number} */
+HTMLMediaElement.prototype.networkState;
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.autobuffer;
+
+/** @type {TimeRanges} */
+HTMLMediaElement.prototype.buffered;
+
+/**
+ * Loads the media element.
+ */
+HTMLMediaElement.prototype.load = function() {};
+
+/**
+ * @param {string} type Type of the element in question in question.
+ * @return {string} Whether it can play the type.
+ * @nosideeffects
+ */
+HTMLMediaElement.prototype.canPlayType = function(type) {};
+
+/**
+ * Callback when the media is buffered and ready to play through.
+ * @type {function(!Event)}
+ */
+HTMLMediaElement.prototype.oncanplaythrough;
+
+/** @type {number} */
+HTMLMediaElement.prototype.readyState;
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.seeking;
+
+/**
+ * The current time, in seconds.
+ * @type {number}
+ */
+HTMLMediaElement.prototype.currentTime;
+
+/**
+ * The absolute timeline offset.
+ * @return {!Date}
+ */
+HTMLMediaElement.prototype.getStartDate = function() {};
+
+/**
+ * The length of the media in seconds.
+ * @type {number}
+ */
+HTMLMediaElement.prototype.duration;
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.paused;
+
+/** @type {number} */
+HTMLMediaElement.prototype.defaultPlaybackRate;
+
+/** @type {number} */
+HTMLMediaElement.prototype.playbackRate;
+
+/** @type {TimeRanges} */
+HTMLMediaElement.prototype.played;
+
+/** @type {TimeRanges} */
+HTMLMediaElement.prototype.seekable;
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.ended;
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.autoplay;
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.loop;
+
+/**
+ * Starts playing the media.
+ */
+HTMLMediaElement.prototype.play = function() {};
+
+/**
+ * Pauses the media.
+ */
+HTMLMediaElement.prototype.pause = function() {};
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.controls;
+
+/**
+ * The audio volume, from 0.0 (silent) to 1.0 (loudest).
+ * @type {number}
+ */
+HTMLMediaElement.prototype.volume;
+
+/** @type {boolean} */
+HTMLMediaElement.prototype.muted;
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#dom-media-addtexttrack
+ * @param {string} kind Kind of the text track.
+ * @param {string=} opt_label Label of the text track.
+ * @param {string=} opt_language Language of the text track.
+ * @return {TextTrack} TextTrack object added to the media element.
+ */
+HTMLMediaElement.prototype.addTextTrack =
+    function(kind, opt_label, opt_language) {};
+
+/** @type {TextTrackList} */
+HTMLMediaElement.prototype.textTracks;
+
+
+/**
+ * @see http://www.w3.org/TR/shadow-dom/
+ * @return {!NodeList}
+ */
+Text.prototype.getDestinationInsertionPoints = function() {};
+
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#texttracklist
+ * @constructor
+ */
+function TextTrackList() {}
+
+/** @type {number} */
+TextTrackList.prototype.length;
+
+/**
+ * @param {string} id
+ * @return {TextTrack}
+ */
+TextTrackList.prototype.getTrackById = function(id) {};
+
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#texttrack
+ * @constructor
+ * @implements {EventTarget}
+ */
+function TextTrack() {}
+
+/**
+ * @param {TextTrackCue} cue
+ */
+TextTrack.prototype.addCue = function(cue) {};
+
+/**
+ * @param {TextTrackCue} cue
+ */
+TextTrack.prototype.removeCue = function(cue) {};
+
+/**
+ * @const {TextTrackCueList}
+ */
+TextTrack.prototype.activeCues;
+
+/**
+ * @const {TextTrackCueList}
+ */
+TextTrack.prototype.cues;
+
+/** @override */
+TextTrack.prototype.addEventListener = function(type, listener, useCapture) {};
+
+/** @override */
+TextTrack.prototype.dispatchEvent = function(evt) {};
+
+/** @override */
+TextTrack.prototype.removeEventListener = function(type, listener, useCapture)
+    {};
+
+
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#texttrackcuelist
+ * @constructor
+ */
+function TextTrackCueList() {}
+
+/** @const {number} */
+TextTrackCueList.prototype.length;
+
+/**
+ * @param {string} id
+ * @return {TextTrackCue}
+ */
+TextTrackCueList.prototype.getCueById = function(id) {};
+
+
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/the-video-element.html#texttrackcue
+ * @constructor
+ * @param {number} startTime
+ * @param {number} endTime
+ * @param {string} text
+ */
+function TextTrackCue(startTime, endTime, text) {}
+
+/** @type {string} */
+TextTrackCue.prototype.id;
+
+/** @type {number} */
+TextTrackCue.prototype.startTime;
+
+/** @type {number} */
+TextTrackCue.prototype.endTime;
+
+/** @type {string} */
+TextTrackCue.prototype.text;
+
+
+/**
+ * @see http://dev.w3.org/html5/webvtt/#the-vttcue-interface
+ * @constructor
+ * @extends {TextTrackCue}
+ */
+function VTTCue(startTime, endTime, text) {}
+
+
+/**
+ * @constructor
+ * @extends {HTMLMediaElement}
+ */
+function HTMLAudioElement() {}
+
+/**
+ * @constructor
+ * @extends {HTMLMediaElement}
+ * The webkit-prefixed attributes are defined in
+ * https://code.google.com/p/chromium/codesearch#chromium/src/third_party/WebKit/Source/core/html/HTMLVideoElement.idl
+ */
+function HTMLVideoElement() {}
+
+/**
+ * Starts displaying the video in full screen mode.
+ */
+HTMLVideoElement.prototype.webkitEnterFullscreen = function() {};
+
+/**
+ * Starts displaying the video in full screen mode.
+ */
+HTMLVideoElement.prototype.webkitEnterFullScreen = function() {};
+
+/**
+ * Stops displaying the video in full screen mode.
+ */
+HTMLVideoElement.prototype.webkitExitFullscreen = function() {};
+
+/**
+ * Stops displaying the video in full screen mode.
+ */
+HTMLVideoElement.prototype.webkitExitFullScreen = function() {};
+
+/** @type {string} */
+HTMLVideoElement.prototype.width;
+
+/** @type {string} */
+HTMLVideoElement.prototype.height;
+
+/** @type {number} */
+HTMLVideoElement.prototype.videoWidth;
+
+/** @type {number} */
+HTMLVideoElement.prototype.videoHeight;
+
+/** @type {string} */
+HTMLVideoElement.prototype.poster;
+
+/** @type {boolean} */
+HTMLVideoElement.prototype.webkitSupportsFullscreen;
+
+/** @type {boolean} */
+HTMLVideoElement.prototype.webkitDisplayingFullscreen;
+
+/** @type {number} */
+HTMLVideoElement.prototype.webkitDecodedFrameCount;
+
+/** @type {number} */
+HTMLVideoElement.prototype.webkitDroppedFrameCount;
+
+/**
+ * @constructor
+ */
+function MediaError() {}
+
+/** @type {number} */
+MediaError.prototype.code;
+
+// HTML5 MessageChannel
+/**
+ * @see http://dev.w3.org/html5/spec/comms.html#messagechannel
+ * @constructor
+ */
+function MessageChannel() {}
+
+/**
+ * Returns the first port.
+ * @type {!MessagePort}
+ */
+MessageChannel.prototype.port1;
+
+/**
+ * Returns the second port.
+ * @type {!MessagePort}
+ */
+MessageChannel.prototype.port2;
+
+// HTML5 MessagePort
+/**
+ * @see http://dev.w3.org/html5/spec/comms.html#messageport
+ * @constructor
+ * @implements {EventTarget}
+ * @implements {Transferable}
+ */
+function MessagePort() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+MessagePort.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+MessagePort.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+MessagePort.prototype.dispatchEvent = function(evt) {};
+
+
+/**
+ * Posts a message through the channel, optionally with the given
+ * Array of Transferables.
+ * @param {*} message
+ * @param {Array.<!Transferable>=} opt_transfer
+ */
+MessagePort.prototype.postMessage = function(message, opt_transfer) {
+};
+
+/**
+ * Begins dispatching messages received on the port.
+ */
+MessagePort.prototype.start = function() {};
+
+/**
+ * Disconnects the port, so that it is no longer active.
+ */
+MessagePort.prototype.close = function() {};
+
+/**
+ * TODO(blickly): Change this to MessageEvent.<*> and add casts as needed
+ * @type {?function(!MessageEvent.<?>)}
+ */
+MessagePort.prototype.onmessage;
+
+// HTML5 MessageEvent class
+/**
+ * @see http://dev.w3.org/html5/spec/comms.html#messageevent
+ * @constructor
+ * @extends {Event}
+ * @template T
+ */
+function MessageEvent() {}
+
+/**
+ * The data payload of the message.
+ * @type {T}
+ */
+MessageEvent.prototype.data;
+
+/**
+ * The origin of the message, for server-sent events and cross-document
+ * messaging.
+ * @type {string}
+ */
+MessageEvent.prototype.origin;
+
+/**
+ * The last event ID, for server-sent events.
+ * @type {string}
+ */
+MessageEvent.prototype.lastEventId;
+
+/**
+ * The window that dispatched the event.
+ * @type {Window}
+ */
+MessageEvent.prototype.source;
+
+/**
+ * The Array of MessagePorts sent with the message, for cross-document
+ * messaging and channel messaging.
+ * @type {Array.<MessagePort>}
+ */
+MessageEvent.prototype.ports;
+
+/**
+ * Initializes the event in a manner analogous to the similarly-named methods in
+ * the DOM Events interfaces.
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {T} dataArg
+ * @param {string} originArg
+ * @param {string} lastEventIdArg
+ * @param {Window} sourceArg
+ * @param {Array.<MessagePort>} portsArg
+ */
+MessageEvent.prototype.initMessageEvent = function(typeArg, canBubbleArg,
+    cancelableArg, dataArg, originArg, lastEventIdArg, sourceArg, portsArg) {};
+
+/**
+ * Initializes the event in a manner analogous to the similarly-named methods in
+ * the DOM Events interfaces.
+ * @param {string} namespaceURI
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {T} dataArg
+ * @param {string} originArg
+ * @param {string} lastEventIdArg
+ * @param {Window} sourceArg
+ * @param {Array.<MessagePort>} portsArg
+ */
+MessageEvent.prototype.initMessageEventNS = function(namespaceURI, typeArg,
+    canBubbleArg, cancelableArg, dataArg, originArg, lastEventIdArg, sourceArg,
+    portsArg) {};
+
+/**
+ * HTML5 DataTransfer class.
+ *
+ * We say that this extends ClipboardData, because Event.prototype.clipboardData
+ * is a DataTransfer on WebKit but a ClipboardData on IE. The interfaces are so
+ * similar that it's easier to merge them.
+ *
+ * @see http://www.w3.org/TR/2011/WD-html5-20110113/dnd.html
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html
+ * @see http://developers.whatwg.org/dnd.html#datatransferitem
+ * @constructor
+ * @extends {ClipboardData}
+ */
+function DataTransfer() {}
+
+/** @type {string} */
+DataTransfer.prototype.dropEffect;
+
+/** @type {string} */
+DataTransfer.prototype.effectAllowed;
+
+/** @type {Array.<string>} */
+DataTransfer.prototype.types;
+
+/** @type {FileList} */
+DataTransfer.prototype.files;
+
+/**
+ * @param {string=} opt_format Format for which to remove data.
+ * @override
+ */
+DataTransfer.prototype.clearData = function(opt_format) {};
+
+/**
+ * @param {string} format Format for which to set data.
+ * @param {string} data Data to add.
+ * @override
+ */
+DataTransfer.prototype.setData = function(format, data) {};
+
+/**
+ * @param {string} format Format for which to set data.
+ * @return {string} Data for the given format.
+ * @override
+ */
+DataTransfer.prototype.getData = function(format) { return ''; };
+
+/**
+ * @param {HTMLElement} img The image to use when dragging.
+ * @param {number} x Horizontal position of the cursor.
+ * @param {number} y Vertical position of the cursor.
+ */
+DataTransfer.prototype.setDragImage = function(img, x, y) {};
+
+/**
+ * @param {HTMLElement} elem Element to receive drag result events.
+ */
+DataTransfer.prototype.addElement = function(elem) {};
+
+/**
+ * Addition for accessing clipboard file data that are part of the proposed
+ * HTML5 spec.
+ * @type {DataTransfer}
+ */
+MouseEvent.prototype.dataTransfer;
+
+/**
+ * @typedef {{
+ *   bubbles: (boolean|undefined),
+ *   cancelable: (boolean|undefined),
+ *   view: (Window|undefined),
+ *   detail: (number|undefined),
+ *   screenX: (number|undefined),
+ *   screenY: (number|undefined),
+ *   clientX: (number|undefined),
+ *   clientY: (number|undefined),
+ *   ctrlKey: (boolean|undefined),
+ *   shiftKey: (boolean|undefined),
+ *   altKey: (boolean|undefined),
+ *   metaKey: (boolean|undefined),
+ *   button: (number|undefined),
+ *   buttons: (number|undefined),
+ *   relatedTarget: (EventTarget|undefined),
+ *   deltaX: (number|undefined),
+ *   deltaY: (number|undefined),
+ *   deltaZ: (number|undefined),
+ *   deltaMode: (number|undefined)
+ * }}
+ */
+var WheelEventInit;
+
+/**
+ * @param {string} type
+ * @param {WheelEventInit=} opt_eventInitDict
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#interface-WheelEvent
+ * @constructor
+ * @extends {MouseEvent}
+ */
+var WheelEvent = function(type, opt_eventInitDict) {};
+
+/** @const {number} */
+WheelEvent.prototype.deltaX;
+
+/** @const {number} */
+WheelEvent.prototype.deltaY;
+
+/** @const {number} */
+WheelEvent.prototype.deltaZ;
+
+/** @const {number} */
+WheelEvent.prototype.deltaMode;
+
+/**
+ * HTML5 DataTransferItem class.
+ *
+ * @see http://www.w3.org/TR/2011/WD-html5-20110113/dnd.html
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html
+ * @see http://developers.whatwg.org/dnd.html#datatransferitem
+ * @constructor
+ */
+var DataTransferItem = function() {};
+
+/** @type {string} */
+DataTransferItem.prototype.kind;
+
+/** @type {string} */
+DataTransferItem.prototype.type;
+
+/**
+ * @param {function(string)} callback
+ * @nosideeffects
+ */
+DataTransferItem.prototype.getAsString = function(callback) {};
+
+/**
+ * @return {?File} The file corresponding to this item, or null.
+ * @nosideeffects
+ */
+DataTransferItem.prototype.getAsFile = function() { return null; };
+
+/**
+ * @return {?Entry} The Entry corresponding to this item, or null. Note that
+ * despite its name,this method only works in Chrome, and will eventually
+ * be renamed to {@code getAsEntry}.
+ * @nosideeffects
+ */
+DataTransferItem.prototype.webkitGetAsEntry = function() { return null; };
+
+/**
+ * HTML5 DataTransferItemList class. There are some discrepancies in the docs
+ * on the whatwg.org site. When in doubt, these prototypes match what is
+ * implemented as of Chrome 30.
+ *
+ * @see http://www.w3.org/TR/2011/WD-html5-20110113/dnd.html
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html
+ * @see http://developers.whatwg.org/dnd.html#datatransferitem
+ * @constructor
+ */
+var DataTransferItemList = function() {};
+
+/** @type {number} */
+DataTransferItemList.prototype.length;
+
+/**
+ * @param {number} i File to return from the list.
+ * @return {DataTransferItem} The ith DataTransferItem in the list, or null.
+ * @nosideeffects
+ */
+DataTransferItemList.prototype.item = function(i) { return null; };
+
+/**
+ * Adds an item to the list.
+ * @param {string|!File} data Data for the item being added.
+ * @param {string=} opt_type Mime type of the item being added. MUST be present
+ *     if the {@code data} parameter is a string.
+ */
+DataTransferItemList.prototype.add = function(data, opt_type) {};
+
+/**
+ * Removes an item from the list.
+ * @param {number} i File to remove from the list.
+ */
+DataTransferItemList.prototype.remove = function(i) {};
+
+/**
+ * Removes all items from the list.
+ */
+DataTransferItemList.prototype.clear = function() {};
+
+/** @type {!DataTransferItemList} */
+DataTransfer.prototype.items;
+
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/multipage/dnd.html#the-dragevent-interface
+ * @constructor
+ * @extends {MouseEvent}
+ */
+function DragEvent() {}
+
+/** @type {DataTransfer} */
+DragEvent.prototype.dataTransfer;
+
+
+/**
+ * @typedef {{
+ *   lengthComputable: (boolean|undefined),
+ *   loaded: (number|undefined),
+ *   total: (number|undefined)
+ * }}
+ */
+var ProgressEventInit;
+
+/**
+ * @constructor
+ * @param {string} type
+ * @param {ProgressEventInit=} opt_progressEventInitDict
+ * @extends {Event}
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
+ */
+function ProgressEvent(type, opt_progressEventInitDict) {}
+
+/** @type {number} */
+ProgressEvent.prototype.total;
+
+/** @type {number} */
+ProgressEvent.prototype.loaded;
+
+/** @type {boolean} */
+ProgressEvent.prototype.lengthComputable;
+
+
+/**
+ * @constructor
+ */
+function TimeRanges() {}
+
+/** @type {number} */
+TimeRanges.prototype.length;
+
+/**
+ * @param {number} index The index.
+ * @return {number} The start time of the range at index.
+ * @throws {DOMException}
+ */
+TimeRanges.prototype.start = function(index) { return 0; };
+
+/**
+ * @param {number} index The index.
+ * @return {number} The end time of the range at index.
+ * @throws {DOMException}
+ */
+TimeRanges.prototype.end = function(index) { return 0; };
+
+
+// HTML5 Web Socket class
+/**
+ * @see http://dev.w3.org/html5/websockets/
+ * @constructor
+ * @param {string} url
+ * @param {string=} opt_protocol
+ * @implements {EventTarget}
+ */
+function WebSocket(url, opt_protocol) {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+WebSocket.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+WebSocket.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+WebSocket.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * Returns the URL value that was passed to the constructor.
+ * @type {string}
+ */
+WebSocket.prototype.URL;
+
+/**
+ * The connection has not yet been established.
+ * @type {number}
+ */
+WebSocket.prototype.CONNECTING = 0;
+
+/**
+ * The Web Socket connection is established and communication is possible.
+ * @type {number}
+ */
+WebSocket.prototype.OPEN = 1;
+
+/**
+ * The connection has been closed or could not be opened.
+ * @type {number}
+ */
+WebSocket.prototype.CLOSED = 2;
+
+/**
+ * Represents the state of the connection.
+ * @type {number}
+ */
+WebSocket.prototype.readyState;
+
+/**
+ * Returns the number of bytes that have been queued but not yet sent.
+ * @type {number}
+ */
+WebSocket.prototype.bufferedAmount;
+
+/**
+ * An event handler called on open event.
+ * @type {?function(!Event)}
+ */
+WebSocket.prototype.onopen;
+
+/**
+ * An event handler called on message event.
+ * TODO(blickly): Change this to MessageEvent.<*> and add casts as needed
+ * @type {?function(!MessageEvent.<?>)}
+ */
+WebSocket.prototype.onmessage;
+
+/**
+ * An event handler called on close event.
+ * @type {?function(!Event)}
+ */
+WebSocket.prototype.onclose;
+
+/**
+ * Transmits data using the connection.
+ * @param {string|ArrayBuffer|ArrayBufferView} data
+ * @return {boolean}
+ */
+WebSocket.prototype.send = function(data) {};
+
+/**
+ * Closes the Web Socket connection or connection attempt, if any.
+ */
+WebSocket.prototype.close = function() {};
+
+/**
+ * @type {string} Sets the type of data (blob or arraybuffer) for binary data.
+ */
+WebSocket.prototype.binaryType;
+
+// HTML5 History
+/**
+ * Pushes a new state into the session history.
+ * @see http://www.w3.org/TR/html5/history.html#the-history-interface
+ * @param {*} data New state.
+ * @param {string} title The title for a new session history entry.
+ * @param {string=} opt_url The URL for a new session history entry.
+ */
+History.prototype.pushState = function(data, title, opt_url) {};
+
+/**
+ * Replaces the current state in the session history.
+ * @see http://www.w3.org/TR/html5/history.html#the-history-interface
+ * @param {*} data New state.
+ * @param {string} title The title for a session history entry.
+ * @param {string=} opt_url The URL for a new session history entry.
+ */
+History.prototype.replaceState = function(data, title, opt_url) {};
+
+/**
+ * Pending state object.
+ * @see https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Manipulating_the_browser_history#Reading_the_current_state
+ * @type {*}
+ */
+History.prototype.state;
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/#popstateevent
+ * @constructor
+ * @extends {Event}
+ *
+ * @param {string} type
+ * @param {{state: *}=} opt_eventInitDict
+ */
+function PopStateEvent(type, opt_eventInitDict) {}
+
+/**
+ * @type {*}
+ */
+PopStateEvent.prototype.state;
+
+/**
+ * Initializes the event after it has been created with document.createEvent
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {*} stateArg
+ */
+PopStateEvent.prototype.initPopStateEvent = function(typeArg, canBubbleArg,
+    cancelableArg, stateArg) {};
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/#hashchangeevent
+ * @constructor
+ * @extends {Event}
+ *
+ * @param {string} type
+ * @param {{oldURL: string, newURL: string}=} opt_eventInitDict
+ */
+function HashChangeEvent(type, opt_eventInitDict) {}
+
+/** @type {string} */
+HashChangeEvent.prototype.oldURL;
+
+/** @type {string} */
+HashChangeEvent.prototype.newURL;
+
+/**
+ * Initializes the event after it has been created with document.createEvent
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {string} oldURLArg
+ * @param {string} newURLArg
+ */
+HashChangeEvent.prototype.initHashChangeEvent = function(typeArg, canBubbleArg,
+    cancelableArg, oldURLArg, newURLArg) {};
+
+/**
+ * @see http://www.whatwg.org/specs/web-apps/current-work/#pagetransitionevent
+ * @constructor
+ * @extends {Event}
+ *
+ * @param {string} type
+ * @param {{persisted: boolean}=} opt_eventInitDict
+ */
+function PageTransitionEvent(type, opt_eventInitDict) {}
+
+/** @type {boolean} */
+PageTransitionEvent.prototype.persisted;
+
+/**
+ * Initializes the event after it has been created with document.createEvent
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {*} persistedArg
+ */
+PageTransitionEvent.prototype.initPageTransitionEvent = function(typeArg,
+    canBubbleArg, cancelableArg, persistedArg) {};
+
+/**
+ * @constructor
+ */
+function FileList() {}
+
+/** @type {number} */
+FileList.prototype.length;
+
+/**
+ * @param {number} i File to return from the list.
+ * @return {File} The ith file in the list.
+ * @nosideeffects
+ */
+FileList.prototype.item = function(i) { return null; };
+
+/**
+ * @type {boolean}
+ * @see http://dev.w3.org/2006/webapi/XMLHttpRequest-2/#withcredentials
+ */
+XMLHttpRequest.prototype.withCredentials;
+
+/**
+ * @type {XMLHttpRequestUpload}
+ * @see http://dev.w3.org/2006/webapi/XMLHttpRequest-2/#the-upload-attribute
+ */
+XMLHttpRequest.prototype.upload;
+
+/**
+ * @param {string} mimeType The mime type to override with.
+ */
+XMLHttpRequest.prototype.overrideMimeType = function(mimeType) {};
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/2006/webapi/XMLHttpRequest-2/#the-responsetype-attribute
+ */
+XMLHttpRequest.prototype.responseType;
+
+/**
+ * @type {*}
+ * @see http://dev.w3.org/2006/webapi/XMLHttpRequest-2/#the-responsetype-attribute
+ */
+XMLHttpRequest.prototype.response;
+
+
+/**
+ * @type {ArrayBuffer}
+ * Implemented as a draft spec in Firefox 4 as the way to get a requested array
+ * buffer from an XMLHttpRequest.
+ * @see https://developer.mozilla.org/En/Using_XMLHttpRequest#Receiving_binary_data_using_JavaScript_typed_arrays
+ */
+XMLHttpRequest.prototype.mozResponseArrayBuffer;
+
+/**
+ * XMLHttpRequestEventTarget defines events for checking the status of a data
+ * transfer between a client and a server. This should be a common base class
+ * for XMLHttpRequest and XMLHttpRequestUpload.
+ *
+ * @constructor
+ * @implements {EventTarget}
+ */
+function XMLHttpRequestEventTarget() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+XMLHttpRequestEventTarget.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+XMLHttpRequestEventTarget.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+XMLHttpRequestEventTarget.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * An event target to track the status of an upload.
+ *
+ * @constructor
+ * @extends {XMLHttpRequestEventTarget}
+ */
+function XMLHttpRequestUpload() {}
+
+/**
+ * @param {number=} opt_width
+ * @param {number=} opt_height
+ * @constructor
+ * @extends {HTMLImageElement}
+ */
+function Image(opt_width, opt_height) {}
+
+
+/**
+ * Dataset collection.
+ * This is really a DOMStringMap but it behaves close enough to an object to
+ * pass as an object.
+ * @type {Object}
+ * @const
+ */
+HTMLElement.prototype.dataset;
+
+
+/**
+ * @constructor
+ * @see https://dom.spec.whatwg.org/#interface-domtokenlist
+ */
+function DOMTokenList() {}
+
+/**
+ * Returns the number of CSS classes applied to this Element.
+ * @type {number}
+ */
+DOMTokenList.prototype.length;
+
+/**
+ * @param {number} index The index of the item to return.
+ * @return {string} The CSS class at the specified index.
+ * @nosideeffects
+ */
+DOMTokenList.prototype.item = function(index) {};
+
+/**
+ * @param {string} token The CSS class to check for.
+ * @return {boolean} Whether the CSS class has been applied to the Element.
+ * @nosideeffects
+ */
+DOMTokenList.prototype.contains = function(token) {};
+
+/**
+ * @param {...string} var_args The CSS class(es) to add to this element.
+ */
+DOMTokenList.prototype.add = function(var_args) {};
+
+/**
+ * @param {...string} var_args The CSS class(es) to remove from this element.
+ */
+DOMTokenList.prototype.remove = function(var_args) {};
+
+/**
+ * @param {string} token The CSS class to toggle from this element.
+ * @param {boolean=} opt_force True to add the class whether it exists
+ *     or not. False to remove the class whether it exists or not.
+ *     This argument is not supported on IE 10 and below, according to
+ *     the MDN page linked below.
+ * @return {boolean} False if the token was removed; True otherwise.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Element.classList
+ */
+DOMTokenList.prototype.toggle = function(token, opt_force) {};
+
+/**
+ * @return {string} A stringified representation of CSS classes.
+ * @nosideeffects
+ * @override
+ */
+DOMTokenList.prototype.toString = function() {};
+
+/**
+ * A better interface to CSS classes than className.
+ * @type {DOMTokenList}
+ * @see http://www.w3.org/TR/html5/elements.html#dom-classlist
+ * @const
+ */
+HTMLElement.prototype.classList;
+
+/**
+ * Web Cryptography API
+ * @see http://www.w3.org/TR/WebCryptoAPI/
+ */
+
+/** @see https://developer.mozilla.org/en/DOM/window.crypto */
+Window.prototype.crypto;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/window.crypto.getRandomValues
+ * @param {!ArrayBufferView} typedArray
+ * @return {!ArrayBufferView}
+ * @throws {Error}
+ */
+Window.prototype.crypto.getRandomValues = function(typedArray) {};
+
+/**
+ * Constraint Validation API properties and methods
+ * @see http://www.w3.org/TR/2009/WD-html5-20090423/forms.html#the-constraint-validation-api
+ */
+
+/** @return {boolean} */
+HTMLFormElement.prototype.checkValidity = function() {};
+
+/** @type {boolean} */
+HTMLFormElement.prototype.noValidate;
+
+/** @constructor */
+function ValidityState() {}
+
+/** @type {boolean} */
+ValidityState.prototype.customError;
+
+/** @type {boolean} */
+ValidityState.prototype.patternMismatch;
+
+/** @type {boolean} */
+ValidityState.prototype.rangeOverflow;
+
+/** @type {boolean} */
+ValidityState.prototype.rangeUnderflow;
+
+/** @type {boolean} */
+ValidityState.prototype.stepMismatch;
+
+/** @type {boolean} */
+ValidityState.prototype.typeMismatch;
+
+/** @type {boolean} */
+ValidityState.prototype.tooLong;
+
+/** @type {boolean} */
+ValidityState.prototype.valid;
+
+/** @type {boolean} */
+ValidityState.prototype.valueMissing;
+
+
+/** @type {boolean} */
+HTMLButtonElement.prototype.autofocus;
+
+/**
+ * @const
+ * @type {NodeList}
+ */
+HTMLButtonElement.prototype.labels;
+
+/** @type {string} */
+HTMLButtonElement.prototype.validationMessage;
+
+/**
+ * @const
+ * @type {ValidityState}
+ */
+HTMLButtonElement.prototype.validity;
+
+/** @type {boolean} */
+HTMLButtonElement.prototype.willValidate;
+
+/** @return {boolean} */
+HTMLButtonElement.prototype.checkValidity = function() {};
+
+/** @param {string} message */
+HTMLButtonElement.prototype.setCustomValidity = function(message) {};
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formaction
+ */
+HTMLButtonElement.prototype.formAction;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formenctype
+ */
+HTMLButtonElement.prototype.formEnctype;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formmethod
+ */
+HTMLButtonElement.prototype.formMethod;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formtarget
+ */
+HTMLButtonElement.prototype.formTarget;
+
+/** @type {boolean} */
+HTMLInputElement.prototype.autofocus;
+
+/** @type {boolean} */
+HTMLInputElement.prototype.formNoValidate;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formaction
+ */
+HTMLInputElement.prototype.formAction;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formenctype
+ */
+HTMLInputElement.prototype.formEnctype;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formmethod
+ */
+HTMLInputElement.prototype.formMethod;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/forms.html#attr-fs-formtarget
+ */
+HTMLInputElement.prototype.formTarget;
+
+/**
+ * @const
+ * @type {NodeList}
+ */
+HTMLInputElement.prototype.labels;
+
+/** @type {string} */
+HTMLInputElement.prototype.validationMessage;
+
+/**
+ * @const
+ * @type {ValidityState}
+ */
+HTMLInputElement.prototype.validity;
+
+/** @type {boolean} */
+HTMLInputElement.prototype.willValidate;
+
+/** @return {boolean} */
+HTMLInputElement.prototype.checkValidity = function() {};
+
+/** @param {string} message */
+HTMLInputElement.prototype.setCustomValidity = function(message) {};
+
+/** @type {Element} */
+HTMLLabelElement.prototype.control;
+
+/** @type {boolean} */
+HTMLSelectElement.prototype.autofocus;
+
+/**
+ * @const
+ * @type {NodeList}
+ */
+HTMLSelectElement.prototype.labels;
+
+/** @type {HTMLCollection} */
+HTMLSelectElement.prototype.selectedOptions;
+
+/** @type {string} */
+HTMLSelectElement.prototype.validationMessage;
+
+/**
+ * @const
+ * @type {ValidityState}
+ */
+HTMLSelectElement.prototype.validity;
+
+/** @type {boolean} */
+HTMLSelectElement.prototype.willValidate;
+
+/** @return {boolean} */
+HTMLSelectElement.prototype.checkValidity = function() {};
+
+/** @param {string} message */
+HTMLSelectElement.prototype.setCustomValidity = function(message) {};
+
+/** @type {boolean} */
+HTMLTextAreaElement.prototype.autofocus;
+
+/**
+ * @const
+ * @type {NodeList}
+ */
+HTMLTextAreaElement.prototype.labels;
+
+/** @type {string} */
+HTMLTextAreaElement.prototype.validationMessage;
+
+/**
+ * @const
+ * @type {ValidityState}
+ */
+HTMLTextAreaElement.prototype.validity;
+
+/** @type {boolean} */
+HTMLTextAreaElement.prototype.willValidate;
+
+/** @return {boolean} */
+HTMLTextAreaElement.prototype.checkValidity = function() {};
+
+/** @param {string} message */
+HTMLTextAreaElement.prototype.setCustomValidity = function(message) {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/html5/the-embed-element.html#htmlembedelement
+ */
+function HTMLEmbedElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/dimension-attributes.html#dom-dim-width
+ */
+HTMLEmbedElement.prototype.width;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/dimension-attributes.html#dom-dim-height
+ */
+HTMLEmbedElement.prototype.height;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/the-embed-element.html#dom-embed-src
+ */
+HTMLEmbedElement.prototype.src;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/html5/the-embed-element.html#dom-embed-type
+ */
+HTMLEmbedElement.prototype.type;
+
+// Fullscreen APIs.
+
+/**
+ * @see http://www.w3.org/TR/2012/WD-fullscreen-20120703/#dom-element-requestfullscreen
+ */
+Element.prototype.requestFullscreen = function() {};
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2012/WD-fullscreen-20120703/#dom-document-fullscreenenabled
+ */
+Document.prototype.fullscreenEnabled;
+
+/**
+ * @type {Element}
+ * @see http://www.w3.org/TR/2012/WD-fullscreen-20120703/#dom-document-fullscreenelement
+ */
+Document.prototype.fullscreenElement;
+
+/**
+ * @see http://www.w3.org/TR/2012/WD-fullscreen-20120703/#dom-document-exitfullscreen
+ */
+Document.prototype.exitFullscreen = function() {};
+
+// Externs definitions of browser current implementations.
+// Firefox 10 implementation.
+Element.prototype.mozRequestFullScreen = function() {};
+
+Element.prototype.mozRequestFullScreenWithKeys = function() {};
+
+/** @type {boolean} */
+Document.prototype.mozFullScreen;
+
+Document.prototype.mozCancelFullScreen = function() {};
+
+/** @type {Element} */
+Document.prototype.mozFullScreenElement;
+
+/** @type {boolean} */
+Document.prototype.mozFullScreenEnabled;
+
+// Chrome 21 implementation.
+/**
+ * The current fullscreen element for the document is set to this element.
+ * Valid only for Webkit browsers.
+ * @param {number=} opt_allowKeyboardInput Whether keyboard input is desired.
+ *     Should use ALLOW_KEYBOARD_INPUT constant.
+ */
+Element.prototype.webkitRequestFullScreen = function(opt_allowKeyboardInput) {};
+
+/**
+ * The current fullscreen element for the document is set to this element.
+ * Valid only for Webkit browsers.
+ * @param {number=} opt_allowKeyboardInput Whether keyboard input is desired.
+ *     Should use ALLOW_KEYBOARD_INPUT constant.
+ */
+Element.prototype.webkitRequestFullscreen = function(opt_allowKeyboardInput) {};
+
+/** @type {boolean} */
+Document.prototype.webkitIsFullScreen;
+
+Document.prototype.webkitCancelFullScreen = function() {};
+
+/** @type {Element} */
+Document.prototype.webkitCurrentFullScreenElement;
+
+/** @type {Element} */
+Document.prototype.webkitFullscreenElement;
+
+/** @type {boolean} */
+Document.prototype.webkitFullScreenKeyboardInputAllowed;
+
+// IE 11 implementation.
+// http://msdn.microsoft.com/en-us/library/ie/dn265028(v=vs.85).aspx
+/** @return {void} */
+Element.prototype.msRequestFullscreen = function() {};
+
+/** @return {void} */
+Element.prototype.msExitFullscreen = function() {};
+
+/** @type {boolean} */
+Document.prototype.msFullscreenEnabled;
+
+/** @type {Element} */
+Document.prototype.msFullscreenElement;
+
+/** @type {number} */
+Element.ALLOW_KEYBOARD_INPUT = 1;
+
+/** @type {number} */
+Element.prototype.ALLOW_KEYBOARD_INPUT = 1;
+
+
+/** @constructor */
+function MutationObserverInit() {}
+
+/** @type {boolean} */
+MutationObserverInit.prototype.childList;
+
+/** @type {boolean} */
+MutationObserverInit.prototype.attributes;
+
+/** @type {boolean} */
+MutationObserverInit.prototype.characterData;
+
+/** @type {boolean} */
+MutationObserverInit.prototype.subtree;
+
+/** @type {boolean} */
+MutationObserverInit.prototype.attributeOldValue;
+
+/** @type {boolean} */
+MutationObserverInit.prototype.characterDataOldValue;
+
+/** @type {Array.<string>} */
+MutationObserverInit.prototype.attributeFilter;
+
+
+/** @constructor */
+function MutationRecord() {}
+
+/** @type {string} */
+MutationRecord.prototype.type;
+
+/** @type {Node} */
+MutationRecord.prototype.target;
+
+/** @type {NodeList} */
+MutationRecord.prototype.addedNodes;
+
+/** @type {NodeList} */
+MutationRecord.prototype.removedNodes;
+
+/** @type {Node} */
+MutationRecord.prototype.previouSibling;
+
+/** @type {Node} */
+MutationRecord.prototype.nextSibling;
+
+/** @type {?string} */
+MutationRecord.prototype.attributeName;
+
+/** @type {?string} */
+MutationRecord.prototype.attributeNamespace;
+
+/** @type {?string} */
+MutationRecord.prototype.oldValue;
+
+
+/**
+ * @see http://www.w3.org/TR/domcore/#mutation-observers
+ * @param {function(Array.<MutationRecord>, MutationObserver)} callback
+ * @constructor
+ */
+function MutationObserver(callback) {}
+
+/**
+ * @param {Node} target
+ * @param {MutationObserverInit=} options
+ */
+MutationObserver.prototype.observe = function(target, options) {};
+
+MutationObserver.prototype.disconnect = function() {};
+
+/**
+ * @type {function(new:MutationObserver, function(Array.<MutationRecord>))}
+ */
+Window.prototype.WebKitMutationObserver;
+
+/**
+ * @type {function(new:MutationObserver, function(Array.<MutationRecord>))}
+ */
+Window.prototype.MozMutationObserver;
+
+
+/**
+ * @see http://www.w3.org/TR/page-visibility/
+ * @type {VisibilityState}
+ */
+Document.prototype.visibilityState;
+
+/**
+ * @type {string}
+ */
+Document.prototype.mozVisibilityState;
+
+/**
+ * @type {string}
+ */
+Document.prototype.webkitVisibilityState;
+
+/**
+ * @type {string}
+ */
+Document.prototype.msVisibilityState;
+
+/**
+ * @see http://www.w3.org/TR/page-visibility/
+ * @type {boolean}
+ */
+Document.prototype.hidden;
+
+/**
+ * @type {boolean}
+ */
+Document.prototype.mozHidden;
+
+/**
+ * @type {boolean}
+ */
+Document.prototype.webkitHidden;
+
+/**
+ * @type {boolean}
+ */
+Document.prototype.msHidden;
+
+/**
+ * @see http://www.w3.org/TR/components-intro/
+ * @see http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-register
+ * @param {string} type
+ * @param {{extends: (string|undefined), prototype: (Object|undefined)}} options
+ */
+Document.prototype.registerElement;
+
+/**
+ * This method is deprecated and should be removed by the end of 2014.
+ * @see http://www.w3.org/TR/components-intro/
+ * @see http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-register
+ * @param {string} type
+ * @param {{extends: (string|undefined), prototype: (Object|undefined)}} options
+ */
+Document.prototype.register;
+
+/**
+ * @type {!FontFaceSet}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfacesource-fonts
+ */
+Document.prototype.fonts;
+
+
+/**
+ * Definition of ShadowRoot interface,
+ * @see http://www.w3.org/TR/shadow-dom/#api-shadow-root
+ * @constructor
+ * @extends {DocumentFragment}
+ */
+function ShadowRoot() {}
+
+/**
+ * The host element that a ShadowRoot is attached to.
+ * Note: this is not yet W3C standard but is undergoing development.
+ * W3C feature tracking bug:
+ * https://www.w3.org/Bugs/Public/show_bug.cgi?id=22399
+ * Draft specification:
+ * https://dvcs.w3.org/hg/webcomponents/raw-file/6743f1ace623/spec/shadow/index.html#shadow-root-object
+ * @type {!Element}
+ */
+ShadowRoot.prototype.host;
+
+/**
+ * @param {string} id id.
+ * @return {HTMLElement}
+ * @nosideeffects
+ */
+ShadowRoot.prototype.getElementById = function(id) {};
+
+
+/**
+ * @param {string} className
+ * @return {!NodeList}
+ * @nosideeffects
+ */
+ShadowRoot.prototype.getElementsByClassName = function(className) {};
+
+
+/**
+ * @param {string} tagName
+ * @return {!NodeList}
+ * @nosideeffects
+ */
+ShadowRoot.prototype.getElementsByTagName = function(tagName) {};
+
+
+/**
+ * @param {string} namespace
+ * @param {string} localName
+ * @return {!NodeList}
+ * @nosideeffects
+ */
+ShadowRoot.prototype.getElementsByTagNameNS = function(namespace, localName) {};
+
+
+/**
+ * @return {Selection}
+ * @nosideeffects
+ */
+ShadowRoot.prototype.getSelection = function() {};
+
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {Element}
+ * @nosideeffects
+ */
+ShadowRoot.prototype.elementFromPoint = function(x, y) {};
+
+
+/**
+ * @type {boolean}
+ */
+ShadowRoot.prototype.applyAuthorStyles;
+
+
+/**
+ * @type {boolean}
+ */
+ShadowRoot.prototype.resetStyleInheritance;
+
+
+/**
+ * @type {Element}
+ */
+ShadowRoot.prototype.activeElement;
+
+
+/**
+ * @type {?ShadowRoot}
+ */
+ShadowRoot.prototype.olderShadowRoot;
+
+
+/**
+ * @type {string}
+ */
+ShadowRoot.prototype.innerHTML;
+
+
+/**
+ * @type {!StyleSheetList}
+ */
+ShadowRoot.prototype.styleSheets;
+
+
+
+/**
+ * @see http://www.w3.org/TR/shadow-dom/#the-content-element
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLContentElement() {}
+
+/**
+ * @type {!string}
+ */
+HTMLContentElement.prototype.select;
+
+/**
+ * @return {!NodeList}
+ */
+HTMLContentElement.prototype.getDistributedNodes = function() {};
+
+
+/**
+ * @see http://www.w3.org/TR/shadow-dom/#the-shadow-element
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLShadowElement() {}
+
+/**
+ * @return {!NodeList}
+ */
+HTMLShadowElement.prototype.getDistributedNodes = function() {};
+
+
+/**
+ * @see http://www.w3.org/TR/html5/webappapis.html#the-errorevent-interface
+ *
+ * @constructor
+ * @extends {Event}
+ *
+ * @param {string} type
+ * @param {ErrorEventInit=} opt_eventInitDict
+ */
+function ErrorEvent(type, opt_eventInitDict) {}
+
+/** @const {string} */
+ErrorEvent.prototype.message;
+
+/** @const {string} */
+ErrorEvent.prototype.filename;
+
+/** @const {number} */
+ErrorEvent.prototype.lineno;
+
+/** @const {number} */
+ErrorEvent.prototype.colno;
+
+/** @const {*} */
+ErrorEvent.prototype.error;
+
+
+/**
+ * @see http://www.w3.org/TR/html5/webappapis.html#the-errorevent-interface
+ *
+ * @typedef {{
+ *   bubbles: (boolean|undefined),
+ *   cancelable: (boolean|undefined),
+ *   message: string,
+ *   filename: string,
+ *   lineno: number,
+ *   colno: number,
+ *   error: *
+ * }}
+ */
+ var ErrorEventInit;
+
+
+/**
+ * @see http://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument
+ * @param {string=} opt_title A title to give the new HTML document
+ * @return {!HTMLDocument}
+ */
+DOMImplementation.prototype.createHTMLDocument = function(opt_title) {};
+
+
+
+/**
+ * @constructor
+ * @see https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element
+ * @extends {HTMLElement}
+ */
+function HTMLPictureElement() {}
+
+/**
+ * @constructor
+ * @see https://html.spec.whatwg.org/multipage/embedded-content.html#the-picture-element
+ * @extends {HTMLElement}
+ */
+function HTMLSourceElement() {}
+
+/** @type {string} */
+HTMLSourceElement.prototype.media;
+
+/** @type {string} */
+HTMLSourceElement.prototype.sizes;
+
+/** @type {string} */
+HTMLSourceElement.prototype.src;
+
+/** @type {string} */
+HTMLSourceElement.prototype.srcset;
+
+/** @type {string} */
+HTMLSourceElement.prototype.type;
+
+/** @type {string} */
+HTMLImageElement.prototype.sizes;
+
+/** @type {string} */
+HTMLImageElement.prototype.srcset;
+
+
+/**
+ * 4.11 Interactive elements
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html
+ */
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-details-element
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLDetailsElement() {}
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-details-open
+ * @type {boolean}
+ */
+HTMLDetailsElement.prototype.open;
+
+
+// As of 2/20/2015, <summary> has no special web IDL interface nor global
+// constructor (i.e. HTMLSummaryElement).
+
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menu-type
+ * @type {string}
+ */
+HTMLMenuElement.prototype.type;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menu-label
+ * @type {string}
+ */
+HTMLMenuElement.prototype.label;
+
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-menuitem-element
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLMenuItemElement() {}
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menuitem-type
+ * @type {string}
+ */
+HTMLMenuItemElement.prototype.type;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menuitem-label
+ * @type {string}
+ */
+HTMLMenuItemElement.prototype.label;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menuitem-icon
+ * @type {string}
+ */
+HTMLMenuItemElement.prototype.icon;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menuitem-disabled
+ * @type {boolean}
+ */
+HTMLMenuItemElement.prototype.disabled;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menuitem-checked
+ * @type {boolean}
+ */
+HTMLMenuItemElement.prototype.checked;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menuitem-radiogroup
+ * @type {string}
+ */
+HTMLMenuItemElement.prototype.radiogroup;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-menuitem-default
+ * @type {boolean}
+ */
+HTMLMenuItemElement.prototype.default;
+
+// TODO(dbeam): add HTMLMenuItemElement.prototype.command if it's implemented.
+
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#relatedevent
+ * @param {string} type
+ * @param {{relatedTarget: (EventTarget|undefined)}=} opt_eventInitDict
+ * @constructor
+ * @extends {Event}
+ */
+function RelatedEvent(type, opt_eventInitDict) {}
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-relatedevent-relatedtarget
+ * @type {EventTarget|undefined}
+ */
+RelatedEvent.prototype.relatedTarget;
+
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-dialog-element
+ * @constructor
+ * @extends {HTMLElement}
+ */
+function HTMLDialogElement() {}
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-dialog-open
+ * @type {boolean}
+ */
+HTMLDialogElement.prototype.open;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-dialog-returnvalue
+ * @type {string}
+ */
+HTMLDialogElement.prototype.returnValue;
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-dialog-show
+ * @param {(MouseEvent|Element)=} opt_anchor
+ */
+HTMLDialogElement.prototype.show = function(opt_anchor) {};
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-dialog-showmodal
+ * @param {(MouseEvent|Element)=} opt_anchor
+ */
+HTMLDialogElement.prototype.showModal = function(opt_anchor) {};
+
+/**
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#dom-dialog-close
+ * @param {string=} opt_returnValue
+ */
+HTMLDialogElement.prototype.close = function(opt_returnValue) {};

--- a/sdk/tests/deqp/temp_externs/ie_css.js
+++ b/sdk/tests/deqp/temp_externs/ie_css.js
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for IE's custom CSS properties, as defined here:
+ * http://msdn.microsoft.com/en-us/library/aa768661(VS.85).aspx
+ *
+ * This page is also useful for the IDL definitions:
+ * http://source.winehq.org/source/include/mshtml.idl
+ *
+ * @externs
+ * @author nicksantos@google.com
+ */
+
+/** @type {Element} */
+StyleSheet.prototype.owningElement;
+
+/** @type {boolean} */
+StyleSheet.prototype.readOnly;
+
+/** @type {StyleSheetList} */
+StyleSheet.prototype.imports;
+
+/** @type {string} */
+StyleSheet.prototype.id;
+
+/**
+ * @param {string} bstrURL
+ * @param {number} lIndex
+ * @return {number}
+ */
+StyleSheet.prototype.addImport;
+
+/**
+ * @param {string} bstrSelector
+ * @param {string} bstrStyle
+ * @param {number=} opt_iIndex
+ * @return {number}
+ * @see http://msdn.microsoft.com/en-us/library/aa358796%28v=vs.85%29.aspx
+ */
+StyleSheet.prototype.addRule;
+
+/**
+ * @param {number} lIndex
+ */
+StyleSheet.prototype.removeImport;
+
+/**
+ * @param {number} lIndex
+ */
+StyleSheet.prototype.removeRule;
+
+/** @type {string} */
+StyleSheet.prototype.cssText;
+
+/** @type {CSSRuleList} */
+StyleSheet.prototype.rules;
+
+// StyleSheet methods
+
+/**
+ * @param {string} propName
+ * @return {string}
+ * @see http://msdn.microsoft.com/en-us/library/aa358797(VS.85).aspx
+ */
+StyleSheet.prototype.getExpression;
+
+/**
+ * @param {string} name
+ * @param {string} expression
+ * @return {undefined}
+ * @see http://msdn.microsoft.com/en-us/library/ms531196(VS.85).aspx
+ */
+StyleSheet.prototype.setExpression;
+
+/**
+ * @param {string} expression
+ * @return {undefined}
+ * @see http://msdn.microsoft.com/en-us/library/aa358798(VS.85).aspx
+ */
+StyleSheet.prototype.removeExpression;
+
+// IE-only CSS style names.
+
+/** @type {string} */ CSSProperties.prototype.backgroundPositionX;
+
+/** @type {string} */ CSSProperties.prototype.backgroundPositionY;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ie/ms531081(v=vs.85).aspx
+ * NOTE: Left untyped to avoid conflict with caller.
+ */
+CSSProperties.prototype.behavior;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms533883.aspx
+ */
+CSSProperties.prototype.imeMode;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms534176(VS.85).aspx
+ */
+CSSProperties.prototype.msInterpolationMode;
+
+/** @type {string} */ CSSProperties.prototype.overflowX;
+
+/** @type {string} */ CSSProperties.prototype.overflowY;
+
+/** @type {number} */ CSSProperties.prototype.pixelWidth;
+
+/** @type {number} */ CSSProperties.prototype.pixelHeight;
+
+/** @type {number} */ CSSProperties.prototype.pixelLeft;
+
+/** @type {number} */ CSSProperties.prototype.pixelTop;
+
+/** @type {string} */ CSSProperties.prototype.styleFloat;
+
+/**
+ * @type {string|number}
+ * @see http://msdn.microsoft.com/en-us/library/ms535169(VS.85).aspx
+ */
+CSSProperties.prototype.zoom;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms535153(VS.85).aspx
+ */
+CSSProperties.prototype.writingMode;
+
+/**
+ * IE-specific extensions.
+ * @see http://blogs.msdn.com/b/ie/archive/2008/09/08/microsoft-css-vendor-extensions.aspx
+ */
+
+/** @type {string} */
+CSSProperties.prototype.MsAccelerator;
+
+/** @type {string} */
+CSSProperties.prototype.MsBackgroundPositionX;
+
+/** @type {string} */
+CSSProperties.prototype.MsBackgroundPositionY;
+
+/** @type {string} */
+CSSProperties.prototype.MsBehavior;
+
+/** @type {string} */
+CSSProperties.prototype.MsBlockProgression;
+
+/** @type {string} */
+CSSProperties.prototype.MsFilter;
+
+/** @type {string} */
+CSSProperties.prototype.MsImeMode;
+
+/** @type {string} */
+CSSProperties.prototype.MsLayoutGrid;
+
+/** @type {string} */
+CSSProperties.prototype.MsLayoutGridChar;
+
+/** @type {string} */
+CSSProperties.prototype.MsLayoutGridLine;
+
+/** @type {string} */
+CSSProperties.prototype.MsLayoutGridMode;
+
+/** @type {string} */
+CSSProperties.prototype.MsLayoutGridType;
+
+/** @type {string} */
+CSSProperties.prototype.MsLineBreak;
+
+/** @type {string} */
+CSSProperties.prototype.MsLineGridMode;
+
+/** @type {string} */
+CSSProperties.prototype.MsInterpolationMode;
+
+/** @type {string} */
+CSSProperties.prototype.MsOverflowX;
+
+/** @type {string} */
+CSSProperties.prototype.MsOverflowY;
+
+/** @type {string} */
+CSSProperties.prototype.MsScrollbar3dlightColor;
+
+/** @type {string} */
+CSSProperties.prototype.MsScrollbarArrowColor;
+
+/** @type {string} */
+CSSProperties.prototype.MsScrollbarBaseColor;
+
+/** @type {string} */
+CSSProperties.prototype.MsScrollbarDarkshadowColor;
+
+/** @type {string} */
+CSSProperties.prototype.MsScrollbarFaceColor;
+
+CSSProperties.prototype.MsScrollbarHighlightColor;
+
+/** @type {string} */
+CSSProperties.prototype.MsScrollbarShadowColor;
+
+/** @type {string} */
+CSSProperties.prototype.MsScrollbarTrackColor;
+
+/** @type {string} */
+CSSProperties.prototype.MsTextAlignLast;
+
+/** @type {string} */
+CSSProperties.prototype.MsTextAutospace;
+
+/** @type {string} */
+CSSProperties.prototype.MsTextJustify;
+
+/** @type {string} */
+CSSProperties.prototype.MsTextKashidaSpace;
+
+/** @type {string} */
+CSSProperties.prototype.MsTextOverflow;
+
+/** @type {string} */
+CSSProperties.prototype.MsTextUnderlinePosition;
+
+/** @type {string} */
+CSSProperties.prototype.MsWordBreak;
+
+/** @type {string} */
+CSSProperties.prototype.MsWordWrap;
+
+/** @type {string} */
+CSSProperties.prototype.MsWritingMode;
+
+/** @type {string} */
+CSSProperties.prototype.MsZoom;
+
+// See: http://msdn.microsoft.com/en-us/library/windows/apps/Hh702466.aspx
+
+/** @type {string} */
+CSSProperties.prototype.msContentZooming;
+
+/** @type {string} */
+CSSProperties.prototype.msTouchAction;
+
+/** @type {string} */
+CSSProperties.prototype.msTransform;
+
+/** @type {string} */
+CSSProperties.prototype.msTransition;

--- a/sdk/tests/deqp/temp_externs/ie_dom.js
+++ b/sdk/tests/deqp/temp_externs/ie_dom.js
@@ -1,0 +1,1395 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for all the extensions over the
+ *  W3C's DOM specification by IE in JScript. This file depends on
+ *  w3c_dom2.js. The whole file has NOT been fully type annotated.
+ *
+ * When a non-standard extension appears in both Gecko and IE, we put
+ * it in gecko_dom.js
+ *
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ */
+
+// TODO(nicksantos): Rewrite all the DOM interfaces as interfaces, instead
+// of kludging them as an inheritance hierarchy.
+
+/**
+ * @constructor
+ * @extends {Document}
+ * @see http://msdn.microsoft.com/en-us/library/ms757878(VS.85).aspx
+ */
+function XMLDOMDocument() {}
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms761398(VS.85).aspx
+ */
+XMLDOMDocument.prototype.async;
+
+/**
+ * @type {!Function}
+ * @see http://msdn.microsoft.com/en-us/library/ms762647(VS.85).aspx
+ */
+XMLDOMDocument.prototype.ondataavailable;
+
+/**
+ * @type {!Function}
+ * @see http://msdn.microsoft.com/en-us/library/ms764640(VS.85).aspx
+ */
+XMLDOMDocument.prototype.onreadystatechange;
+
+/**
+ * @type {!Function}
+ * @see http://msdn.microsoft.com/en-us/library/ms753795(VS.85).aspx
+ */
+XMLDOMDocument.prototype.ontransformnode;
+
+/**
+ * @type {Object}
+ * @see http://msdn.microsoft.com/en-us/library/ms756041(VS.85).aspx
+ */
+XMLDOMDocument.prototype.parseError;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms761353(VS.85).aspx
+ */
+XMLDOMDocument.prototype.preserveWhiteSpace;
+
+/**
+ * @type {number}
+ * @see http://msdn.microsoft.com/en-us/library/ms753702(VS.85).aspx
+ */
+XMLDOMDocument.prototype.readyState;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms762283(VS.85).aspx
+ * @type {boolean}
+ */
+XMLDOMDocument.prototype.resolveExternals;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms760290(v=vs.85).aspx
+ * @param {string} name
+ * @param {*} value
+ */
+XMLDOMDocument.prototype.setProperty = function(name, value) {};
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms767669(VS.85).aspx
+ */
+XMLDOMDocument.prototype.url;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms762791(VS.85).aspx
+ */
+XMLDOMDocument.prototype.validateOnParse;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms763830(VS.85).aspx
+ */
+XMLDOMDocument.prototype.abort = function() {};
+
+/**
+ * @param {*} type
+ * @param {string} name
+ * @param {string} namespaceURI
+ * @return {Node}
+ * @see http://msdn.microsoft.com/en-us/library/ms757901(VS.85).aspx
+ * @nosideeffects
+ */
+XMLDOMDocument.prototype.createNode = function(type, name, namespaceURI) {};
+
+/**
+ * @param {string} xmlSource
+ * @return {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms762722(VS.85).aspx
+ * @override
+ */
+XMLDOMDocument.prototype.load = function(xmlSource) {};
+
+/**
+ * @param {string} xmlString
+ * @return {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms754585(VS.85).aspx
+ * @override
+ */
+XMLDOMDocument.prototype.loadXML = function(xmlString) {};
+
+/**
+ * @param {string} id
+ * @return {Node}
+ * @see http://msdn.microsoft.com/en-us/library/ms766397(VS.85).aspx
+ */
+XMLDOMDocument.prototype.nodeFromID = function(id) {};
+
+//==============================================================================
+// XMLNode methods and properties
+// In a real DOM hierarchy, XMLDOMDocument inherits from XMLNode and Document.
+// Since we can't express that in our type system, we put XMLNode properties
+// on Node.
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms767570(VS.85).aspx
+ */
+Node.prototype.baseName;
+
+/**
+ * @type {?string}
+ * @see http://msdn.microsoft.com/en-us/library/ms762763(VS.85).aspx
+ */
+Node.prototype.dataType;
+
+/**
+ * @type {Node}
+ * @see http://msdn.microsoft.com/en-us/library/ms764733(VS.85).aspx
+ */
+Node.prototype.definition;
+
+/**
+ * IE5 used document instead of ownerDocument.
+ * Old versions of WebKit used document instead of contentDocument.
+ * @type {Document}
+ */
+Node.prototype.document;
+
+
+/**
+ * Inserts the given HTML text into the element at the location.
+ * @param {string} sWhere Where to insert the HTML text, one of 'beforeBegin',
+ *     'afterBegin', 'beforeEnd', 'afterEnd'.
+ * @param {string} sText HTML text to insert.
+ * @see http://msdn.microsoft.com/en-us/library/ms536452(VS.85).aspx
+ */
+Node.prototype.insertAdjacentHTML = function(sWhere, sText) {};
+
+
+/**
+ * @type {*}
+ * @see http://msdn.microsoft.com/en-us/library/ms762308(VS.85).aspx
+ */
+Node.prototype.nodeTypedValue;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms757895(VS.85).aspx
+ */
+Node.prototype.nodeTypeString;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms762237(VS.85).aspx
+ */
+Node.prototype.parsed;
+
+/**
+ * @type {Element}
+ * @see http://msdn.microsoft.com/en-us/library/ms534327(VS.85).aspx
+ */
+Node.prototype.parentElement;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms753816(VS.85).aspx
+ */
+Node.prototype.specified;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms762687(VS.85).aspx
+ */
+Node.prototype.text;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms755989(VS.85).aspx
+ */
+Node.prototype.xml;
+
+/**
+ * @param {string} expression An XPath expression.
+ * @return {NodeList}
+ * @see http://msdn.microsoft.com/en-us/library/ms754523(VS.85).aspx
+ * @nosideeffects
+ */
+Node.prototype.selectNodes = function(expression) {};
+
+/**
+ * @param {string} expression An XPath expression.
+ * @return {Node}
+ * @see http://msdn.microsoft.com/en-us/library/ms757846(VS.85).aspx
+ * @nosideeffects
+ */
+Node.prototype.selectSingleNode = function(expression) {};
+
+/**
+ * @param {Node} stylesheet XSLT stylesheet.
+ * @return {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms761399(VS.85).aspx
+ * @nosideeffects
+ */
+Node.prototype.transformNode = function(stylesheet) {};
+
+/**
+ * @param {Node} stylesheet XSLT stylesheet.
+ * @param {Object} outputObject
+ * @see http://msdn.microsoft.com/en-us/library/ms766561(VS.85).aspx
+ */
+Node.prototype.transformNodeToObject =
+    function(stylesheet, outputObject) {};
+
+//==============================================================================
+// Node methods
+
+/**
+ * @param {boolean=} opt_bRemoveChildren Whether to remove the entire sub-tree.
+ *    Defaults to false.
+ * @return {Node} The object that was removed.
+ * @see http://msdn.microsoft.com/en-us/library/ms536708(VS.85).aspx
+ */
+Node.prototype.removeNode = function(opt_bRemoveChildren) {};
+
+/**
+ * @constructor
+ */
+function ClipboardData() {}
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535220(VS.85).aspx
+ * @param {string=} opt_type Type of clipboard data to clear. 'Text' or
+ *     'URL' or 'File' or 'HTML' or 'Image'.
+ */
+ClipboardData.prototype.clearData = function(opt_type) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535220(VS.85).aspx
+ * @param {string} type Type of clipboard data to set ('Text' or 'URL').
+ * @param {string} data Data to set
+ * @return {boolean} Whether the data were set correctly.
+ */
+ClipboardData.prototype.setData = function(type, data) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535220(VS.85).aspx
+ * @param {string} type Type of clipboard data to get ('Text' or 'URL').
+ * @return {string} The current data
+ */
+ClipboardData.prototype.getData = function(type) { };
+
+/**
+ * @type {!Window}
+ * @see https://developer.mozilla.org/en/DOM/window
+ */
+var window;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535220(VS.85).aspx
+ * @type ClipboardData
+ */
+Window.prototype.clipboardData;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533724(VS.85).aspx
+ */
+Window.prototype.dialogHeight;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533725(VS.85).aspx
+ */
+Window.prototype.dialogLeft;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533726(VS.85).aspx
+ */
+Window.prototype.dialogTop;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533727(VS.85).aspx
+ */
+Window.prototype.dialogWidth;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535863(VS.85).aspx
+ */
+Window.prototype.event;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/cc197012(VS.85).aspx
+ */
+Window.prototype.maxConnectionsPer1_0Server;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/cc197013(VS.85).aspx
+ */
+Window.prototype.maxConnectionsPerServer;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534198(VS.85).aspx
+ */
+Window.prototype.offscreenBuffering;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534389(VS.85).aspx
+ */
+Window.prototype.screenLeft;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534389(VS.85).aspx
+ */
+Window.prototype.screenTop;
+
+// Functions
+
+/**
+ * @param {string} event
+ * @param {Function} handler
+ * @see http://msdn.microsoft.com/en-us/library/ms536343(VS.85).aspx
+ */
+Window.prototype.attachEvent;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536392(VS.85).aspx
+ */
+Window.prototype.createPopup;
+
+/**
+ * @param {string} event
+ * @param {Function} handler
+ * @see http://msdn.microsoft.com/en-us/library/ms536411(VS.85).aspx
+ */
+Window.prototype.detachEvent;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536420(VS.85).aspx
+ */
+Window.prototype.execScript;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536425(VS.85).aspx
+ */
+Window.prototype.focus;
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @see http://msdn.microsoft.com/en-us/library/ms536618(VS.85).aspx
+ */
+Window.prototype.moveBy = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @see http://msdn.microsoft.com/en-us/library/ms536626(VS.85).aspx
+ */
+Window.prototype.moveTo = function(x, y) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536638(VS.85).aspx
+ */
+Window.prototype.navigate;
+
+/**
+ * @param {*=} opt_url
+ * @param {string=} opt_windowName
+ * @param {string=} opt_windowFeatures
+ * @param {boolean=} opt_replace
+ * @return {Window}
+ * @see http://msdn.microsoft.com/en-us/library/ms536651(VS.85).aspx
+ */
+Window.prototype.open = function(opt_url, opt_windowName, opt_windowFeatures,
+                                 opt_replace) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536672(VS.85).aspx
+ */
+Window.prototype.print = function() {};
+
+/**
+ * @param {number} width
+ * @param {number} height
+ * @see http://msdn.microsoft.com/en-us/library/ms536722(VS.85).aspx
+ */
+Window.prototype.resizeBy = function(width, height) {};
+
+/**
+ * @param {number} width
+ * @param {number} height
+ * @see http://msdn.microsoft.com/en-us/library/ms536723(VS.85).aspx
+ */
+Window.prototype.resizeTo = function(width, height) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536738(VS.85).aspx
+ */
+Window.prototype.setActive;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536758(VS.85).aspx
+ */
+Window.prototype.showHelp;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536761(VS.85).aspx
+ */
+Window.prototype.showModelessDialog;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535246%28v=vs.85%29.aspx
+ * @const {!Object}
+ */
+Window.prototype.external;
+
+/**
+ * @constructor
+ */
+function History() { };
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
+ * @param {number|string} delta The number of entries to go back, or
+ *     the URL to which to go back. (URL form is supported only in IE)
+ */
+History.prototype.go = function(delta) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
+ * @param {number=} opt_distance The number of entries to go back
+ *     (Mozilla doesn't support distance -- use #go instead)
+ */
+History.prototype.back = function(opt_distance) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
+ * @type {number}
+ */
+History.prototype.length;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535864(VS.85).aspx
+ */
+History.prototype.forward = function() {};
+
+/**
+ * @type {boolean}
+ * @implicitCast
+ * @see http://msdn.microsoft.com/en-us/library/ie/ms533072(v=vs.85).aspx
+ */
+HTMLFrameElement.prototype.allowTransparency;
+
+/**
+ * @type {Window}
+ * @see http://msdn.microsoft.com/en-us/library/ms533692(VS.85).aspx
+ */
+HTMLFrameElement.prototype.contentWindow;
+
+/**
+ * @type {boolean}
+ * @implicitCast
+ * @see http://msdn.microsoft.com/en-us/library/ie/ms533072(v=vs.85).aspx
+ */
+HTMLIFrameElement.prototype.allowTransparency;
+
+/**
+ * @type {Window}
+ * @see http://msdn.microsoft.com/en-us/library/ms533692(VS.85).aspx
+ */
+HTMLIFrameElement.prototype.contentWindow;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536385(VS.85).aspx
+ */
+HTMLBodyElement.prototype.createControlRange;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms534359(VS.85).aspx
+ */
+HTMLScriptElement.prototype.readyState;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms534359(VS.85).aspx
+ */
+HTMLIFrameElement.prototype.readyState;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms534359(VS.85).aspx
+ */
+HTMLImageElement.prototype.readyState;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms534359(VS.85).aspx
+ */
+HTMLObjectElement.prototype.readyState;
+
+
+/**
+ * @constructor
+ */
+function ControlRange() {}
+
+ControlRange.prototype.add;
+ControlRange.prototype.addElement;
+ControlRange.prototype.execCommand;
+ControlRange.prototype.item;
+ControlRange.prototype.queryCommandEnabled;
+ControlRange.prototype.queryCommandIndeterm;
+ControlRange.prototype.queryCommandState;
+ControlRange.prototype.queryCommandSupported;
+ControlRange.prototype.queryCommandValue;
+ControlRange.prototype.remove;
+ControlRange.prototype.scrollIntoView;
+ControlRange.prototype.select;
+
+/**
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/ms535872.aspx
+ */
+function TextRange() {}
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533538(VS.85).aspx
+ */
+TextRange.prototype.boundingHeight;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533539(VS.85).aspx
+ */
+TextRange.prototype.boundingLeft;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533540(VS.85).aspx
+ */
+TextRange.prototype.boundingTop;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533541(VS.85).aspx
+ */
+TextRange.prototype.boundingWidth;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533874(VS.85).aspx
+ */
+TextRange.prototype.htmlText;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534200(VS.85).aspx
+ */
+TextRange.prototype.offsetLeft;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534303(VS.85).aspx
+ */
+TextRange.prototype.offsetTop;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534676(VS.85).aspx
+ */
+TextRange.prototype.text;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536371(VS.85).aspx
+ */
+TextRange.prototype.collapse;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536373(VS.85).aspx
+ */
+TextRange.prototype.compareEndPoints;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536416(VS.85).aspx
+ */
+TextRange.prototype.duplicate;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536419(VS.85).aspx
+ */
+TextRange.prototype.execCommand;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536421(VS.85).aspx
+ */
+TextRange.prototype.expand;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536422(VS.85).aspx
+ */
+TextRange.prototype.findText;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536432(VS.85).aspx
+ */
+TextRange.prototype.getBookmark;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536433(VS.85).aspx
+ */
+TextRange.prototype.getBoundingClientRect;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536435(VS.85).aspx
+ */
+TextRange.prototype.getClientRects;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536450(VS.85).aspx
+ */
+TextRange.prototype.inRange;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536458(VS.85).aspx
+ */
+TextRange.prototype.isEqual;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536616(VS.85).aspx
+ */
+TextRange.prototype.move;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536620(VS.85).aspx
+ */
+TextRange.prototype.moveEnd;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536623(VS.85).aspx
+ */
+TextRange.prototype.moveStart;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536628(VS.85).aspx
+ */
+TextRange.prototype.moveToBookmark;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536630(VS.85).aspx
+ */
+TextRange.prototype.moveToElementText;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536632(VS.85).aspx
+ */
+TextRange.prototype.moveToPoint;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536654(VS.85).aspx
+ */
+TextRange.prototype.parentElement;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536656(VS.85).aspx
+ */
+TextRange.prototype.pasteHTML;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536676(VS.85).aspx
+ */
+TextRange.prototype.queryCommandEnabled;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536678(VS.85).aspx
+ */
+TextRange.prototype.queryCommandIndeterm;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536679(VS.85).aspx
+ */
+TextRange.prototype.queryCommandState;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536681(VS.85).aspx
+ */
+TextRange.prototype.queryCommandSupported;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536683(VS.85).aspx
+ */
+TextRange.prototype.queryCommandValue;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536730(VS.85).aspx
+ */
+TextRange.prototype.scrollIntoView;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536735(VS.85).aspx
+ */
+TextRange.prototype.select;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536745(VS.85).aspx
+ */
+TextRange.prototype.setEndPoint;
+
+/**
+ * @return {undefined}
+ * @see http://msdn.microsoft.com/en-us/library/ms536418(VS.85).aspx
+ */
+Selection.prototype.clear = function() {};
+
+/**
+ * @return {TextRange|ControlRange}
+ * @see http://msdn.microsoft.com/en-us/library/ms536394(VS.85).aspx
+ */
+Selection.prototype.createRange = function() {};
+
+/**
+ * @return {Array.<TextRange>}
+ * @see http://msdn.microsoft.com/en-us/library/ms536396(VS.85).aspx
+ */
+Selection.prototype.createRangeCollection = function() {};
+
+/**
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/ms537447(VS.85).aspx
+ */
+function controlRange() {}
+
+
+Document.prototype.loadXML;
+
+
+// http://msdn.microsoft.com/en-us/library/ms531073(VS.85).aspx
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533065(VS.85).aspx
+ */
+Document.prototype.activeElement;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533553(VS.85).aspx
+ */
+Document.prototype.charset;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533693(VS.85).aspx
+ */
+Document.prototype.cookie;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533714(VS.85).aspx
+ */
+Document.prototype.defaultCharset;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533731(VS.85).aspx
+ */
+Document.prototype.dir;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/cc196988(VS.85).aspx
+ */
+Document.prototype.documentMode;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533747(VS.85).aspx
+ */
+Document.prototype.expando;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533750(VS.85).aspx
+ */
+Document.prototype.fileCreatedDate;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533751(VS.85).aspx
+ */
+Document.prototype.fileModifiedDate;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533752(VS.85).aspx
+ */
+Document.prototype.fileSize;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534331(VS.85).aspx
+ */
+Document.prototype.parentWindow;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534353(VS.85).aspx
+ */
+Document.prototype.protocol;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms534359(VS.85).aspx
+ */
+HTMLDocument.prototype.readyState;
+
+/**
+ * @type {Selection}
+ * @see http://msdn.microsoft.com/en-us/library/ms535869(VS.85).aspx
+ */
+Document.prototype.selection;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534704(VS.85).aspx
+ */
+Document.prototype.uniqueID;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534709(VS.85).aspx
+ */
+Document.prototype.URLUnencoded;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535155(VS.85).aspx
+ */
+Document.prototype.XMLDocument;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535163(VS.85).aspx
+ */
+Document.prototype.XSLDocument;
+
+// functions
+
+/**
+ * @param {string} event
+ * @param {Function} handler
+ * @see http://msdn.microsoft.com/en-us/library/ms536343(VS.85).aspx
+ */
+Document.prototype.attachEvent;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536390(VS.85).aspx
+ */
+Document.prototype.createEventObject;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms531194(VS.85).aspx
+ */
+Document.prototype.createStyleSheet;
+
+/**
+ * @param {string} event
+ * @param {Function} handler
+ * @see http://msdn.microsoft.com/en-us/library/ms536411(VS.85).aspx
+ */
+Document.prototype.detachEvent;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536425(VS.85).aspx
+ */
+Document.prototype.focus;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536447(VS.85).aspx
+ * @return {boolean}
+ */
+Document.prototype.hasFocus = function() {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536614(VS.85).aspx
+ */
+Document.prototype.mergeAttributes;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536685(VS.85).aspx
+ */
+Document.prototype.recalc;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536689(VS.85).aspx
+ */
+Document.prototype.releaseCapture;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536738(VS.85).aspx
+ */
+Document.prototype.setActive;
+
+
+// collections
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms537434(VS.85).aspx
+ */
+Document.prototype.all;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms537445(VS.85).aspx
+ */
+Document.prototype.childNodes;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms537459(VS.85).aspx
+ */
+Document.prototype.frames;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms537470(VS.85).aspx
+ */
+Document.prototype.namespaces;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms537487(VS.85).aspx
+ */
+Document.prototype.scripts;
+
+/**
+ * @param {string} sUrl
+ * @return {number}
+ * @see http://msdn.microsoft.com/en-us/library/ms535922(VS.85).aspx
+ */
+Element.prototype.addBehavior = function(sUrl) {};
+
+/**
+ * @param {string} event
+ * @param {Function} handler
+ * @see http://msdn.microsoft.com/en-us/library/mm536343(v=vs.85).aspx
+ */
+Element.prototype.attachEvent;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms533546(VS.85).aspx
+ */
+Element.prototype.canHaveChildren;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms533559(v=vs.85).aspx
+ */
+Element.prototype.classid;
+
+/**
+ * @param {number} iCoordX Integer that specifies the client window coordinate
+ *     of x.
+ * @param {number} iCoordY Integer that specifies the client window coordinate
+ *     of y.
+ * @return {string} The component of an element located at the specified
+ *     coordinates.
+ * @see http://msdn.microsoft.com/en-us/library/ms536375(VS.85).aspx
+ * @nosideeffects
+ */
+Element.prototype.componentFromPoint = function(iCoordX, iCoordY) {};
+
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms533690(VS.85).aspx
+ */
+Element.prototype.contentEditable;
+
+/**
+ * @return {TextRange}
+ * @see http://msdn.microsoft.com/en-us/library/ms536401(VS.85).aspx
+ */
+Element.prototype.createTextRange;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms535231(VS.85).aspx
+ */
+Element.prototype.currentStyle;
+
+/**
+ * @param {string} event
+ * @param {Function} handler
+ * @see http://msdn.microsoft.com/en-us/library/ie/ms536411(v=vs.85).aspx
+ */
+Element.prototype.detachEvent;
+
+/**
+ * @param {string=} opt_action
+ * @see http://msdn.microsoft.com/en-us/library/ms536414%28VS.85%29.aspx
+ */
+Element.prototype.doScroll = function(opt_action) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536423(VS.85).aspx
+ */
+Element.prototype.fireEvent;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms533783(VS.85).aspx
+ */
+Element.prototype.hideFocus;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533899.aspx
+ */
+Element.prototype.innerText;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms537838(VS.85).aspx
+ */
+Element.prototype.isContentEditable;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms531395(v=vs.85).aspx
+ * NOTE: Left untyped to avoid conflict with subclasses.
+ */
+Element.prototype.load;
+
+/**
+ * @param {number} pointerId Id of the pointer that is assign to the element.
+ * @see http://msdn.microsoft.com/en-us/library/ie/hh771882(v=vs.85).aspx
+ */
+Element.prototype.msSetPointerCapture = function(pointerId) {};
+
+/**
+ * @param {number} pointerId
+ * @see http://msdn.microsoft.com/en-us/library/ie/hh771880.aspx
+ */
+Element.prototype.msReleasePointerCapture = function(pointerId) {};
+
+/**
+ * @type {?function(Event)}
+ * @see http://msdn.microsoft.com/en-us/library/ms536903(v=vs.85).aspx
+ */
+Element.prototype.onbeforedeactivate;
+
+/**
+ * @type {?function(Event)}
+ * @see http://msdn.microsoft.com/en-us/library/ms536945(VS.85).aspx
+ */
+Element.prototype.onmouseenter;
+
+/**
+ * @type {?function(Event)}
+ * @see http://msdn.microsoft.com/en-us/library/ms536946(VS.85).aspx
+ */
+Element.prototype.onmouseleave;
+
+/**
+ * @type {?function(Event)}
+ * @see http://msdn.microsoft.com/en-us/library/ms536969(VS.85).aspx
+ */
+Element.prototype.onselectstart;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/aa752326(VS.85).aspx
+ */
+Element.prototype.outerHTML;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536689(VS.85).aspx
+ */
+Element.prototype.releaseCapture = function() {};
+
+/**
+ * @param {number} iID
+ * @return {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms536700(VS.85).aspx
+ */
+Element.prototype.removeBehavior = function(iID) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/aa703996(VS.85).aspx
+ */
+Element.prototype.runtimeStyle;
+
+/**
+ * @param {string} sStoreName The arbitrary name assigned to a persistent object
+ *     in a UserData store.
+ * @see http://msdn.microsoft.com/en-us/library/ms531403(v=vs.85).aspx
+ */
+Element.prototype.save = function(sStoreName) {};
+
+/**
+ * @param {boolean=} opt_bContainerCapture Events originating in a container are
+ *     captured by the container. Defaults to true.
+ * @see http://msdn.microsoft.com/en-us/library/ms536742(VS.85).aspx
+ */
+Element.prototype.setCapture = function(opt_bContainerCapture) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534635(VS.85).aspx
+ */
+Element.prototype.sourceIndex;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms537840.aspx
+ */
+Element.prototype.unselectable;
+
+/**
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/aa752462(v=vs.85).aspx
+ */
+function HTMLFiltersCollection() {}
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/aa752463(v=vs.85).aspx
+ * @type {number}
+ */
+HTMLFiltersCollection.prototype.length;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms537452(v=vs.85).aspx
+ * @type {HTMLFiltersCollection}
+ */
+Element.prototype.filters;
+
+/**
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/ms532853(v=vs.85).aspx
+ */
+function HTMLFilter() {}
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms532954(v=vs.85).aspx
+ */
+HTMLFilter.prototype.apply = function() {};
+
+/**
+ * @constructor
+ * @extends {HTMLFilter}
+ * @see http://msdn.microsoft.com/en-us/library/ms532967(v=vs.85).aspx
+ */
+function AlphaFilter() {}
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms532910(v=vs.85).aspx
+ * @type {number}
+ */
+AlphaFilter.prototype.Opacity;
+
+/**
+ * @constructor
+ * @extends {HTMLFilter}
+ * @see http://msdn.microsoft.com/en-us/library/ms532969(v=vs.85).aspx
+ */
+function AlphaImageLoaderFilter() {}
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms532920(v=vs.85).aspx
+ * @type {string}
+ */
+AlphaImageLoaderFilter.prototype.sizingMethod;
+
+/**
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/ms535866(VS.85).aspx
+ */
+function Location() {}
+
+/**
+ * @see http://trac.webkit.org/changeset/113945
+ * @type {DOMStringList}
+ */
+Location.prototype.ancestorOrigins;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533775(VS.85).aspx
+ * @type {string}
+ */
+Location.prototype.hash;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533784(VS.85).aspx
+ * @type {string}
+ */
+Location.prototype.host;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533785(VS.85).aspx
+ * @type {string}
+ */
+Location.prototype.hostname;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms533867(VS.85).aspx
+ * @type {string}
+ */
+Location.prototype.href;
+
+/**
+ * @see https://docs.google.com/document/view?id=1r_VTFKApVOaNIkocrg0z-t7lZgzisTuGTXkdzAk4gLU&hl=en
+ * @type {string}
+ */
+Location.prototype.origin;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534332(VS.85).aspx
+ * @type {string}
+ */
+Location.prototype.pathname;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534342(VS.85).aspx
+ */
+Location.prototype.port;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534353(VS.85).aspx
+ * @type {string}
+ */
+Location.prototype.protocol;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms534620(VS.85).aspx
+ * @type {string}
+ */
+Location.prototype.search;
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ms536342(VS.85).aspx
+ * @param {string} url
+ */
+Location.prototype.assign = function(url) {};
+
+/**
+ * @param {boolean=} opt_forceReload If true, reloads the page from
+ *     the server. Defaults to false.
+ * @see http://msdn.microsoft.com/en-us/library/ms536691(VS.85).aspx
+ */
+Location.prototype.reload = function(opt_forceReload) {};
+
+/**
+ * @param {string} url
+ * @see http://msdn.microsoft.com/en-us/library/ms536712(VS.85).aspx
+ */
+Location.prototype.replace = function(url) {};
+
+
+// For IE, returns an object representing key-value pairs for all the global
+// variables prefixed with str, e.g. test*
+
+/** @param {*=} opt_str */
+function RuntimeObject(opt_str) {}
+
+
+/**
+ * @type {StyleSheet}
+ * @see http://msdn.microsoft.com/en-us/library/dd347030(VS.85).aspx
+ */
+HTMLStyleElement.prototype.styleSheet;
+
+
+/**
+ * IE implements Cross Origin Resource Sharing (cross-domain XMLHttpRequests)
+ * via the XDomainRequest object.
+ *
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/cc288060(v=vs.85).aspx
+ * @see http://www.w3.org/TR/cors/
+ */
+function XDomainRequest() {}
+
+/**
+ * Aborts the request.
+ * @see http://msdn.microsoft.com/en-us/library/cc288129(v=vs.85).aspx
+ */
+XDomainRequest.prototype.abort = function() {};
+
+/**
+ * Sets the method and URL for the request.
+ * @param {string} bstrMethod Either "GET" or "POST"
+ * @param {string} bstrUrl The target URL
+ * @see http://msdn.microsoft.com/en-us/library/cc288168(v=vs.85).aspx
+ */
+XDomainRequest.prototype.open = function(bstrMethod, bstrUrl) {};
+
+/**
+ * Sends the request.
+ * @param {string=} varBody The POST body to send to the server. If omitted,
+ *     the behavior is identical to sending an empty string.
+ * @see http://msdn.microsoft.com/en-us/library/cc288207(v=vs.85).aspx
+ */
+XDomainRequest.prototype.send = function(varBody) {};
+
+/**
+ * Called if the request could not be completed. Note that error information is
+ * not available.
+ * @see http://msdn.microsoft.com/en-us/library/ms536930%28v=VS.85%29.aspx
+ * @type {?function()}
+ */
+XDomainRequest.prototype.onerror;
+
+/**
+ * Called when the response has finished.
+ * @see http://msdn.microsoft.com/en-us/library/ms536942%28v=VS.85%29.aspx
+ * @type {?function()}
+ */
+XDomainRequest.prototype.onload;
+
+/**
+ * Called every time part of the response has been received.
+ * @see http://msdn.microsoft.com/en-us/library/cc197058%28v=VS.85%29.aspx
+ * @type {?function()}
+ */
+XDomainRequest.prototype.onprogress;
+
+/**
+ * Called if the timeout period has elapsed.
+ * @see http://msdn.microsoft.com/en-us/library/cc197061%28v=VS.85%29.aspx
+ * @type {?function()}
+ */
+XDomainRequest.prototype.ontimeout;
+
+/**
+ * The current response body.
+ * @see http://msdn.microsoft.com/en-us/library/cc287956%28v=VS.85%29.aspx
+ * @type {string}
+ */
+XDomainRequest.prototype.responseText;
+
+/**
+ * The timeout (in milliseconds) for the request.
+ * @type {number}
+ */
+XDomainRequest.prototype.timeout;
+
+/**
+ * The Content-Type of the response, or an empty string.
+ * @type {string}
+ */
+XDomainRequest.prototype.contentType;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/ms533542(v=vs.85).aspx
+ */
+Navigator.prototype.browserLanguage;
+
+/**
+ * @type {boolean}
+ * @see http://blogs.msdn.com/b/ie/archive/2011/09/20/touch-input-for-ie10-and-metro-style-apps.aspx
+ */
+Navigator.prototype.msPointerEnabled;
+
+/**
+ * @type {number}
+ * @see http://msdn.microsoft.com/en-us/library/ms533721(v=vs.85).aspx
+ */
+Screen.prototype.deviceXDPI;
+
+/**
+ * @type {number}
+ * @see http://msdn.microsoft.com/en-us/library/ms534128%28v=vs.85%29.aspx
+ */
+Screen.prototype.logicalXDPI;
+
+/**
+ * @type {number}
+ * @see http://msdn.microsoft.com/en-us/library/ms534130%28v=vs.85%29.aspx
+ */
+Screen.prototype.logicalYDPI;

--- a/sdk/tests/deqp/temp_externs/ie_event.js
+++ b/sdk/tests/deqp/temp_externs/ie_event.js
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for all the extensions over the
+ *  W3C's event specification by IE in JScript. This file depends on
+ *  w3c_event.js.
+ *
+ * @see http://msdn.microsoft.com/en-us/library/ms535863.aspx
+ * @externs
+ */
+
+/** @type {string} */
+Event.prototype.Abstract;
+
+/** @type {boolean} */
+Event.prototype.altLeft;
+
+/** @type {string} */
+Event.prototype.Banner;
+
+/**
+ * A ClipboardData on IE, but a DataTransfer on WebKit.
+ * @see http://msdn.microsoft.com/en-us/library/ms535220.aspx
+ * @type {(ClipboardData|undefined)}
+ */
+Event.prototype.clipboardData;
+
+/** @type {boolean} */
+Event.prototype.contentOverflow;
+
+/** @type {boolean} */
+Event.prototype.ctrlLeft;
+
+/** @type {string} */
+Event.prototype.dataFld;
+
+Event.prototype.domain;
+
+/** @type {Element} */
+Event.prototype.fromElement;
+
+/** @type {string} */
+Event.prototype.MoreInfo;
+
+/** @type {string} */
+Event.prototype.nextPage;
+
+/** @type {number} */
+Event.prototype.offsetX;
+
+/** @type {number} */
+Event.prototype.offsetY;
+
+/** @type {string} */
+Event.prototype.propertyName;
+
+/** @type {string} */
+Event.prototype.qualifier;
+
+/** @type {number} */
+Event.prototype.reason;
+
+/** @type {Object.<*,*>} */
+Event.prototype.recordset;
+
+/** @type {boolean} */
+Event.prototype.repeat;
+
+/** @type {(boolean|string|undefined)} */
+Event.prototype.returnValue;
+
+/** @type {string} */
+Event.prototype.saveType;
+
+Event.prototype.scheme;
+
+/** @type {boolean} */
+Event.prototype.shiftLeft;
+
+/** @type {Window} */
+Event.prototype.source;
+
+/** @type {Element} */
+Event.prototype.srcElement;
+
+Event.prototype.srcFilter;
+
+/** @type {string} */
+Event.prototype.srcUrn;
+
+/** @type {Element} */
+Event.prototype.toElement;
+
+Event.prototype.userName;
+
+/** @type {number} */
+Event.prototype.wheelDelta;
+
+/** @type {number} */
+Event.prototype.x;
+
+/** @type {number} */
+Event.prototype.y;
+
+/**
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/windows/apps/hh441257.aspx
+ */
+function MSPointerPoint() {}
+
+/** @type {number} */
+MSPointerPoint.prototype.pointerId;
+
+/** @type {number} */
+MSPointerPoint.prototype.pointerType;
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @see http://msdn.microsoft.com/en-us/library/windows/apps/hh441233.aspx
+ */
+function MSPointerEvent() {}
+
+/** @type {number} */
+MSPointerEvent.MSPOINTER_TYPE_MOUSE;
+
+/** @type {number} */
+MSPointerEvent.MSPOINTER_TYPE_PEN;
+
+/** @type {number} */
+MSPointerEvent.MSPOINTER_TYPE_TOUCH;
+
+/** @type {number} */
+MSPointerEvent.prototype.height;
+
+/** @type {number} */
+MSPointerEvent.prototype.hwTimestamp;
+
+/** @type {boolean} */
+MSPointerEvent.prototype.isPrimary;
+
+/** @type {number} */
+MSPointerEvent.prototype.pointerId;
+
+/** @type {number} */
+MSPointerEvent.prototype.pointerType;
+
+/** @type {number} */
+MSPointerEvent.prototype.pressure;
+
+/** @type {number} */
+MSPointerEvent.prototype.rotation;
+
+/** @type {number} */
+MSPointerEvent.prototype.tiltX;
+
+/** @type {number} */
+MSPointerEvent.prototype.tiltY;
+
+/** @type {number} */
+MSPointerEvent.prototype.timeStamp;
+
+/** @type {number} */
+MSPointerEvent.prototype.width;
+
+/**
+ * @param {number} pointerId
+ * @return {undefined}
+ */
+MSPointerEvent.prototype.msReleasePointerCapture;
+
+/**
+ * @param {number} pointerId
+ * @return {undefined}
+ */
+MSPointerEvent.prototype.msSetPointerCapture;
+
+/**
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {Window} viewArg
+ * @param {number} detailArg
+ * @param {number} screenXArg
+ * @param {number} screenYArg
+ * @param {number} clientXArg
+ * @param {number} clientYArg
+ * @param {boolean} ctrlKeyArg
+ * @param {boolean} altKeyArg
+ * @param {boolean} shiftKeyArg
+ * @param {boolean} metaKeyArg
+ * @param {number} buttonArg
+ * @param {Element} relatedTargetArg
+ * @param {number} offsetXArg
+ * @param {number} offsetYArg
+ * @param {number} widthArg
+ * @param {number} heightArg
+ * @param {number} pressure
+ * @param {number} rotation
+ * @param {number} tiltX
+ * @param {number} tiltY
+ * @param {number} pointerIdArg
+ * @param {number} pointerType
+ * @param {number} hwTimestampArg
+ * @param {boolean} isPrimary
+ * @return {undefined}
+ * @see http://msdn.microsoft.com/en-us/library/windows/apps/hh441246.aspx
+ */
+MSPointerEvent.prototype.initPointerEvent;
+
+/**
+ * @constructor
+ * @see http://msdn.microsoft.com/en-us/library/ie/hh968249(v=vs.85).aspx
+ */
+function MSGesture() {}
+
+/**
+ * @type {Element}
+ */
+MSGesture.prototype.target;
+
+/**
+ * @param {number} pointerId
+ */
+MSGesture.prototype.addPointer = function(pointerId) {};
+
+MSGesture.prototype.stop = function() {};
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @see http://msdn.microsoft.com/en-us/library/ie/hh772076(v=vs.85).aspx
+ */
+function MSGestureEvent() {}
+
+/** @type {number} */
+MSGestureEvent.prototype.expansion;
+
+/** @type {!MSGesture} */
+MSGestureEvent.prototype.gestureObject;
+
+/** @type {number} */
+MSGestureEvent.prototype.hwTimestamp;
+
+/** @type {number} */
+MSGestureEvent.prototype.rotation;
+
+/** @type {number} */
+MSGestureEvent.prototype.scale;
+
+/** @type {number} */
+MSGestureEvent.prototype.translationX;
+
+/** @type {number} */
+MSGestureEvent.prototype.translationY;
+
+/** @type {number} */
+MSGestureEvent.prototype.velocityAngular;
+
+/** @type {number} */
+MSGestureEvent.prototype.velocityExpansion;
+
+/** @type {number} */
+MSGestureEvent.prototype.velocityX;
+
+/** @type {number} */
+MSGestureEvent.prototype.velocityY;
+
+/**
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {Window} viewArg
+ * @param {number} detailArg
+ * @param {number} screenXArg
+ * @param {number} screenYArg
+ * @param {number} clientXArg
+ * @param {number} clientYArg
+ * @param {number} offsetXArg
+ * @param {number} offsetYArg
+ * @param {number} translationXArg
+ * @param {number} translationYArg
+ * @param {number} scaleArg
+ * @param {number} expansionArg
+ * @param {number} rotationArg
+ * @param {number} velocityXArg
+ * @param {number} velocityYArg
+ * @param {number} velocityExpansionArg
+ * @param {number} velocityAngularArg
+ * @param {number} hwTimestampArg
+ * @param {EventTarget} relatedTargetArg
+ * @return {undefined}
+ * @see http://msdn.microsoft.com/en-us/library/windows/apps/hh441187.aspx
+ */
+MSGestureEvent.prototype.initGestureEvent;

--- a/sdk/tests/deqp/temp_externs/ie_vml.js
+++ b/sdk/tests/deqp/temp_externs/ie_vml.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2009 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for IE's vector markup language, or VML.
+ *
+ * @externs
+ * @author robbyw@google.com (Robby Walker)
+ */
+
+
+/**
+ * @type {Object|string}
+ * @see http://msdn.microsoft.com/en-us/library/bb263836(VS.85).aspx
+ */
+Element.prototype.coordorigin;
+
+/**
+ * @type {Object|string}
+ * @see http://msdn.microsoft.com/en-us/library/bb263837(VS.85).aspx
+ */
+Element.prototype.coordsize;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/bb263839(VS.85).aspx
+ */
+Element.prototype.fillcolor;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/bb263840(VS.85).aspx
+ */
+Element.prototype.filled;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/bb263871(VS.85).aspx
+ */
+Element.prototype.path;
+
+/**
+ * @type {number|string}
+ * @see http://msdn.microsoft.com/en-us/library/bb263877(VS.85).aspx
+ */
+Element.prototype.rotation;
+
+/**
+ * @type {string}
+ * @see http://msdn.microsoft.com/en-us/library/bb263881(VS.85).aspx
+ */
+Element.prototype.strokecolor;
+
+/**
+ * @type {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/bb263882(VS.85).aspx
+ */
+Element.prototype.stroked;
+
+/**
+ * @type {number|string}
+ * @see http://msdn.microsoft.com/en-us/library/bb263883(VS.85).aspx
+ */
+Element.prototype.strokeweight;

--- a/sdk/tests/deqp/temp_externs/intl.js
+++ b/sdk/tests/deqp/temp_externs/intl.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2013 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for the JS Internationalization API as defined in
+ * http://www.ecma-international.org/ecma-402/1.0/
+ *
+ * @externs
+ */
+
+/** @const */
+var Intl = {};
+
+/**
+ * NOTE: this API is not from ecma402 and is subject to change.
+ * @param {string|Array.<string>=} opt_locales
+ * @param {{type: (string|undefined)}=}
+ *         opt_options
+ * @constructor
+ */
+Intl.v8BreakIterator = function(opt_locales, opt_options) {};
+
+/**
+ * @param {string} text
+ */
+Intl.v8BreakIterator.prototype.adoptText = function(text) {};
+
+/**
+ * @return {string}
+ */
+Intl.v8BreakIterator.prototype.breakType = function() {};
+
+/**
+ * @return {number}
+ */
+Intl.v8BreakIterator.prototype.current = function() {};
+
+/**
+ * @return {number}
+ */
+Intl.v8BreakIterator.prototype.first = function() {};
+
+/**
+ * @return {number}
+ */
+Intl.v8BreakIterator.prototype.next = function() {};
+
+/**
+ * @constructor
+ * @param {string|Array.<string>=} opt_locales
+ * @param {{usage: (string|undefined), localeMatcher: (string|undefined),
+ *     sensitivity: (string|undefined), ignorePunctuation: (boolean|undefined),
+ *     numeric: (boolean|undefined), caseFirst: (string|undefined)}=}
+ *         opt_options
+ */
+Intl.Collator = function(opt_locales, opt_options) {};
+
+/**
+ * @param {Array.<string>} locales
+ * @param {{localeMatcher: (string|undefined)}=} opt_options
+ */
+Intl.Collator.supportedLocalesOf = function(locales, opt_options) {};
+
+/**
+ * @param {string} arg1
+ * @param {string} arg2
+ * @return {number}
+ */
+Intl.Collator.prototype.compare = function(arg1, arg2) {};
+
+/**
+ * @return {{locale: string, usage: string, sensitivity: string,
+ *     ignorePunctuation: boolean, collation: string, numeric: boolean,
+ *     caseFirst: string}}
+ */
+Intl.Collator.prototype.resolvedOptions = function() {};
+
+/**
+ * @constructor
+ * @param {string|Array.<string>=} opt_locales
+ * @param {{localeMatcher: (string|undefined), useGrouping: (boolean|undefined),
+ *     numberingSystem: (string|undefined), style: (string|undefined),
+ *     currency: (string|undefined), currencyDisplay: (string|undefined),
+ *     minimumIntegerDigits: (number|undefined),
+ *     minimumFractionDigits: (number|undefined),
+ *     maximumFractionDigits: (number|undefined),
+ *     minimumSignificantDigits: (number|undefined),
+ *     maximumSignificantDigits: (number|undefined)}=}
+ *         opt_options
+ */
+Intl.NumberFormat = function(opt_locales, opt_options) {};
+
+/**
+ * @param {Array.<string>} locales
+ * @param {{localeMatcher: (string|undefined)}=} opt_options
+ */
+Intl.NumberFormat.supportedLocalesOf = function(locales, opt_options) {};
+
+/**
+ * @param {number} num
+ * @return {string}
+ */
+Intl.NumberFormat.prototype.format = function(num) {};
+
+/**
+ * @return {{locale: string, numberingSystem: string, style: string,
+ *     currency: (string|undefined), currencyDisplay: (string|undefined),
+ *     minimumIntegerDigits: number, minimumFractionDigits: number,
+ *     maximumFractionDigits: number, minimumSignificantDigits: number,
+ *     maximumSignificantDigits: number, useGrouping: boolean}}
+ */
+Intl.NumberFormat.prototype.resolvedOptions = function() {};
+
+/**
+ * @constructor
+ * @param {string|Array.<string>=} opt_locales
+ * @param {{localeMatcher: (string|undefined),
+ *    formatMatcher: (string|undefined), calendar: (string|undefined),
+ *    numberingSystem: (string|undefined), tz: (string|undefined),
+ *    weekday: (string|undefined), era: (string|undefined),
+ *    year: (string|undefined), month: (string|undefined),
+ *    day: (string|undefined), hour: (string|undefined),
+ *    minute: (string|undefined), second: (string|undefined),
+ *    timeZoneName: (string|undefined), hour12: (boolean|undefined)}=}
+ *        opt_options
+ */
+Intl.DateTimeFormat = function(opt_locales, opt_options) {};
+
+/**
+ * @param {Array.<string>} locales
+ * @param {{localeMatcher: string}=} opt_options
+ */
+Intl.DateTimeFormat.supportedLocalesOf = function(locales, opt_options) {};
+
+/**
+ * @param {number} date
+ * @return {string}
+ */
+Intl.DateTimeFormat.prototype.format = function(date) {};
+
+/**
+ * @return {{locale: string, calendar: string, numberingSystem: string,
+ *    timeZone: (string|undefined), weekday: (string|undefined),
+ *    era: (string|undefined), year: (string|undefined),
+ *    month: (string|undefined), day: (string|undefined),
+ *    hour: (string|undefined), minute: (string|undefined),
+ *    second: (string|undefined), timeZoneName: (string|undefined),
+ *    hour12: (boolean|undefined)}}
+ */
+Intl.DateTimeFormat.prototype.resolvedOptions = function() {};

--- a/sdk/tests/deqp/temp_externs/iphone.js
+++ b/sdk/tests/deqp/temp_externs/iphone.js
@@ -1,0 +1,362 @@
+/*
+ * Copyright 2009 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for all iPhone extensions. Created from:
+ * http://developer.apple.com/library/safari/navigation/
+ *
+ * @externs
+ * @author agrieve@google.com (Andrew Grieve)
+ */
+
+/**
+ * The Touch class represents a single touch on the surface. A touch is the
+ * presence or movement of a finger that is part of a unique multi-touch
+ * sequence.
+ * @see http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/TouchClassReference/Touch/Touch.html
+ * @constructor
+ */
+function Touch() {}
+
+/**
+ * The x-coordinate of the touch's location relative to the window's viewport.
+ * @type {number}
+ */
+Touch.prototype.clientX;
+
+/**
+ * The y-coordinate of the touch's location relative to the window's viewport.
+ * @type {number}
+ */
+Touch.prototype.clientY;
+
+/**
+ * The unique identifier for this touch object.
+ * @type {number}
+ */
+Touch.prototype.identifier;
+
+/**
+ * The x-coordinate of the touch's location in page coordinates.
+ * @type {number}
+ */
+Touch.prototype.pageX;
+
+/**
+ * The y-coordinate of the touch's location in page coordinates.
+ * @type {number}
+ */
+Touch.prototype.pageY;
+
+/**
+ * The x-coordinate of the touch's location in screen coordinates.
+ * @type {number}
+ */
+Touch.prototype.screenX;
+
+/**
+ * The y-coordinate of the touch's location in screen coordinates.
+ * @type {number}
+ */
+Touch.prototype.screenY;
+
+/**
+ * The target of this touch.
+ * @type {EventTarget}
+ */
+Touch.prototype.target;
+
+/**
+ * Creates a new Touch object.
+ * @see http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/DocumentAdditionsReference/DocumentAdditions/DocumentAdditions.html#//apple_ref/javascript/instm/Document/createTouch
+ * @param {Window} view
+ * @param {EventTarget} target
+ * @param {number} identifier
+ * @param {number} pageX
+ * @param {number} pageY
+ * @param {number} screenX
+ * @param {number} screenY
+ * @return {Touch}
+ */
+Document.prototype.createTouch = function(view, target, identifier, pageX,
+    pageY, screenX, screenY) {};
+
+/**
+ * The TouchList class is used to represent a collection of Touch objects.
+ * @see http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/TouchListClassReference/TouchList/TouchList.html
+ * @constructor
+ */
+function TouchList() {}
+
+/**
+ * The number of Touch objects in this TouchList object.
+ * @type {number}
+ */
+TouchList.prototype.length;
+
+/**
+ * Returns the Touch object at the given index.
+ * @param {number} index
+ * @return {!Touch}
+ */
+TouchList.prototype.item = function(index) {};
+
+/**
+ * Creates a new TouchList object.
+ * @see http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/DocumentAdditionsReference/DocumentAdditions/DocumentAdditions.html#//apple_ref/javascript/instm/Document/createTouchList
+ * @param {Array.<Touch>} touches
+ * @return {TouchList}
+ */
+Document.prototype.createTouchList = function(touches) {};
+
+/**
+ * The TouchEvent class encapsulates information about a touch event.
+ *
+ * <p>The system continually sends TouchEvent objects to an application as
+ * fingers touch and move across a surface. A touch event provides a snapshot of
+ * all touches during a multi-touch sequence, most importantly the touches that
+ * are new or have changed for a particular target. A multi-touch sequence
+ * begins when a finger first touches the surface. Other fingers may
+ * subsequently touch the surface, and all fingers may move across the surface.
+ * The sequence ends when the last of these fingers is lifted from the surface.
+ * An application receives touch event objects during each phase of any touch.
+ * </p>
+ *
+ * <p>The different types of TouchEvent objects that can occur are:
+ * <ul>
+ *   <li>touchstart - Sent when a finger for a given event touches the surface.
+ *   <li>touchmove - Sent when a given event moves on the surface.
+ *   <li>touchend - Sent when a given event lifts from the surface.
+ *   <li>touchcancel - Sent when the system cancels tracking for the touch.
+ * </ul>
+ * TouchEvent objects are combined together to form high-level GestureEvent
+ * objects that are also sent during a multi-touch sequence.</p>
+ *
+ * @see http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/TouchEventClassReference/TouchEvent/TouchEvent.html
+ * @extends {UIEvent}
+ * @constructor
+ */
+function TouchEvent() {}
+
+/**
+ * A collection of Touch objects representing all touches associated with this
+ * target.
+ * @type {TouchList}
+ */
+TouchEvent.prototype.touches;
+
+/**
+ * A collection of Touch objects representing all touches associated with this
+ * target.
+ * @type {TouchList}
+ */
+TouchEvent.prototype.targetTouches;
+
+/**
+ * A collection of Touch objects representing all touches that changed in this event.
+ * @type {TouchList}
+ */
+TouchEvent.prototype.changedTouches;
+
+/**
+ * The distance between two fingers since the start of an event as a multiplier
+ * of the initial distance. The initial value is 1.0. If less than 1.0, the
+ * gesture is pinch close (to zoom out). If greater than 1.0, the gesture is
+ * pinch open (to zoom in).
+ * @type {number}
+ */
+TouchEvent.prototype.scale;
+
+/**
+ * The delta rotation since the start of an event, in degrees, where clockwise
+ * is positive and counter-clockwise is negative. The initial value is 0.0.
+ * @type {number}
+ */
+TouchEvent.prototype.rotation;
+
+/**
+ * Initializes a newly created TouchEvent object.
+ * @param {string} type
+ * @param {boolean} canBubble
+ * @param {boolean} cancelable
+ * @param {Window} view
+ * @param {number} detail
+ * @param {number} screenX
+ * @param {number} screenY
+ * @param {number} clientX
+ * @param {number} clientY
+ * @param {boolean} ctrlKey
+ * @param {boolean} altKey
+ * @param {boolean} shiftKey
+ * @param {boolean} metaKey
+ * @param {TouchList} touches
+ * @param {TouchList} targetTouches
+ * @param {TouchList} changedTouches
+ * @param {number} scale
+ * @param {number} rotation
+ */
+TouchEvent.prototype.initTouchEvent = function(type, canBubble, cancelable,
+    view, detail, screenX, screenY, clientX, clientY, ctrlKey, altKey, shiftKey,
+    metaKey, touches, targetTouches, changedTouches, scale, rotation) {};
+
+/**
+ * The GestureEvent class encapsulates information about a multi-touch gesture.
+ *
+ * GestureEvent objects are high-level events that encapsulate the low-level
+ * TouchEvent objects. Both GestureEvent and TouchEvent events are sent during
+ * a multi-touch sequence. Gesture events contain scaling and rotation
+ * information allowing gestures to be combined, if supported by the platform.
+ * If not supported, one gesture ends before another starts. Listen for
+ * GestureEvent events if you want to respond to gestures only, not process
+ * the low-level TouchEvent objects.
+ *
+ * @see http://developer.apple.com/library/safari/#documentation/UserExperience/Reference/GestureEventClassReference/GestureEvent/GestureEvent.html
+ * @extends {UIEvent}
+ * @constructor
+ */
+function GestureEvent() {}
+
+/**
+ * The distance between two fingers since the start of an event as a multiplier
+ * of the initial distance. The initial value is 1.0. If less than 1.0, the
+ * gesture is pinch close (to zoom out). If greater than 1.0, the gesture is
+ * pinch open (to zoom in).
+ * @type {number}
+ */
+GestureEvent.prototype.scale;
+
+/**
+ * The delta rotation since the start of an event, in degrees, where clockwise
+ * is positive and counter-clockwise is negative. The initial value is 0.0.
+ * @type {number}
+ */
+GestureEvent.prototype.rotation;
+
+/**
+ * The target of this gesture.
+ * @type {EventTarget}
+ */
+GestureEvent.prototype.target;
+
+/**
+ * Initializes a newly created GestureEvent object.
+ * @param {string} type
+ * @param {boolean} canBubble
+ * @param {boolean} cancelable
+ * @param {Window} view
+ * @param {number} detail
+ * @param {number} screenX
+ * @param {number} screenY
+ * @param {number} clientX
+ * @param {number} clientY
+ * @param {boolean} ctrlKey
+ * @param {boolean} altKey
+ * @param {boolean} shiftKey
+ * @param {boolean} metaKey
+ * @param {EventTarget} target
+ * @param {number} scale
+ * @param {number} rotation
+ */
+GestureEvent.prototype.initGestureEvent = function(type, canBubble, cancelable,
+    view, detail, screenX, screenY, clientX, clientY, ctrlKey, altKey, shiftKey,
+    metaKey, target, scale, rotation) {};
+
+/**
+ * Specifies the JavaScript method to invoke when the system cancels tracking
+ * for the touch.
+ * @type {?function(!TouchEvent)}
+ */
+Element.prototype.ontouchcancel;
+
+/**
+ * Specifies the JavaScript method to invoke when a given event lifts from the
+ * surface.
+ * @type {?function(!TouchEvent)}
+ */
+Element.prototype.ontouchend;
+
+/**
+ * Specifies the JavaScript method to invoke when a finger for a given event
+ * moves on the surface.
+ * @type {?function(!TouchEvent)}
+ */
+Element.prototype.ontouchmove;
+
+/**
+ * Specifies the JavaScript method to invoke when a finger for a given event
+ * touches the surface.
+ * @type {?function(!TouchEvent)}
+ */
+Element.prototype.ontouchstart;
+
+/**
+ * Specifies the JavaScript method to invoke when a gesture is started by
+ * two or more fingers touching the surface.
+ * @type {?function(!GestureEvent)}
+ */
+Element.prototype.ongesturestart;
+
+/**
+ * Specifies the JavaScript method to invoke when fingers are moved during a
+ * gesture.
+ * @type {?function(!GestureEvent)}
+ */
+Element.prototype.ongesturechange;
+
+/**
+ * Specifies the JavaScript method to invoke when a gesture ends (when there are
+ * 0 or 1 fingers touching the surface).
+ * @type {?function(!GestureEvent)}
+ */
+Element.prototype.ongestureend;
+
+/**
+ * Specifies the JavaScript method to invoke when the browser device's
+ * orientation changes, i.e.the device is rotated.
+ * @type {?function(!Event)}
+ * @see http://developer.apple.com/library/IOS/#documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html
+ */
+Window.prototype.onorientationchange;
+
+/**
+ * Returns the orientation of the browser's device, one of [-90, 0, 90, 180].
+ * @type {number}
+ * @see http://developer.apple.com/library/IOS/#documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html
+ */
+Window.prototype.orientation;
+
+/**
+ * @implicitCast
+ * @type {boolean}
+ */
+HTMLInputElement.prototype.autocorrect;
+
+/**
+ * @implicitCast
+ * @type {boolean}
+ */
+HTMLInputElement.prototype.autocapitalize;
+
+/**
+ * @implicitCast
+ * @type {boolean}
+ */
+HTMLTextAreaElement.prototype.autocorrect;
+
+/**
+ * @implicitCast
+ * @type {boolean}
+ */
+HTMLTextAreaElement.prototype.autocapitalize;

--- a/sdk/tests/deqp/temp_externs/mediasource.js
+++ b/sdk/tests/deqp/temp_externs/mediasource.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for the Media Source Extensions. Note that the
+ * properties available here are the union of several versions of the spec.
+ * @see http://dvcs.w3.org/hg/html-media/raw-file/tip/media-source/media-source.html
+ *
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @implements {EventTarget}
+ */
+function MediaSource() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+MediaSource.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+MediaSource.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+MediaSource.prototype.dispatchEvent = function(evt) {};
+
+/** @type {Array.<SourceBuffer>} */
+MediaSource.prototype.sourceBuffers;
+
+/** @type {Array.<SourceBuffer>} */
+MediaSource.prototype.activeSourceBuffers;
+
+/** @type {number} */
+MediaSource.prototype.duration;
+
+/**
+ * @param {string} type
+ * @return {SourceBuffer}
+ */
+MediaSource.prototype.addSourceBuffer = function(type) {};
+
+/**
+ * @param {SourceBuffer} sourceBuffer
+ */
+MediaSource.prototype.removeSourceBuffer = function(sourceBuffer) {};
+
+/** @type {string} */
+MediaSource.prototype.readyState;
+
+/**
+ * @param {string=} opt_error
+ */
+MediaSource.prototype.endOfStream = function(opt_error) {};
+
+/**
+ * @param {string} type
+ * @return {boolean}
+ */
+MediaSource.isTypeSupported = function(type) {};
+
+
+/**
+ * @constructor
+ * @implements {EventTarget}
+ */
+function SourceBuffer() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+SourceBuffer.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+SourceBuffer.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+SourceBuffer.prototype.dispatchEvent = function(evt) {};
+
+/** @type {string} */
+SourceBuffer.prototype.appendMode;
+
+/** @type {boolean} */
+SourceBuffer.prototype.updating;
+
+/** @type {TimeRanges} */
+SourceBuffer.prototype.buffered;
+
+/** @type {number} */
+SourceBuffer.prototype.timestampOffset;
+
+/** @type {number} */
+SourceBuffer.prototype.appendWindowStart;
+
+/** @type {number} */
+SourceBuffer.prototype.appendWindowEnd;
+
+/**
+ * @param {Uint8Array} data
+ */
+SourceBuffer.prototype.append = function(data) {};
+
+/**
+ * @param {ArrayBuffer|ArrayBufferView} data
+ */
+SourceBuffer.prototype.appendBuffer = function(data) {};
+
+/**
+ * Abort the current segment append sequence.
+ */
+SourceBuffer.prototype.abort = function() {};
+
+/**
+ * @param {number} start
+ * @param {number} end
+ */
+SourceBuffer.prototype.remove = function(start, end) {};

--- a/sdk/tests/deqp/temp_externs/page_visibility.js
+++ b/sdk/tests/deqp/temp_externs/page_visibility.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Externs for Page Visibility.
+ *
+ * @see http://www.w3.org/TR/page-visibility
+ * @externs
+ */
+
+/**
+ * @enum {string}
+ * @see http://www.w3.org/TR/page-visibility/#VisibilityState
+ */
+var VisibilityState = {
+  HIDDEN: 'hidden',
+  VISIBLE: 'visible',
+  PRERENDER: 'prerender',
+  UNLOADED: 'unloaded'
+};

--- a/sdk/tests/deqp/temp_externs/v8.js
+++ b/sdk/tests/deqp/temp_externs/v8.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2013 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file describes the externs API for V8-specific objects.
+ * @externs
+ */
+
+
+
+/**
+ * Stack frame elements in V8.
+ * @constructor
+ */
+function CallSite() {}
+
+
+/**
+ * Returns the value of this.
+ * @return {Object|undefined}
+ */
+CallSite.prototype.getThis = function() {};
+
+
+/**
+ * Returns the type of this as a string. This is the name of the function stored
+ * in the constructor field of this, if available, otherwise the object's
+ * [[Class]] internal property.
+ * @return {string|undefined}
+ */
+CallSite.prototype.getTypeName = function() {};
+
+
+/**
+ * Returns the current function.
+ * @return {!Function|undefined}
+ */
+CallSite.prototype.getFunction = function() {};
+
+
+/**
+ * Returns the name of the current function, typically its name property. If a
+ * name property is not available an attempt will be made to try to infer a name
+ * from the function's context.
+ * @return {string|undefined}
+ */
+CallSite.prototype.getFunctionName = function() {};
+
+
+/**
+ * Returns the name of the property of this or one of its prototypes that holds
+ * the current function.
+ * @return {string|undefined}
+ */
+CallSite.prototype.getMethodName = function() {};
+
+
+/**
+ * If this function was defined in a script returns the name of the script
+ * @return {string|undefined}
+ */
+CallSite.prototype.getFileName = function() {};
+
+
+/**
+ * If this function was defined in a script returns the current line number.
+ * @return {number|undefined}
+ */
+CallSite.prototype.getLineNumber = function() {};
+
+
+/**
+ * If this function was defined in a script returns the current column number.
+ * @return {number|undefined}
+ */
+CallSite.prototype.getColumnNumber = function() {};
+
+
+/**
+ * If this function was created using a call to eval, returns a CallSite object
+ * representing the location where eval was called
+ * @return {CallSite|undefined}
+ */
+CallSite.prototype.getEvalOrigin = function() {};
+
+
+/**
+ * Is this a toplevel invocation, that is, is this the global object?
+ * @return {boolean}
+ */
+CallSite.prototype.isToplevel = function() {};
+
+
+/**
+ * Does this call take place in code defined by a call to eval?
+ * @return {boolean}
+ */
+CallSite.prototype.isEval = function() {};
+
+
+/**
+ * Is this call in native V8 code?
+ * @return {boolean}
+ */
+CallSite.prototype.isNative = function() {};
+
+
+/**
+ * Is this a constructor call?
+ * @return {boolean}
+ */
+CallSite.prototype.isConstructor = function() {};

--- a/sdk/tests/deqp/temp_externs/w3c_anim_timing.js
+++ b/sdk/tests/deqp/temp_externs/w3c_anim_timing.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2011 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for timing control for script base animations. The
+ *  whole file has been fully type annotated.
+ *
+ * @see http://www.w3.org/TR/animation-timing/
+ * @see http://webstuff.nfshost.com/anim-timing/Overview.html
+ * @externs
+ */
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element In early versions of this API, the callback
+ *     was invoked only if the element was visible.
+ * @return {number}
+ */
+function requestAnimationFrame(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+function cancelRequestAnimationFrame(handle) {};
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+function webkitRequestAnimationFrame(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+function webkitCancelRequestAnimationFrame(handle) {};
+
+/**
+ * @param {number} handle
+ */
+function webkitCancelAnimationFrame(handle) {};
+
+/**
+ * @param {?function(number)} callback It's legitimate to pass a null
+ *     callback and listen on the MozBeforePaint event instead.
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+function mozRequestAnimationFrame(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+function mozCancelRequestAnimationFrame(handle) {};
+
+/**
+ * @param {number} handle
+ */
+function mozCancelAnimationFrame(handle) {};
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+function msRequestAnimationFrame(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+function msCancelRequestAnimationFrame(handle) {};
+
+/**
+ * @param {number} handle
+ */
+function msCancelAnimationFrame(handle) {};
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+function oRequestAnimationFrame(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+function oCancelRequestAnimationFrame(handle) {};
+
+/**
+ * @param {number} handle
+ */
+function oCancelAnimationFrame(handle) {};
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+Window.prototype.requestAnimationFrame = function(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.cancelRequestAnimationFrame = function(handle) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.cancelAnimationFrame = function(handle) {};
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+Window.prototype.webkitRequestAnimationFrame = function(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.webkitCancelRequestAnimationFrame = function(handle) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.webkitCancelAnimationFrame = function(handle) {};
+
+/**
+ * @param {?function(number)} callback It's legitimate to pass a null
+ *     callback and listen on the MozBeforePaint event instead.
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+Window.prototype.mozRequestAnimationFrame = function(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.mozCancelRequestAnimationFrame = function(handle) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.mozCancelAnimationFrame = function(handle) {};
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+Window.prototype.msRequestAnimationFrame = function(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.msCancelRequestAnimationFrame = function(handle) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.msCancelAnimationFrame = function(handle) {};
+
+/**
+ * @param {function(number)} callback
+ * @param {Element=} opt_element
+ * @return {number}
+ */
+Window.prototype.oRequestAnimationFrame = function(callback, opt_element) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.oCancelRequestAnimationFrame = function(handle) {};
+
+/**
+ * @param {number} handle
+ */
+Window.prototype.oCancelAnimationFrame = function(handle) {};

--- a/sdk/tests/deqp/temp_externs/w3c_css.js
+++ b/sdk/tests/deqp/temp_externs/w3c_css.js
@@ -1,0 +1,2505 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's CSS specification
+ *  The whole file has been fully type annotated.
+ *  http://www.w3.org/TR/DOM-Level-2-Style/css.html
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ *
+ * TODO(nicksantos): When there are no more occurrences of w3c_range.js and
+ * gecko_dom.js being included directly in BUILD files, bug dbeam to split the
+ * bottom part of this file into a separate externs.
+ */
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet
+ */
+function StyleSheet() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-type
+ */
+StyleSheet.prototype.type;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-disabled
+ */
+StyleSheet.prototype.disabled;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-owner
+ */
+StyleSheet.prototype.ownerNode;
+
+/**
+ * @type {StyleSheet}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-parentStyleSheet
+ */
+StyleSheet.prototype.parentStyleSheet;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-href
+ */
+StyleSheet.prototype.href;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-title
+ */
+StyleSheet.prototype.title;
+
+/**
+ * @type {MediaList}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-media
+ */
+StyleSheet.prototype.media;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheetList
+ */
+function StyleSheetList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheetList-length
+ */
+StyleSheetList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {StyleSheet}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheetList-item
+ */
+StyleSheetList.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-MediaList
+ */
+function MediaList() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-MediaList-mediaText
+ */
+MediaList.prototype.mediaText;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-MediaList-length
+ */
+MediaList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-MediaList-item
+ */
+MediaList.prototype.item = function(index) {};
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-LinkStyle
+ */
+function LinkStyle() {}
+
+/**
+ * @type {StyleSheet}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-LinkStyle-sheet
+ */
+LinkStyle.prototype.sheet;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-DocumentStyle
+ */
+function DocumentStyle() {}
+
+/**
+ * @type {StyleSheetList}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/stylesheets.html#StyleSheets-StyleSheet-DocumentStyle-styleSheets
+ */
+DocumentStyle.prototype.styleSheets;
+
+/**
+ * @constructor
+ * @extends {StyleSheet}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleSheet
+ */
+function CSSStyleSheet() {}
+
+/**
+ * @type {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleSheet-ownerRule
+ */
+CSSStyleSheet.prototype.ownerRule;
+
+/**
+ * @type {CSSRuleList}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleSheet-cssRules
+ */
+CSSStyleSheet.prototype.cssRules;
+
+/**
+ * @param {string} rule
+ * @param {number} index
+ * @return {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleSheet-insertRule
+ */
+CSSStyleSheet.prototype.insertRule = function(rule, index) {};
+
+/**
+ * @param {number} index
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleSheet-deleteRule
+ */
+CSSStyleSheet.prototype.deleteRule = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRuleList
+ */
+function CSSRuleList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRuleList-length
+ */
+CSSRuleList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRuleList-item
+ */
+CSSRuleList.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule
+ */
+function CSSRule() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.prototype.type;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-cssText
+ */
+CSSRule.prototype.cssText;
+
+/**
+ * @type {CSSStyleSheet}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-sheet
+ */
+CSSRule.prototype.parentStyleSheet;
+
+/**
+ * @type {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-parentRule
+ */
+CSSRule.prototype.parentRule;
+
+/**
+ * @type {CSSStyleDeclaration}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleRule
+ */
+CSSRule.prototype.style;
+
+/**
+ * Indicates that the rule is a {@see CSSUnknownRule}.
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.UNKNOWN_RULE = 0;
+
+/**
+ * Indicates that the rule is a {@see CSSStyleRule}.
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.STYLE_RULE = 1;
+
+/**
+ * Indicates that the rule is a {@see CSSCharsetRule}.
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.CHARSET_RULE = 2;
+
+/**
+ * Indicates that the rule is a {@see CSSImportRule}.
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.IMPORT_RULE = 3;
+
+/**
+ * Indicates that the rule is a {@see CSSMediaRule}.
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.MEDIA_RULE = 4;
+
+/**
+ * Indicates that the rule is a {@see CSSFontFaceRule}.
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.FONT_FACE_RULE = 5;
+
+/**
+ * Indicates that the rule is a {@see CSSPageRule}.
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSRule-ruleType
+ */
+CSSRule.PAGE_RULE = 6;
+
+/**
+ * @constructor
+ * @extends {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleRule
+ */
+function CSSStyleRule() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleRule-selectorText
+ */
+CSSStyleRule.prototype.selectorText;
+
+/**
+ * @type {CSSStyleDeclaration}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleRule-style
+ */
+CSSStyleRule.prototype.style;
+
+/**
+ * @constructor
+ * @extends {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSMediaRule
+ */
+function CSSMediaRule() {}
+
+/**
+ * @type {MediaList}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSMediaRule-mediaTypes
+ */
+CSSMediaRule.prototype.media;
+
+/**
+ * @type {CSSRuleList}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSMediaRule-cssRules
+ */
+CSSMediaRule.prototype.cssRules;
+
+/**
+ * @param {string} rule
+ * @param {number} index
+ * @return {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSMediaRule-insertRule
+ */
+CSSMediaRule.prototype.insertRule = function(rule, index) {};
+
+/**
+ * @param {number} index
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSMediaRule-deleteRule
+ */
+CSSMediaRule.prototype.deleteRule = function(index) {};
+
+/**
+ * @constructor
+ * @extends {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSFontFaceRule
+ */
+function CSSFontFaceRule() {}
+
+/**
+ * @type {CSSStyleDeclaration}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSFontFaceRule-style
+ */
+CSSFontFaceRule.prototype.style;
+
+/**
+ * @constructor
+ * @extends {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPageRule
+ */
+function CSSPageRule() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPageRule-name
+ */
+CSSPageRule.prototype.selectorText;
+
+/**
+ * @type {CSSStyleDeclaration}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPageRule-style
+ */
+CSSPageRule.prototype.style;
+
+/**
+ * @constructor
+ * @extends {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSImportRule
+ */
+function CSSImportRule() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSImportRule-href
+ */
+CSSImportRule.prototype.href;
+
+/**
+ * @type {MediaList}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSImportRule-media
+ */
+CSSImportRule.prototype.media;
+
+/**
+ * @type {CSSStyleSheet}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSImportRule-styleSheet
+ */
+CSSImportRule.prototype.styleSheet;
+
+/**
+ * @constructor
+ * @extends {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSCharsetRule
+ */
+function CSSCharsetRule() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSCharsetRule-encoding
+ */
+CSSCharsetRule.prototype.encoding;
+
+/**
+ * @constructor
+ * @extends {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSUnknownRule
+ */
+function CSSUnknownRule() {}
+
+/**
+ * @constructor
+ * @extends {CSSProperties}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration
+ */
+function CSSStyleDeclaration() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-cssText
+ */
+CSSStyleDeclaration.prototype.cssText;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-length
+ */
+CSSStyleDeclaration.prototype.length;
+
+/**
+ * @type {CSSRule}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-parentRule
+ */
+CSSStyleDeclaration.prototype.parentRule;
+
+/**
+ * @param {string} propertyName
+ * @return {CSSValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-getPropertyCSSValue
+ */
+CSSStyleDeclaration.prototype.getPropertyCSSValue = function(propertyName) {};
+
+/**
+ * @param {string} propertyName
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-getPropertyPriority
+ */
+CSSStyleDeclaration.prototype.getPropertyPriority = function(propertyName) {};
+
+/**
+ * @param {string} propertyName
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-getPropertyValue
+ */
+CSSStyleDeclaration.prototype.getPropertyValue = function(propertyName) {};
+
+/**
+ * @param {number} index
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-item
+ */
+CSSStyleDeclaration.prototype.item = function(index) {};
+
+/**
+ * @param {string} propertyName
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-removeProperty
+ */
+CSSStyleDeclaration.prototype.removeProperty = function(propertyName) {};
+
+/**
+ * @param {string} propertyName
+ * @param {string} value
+ * @param {string=} opt_priority
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSStyleDeclaration-setProperty
+ */
+CSSStyleDeclaration.prototype.setProperty = function(propertyName, value, opt_priority) {};
+
+// IE-specific
+
+/**
+ * @param {string} name
+ * @param {number=} opt_flags
+ * @return {string|number|boolean|null}
+ * @see http://msdn.microsoft.com/en-us/library/ms536429(VS.85).aspx
+ */
+CSSStyleDeclaration.prototype.getAttribute = function(name, opt_flags) {};
+
+/**
+ * @param {string} name
+ * @return {string|number|boolean|null}
+ * @see http://msdn.microsoft.com/en-us/library/aa358797(VS.85).aspx
+ */
+CSSStyleDeclaration.prototype.getExpression = function(name) {};
+
+/**
+ * @param {string} name
+ * @param {number=} opt_flags
+ * @return {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/ms536696(VS.85).aspx
+ */
+CSSStyleDeclaration.prototype.removeAttribute =
+    function(name, opt_flags) {};
+
+/**
+ * @param {string} name
+ * @return {boolean}
+ * @see http://msdn.microsoft.com/en-us/library/aa358798(VS.85).aspx
+ */
+CSSStyleDeclaration.prototype.removeExpression = function(name) {};
+
+/**
+ * @param {string} name
+ * @param {*} value
+ * @param {number=} opt_flags
+ * @see http://msdn.microsoft.com/en-us/library/ms536739(VS.85).aspx
+ */
+CSSStyleDeclaration.prototype.setAttribute = function(name, value, opt_flags) {};
+
+/**
+ * @param {string} name
+ * @param {string} expr
+ * @param {string=} opt_language
+ * @return {undefined}
+ * @see http://msdn.microsoft.com/en-us/library/ms531196(VS.85).aspx
+ */
+CSSStyleDeclaration.prototype.setExpression =
+    function(name, expr, opt_language) {};
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue
+ */
+function CSSValue() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-cssText
+ */
+CSSValue.prototype.cssText;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-cssValueType
+ */
+CSSValue.prototype.cssValueType;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
+ */
+CSSValue.CSS_INHERIT = 0;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
+ */
+CSSValue.CSS_PRIMITIVE_VALUE = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
+ */
+CSSValue.CSS_VALUE_LIST = 2;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValue-types
+ */
+CSSValue.CSS_CUSTOM = 3;
+
+/**
+ * @constructor
+ * @extends {CSSValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+function CSSPrimitiveValue() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.prototype.primitiveType;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_UNKNOWN = 0;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_NUMBER = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_PERCENTAGE = 2;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_EMS = 3;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_EXS = 4;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_PX = 5;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_CM = 6;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_MM = 7;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_IN = 8;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_PT = 9;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_PC = 10;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_DEG = 11;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_RAD = 12;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_GRAD = 13;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_MS = 14;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_S = 15;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_HZ = 16;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_KHZ = 17;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_DIMENSION = 18;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_STRING = 19;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_URI = 20;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_IDENT = 21;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_ATTR = 22;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_COUNTER = 23;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_RECT = 24;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue
+ */
+CSSPrimitiveValue.CSS_RGBCOLOR = 25;
+
+/**
+ * @return {Counter}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getCounterValue
+ * @throws DOMException {@see DomException.INVALID_ACCESS_ERR}
+ */
+CSSPrimitiveValue.prototype.getCounterValue = function() {};
+
+/**
+ * @param {number} unitType
+ * @return {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getFloatValue
+ * @throws DOMException {@see DomException.INVALID_ACCESS_ERR}
+ */
+CSSPrimitiveValue.prototype.getFloatValue = function(unitType) {};
+
+/**
+ * @return {RGBColor}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getRGBColorValue
+ * @throws DOMException {@see DomException.INVALID_ACCESS_ERR}
+ */
+CSSPrimitiveValue.prototype.getRGBColorValue = function() {};
+
+/**
+ * @return {Rect}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getRectValue
+ * @throws DOMException {@see DomException.INVALID_ACCESS_ERR}
+ */
+CSSPrimitiveValue.prototype.getRectValue = function() {};
+
+/**
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-getStringValue
+ * @throws DOMException {@see DomException.INVALID_ACCESS_ERR}
+ */
+CSSPrimitiveValue.prototype.getStringValue = function() {};
+
+/**
+ * @param {number} unitType
+ * @param {number} floatValue
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-setFloatValue
+ * @throws DOMException {@see DomException.INVALID_ACCESS_ERR},
+ *                      {@see DomException.NO_MODIFICATION_ALLOWED_ERR}
+ */
+CSSPrimitiveValue.prototype.setFloatValue = function(unitType, floatValue) {};
+
+/**
+ * @param {number} stringType
+ * @param {string} stringValue
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-setStringValue
+ * @throws DOMException {@see DomException.INVALID_ACCESS_ERR},
+ *                      {@see DomException.NO_MODIFICATION_ALLOWED_ERR}
+ */
+CSSPrimitiveValue.prototype.setStringValue = function(stringType, stringValue) {};
+
+/**
+ * @constructor
+ * @extends {CSSValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValueList
+ */
+function CSSValueList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValueList-length
+ */
+CSSValueList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {CSSValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSValueList-item
+ */
+CSSValueList.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-RGBColor
+ */
+function RGBColor() {}
+
+/**
+ * @type {CSSPrimitiveValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-RGBColor-red
+ */
+RGBColor.prototype.red;
+
+/**
+ * @type {CSSPrimitiveValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-RGBColor-green
+ */
+RGBColor.prototype.green;
+
+/**
+ * @type {CSSPrimitiveValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-RGBColor-blue
+ */
+RGBColor.prototype.blue;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Rect
+ */
+function Rect() {}
+
+/**
+ * @type {CSSPrimitiveValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Rect-top
+ */
+Rect.prototype.top;
+
+/**
+ * @type {CSSPrimitiveValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Rect-right
+ */
+Rect.prototype.right;
+
+/**
+ * @type {CSSPrimitiveValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Rect-bottom
+ */
+Rect.prototype.bottom;
+
+/**
+ * @type {CSSPrimitiveValue}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Rect-left
+ */
+Rect.prototype.left;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter
+ */
+function Counter() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter-identifier
+ */
+Counter.prototype.identifier;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter-listStyle
+ */
+Counter.prototype.listStyle;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-Counter-separator
+ */
+Counter.prototype.separator;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-ViewCSS
+ */
+function ViewCSS() {}
+
+/**
+ * @param {Element} elt
+ * @param {?string=} opt_pseudoElt This argument is required according to the
+ *     CSS2 specification, but optional in all major browsers. See the note at
+ *     https://developer.mozilla.org/en-US/docs/Web/API/Window.getComputedStyle
+ * @return {CSSStyleDeclaration}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSview-getComputedStyle
+ */
+ViewCSS.prototype.getComputedStyle = function(elt, opt_pseudoElt) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-DocumentCSS
+ */
+function DocumentCSS() {}
+
+/**
+ * @param {Element} elt
+ * @param {string} pseudoElt
+ * @return {CSSStyleDeclaration}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-DocumentCSS-getOverrideStyle
+ */
+DocumentCSS.prototype.getOverrideStyle = function(elt, pseudoElt) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-DOMImplementationCSS
+ */
+function DOMImplementationCSS() {}
+
+/**
+ * @param {string} title
+ * @param {string} media
+ * @return {CSSStyleSheet}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-DOMImplementationCSS-createCSSStyleSheet
+ * @throws DOMException {@see DomException.SYNTAX_ERR}
+ */
+DOMImplementationCSS.prototype.createCSSStyleSheet = function(title, media) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-ElementCSSInlineStyle
+ */
+function ElementCSSInlineStyle() {}
+
+/**
+ * @type {CSSStyleDeclaration}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-ElementCSSInlineStyle-style
+ */
+ElementCSSInlineStyle.prototype.style;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties
+ */
+function CSSProperties() {}
+
+// CSS 2 properties
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-azimuth
+ */
+CSSProperties.prototype.azimuth;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-background
+ */
+CSSProperties.prototype.background;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-backgroundAttachment
+ */
+CSSProperties.prototype.backgroundAttachment;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-backgroundColor
+ */
+CSSProperties.prototype.backgroundColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-backgroundImage
+ */
+CSSProperties.prototype.backgroundImage;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-backgroundPosition
+ */
+CSSProperties.prototype.backgroundPosition;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-backgroundRepeat
+ */
+CSSProperties.prototype.backgroundRepeat;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-background/#the-background-size
+ */
+CSSProperties.prototype.backgroundSize;
+
+/**
+ * @implicitCast
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-border
+ */
+CSSProperties.prototype.border;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderCollapse
+ */
+CSSProperties.prototype.borderCollapse;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderColor
+ */
+CSSProperties.prototype.borderColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderSpacing
+ */
+CSSProperties.prototype.borderSpacing;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSPrimitiveValue-borderStyle
+ */
+CSSProperties.prototype.borderStyle;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderTop
+ */
+CSSProperties.prototype.borderTop;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderRight
+ */
+CSSProperties.prototype.borderRight;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderBottom
+ */
+CSSProperties.prototype.borderBottom;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderLeft
+ */
+CSSProperties.prototype.borderLeft;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderTopColor
+ */
+CSSProperties.prototype.borderTopColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderRightColor
+ */
+CSSProperties.prototype.borderRightColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderBottomColor
+ */
+CSSProperties.prototype.borderBottomColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderLeftColor
+ */
+CSSProperties.prototype.borderLeftColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderTopStyle
+ */
+CSSProperties.prototype.borderTopStyle;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderRightStyle
+ */
+CSSProperties.prototype.borderRightStyle;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderBottomStyle
+ */
+CSSProperties.prototype.borderBottomStyle;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderLeftStyle
+ */
+CSSProperties.prototype.borderLeftStyle;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderTopWidth
+ */
+CSSProperties.prototype.borderTopWidth;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderRightWidth
+ */
+CSSProperties.prototype.borderRightWidth;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderBottomWidth
+ */
+CSSProperties.prototype.borderBottomWidth;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderLeftWidth
+ */
+CSSProperties.prototype.borderLeftWidth;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-borderWidth
+ */
+CSSProperties.prototype.borderWidth;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-background/#the-border-radius
+ */
+CSSProperties.prototype.borderRadius;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-background/#the-border-radius
+ */
+CSSProperties.prototype.borderBottomLeftRadius;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-background/#the-border-radius
+ */
+CSSProperties.prototype.borderBottomRightRadius;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-background/#the-border-radius
+ */
+CSSProperties.prototype.borderTopLeftRadius;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-background/#the-border-radius
+ */
+CSSProperties.prototype.borderTopRightRadius;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-bottom
+ */
+CSSProperties.prototype.bottom;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-captionSide
+ */
+CSSProperties.prototype.captionSide;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-clear
+ */
+CSSProperties.prototype.clear;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-clip
+ */
+CSSProperties.prototype.clip;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-color
+ */
+CSSProperties.prototype.color;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-content
+ */
+CSSProperties.prototype.content;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-counterIncrement
+ */
+CSSProperties.prototype.counterIncrement;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-counterReset
+ */
+CSSProperties.prototype.counterReset;
+
+/**
+ * This is not an official part of the W3C spec. In practice, this is a settable
+ * property that works cross-browser. It is used in goog.dom.setProperties() and
+ * needs to be extern'd so the --disambiguate_properties JS compiler pass works.
+ * @type {string}
+ */
+CSSProperties.prototype.cssText;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-cue
+ */
+CSSProperties.prototype.cue;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-cueAfter
+ */
+CSSProperties.prototype.cueAfter;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-cueBefore
+ */
+CSSProperties.prototype.cueBefore;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-cursor
+ */
+CSSProperties.prototype.cursor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-direction
+ */
+CSSProperties.prototype.direction;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-display
+ */
+CSSProperties.prototype.display;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-elevation
+ */
+CSSProperties.prototype.elevation;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-emptyCells
+ */
+CSSProperties.prototype.emptyCells;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-cssFloat
+ */
+CSSProperties.prototype.cssFloat;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-font
+ */
+CSSProperties.prototype.font;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-fontFamily
+ */
+CSSProperties.prototype.fontFamily;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-fontSize
+ */
+CSSProperties.prototype.fontSize;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-fontSizeAdjust
+ */
+CSSProperties.prototype.fontSizeAdjust;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-fontStretch
+ */
+CSSProperties.prototype.fontStretch;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-fontStyle
+ */
+CSSProperties.prototype.fontStyle;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-fontVariant
+ */
+CSSProperties.prototype.fontVariant;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-fontWeight
+ */
+CSSProperties.prototype.fontWeight;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-height
+ */
+CSSProperties.prototype.height;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-left
+ */
+CSSProperties.prototype.left;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-letterSpacing
+ */
+CSSProperties.prototype.letterSpacing;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-lineHeight
+ */
+CSSProperties.prototype.lineHeight;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-listStyle
+ */
+CSSProperties.prototype.listStyle;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-listStyleImage
+ */
+CSSProperties.prototype.listStyleImage;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-listStylePosition
+ */
+CSSProperties.prototype.listStylePosition;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-listStyleType
+ */
+CSSProperties.prototype.listStyleType;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-margin
+ */
+CSSProperties.prototype.margin;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-marginTop
+ */
+CSSProperties.prototype.marginTop;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-marginRight
+ */
+CSSProperties.prototype.marginRight;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-marginBottom
+ */
+CSSProperties.prototype.marginBottom;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-marginLeft
+ */
+CSSProperties.prototype.marginLeft;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-markerOffset
+ */
+CSSProperties.prototype.markerOffset;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-marks
+ */
+CSSProperties.prototype.marks;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-maxHeight
+ */
+CSSProperties.prototype.maxHeight;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-maxWidth
+ */
+CSSProperties.prototype.maxWidth;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-minHeight
+ */
+CSSProperties.prototype.minHeight;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-minWidth
+ */
+CSSProperties.prototype.minWidth;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-orphans
+ */
+CSSProperties.prototype.orphans;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-outline
+ */
+CSSProperties.prototype.outline;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-outlineColor
+ */
+CSSProperties.prototype.outlineColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-outlineStyle
+ */
+CSSProperties.prototype.outlineStyle;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-outlineWidth
+ */
+CSSProperties.prototype.outlineWidth;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-overflow
+ */
+CSSProperties.prototype.overflow;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-padding
+ */
+CSSProperties.prototype.padding;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-paddingTop
+ */
+CSSProperties.prototype.paddingTop;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-paddingRight
+ */
+CSSProperties.prototype.paddingRight;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-paddingBottom
+ */
+CSSProperties.prototype.paddingBottom;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-paddingLeft
+ */
+CSSProperties.prototype.paddingLeft;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-page
+ */
+CSSProperties.prototype.page;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pageBreakAfter
+ */
+CSSProperties.prototype.pageBreakAfter;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pageBreakBefore
+ */
+CSSProperties.prototype.pageBreakBefore;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pageBreakInside
+ */
+CSSProperties.prototype.pageBreakInside;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pause
+ */
+CSSProperties.prototype.pause;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pauseAfter
+ */
+CSSProperties.prototype.pauseAfter;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pauseBefore
+ */
+CSSProperties.prototype.pauseBefore;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pitch
+ */
+CSSProperties.prototype.pitch;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-pitchRange
+ */
+CSSProperties.prototype.pitchRange;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-playDuring
+ */
+CSSProperties.prototype.playDuring;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-position
+ */
+CSSProperties.prototype.position;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-quotes
+ */
+CSSProperties.prototype.quotes;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-ui/#resize
+ */
+CSSProperties.prototype.resize;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-richness
+ */
+CSSProperties.prototype.richness;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-right
+ */
+CSSProperties.prototype.right;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-size
+ */
+CSSProperties.prototype.size;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-speak
+ */
+CSSProperties.prototype.speak;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-speakHeader
+ */
+CSSProperties.prototype.speakHeader;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-speakNumeral
+ */
+CSSProperties.prototype.speakNumeral;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-speakPunctuation
+ */
+CSSProperties.prototype.speakPunctuation;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-speechRate
+ */
+CSSProperties.prototype.speechRate;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-stress
+ */
+CSSProperties.prototype.stress;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-tableLayout
+ */
+CSSProperties.prototype.tableLayout;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-textAlign
+ */
+CSSProperties.prototype.textAlign;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-textDecoration
+ */
+CSSProperties.prototype.textDecoration;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-textIndent
+ */
+CSSProperties.prototype.textIndent;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-textShadow
+ */
+CSSProperties.prototype.textShadow;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-textTransform
+ */
+CSSProperties.prototype.textTransform;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-top
+ */
+CSSProperties.prototype.top;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-unicodeBidi
+ */
+CSSProperties.prototype.unicodeBidi;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-verticalAlign
+ */
+CSSProperties.prototype.verticalAlign;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-visibility
+ */
+CSSProperties.prototype.visibility;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-voiceFamily
+ */
+CSSProperties.prototype.voiceFamily;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-volume
+ */
+CSSProperties.prototype.volume;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-whiteSpace
+ */
+CSSProperties.prototype.whiteSpace;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-widows
+ */
+CSSProperties.prototype.widows;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-width
+ */
+CSSProperties.prototype.width;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-wordSpacing
+ */
+CSSProperties.prototype.wordSpacing;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-wordWrap
+ */
+CSSProperties.prototype.wordWrap;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Style/css.html#CSS-CSSProperties-zIndex
+ */
+CSSProperties.prototype.zIndex;
+
+// CSS 3 properties
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-background/#box-shadow
+ */
+CSSProperties.prototype.boxShadow;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-ui/#box-sizing
+ */
+CSSProperties.prototype.boxSizing;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-color/#transparency
+ */
+CSSProperties.prototype.opacity;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-ui/#text-overflow
+ */
+CSSProperties.prototype.textOverflow;
+
+// CSS 3 transforms
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-2d-transforms/#backface-visibility-property
+ */
+CSSProperties.prototype.backfaceVisibility;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-2d-transforms/#perspective
+ */
+CSSProperties.prototype.perspective;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-2d-transforms/#perspective-origin
+ */
+CSSProperties.prototype.perspectiveOrigin;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-2d-transforms/#effects
+ */
+CSSProperties.prototype.transform;
+
+/**
+ * @type {string|number}
+ * @see http://www.w3.org/TR/css3-2d-transforms/#transform-origin
+ */
+CSSProperties.prototype.transformOrigin;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-2d-transforms/#transform-style
+ */
+CSSProperties.prototype.transformStyle;
+
+// CSS 3 transitions
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-transitions/#transition
+ */
+CSSProperties.prototype.transition;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-transitions/#transition-delay
+ */
+CSSProperties.prototype.transitionDelay;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-transitions/#transition-duration
+ */
+CSSProperties.prototype.transitionDuration;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-transitions/#transition-property-property
+ */
+CSSProperties.prototype.transitionProperty;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/css3-transitions/#transition-timing-function
+ */
+CSSProperties.prototype.transitionTimingFunction;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/SVG11/interact.html#PointerEventsProperty
+ */
+CSSProperties.prototype.pointerEvents;
+
+/**
+ * TODO(dbeam): Put this in separate file named w3c_cssom.js.
+ * Externs for the CSSOM View Module.
+ * @see http://www.w3.org/TR/cssom-view/
+ */
+
+// http://www.w3.org/TR/cssom-view/#extensions-to-the-window-interface
+
+/**
+ * @param {string} media_query_list
+ * @return {MediaQueryList}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-matchmedia
+ */
+Window.prototype.matchMedia = function(media_query_list) {};
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-innerwidth
+ */
+Window.prototype.innerWidth;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-innerheight
+ */
+Window.prototype.innerHeight;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-scrollx
+ */
+Window.prototype.scrollX;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-pagexoffset
+ */
+Window.prototype.pageXOffset;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-scrolly
+ */
+Window.prototype.scrollY;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-pageyoffset
+ */
+Window.prototype.pageYOffset;
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-scroll
+ */
+Window.prototype.scroll = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-scrollto
+ */
+Window.prototype.scrollTo = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-scrollby
+ */
+Window.prototype.scrollBy = function(x, y) {};
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-screenx
+ */
+Window.prototype.screenX;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-screeny
+ */
+Window.prototype.screenY;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-outerwidth
+ */
+Window.prototype.outerWidth;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-window-outerheight
+ */
+Window.prototype.outerHeight;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/cssom-view/#mediaquerylist
+ */
+function MediaQueryList() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mediaquerylist-media
+ */
+MediaQueryList.prototype.media;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mediaquerylist-matches
+ */
+MediaQueryList.prototype.matches;
+
+/**
+ * @param {MediaQueryListListener} listener
+ * @see http://www.w3.org/TR/cssom-view/#dom-mediaquerylist-addlistener
+ */
+MediaQueryList.prototype.addListener = function(listener) {};
+
+/**
+ * @param {MediaQueryListListener} listener
+ * @see http://www.w3.org/TR/cssom-view/#dom-mediaquerylist-removelistener
+ */
+MediaQueryList.prototype.removeListener = function(listener) {};
+
+/**
+ * @typedef {(function(!MediaQueryList) : void)}
+ * @see http://www.w3.org/TR/cssom-view/#mediaquerylistlistener
+ */
+var MediaQueryListListener;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/cssom-view/#screen
+ */
+function Screen() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-screen-availwidth
+ */
+Screen.prototype.availWidth;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-screen-availheight
+ */
+Screen.prototype.availHeight;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-screen-width
+ */
+Screen.prototype.width;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-screen-height
+ */
+Screen.prototype.height;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-screen-colordepth
+ */
+Screen.prototype.colorDepth;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-screen-pixeldepth
+ */
+Screen.prototype.pixelDepth;
+
+
+// http://www.w3.org/TR/cssom-view/#extensions-to-the-document-interface
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {?Element}
+ * @see http://www.w3.org/TR/cssom-view/#dom-document-elementfrompoint
+ */
+Document.prototype.elementFromPoint = function(x, y) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @return {CaretPosition}
+ * @see http://www.w3.org/TR/cssom-view/#dom-document-caretpositionfrompoint
+ */
+Document.prototype.caretPositionFromPoint = function(x, y) {};
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/cssom-view/#caretposition
+ */
+function CaretPosition() {}
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/cssom-view/#dom-caretposition-offsetnode
+ */
+CaretPosition.prototype.offsetNode;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-caretposition-offset
+ */
+CaretPosition.prototype.offset;
+
+
+// http://www.w3.org/TR/cssom-view/#extensions-to-the-element-interface
+
+/**
+ * @return {!ClientRectList}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-getclientrects
+ */
+Element.prototype.getClientRects = function() {};
+
+/**
+ * @return {!ClientRect}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-getboundingclientrect
+ */
+Element.prototype.getBoundingClientRect = function() {};
+
+/**
+ * @param {boolean=} opt_top
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-scrollintoview
+ */
+Element.prototype.scrollIntoView = function(opt_top) {};
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-scrolltop
+ */
+Element.prototype.scrollTop;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-scrollleft
+ */
+Element.prototype.scrollLeft;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-scrollwidth
+ */
+Element.prototype.scrollWidth;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-scrollheight
+ */
+Element.prototype.scrollHeight;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-clienttop
+ */
+Element.prototype.clientTop;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-clientleft
+ */
+Element.prototype.clientLeft;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-clientwidth
+ */
+Element.prototype.clientWidth;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-element-clientheight
+ */
+Element.prototype.clientHeight;
+
+// http://www.w3.org/TR/cssom-view/#extensions-to-the-htmlelement-interface
+
+/**
+ * @type {Element}
+ * @see http://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetparent
+ */
+HTMLElement.prototype.offsetParent;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-htmlelement-offsettop
+ */
+HTMLElement.prototype.offsetTop;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetleft
+ */
+HTMLElement.prototype.offsetLeft;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetwidth
+ */
+HTMLElement.prototype.offsetWidth;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-htmlelement-offsetheight
+ */
+HTMLElement.prototype.offsetHeight;
+
+
+// http://www.w3.org/TR/cssom-view/#extensions-to-the-range-interface
+
+/**
+ * @return {!ClientRectList}
+ * @see http://www.w3.org/TR/cssom-view/#dom-range-getclientrects
+ */
+Range.prototype.getClientRects = function() {};
+
+/**
+ * @return {!ClientRect}
+ * @see http://www.w3.org/TR/cssom-view/#dom-range-getboundingclientrect
+ */
+Range.prototype.getBoundingClientRect = function() {};
+
+
+// http://www.w3.org/TR/cssom-view/#extensions-to-the-mouseevent-interface
+
+// MouseEvent: screen{X,Y} and client{X,Y} are in DOM Level 2/3 Event as well,
+// so it seems like a specification issue. I've emailed www-style@w3.org in
+// hopes of resolving the conflict, but in the mean time they can live here
+// (http://lists.w3.org/Archives/Public/www-style/2012May/0039.html).
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-screenx
+ */
+//MouseEvent.prototype.screenX;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-screeny
+ */
+//MouseEvent.prototype.screenY;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-pagex
+ */
+MouseEvent.prototype.pageX;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-pagey
+ */
+MouseEvent.prototype.pageY;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-clientx
+ */
+//MouseEvent.prototype.clientX;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-clienty
+ */
+//MouseEvent.prototype.clientY;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-x
+ */
+MouseEvent.prototype.x;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-y
+ */
+MouseEvent.prototype.y;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-offsetx
+ */
+MouseEvent.prototype.offsetX;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-mouseevent-offsety
+ */
+MouseEvent.prototype.offsetY;
+
+
+// http://www.w3.org/TR/cssom-view/#rectangles
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/cssom-view/#the-clientrectlist-interface
+ */
+function ClientRectList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrectlist-length
+ */
+ClientRectList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {ClientRect}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrectlist-item
+ */
+ClientRectList.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/cssom-view/#the-clientrect-interface
+ */
+function ClientRect() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrect-top
+ */
+ClientRect.prototype.top;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrect-right
+ */
+ClientRect.prototype.right;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrect-bottom
+ */
+ClientRect.prototype.bottom;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrect-left
+ */
+ClientRect.prototype.left;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrect-width
+ */
+ClientRect.prototype.width;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/cssom-view/#dom-clientrect-height
+ */
+ClientRect.prototype.height;
+
+/**
+ * @constructor
+ * http://www.w3.org/TR/css3-conditional/#CSS-interface
+ */
+function CSSInterface() {}
+
+/**
+ * @param {string} property
+ * @param {string=} opt_value
+ * @return {boolean}
+ */
+CSSInterface.prototype.supports = function(property, opt_value) {};
+
+/**
+ * TODO(nicksantos): This suppress tag probably isn't needed, and
+ * should be removed.
+ * @suppress {duplicate}
+ * @type {CSSInterface}
+ */
+var CSS;
+
+/** @type {CSSInterface} */
+Window.prototype.CSS;
+
+// http://dev.w3.org/csswg/css-font-loading/
+
+/**
+ * @enum {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#enumdef-fontfaceloadstatus
+ */
+var FontFaceLoadStatus = {
+  ERROR: 'error',
+  LOADED: 'loaded',
+  LOADING: 'loading',
+  UNLOADED: 'unloaded'
+};
+
+/**
+ * @typedef {{
+ *   style: (string|undefined),
+ *   weight: (string|undefined),
+ *   stretch: (string|undefined),
+ *   unicodeRange: (string|undefined),
+ *   variant: (string|undefined),
+ *   featureSettings: (string|undefined)
+ * }}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dictdef-fontfacedescriptors
+ */
+var FontFaceDescriptors;
+
+/**
+ * @constructor
+ * @param {string} fontFamily
+ * @param {string} source
+ * @param {!FontFaceDescriptors} descriptors
+ * @see http://dev.w3.org/csswg/css-font-loading/#font-face-constructor
+ */
+function FontFace(fontFamily, source, descriptors) {}
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-family
+ */
+FontFace.prototype.family;
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-style
+ */
+FontFace.prototype.style;
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-weight
+ */
+FontFace.prototype.weight;
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-stretch
+ */
+FontFace.prototype.stretch;
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-unicoderange
+ */
+FontFace.prototype.unicodeRange;
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-variant
+ */
+FontFace.prototype.variant;
+
+/**
+ * @type {string}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-featuresettings
+ */
+FontFace.prototype.featureSettings;
+
+/**
+ * @type {FontFaceLoadStatus}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontface-status
+ */
+FontFace.prototype.status;
+
+/**
+ * @return {!Promise.<!FontFace>}
+ * @see http://dev.w3.org/csswg/css-font-loading/#font-face-load
+ */
+FontFace.prototype.load = function() {};
+
+/**
+ * @enum
+ * @see http://dev.w3.org/csswg/css-font-loading/#enumdef-fontfacesetloadstatus
+ */
+var FontFaceSetLoadStatus = {
+  LOADED: 'loaded',
+  LOADING: 'loading'
+};
+
+/**
+ * @interface
+ * @see http://dev.w3.org/csswg/css-font-loading/#FontFaceSet-interface
+ */
+function FontFaceSet() {}
+
+// Event handlers
+// http://dev.w3.org/csswg/css-font-loading/#FontFaceSet-events
+
+/** @type {?function (Event)} */ FontFaceSet.prototype.onloading;
+/** @type {?function (Event)} */ FontFaceSet.prototype.onloadingdone;
+/** @type {?function (Event)} */ FontFaceSet.prototype.onloadingerror;
+
+/**
+ * @param {!FontFace} value
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-add
+ */
+FontFaceSet.prototype.add = function(value) {};
+
+/**
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-clear
+ */
+FontFaceSet.prototype.clear = function() {};
+
+/**
+ * @param {!FontFace} value
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-delete
+ */
+FontFaceSet.prototype.delete = function(value) {};
+
+/**
+ * @param {!FontFace} font
+ * @return {boolean}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-has
+ */
+FontFaceSet.prototype.has = function(font) {};
+
+/**
+ * @param {function(!FontFace, number, !FontFaceSet)} cb
+ * @param {Object|undefined=} opt_selfObj
+ * see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-foreach
+ */
+FontFaceSet.prototype.forEach = function(cb, opt_selfObj) {};
+
+/**
+ * @param {string} font
+ * @param {string=} opt_text
+ * @return {!Promise.<!Array.<!FontFace>>}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-load
+ */
+FontFaceSet.prototype.load = function(font, opt_text) {};
+
+/**
+ * @param {string} font
+ * @param {string=} opt_text
+ * @return {boolean}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-check
+ */
+FontFaceSet.prototype.check = function(font, opt_text) {};
+
+/**
+ * @type {!Promise.<!FontFaceSet>}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-ready
+ */
+FontFaceSet.prototype.ready;
+
+/**
+ * @type {FontFaceSetLoadStatus}
+ * @see http://dev.w3.org/csswg/css-font-loading/#dom-fontfaceset-status
+ */
+FontFaceSet.prototype.status;

--- a/sdk/tests/deqp/temp_externs/w3c_css3d.js
+++ b/sdk/tests/deqp/temp_externs/w3c_css3d.js
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2010 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's CSS 3D Transforms specification.
+ *  The whole file has been fully type annotated. Created from
+ *  https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html
+ *
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @param {string=} opt_matrix
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#the-cssmatrix-interface
+ */
+function CSSMatrix(opt_matrix) {}
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m11;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m12;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m13;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m14;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m21;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m22;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m23;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m24;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m31;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m32;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m33;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m34;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m41;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m42;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m43;
+
+/**
+ * @type {number}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#three-dimensional-attributes
+ */
+CSSMatrix.prototype.m44;
+
+/**
+ * @param {string} string
+ * @return {void}
+ */
+CSSMatrix.prototype.setMatrixValue = function(string) {};
+
+/**
+ * @param {!CSSMatrix} secondMatrix
+ * @return {!CSSMatrix}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#widl-CSSMatrix-multiply-CSSMatrix-CSSMatrix-other
+ */
+CSSMatrix.prototype.multiply = function(secondMatrix) {};
+
+/**
+ * @return {CSSMatrix} Returns void if the matrix is non-invertable.
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#widl-CSSMatrix-inverse-CSSMatrix
+ */
+CSSMatrix.prototype.inverse = function() {};
+
+/**
+ * @param {number=} opt_x Defaults to 0.
+ * @param {number=} opt_y Defaults to 0.
+ * @param {number=} opt_z Defaults to 0.
+ * @return {!CSSMatrix}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#widl-CSSMatrix-translate-CSSMatrix-unrestricted-double-tx-unrestricted-double-ty-unrestricted-double-tz
+ */
+CSSMatrix.prototype.translate = function(opt_x, opt_y, opt_z) {};
+
+/**
+ * @param {number=} opt_scaleX Defaults to 1.
+ * @param {number=} opt_scaleY Defaults to scaleX.
+ * @param {number=} opt_scaleZ Defaults to 1.
+ * @return {!CSSMatrix}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#widl-CSSMatrix-scale-CSSMatrix-unrestricted-double-scale-unrestricted-double-originX-unrestricted-double-originY
+ */
+CSSMatrix.prototype.scale = function(opt_scaleX, opt_scaleY, opt_scaleZ) {};
+
+/**
+ * @param {number=} opt_rotX Defaults to 0.
+ * @param {number=} opt_rotY Defaults to 0.
+ * @param {number=} opt_rotZ Defaults to rotX if rotY is not defined, else 0.
+ * @return {!CSSMatrix}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#widl-CSSMatrix-rotate-CSSMatrix-unrestricted-double-angle-unrestricted-double-originX-unrestricted-double-originY
+ */
+CSSMatrix.prototype.rotate = function(opt_rotX, opt_rotY, opt_rotZ) {};
+
+/**
+ * @param {number=} opt_x Defaults to 0.
+ * @param {number=} opt_y Defaults to 0.
+ * @param {number=} opt_z Defaults to 0.
+ * @param {number=} opt_angle Defaults to 0.
+ * @return {!CSSMatrix}
+ * @see https://dvcs.w3.org/hg/FXTF/raw-file/tip/matrix/index.html#widl-CSSMatrix-rotateAxisAngle-CSSMatrix-unrestricted-double-x-unrestricted-double-y-unrestricted-double-z-unrestricted-double-angle
+ */
+CSSMatrix.prototype.rotateAxisAngle =
+    function(opt_x, opt_y, opt_z, opt_angle) {};
+
+/**
+ * @constructor
+ * @param {string=} opt_matrix
+ * @extends {CSSMatrix}
+ * @see http://developer.apple.com/safari/library/documentation/AudioVideo/Reference/WebKitCSSMatrixClassReference/WebKitCSSMatrix/WebKitCSSMatrix.html#//apple_ref/javascript/instm/WebKitCSSMatrix/setMatrixValue
+ */
+function WebKitCSSMatrix(opt_matrix) {}
+
+/**
+ * @constructor
+ * @param {string=} opt_matrix
+ * @extends {CSSMatrix}
+ * @see http://msdn.microsoft.com/en-us/library/windows/apps/hh453593.aspx
+ */
+function MSCSSMatrix(opt_matrix) {}

--- a/sdk/tests/deqp/temp_externs/w3c_device_sensor_event.js
+++ b/sdk/tests/deqp/temp_externs/w3c_device_sensor_event.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's device orientation and device motion
+ *  events specification.
+ *  This file depends on w3c_event.js.
+ *  The whole file has been partially type annotated.
+ *  Created from http://dev.w3.org/geo/api/spec-source-orientation.
+ *
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @extends {Event}
+ */
+function DeviceOrientationEvent() {}
+
+/** @type {?number} */
+DeviceOrientationEvent.prototype.alpha;
+
+/** @type {?number} */
+DeviceOrientationEvent.prototype.beta;
+
+/** @type {?number} */
+DeviceOrientationEvent.prototype.gamma;
+
+/** @type {boolean} */
+DeviceOrientationEvent.prototype.absolute;
+
+/**
+ * @type {?number}
+ * @see https://developer.apple.com/library/safari/documentation/SafariDOMAdditions/Reference/DeviceOrientationEventClassRef/DeviceOrientationEvent/DeviceOrientationEvent.html#//apple_ref/javascript/instp/DeviceOrientationEvent/webkitCompassAccuracy
+ */
+DeviceOrientationEvent.prototype.webkitCompassAccuracy;
+
+/**
+ * @type {?number}
+ * @see https://developer.apple.com/library/safari/documentation/SafariDOMAdditions/Reference/DeviceOrientationEventClassRef/DeviceOrientationEvent/DeviceOrientationEvent.html#//apple_ref/javascript/instp/DeviceOrientationEvent/webkitCompassHeading
+ */
+DeviceOrientationEvent.prototype.webkitCompassHeading;
+
+/**
+ * @constructor
+ */
+function DeviceAcceleration() {}
+
+/** @type {?number} */
+DeviceAcceleration.prototype.x;
+
+/** @type {?number} */
+DeviceAcceleration.prototype.y;
+
+/** @type {?number} */
+DeviceAcceleration.prototype.z;
+
+/**
+ * @constructor
+ */
+function DeviceRotationRate() {}
+
+/** @type {?number} */
+DeviceRotationRate.prototype.alpha;
+
+/** @type {?number} */
+DeviceRotationRate.prototype.beta;
+
+/** @type {?number} */
+DeviceRotationRate.prototype.gamma;
+
+/**
+ * @constructor
+ * @extends {Event}
+ */
+function DeviceMotionEvent() {}
+
+/** @type {?DeviceAcceleration} */
+DeviceMotionEvent.prototype.acceleration;
+
+/** @type {?DeviceAcceleration} */
+DeviceMotionEvent.prototype.accelerationIncludingGravity;
+
+/** @type {?DeviceRotationRate} */
+DeviceMotionEvent.prototype.rotationRate;
+
+/** @type {?number} */
+DeviceMotionEvent.prototype.interval;

--- a/sdk/tests/deqp/temp_externs/w3c_dom1.js
+++ b/sdk/tests/deqp/temp_externs/w3c_dom1.js
@@ -1,0 +1,874 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's DOM Level 1 specification.
+ *  The whole file has been fully type annotated. Created from
+ *  http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
+ *
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ */
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-17189187
+ */
+function DOMException() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.INDEX_SIZE_ERR = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.DOMSTRING_SIZE_ERR = 2;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.HIERARCHY_REQUEST_ERR = 3;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.WRONG_DOCUMENT_ERR = 4;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.INVALID_CHARACTER_ERR = 5;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.NO_DATA_ALLOWED_ERR = 6;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.NO_MODIFICATION_ALLOWED_ERR = 7;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.NOT_FOUND_ERR = 8;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.NOT_SUPPORTED_ERR = 9;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+DOMException.INUSE_ATTRIBUTE_ERR = 10;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-258A00AF
+ */
+function ExceptionCode() {}
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-102161490
+ */
+function DOMImplementation() {}
+
+/**
+ * @param {string} feature
+ * @param {string} version
+ * @return {boolean}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-5CED94D7
+ * @nosideeffects
+ */
+DOMImplementation.prototype.hasFeature = function(feature, version) {};
+
+/**
+ * @constructor
+ * @implements {EventTarget}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+function Node() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Node.prototype.addEventListener = function(type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Node.prototype.removeEventListener = function(type, listener, opt_useCapture) {};
+
+/** @override */
+Node.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * @type {NamedNodeMap}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-attributes
+ */
+Node.prototype.attributes;
+
+/**
+ * @type {!NodeList}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-childNodes
+ */
+Node.prototype.childNodes;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-firstChild
+ */
+Node.prototype.firstChild;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-lastChild
+ */
+Node.prototype.lastChild;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-nextSibling
+ */
+Node.prototype.nextSibling;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-nodeName
+ */
+Node.prototype.nodeName;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-nodeValue
+ */
+Node.prototype.nodeValue;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-nodeType
+ */
+Node.prototype.nodeType;
+
+/**
+ * @type {Document}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-ownerDocument
+ */
+Node.prototype.ownerDocument;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-parentNode
+ */
+Node.prototype.parentNode;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-previousSibling
+ */
+Node.prototype.previousSibling;
+
+/**
+ * @param {Node} newChild
+ * @return {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-appendChild
+ */
+Node.prototype.appendChild = function(newChild) {};
+
+/**
+ * @param {boolean} deep
+ * @return {!Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-cloneNode
+ * @nosideeffects
+ */
+Node.prototype.cloneNode = function(deep) {};
+
+/**
+ * @return {boolean}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-hasChildNodes
+ * @nosideeffects
+ */
+Node.prototype.hasChildNodes = function() {};
+
+/**
+ * @param {Node} newChild
+ * @param {Node} refChild
+ * @return {!Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-insertBefore
+ */
+Node.prototype.insertBefore = function(newChild, refChild) {};
+
+/**
+ * @param {Node} oldChild
+ * @return {!Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-removeChild
+ */
+Node.prototype.removeChild = function(oldChild) {};
+
+/**
+ * @param {Node} newChild
+ * @param {Node} oldChild
+ * @return {!Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-replaceChild
+ */
+Node.prototype.replaceChild = function(newChild, oldChild) {};
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.ATTRIBUTE_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.CDATA_SECTION_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.COMMENT_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.DOCUMENT_FRAGMENT_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.DOCUMENT_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.DOCUMENT_TYPE_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.ELEMENT_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.ENTITY_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.ENTITY_REFERENCE_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.PROCESSING_INSTRUCTION_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.TEXT_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.XPATH_NAMESPACE_NODE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1950641247
+ */
+Node.NOTATION_NODE;
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-B63ED1A3
+ */
+function DocumentFragment() {}
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#i-Document
+ */
+function Document() {}
+
+/**
+ * @type {DocumentType}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-doctype
+ */
+Document.prototype.doctype;
+
+/**
+ * @type {!Element}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-documentElement
+ */
+Document.prototype.documentElement;
+
+/**
+ * @type {DOMImplementation}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-implementation
+ */
+Document.prototype.implementation;
+
+/**
+ * @param {string} name
+ * @return {!Attr}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createAttribute
+ * @nosideeffects
+ */
+Document.prototype.createAttribute = function(name) {};
+
+/**
+ * @param {string} data
+ * @return {!Comment}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createComment
+ * @nosideeffects
+ */
+Document.prototype.createComment = function(data) {};
+
+/**
+ * @param {string} data
+ * @return {!CDATASection}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createCDATASection
+ * @nosideeffects
+ */
+Document.prototype.createCDATASection = function(data) {};
+
+/**
+ * @return {!DocumentFragment}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createDocumentFragment
+ * @nosideeffects
+ */
+Document.prototype.createDocumentFragment = function() {};
+
+/**
+ * Create a DOM element.
+ *
+ * Web components introduced the second parameter as a way of extending existing
+ * tags (e.g. document.createElement('button', 'fancy-button')).
+ *
+ * @param {string} tagName
+ * @param {string=} opt_typeExtension
+ * @return {!Element}
+ * @nosideeffects
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createElement
+ * @see http://w3c.github.io/webcomponents/spec/custom/#extensions-to-document-interface-to-instantiate
+ */
+Document.prototype.createElement = function(tagName, opt_typeExtension) {};
+
+/**
+ * @param {string} name
+ * @return {!EntityReference}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createEntityReference
+ * @nosideeffects
+ */
+Document.prototype.createEntityReference = function(name) {};
+
+/**
+ * @param {string} target
+ * @param {string} data
+ * @return {!ProcessingInstruction}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createProcessingInstruction
+ * @nosideeffects
+ */
+Document.prototype.createProcessingInstruction = function(target, data) {};
+
+/**
+ * @param {number|string} data
+ * @return {!Text}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-createTextNode
+ * @nosideeffects
+ */
+Document.prototype.createTextNode = function(data) {};
+
+/**
+ * @param {string} tagname
+ * @return {!NodeList}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-A6C9094
+ * @nosideeffects
+ */
+Document.prototype.getElementsByTagName = function(tagname) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-536297177
+ */
+function NodeList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-203510337
+ */
+NodeList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-844377136
+ */
+NodeList.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1780488922
+ */
+function NamedNodeMap() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-6D0FB19E
+ */
+NamedNodeMap.prototype.length;
+
+/**
+ * @param {string} name
+ * @return {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1074577549
+ * @nosideeffects
+ */
+NamedNodeMap.prototype.getNamedItem = function(name) {};
+
+/**
+ * @param {number} index
+ * @return {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-349467F9
+ * @nosideeffects
+ */
+NamedNodeMap.prototype.item = function(index) {};
+
+/**
+ * @param {string} name
+ * @return {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-D58B193
+ */
+NamedNodeMap.prototype.removeNamedItem = function(name) {};
+
+/**
+ * @param {Node} arg
+ * @return {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1025163788
+ */
+NamedNodeMap.prototype.setNamedItem = function(arg) {};
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-FF21A306
+ */
+function CharacterData() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-72AB8359
+ */
+CharacterData.prototype.data;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-7D61178C
+ */
+CharacterData.prototype.length;
+
+/**
+ * @param {string} arg
+ * @return {undefined}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-32791A2F
+ */
+CharacterData.prototype.appendData = function(arg) {};
+
+/**
+ * @param {number} offset
+ * @param {number} count
+ * @return {undefined}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-7C603781
+ */
+CharacterData.prototype.deleteData = function(offset, count) {};
+
+/**
+ * @param {number} offset
+ * @param {string} arg
+ * @return {undefined}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-3EDB695F
+ */
+CharacterData.prototype.insertData = function(offset, arg) {};
+
+/**
+ * @param {number} offset
+ * @param {number} count
+ * @param {string} arg
+ * @return {undefined}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-E5CBA7FB
+ */
+CharacterData.prototype.replaceData = function(offset, count, arg) {};
+
+/**
+ * @param {number} offset
+ * @param {number} count
+ * @return {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-6531BCCF
+ * @nosideeffects
+ */
+CharacterData.prototype.substringData = function(offset, count) {};
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-637646024
+ */
+function Attr() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1112119403
+ */
+Attr.prototype.name;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-862529273
+ */
+Attr.prototype.specified;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-221662474
+ */
+Attr.prototype.value;
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-745549614
+ */
+function Element() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#attribute-tagName
+ */
+Element.prototype.tagName;
+
+/**
+ * @param {string} name
+ * @param {number?=} opt_flags
+ * @return {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-getAttribute
+ * @see http://msdn.microsoft.com/en-us/library/ms536429(VS.85).aspx
+ * @nosideeffects
+ */
+Element.prototype.getAttribute = function(name, opt_flags) {};
+
+/**
+ * @param {string} name
+ * @return {Attr}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-getAttributeNode
+ * @nosideeffects
+ */
+Element.prototype.getAttributeNode = function(name) {};
+
+/**
+ * @param {string} tagname
+ * @return {!NodeList}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1938918D
+ * @nosideeffects
+ */
+Element.prototype.getElementsByTagName = function(tagname) {};
+
+/**
+ * @param {string} name
+ * @return {undefined}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-removeAttribute
+ */
+Element.prototype.removeAttribute = function(name) {};
+
+/**
+ * @param {Attr} oldAttr
+ * @return {?Attr}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-removeAttributeNode
+ */
+Element.prototype.removeAttributeNode = function(oldAttr) {};
+
+/**
+ * @param {string} name
+ * @param {string|number|boolean} value Values are converted to strings with
+ *     ToString, so we accept number and boolean since both convert easily to
+ *     strings.
+ * @return {undefined}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-setAttribute
+ */
+Element.prototype.setAttribute = function(name, value) {};
+
+/**
+ * @param {Attr} newAttr
+ * @return {?Attr}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-setAttributeNode
+ */
+Element.prototype.setAttributeNode = function(newAttr) {};
+
+// Event handlers
+// The DOM level 3 spec has a good index of these
+// http://www.w3.org/TR/DOM-Level-3-Events/#event-types
+
+/** @type {?function (Event)} */ Element.prototype.onabort;
+/** @type {?function (Event)} */ Element.prototype.onbeforeinput;
+/** @type {?function (Event)} */ Element.prototype.onbeforeunload;
+/** @type {?function (Event)} */ Element.prototype.onblur;
+/** @type {?function (Event)} */ Element.prototype.onchange;
+/** @type {?function (Event)} */ Element.prototype.onclick;
+/** @type {?function (Event)} */ Element.prototype.oncompositionstart;
+/** @type {?function (Event)} */ Element.prototype.oncompositionupdate;
+/** @type {?function (Event)} */ Element.prototype.oncompositionend;
+/** @type {?function (Event)} */ Element.prototype.oncontextmenu;
+/** @type {?function (Event)} */ Element.prototype.oncopy;
+/** @type {?function (Event)} */ Element.prototype.oncut;
+/** @type {?function (Event)} */ Element.prototype.ondblclick;
+/** @type {?function (Event)} */ Element.prototype.onerror;
+/** @type {?function (Event)} */ Element.prototype.onfocus;
+/** @type {?function (Event)} */ Element.prototype.onfocusin;
+/** @type {?function (Event)} */ Element.prototype.onfocusout;
+/** @type {?function (Event)} */ Element.prototype.oninput;
+/** @type {?function (Event)} */ Element.prototype.onkeydown;
+/** @type {?function (Event)} */ Element.prototype.onkeypress;
+/** @type {?function (Event)} */ Element.prototype.onkeyup;
+/** @type {?function (Event)} */ Element.prototype.onload;
+/** @type {?function (Event)} */ Element.prototype.onunload;
+/** @type {?function (Event)} */ Element.prototype.onmousedown;
+/** @type {?function (Event)} */ Element.prototype.onmousemove;
+/** @type {?function (Event)} */ Element.prototype.onmouseout;
+/** @type {?function (Event)} */ Element.prototype.onmouseover;
+/** @type {?function (Event)} */ Element.prototype.onmouseup;
+/** @type {?function (Event)} */ Element.prototype.onmousewheel;
+/** @type {?function (Event)} */ Element.prototype.onpaste;
+/** @type {?function (Event)} */ Element.prototype.onreset;
+/** @type {?function (Event)} */ Element.prototype.onresize;
+/** @type {?function (Event)} */ Element.prototype.onscroll;
+/** @type {?function (Event)} */ Element.prototype.onselect;
+/** @type {?function (Event=)} */ Element.prototype.onsubmit;
+/** @type {?function (Event)} */ Element.prototype.ontextinput;
+/** @type {?function (Event)} */ Element.prototype.onwheel;
+
+/**
+ * @constructor
+ * @extends {CharacterData}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1312295772
+ */
+function Text() {}
+
+/**
+ * @param {number} offset
+ * @return {Text}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-38853C1D
+ */
+Text.prototype.splitText = function(offset) {};
+
+/**
+ * @constructor
+ * @extends {CharacterData}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1728279322
+ */
+function Comment() {}
+
+/**
+ * @constructor
+ * @extends {Text}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-667469212
+ */
+function CDATASection() {}
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-412266927
+ */
+function DocumentType() {}
+
+/**
+ * @type {NamedNodeMap}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1788794630
+ */
+DocumentType.prototype.entities;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1844763134
+ */
+DocumentType.prototype.name;
+
+/**
+ * @type {NamedNodeMap}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-D46829EF
+ */
+DocumentType.prototype.notations;
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-5431D1B9
+ */
+function Notation() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-54F2B4D0
+ */
+Notation.prototype.publicId;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-E8AAB1D0
+ */
+Notation.prototype.systemId;
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-527DCFF2
+ */
+function Entity() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-D7303025
+ */
+Entity.prototype.publicId;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-D7C29F3E
+ */
+Entity.prototype.systemId;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-6ABAEB38
+ */
+Entity.prototype.notationName;
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-11C98490
+ */
+function EntityReference() {}
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1004215813
+ */
+function ProcessingInstruction() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-837822393
+ */
+ProcessingInstruction.prototype.data;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#ID-1478689192
+ */
+ProcessingInstruction.prototype.target;
+
+
+/**
+ * @constructor
+ * @implements {EventTarget}
+ */
+function Window() {}
+Window.prototype.Window;
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Window.prototype.addEventListener = function(type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Window.prototype.removeEventListener = function(type, listener, opt_useCapture)
+    {};
+
+/** @override */
+Window.prototype.dispatchEvent = function(evt) {};
+
+/** @type {?function (Event)} */ Window.prototype.onabort;
+/** @type {?function (Event)} */ Window.prototype.onbeforeunload;
+/** @type {?function (Event)} */ Window.prototype.onblur;
+/** @type {?function (Event)} */ Window.prototype.onchange;
+/** @type {?function (Event)} */ Window.prototype.onclick;
+/** @type {?function (Event)} */ Window.prototype.onclose;
+/** @type {?function (Event)} */ Window.prototype.oncontextmenu;
+/** @type {?function (Event)} */ Window.prototype.ondblclick;
+/** @type {?function (Event)} */ Window.prototype.ondragdrop;
+// onerror has a special signature.
+// See https://developer.mozilla.org/en/DOM/window.onerror
+// and http://msdn.microsoft.com/en-us/library/cc197053(VS.85).aspx
+/** @type {?function (string, string, number)} */
+Window.prototype.onerror;
+/** @type {?function (Event)} */ Window.prototype.onfocus;
+/** @type {?function (Event)} */ Window.prototype.onhashchange;
+/** @type {?function (Event)} */ Window.prototype.onkeydown;
+/** @type {?function (Event)} */ Window.prototype.onkeypress;
+/** @type {?function (Event)} */ Window.prototype.onkeyup;
+/** @type {?function (Event)} */ Window.prototype.onload;
+/** @type {?function (Event)} */ Window.prototype.onmousedown;
+/** @type {?function (Event)} */ Window.prototype.onmousemove;
+/** @type {?function (Event)} */ Window.prototype.onmouseout;
+/** @type {?function (Event)} */ Window.prototype.onmouseover;
+/** @type {?function (Event)} */ Window.prototype.onmouseup;
+/** @type {?function (Event)} */ Window.prototype.onmousewheel;
+/** @type {?function (Event)} */ Window.prototype.onpaint;
+/** @type {?function (Event)} */ Window.prototype.onpopstate;
+/** @type {?function (Event)} */ Window.prototype.onreset;
+/** @type {?function (Event)} */ Window.prototype.onresize;
+/** @type {?function (Event)} */ Window.prototype.onscroll;
+/** @type {?function (Event)} */ Window.prototype.onselect;
+/** @type {?function (Event=)} */ Window.prototype.onsubmit;
+/** @type {?function (Event)} */ Window.prototype.onunload;
+/** @type {?function (Event)} */ Window.prototype.onwheel;

--- a/sdk/tests/deqp/temp_externs/w3c_dom2.js
+++ b/sdk/tests/deqp/temp_externs/w3c_dom2.js
@@ -1,0 +1,2619 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's DOM Level 2 specification.
+ *  This file depends on w3c_dom1.js.
+ *  The whole file has been fully type annotated.
+ *  Created from
+ *  http://www.w3.org/TR/REC-DOM-Level-1/ecma-script-language-binding.html
+ *
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ */
+// All the provided definitions have been type annotated.
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75708506
+ */
+function HTMLCollection() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-40057551
+ */
+HTMLCollection.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {Node}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-33262535
+ * @nosideeffects
+ */
+HTMLCollection.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-HTML/html.html#HTMLOptionsCollection
+ */
+function HTMLOptionsCollection() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-HTML/html.html#HTMLOptionsCollection-length
+ */
+HTMLOptionsCollection.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {Node}
+ * @see http://www.w3.org/TR/DOM-Level-2-HTML/html.html#HTMLOptionsCollection-item
+ * @nosideeffects
+ */
+HTMLOptionsCollection.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @extends {Document}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-26809268
+ */
+function HTMLDocument() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-18446827
+ */
+HTMLDocument.prototype.title;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-95229140
+ */
+HTMLDocument.prototype.referrer;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-2250147
+ */
+HTMLDocument.prototype.domain;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-46183437
+ */
+HTMLDocument.prototype.URL;
+
+/**
+ * @type {HTMLBodyElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-56360201
+ */
+HTMLDocument.prototype.body;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-90379117
+ */
+HTMLDocument.prototype.images;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-85113862
+ */
+HTMLDocument.prototype.applets;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-7068919
+ */
+HTMLDocument.prototype.links;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-1689064
+ */
+HTMLDocument.prototype.forms;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-7577272
+ */
+HTMLDocument.prototype.anchors;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-8747038
+ */
+HTMLDocument.prototype.cookie;
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-72161170
+ * @override
+ */
+HTMLDocument.prototype.open = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-98948567
+ * @override
+ */
+HTMLDocument.prototype.close = function() {};
+
+/**
+ * @param {string} text
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75233634
+ * @override
+ */
+HTMLDocument.prototype.write = function(text) {};
+
+/**
+ * @param {string} text
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-35318390
+ * @override
+ */
+HTMLDocument.prototype.writeln = function(text) {};
+
+/**
+ * @param {string} elementName
+ * @return {!NodeList}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-71555259
+ * @override
+ * @nosideeffects
+ */
+HTMLDocument.prototype.getElementsByName = function(elementName) {};
+
+/**
+ * @param {Node} root
+ * @param {number=} whatToShow
+ * @param {NodeFilter=} filter
+ * @param {boolean=} entityReferenceExpansion
+ * @return {!NodeIterator}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-Document
+ * @nosideeffects
+ */
+HTMLDocument.prototype.createNodeIterator = function(
+    root, whatToShow, filter, entityReferenceExpansion) {};
+
+/**
+ * @param {Node} root
+ * @param {number=} whatToShow
+ * @param {NodeFilter=} filter
+ * @param {boolean=} entityReferenceExpansion
+ * @return {!TreeWalker}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-Document
+ * @nosideeffects
+ */
+HTMLDocument.prototype.createTreeWalker = function(
+    root, whatToShow, filter, entityReferenceExpansion) {};
+
+
+/** @typedef {{
+  createNodeIterator: function(Node, number=, NodeFilter=, boolean=) : NodeIterator,
+  createTreeWalker: function(Node, number=, NodeFilter=, boolean=) : TreeWalker
+}} */
+var TraversalDocument;
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-NodeFilter
+*/
+function NodeFilter() {}
+
+/* Constants for whatToShow */
+/** @const {number} */ NodeFilter.SHOW_ALL;
+/** @const {number} */ NodeFilter.SHOW_ATTRIBUTE;
+/** @const {number} */ NodeFilter.SHOW_CDATA_SECTION;
+/** @const {number} */ NodeFilter.SHOW_COMMENT;
+/** @const {number} */ NodeFilter.SHOW_DOCUMENT;
+/** @const {number} */ NodeFilter.SHOW_DOCUMENT_FRAGMENT;
+/** @const {number} */ NodeFilter.SHOW_DOCUMENT_TYPE;
+/** @const {number} */ NodeFilter.SHOW_ELEMENT;
+/** @const {number} */ NodeFilter.SHOW_ENTITY;
+/** @const {number} */ NodeFilter.SHOW_ENTITY_REFERENCE;
+/** @const {number} */ NodeFilter.SHOW_NOTATION;
+/** @const {number} */ NodeFilter.SHOW_PROCESSING_INSTRUCTION;
+/** @const {number} */ NodeFilter.SHOW_TEXT;
+
+/* Consants for acceptNode */
+/** @const {number} */ NodeFilter.FILTER_ACCEPT;
+/** @const {number} */ NodeFilter.FILTER_REJECT;
+/** @const {number} */ NodeFilter.FILTER_SKIP;
+
+/**
+ * @param {Node} n
+ * @return {number} Any of NodeFilter.FILTER_* constants.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-NodeFilter-acceptNode
+*/
+NodeFilter.prototype.acceptNode = function(n) {};
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-NodeIterator
+*/
+function NodeIterator() {}
+
+/**
+ * Detach and invalidate the NodeIterator.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-NodeIterator-detach
+ */
+NodeIterator.prototype.detach = function() {};
+
+/**
+ * @return {Node} Next node in the set.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-NodeIterator-nextNode
+ */
+NodeIterator.prototype.nextNode = function() {};
+
+/**
+ * @return {Node} Previous node in the set.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-NodeIterator-previousNode
+ */
+NodeIterator.prototype.previousNode = function() {};
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker
+*/
+function TreeWalker() {}
+
+/**
+ * @return {?Node} The new Node or null.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker-firstChild
+ */
+TreeWalker.prototype.firstChild = function() {};
+
+/**
+ * @return {?Node} The new Node or null..
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker-lastChild
+ */
+TreeWalker.prototype.lastChild = function() {};
+
+/**
+ * @return {?Node} The new Node or null.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker-nextNode
+ */
+TreeWalker.prototype.nextNode = function() {};
+
+/**
+ * @return {?Node} The new Node or null.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker-nextSibling
+ */
+TreeWalker.prototype.nextSibling = function() {};
+
+/**
+ * @return {?Node} The new Node or null.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker-parentNode
+ */
+TreeWalker.prototype.parentNode = function() {};
+
+/**
+ * @return {?Node} The new Node or null.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker-previousNode
+ */
+TreeWalker.prototype.previousNode = function() {};
+
+/**
+ * @return {?Node} The new Node or null.
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-TreeWalker-previousSibling
+ */
+TreeWalker.prototype.previousSibling = function() {};
+
+/**
+ * @type {Node}
+ */
+TreeWalker.prototype.root;
+
+/**
+ * @type {number}
+ */
+TreeWalker.prototype.whatToShow;
+
+/**
+ * @type {NodeFilter}
+ */
+TreeWalker.prototype.filter;
+
+/**
+ * @type {boolean}
+ */
+TreeWalker.prototype.expandEntityReference;
+
+/**
+ * @type {Node}
+ */
+TreeWalker.prototype.currentNode;
+
+/**
+ * @constructor
+ * @extends {Element}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-58190037
+ */
+function HTMLElement() {}
+
+/**
+ * @implicitCast
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-63534901
+ */
+HTMLElement.prototype.id;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-78276800
+ */
+HTMLElement.prototype.title;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-59132807
+ */
+HTMLElement.prototype.lang;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-52460740
+ */
+HTMLElement.prototype.dir;
+
+/**
+ * @implicitCast
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-95362176
+ */
+HTMLElement.prototype.className;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-33759296
+ */
+function HTMLHtmlElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-9383775
+ */
+HTMLHtmlElement.prototype.version;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-77253168
+ */
+function HTMLHeadElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-96921909
+ */
+HTMLHeadElement.prototype.profile;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @implements {LinkStyle}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-35143001
+ */
+function HTMLLinkElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-87355129
+ */
+HTMLLinkElement.prototype.disabled;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-63954491
+ */
+HTMLLinkElement.prototype.charset;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-33532588
+ */
+HTMLLinkElement.prototype.href;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-85145682
+ */
+HTMLLinkElement.prototype.hreflang;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75813125
+ */
+HTMLLinkElement.prototype.media;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-41369587
+ */
+HTMLLinkElement.prototype.rel;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-40715461
+ */
+HTMLLinkElement.prototype.rev;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-84183095
+ */
+HTMLLinkElement.prototype.target;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-32498296
+ */
+HTMLLinkElement.prototype.type;
+
+/** @type {StyleSheet} */
+HTMLLinkElement.prototype.sheet;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79243169
+ */
+function HTMLTitleElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-77500413
+ */
+HTMLTitleElement.prototype.text;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-37041454
+ */
+function HTMLMetaElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-87670826
+ */
+HTMLMetaElement.prototype.content;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-77289449
+ */
+HTMLMetaElement.prototype.httpEquiv;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-31037081
+ */
+HTMLMetaElement.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-35993789
+ */
+HTMLMetaElement.prototype.scheme;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-73629039
+ */
+function HTMLBaseElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-65382887
+ */
+HTMLBaseElement.prototype.href;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-73844298
+ */
+HTMLBaseElement.prototype.target;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-85283003
+ */
+function HTMLIsIndexElement() {}
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-87069980
+ */
+HTMLIsIndexElement.prototype.form;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-33589862
+ */
+HTMLIsIndexElement.prototype.prompt;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @implements {LinkStyle}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-16428977
+ */
+function HTMLStyleElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-51162010
+ */
+HTMLStyleElement.prototype.disabled;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-76412738
+ */
+HTMLStyleElement.prototype.media;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-22472002
+ */
+HTMLStyleElement.prototype.type;
+
+/** @type {StyleSheet} */
+HTMLStyleElement.prototype.sheet;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-62018039
+ */
+function HTMLBodyElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-59424581
+ */
+HTMLBodyElement.prototype.aLink;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-37574810
+ */
+HTMLBodyElement.prototype.background;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-24940084
+ */
+HTMLBodyElement.prototype.bgColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-7662206
+ */
+HTMLBodyElement.prototype.link;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-73714763
+ */
+HTMLBodyElement.prototype.text;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-83224305
+ */
+HTMLBodyElement.prototype.vLink;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-40002357
+ */
+function HTMLFormElement() {}
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-76728479
+ */
+HTMLFormElement.prototype.elements;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#HTML-HTMLFormElement-length
+ */
+HTMLFormElement.prototype.length;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-22051454
+ */
+HTMLFormElement.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-19661795
+ */
+HTMLFormElement.prototype.acceptCharset;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-74049184
+ */
+HTMLFormElement.prototype.action;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-84227810
+ */
+HTMLFormElement.prototype.enctype;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-82545539
+ */
+HTMLFormElement.prototype.method;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6512890
+ */
+HTMLFormElement.prototype.target;
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-76767676
+ */
+HTMLFormElement.prototype.submit = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-76767677
+ */
+HTMLFormElement.prototype.reset = function() {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-94282980
+ */
+function HTMLSelectElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-58783172
+ */
+HTMLSelectElement.prototype.type;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-85676760
+ */
+HTMLSelectElement.prototype.selectedIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-59351919
+ */
+HTMLSelectElement.prototype.value;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-5933486
+ */
+HTMLSelectElement.prototype.length;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-20489458
+ */
+HTMLSelectElement.prototype.form;
+
+/**
+ * @type {!HTMLOptionsCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-30606413
+ */
+HTMLSelectElement.prototype.options;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79102918
+ */
+HTMLSelectElement.prototype.disabled;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-13246613
+ */
+HTMLSelectElement.prototype.multiple;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-41636323
+ */
+HTMLSelectElement.prototype.name;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-18293826
+ */
+HTMLSelectElement.prototype.size;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-40676705
+ */
+HTMLSelectElement.prototype.tabIndex;
+
+/**
+ * @param {HTMLElement} element
+ * @param {HTMLElement} before
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-14493106
+ */
+HTMLSelectElement.prototype.add = function(element, before) {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-28216144
+ * @override
+ */
+HTMLSelectElement.prototype.blur = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-32130014
+ * @override
+ */
+HTMLSelectElement.prototype.focus = function() {};
+
+/**
+ * @param {number} index
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-33404570
+ */
+HTMLSelectElement.prototype.remove = function(index) {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-38450247
+ */
+function HTMLOptGroupElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-15518803
+ */
+HTMLOptGroupElement.prototype.disabled;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-95806054
+ */
+HTMLOptGroupElement.prototype.label;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70901257
+ */
+function HTMLOptionElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-37770574
+ */
+HTMLOptionElement.prototype.defaultSelected;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-23482473
+ */
+HTMLOptionElement.prototype.disabled;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-17116503
+ */
+HTMLOptionElement.prototype.form;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-14038413
+ */
+HTMLOptionElement.prototype.index;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-40736115
+ */
+HTMLOptionElement.prototype.label;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70874476
+ */
+HTMLOptionElement.prototype.selected;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-48154426
+ */
+HTMLOptionElement.prototype.text;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6185554
+ */
+HTMLOptionElement.prototype.value;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6043025
+ */
+function HTMLInputElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-15328520
+ */
+HTMLInputElement.prototype.accept;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-59914154
+ */
+HTMLInputElement.prototype.accessKey;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-96991182
+ */
+HTMLInputElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-92701314
+ */
+HTMLInputElement.prototype.alt;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-30233917
+ */
+HTMLInputElement.prototype.checked;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-20509171
+ */
+HTMLInputElement.prototype.defaultChecked;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-26091157
+ */
+HTMLInputElement.prototype.defaultValue;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-50886781
+ */
+HTMLInputElement.prototype.disabled;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-63239895
+ */
+HTMLInputElement.prototype.form;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-54719353
+ */
+HTMLInputElement.prototype.maxLength;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-89658498
+ */
+HTMLInputElement.prototype.name;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-88461592
+ */
+HTMLInputElement.prototype.readOnly;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79659438
+ */
+HTMLInputElement.prototype.size;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-97320704
+ */
+HTMLInputElement.prototype.src;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-62176355
+ */
+HTMLInputElement.prototype.tabIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-62883744
+ */
+HTMLInputElement.prototype.type;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-32463706
+ */
+HTMLInputElement.prototype.useMap;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-49531485
+ */
+HTMLInputElement.prototype.value;
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-26838235
+ * @override
+ */
+HTMLInputElement.prototype.blur = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-2651361
+ * @override
+ */
+HTMLInputElement.prototype.click = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-65996295
+ * @override
+ */
+HTMLInputElement.prototype.focus = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-34677168
+ */
+HTMLInputElement.prototype.select = function() {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-24874179
+ */
+function HTMLTextAreaElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-93102991
+ */
+HTMLTextAreaElement.prototype.accessKey;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-51387225
+ */
+HTMLTextAreaElement.prototype.cols;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-36152213
+ */
+HTMLTextAreaElement.prototype.defaultValue;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-98725443
+ */
+HTMLTextAreaElement.prototype.disabled;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-18911464
+ */
+HTMLTextAreaElement.prototype.form;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70715578
+ */
+HTMLTextAreaElement.prototype.name;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-39131423
+ */
+HTMLTextAreaElement.prototype.readOnly;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-46975887
+ */
+HTMLTextAreaElement.prototype.rows;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-60363303
+ */
+HTMLTextAreaElement.prototype.tabIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#HTML-HTMLTextAreaElement-type
+ */
+HTMLTextAreaElement.prototype.type;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70715579
+ */
+HTMLTextAreaElement.prototype.value;
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6750689
+ * @override
+ */
+HTMLTextAreaElement.prototype.blur = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-39055426
+ * @override
+ */
+HTMLTextAreaElement.prototype.focus = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-48880622
+ */
+HTMLTextAreaElement.prototype.select = function() {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-34812697
+ */
+function HTMLButtonElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-73169431
+ */
+HTMLButtonElement.prototype.accessKey;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-92757155
+ */
+HTMLButtonElement.prototype.disabled;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-71254493
+ */
+HTMLButtonElement.prototype.form;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-11029910
+ */
+HTMLButtonElement.prototype.name;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-39190908
+ */
+HTMLButtonElement.prototype.tabIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-27430092
+ */
+HTMLButtonElement.prototype.type;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-72856782
+ */
+HTMLButtonElement.prototype.value;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-13691394
+ */
+function HTMLLabelElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-43589892
+ */
+HTMLLabelElement.prototype.accessKey;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-32480901
+ */
+HTMLLabelElement.prototype.form;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-96509813
+ */
+HTMLLabelElement.prototype.htmlFor;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-7365882
+ */
+function HTMLFieldSetElement() {}
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75392630
+ */
+HTMLFieldSetElement.prototype.form;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-21482039
+ */
+function HTMLLegendElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-11297832
+ */
+HTMLLegendElement.prototype.accessKey;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79538067
+ */
+HTMLLegendElement.prototype.align;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-29594519
+ */
+HTMLLegendElement.prototype.form;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-86834457
+ */
+function HTMLUListElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-39864178
+ */
+HTMLUListElement.prototype.compact;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-96874670
+ */
+HTMLUListElement.prototype.type;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-58056027
+ */
+function HTMLOListElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-76448506
+ */
+HTMLOListElement.prototype.compact;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-14793325
+ */
+HTMLOListElement.prototype.start;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-40971103
+ */
+HTMLOListElement.prototype.type;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-52368974
+ */
+function HTMLDListElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-21738539
+ */
+HTMLDListElement.prototype.compact;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-71600284
+ */
+function HTMLDirectoryElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75317739
+ */
+HTMLDirectoryElement.prototype.compact;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-72509186
+ * @see http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-menu-element
+ */
+function HTMLMenuElement() {}
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-68436464
+ */
+HTMLMenuElement.prototype.compact;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-74680021
+ */
+function HTMLLIElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-52387668
+ */
+HTMLLIElement.prototype.type;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-45496263
+ */
+HTMLLIElement.prototype.value;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-22445964
+ */
+function HTMLDivElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70908791
+ */
+HTMLDivElement.prototype.align;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-84675076
+ */
+function HTMLParagraphElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-53465507
+ */
+HTMLParagraphElement.prototype.align;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-43345119
+ */
+function HTMLHeadingElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6796462
+ */
+HTMLHeadingElement.prototype.align;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70319763
+ */
+function HTMLQuoteElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-53895598
+ */
+HTMLQuoteElement.prototype.cite;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-11383425
+ */
+function HTMLPreElement() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-13894083
+ */
+HTMLPreElement.prototype.width;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-56836063
+ */
+function HTMLBRElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-82703081
+ */
+HTMLBRElement.prototype.clear;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-32774408
+ */
+function HTMLBaseFontElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-87502302
+ */
+HTMLBaseFontElement.prototype.color;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-88128969
+ */
+HTMLBaseFontElement.prototype.face;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-38930424
+ */
+HTMLBaseFontElement.prototype.size;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-43943847
+ */
+function HTMLFontElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-53532975
+ */
+HTMLFontElement.prototype.color;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-55715655
+ */
+HTMLFontElement.prototype.face;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-90127284
+ */
+HTMLFontElement.prototype.size;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-68228811
+ */
+function HTMLHRElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-15235012
+ */
+HTMLHRElement.prototype.align;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79813978
+ */
+HTMLHRElement.prototype.noShade;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-77612587
+ */
+HTMLHRElement.prototype.size;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-87744198
+ */
+HTMLHRElement.prototype.width;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79359609
+ */
+function HTMLModElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75101708
+ */
+HTMLModElement.prototype.cite;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-88432678
+ */
+HTMLModElement.prototype.dateTime;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-48250443
+ */
+function HTMLAnchorElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-89647724
+ */
+HTMLAnchorElement.prototype.accessKey;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-67619266
+ */
+HTMLAnchorElement.prototype.charset;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-92079539
+ */
+HTMLAnchorElement.prototype.coords;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-88517319
+ */
+HTMLAnchorElement.prototype.href;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-87358513
+ */
+HTMLAnchorElement.prototype.hreflang;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-32783304
+ */
+HTMLAnchorElement.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-3815891
+ */
+HTMLAnchorElement.prototype.rel;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-58259771
+ */
+HTMLAnchorElement.prototype.rev;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-49899808
+ */
+HTMLAnchorElement.prototype.shape;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-41586466
+ */
+HTMLAnchorElement.prototype.tabIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6414197
+ */
+HTMLAnchorElement.prototype.target;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-63938221
+ */
+HTMLAnchorElement.prototype.type;
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-65068939
+ * @override
+ */
+HTMLAnchorElement.prototype.blur = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-47150313
+ * @override
+ */
+HTMLAnchorElement.prototype.focus = function() {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-17701901
+ */
+function HTMLImageElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-3211094
+ */
+HTMLImageElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-95636861
+ */
+HTMLImageElement.prototype.alt;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-136671
+ */
+HTMLImageElement.prototype.border;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-91561496
+ */
+HTMLImageElement.prototype.height;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-53675471
+ */
+HTMLImageElement.prototype.hspace;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-58983880
+ */
+HTMLImageElement.prototype.isMap;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-77376969
+ */
+HTMLImageElement.prototype.longDesc;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-91256910
+ */
+HTMLImageElement.prototype.lowSrc;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-47534097
+ */
+HTMLImageElement.prototype.name;
+
+/**
+ * @type {string}
+ * @implicitCast
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-87762984
+ */
+HTMLImageElement.prototype.src;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-35981181
+ */
+HTMLImageElement.prototype.useMap;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-85374897
+ */
+HTMLImageElement.prototype.vspace;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-13839076
+ */
+HTMLImageElement.prototype.width;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-9893177
+ */
+function HTMLObjectElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-16962097
+ */
+HTMLObjectElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-47783837
+ */
+HTMLObjectElement.prototype.archive;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-82818419
+ */
+HTMLObjectElement.prototype.border;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75241146
+ */
+HTMLObjectElement.prototype.code;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-25709136
+ */
+HTMLObjectElement.prototype.codeBase;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-19945008
+ */
+HTMLObjectElement.prototype.codeType;
+
+/**
+ * @type {Document}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-38538621
+ */
+HTMLObjectElement.prototype.contentDocument;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-81766986
+ */
+HTMLObjectElement.prototype.data;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-942770
+ */
+HTMLObjectElement.prototype.declare;
+
+/**
+ * @type {HTMLFormElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-46094773
+ */
+HTMLObjectElement.prototype.form;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-88925838
+ */
+HTMLObjectElement.prototype.height;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-17085376
+ */
+HTMLObjectElement.prototype.hspace;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-20110362
+ */
+HTMLObjectElement.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-25039673
+ */
+HTMLObjectElement.prototype.standby;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-27083787
+ */
+HTMLObjectElement.prototype.tabIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-91665621
+ */
+HTMLObjectElement.prototype.type;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6649772
+ */
+HTMLObjectElement.prototype.useMap;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-8682483
+ */
+HTMLObjectElement.prototype.vspace;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-38538620
+ */
+HTMLObjectElement.prototype.width;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-64077273
+ */
+function HTMLParamElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-59871447
+ */
+HTMLParamElement.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-18179888
+ */
+HTMLParamElement.prototype.type;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-77971357
+ */
+HTMLParamElement.prototype.value;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-23931872
+ */
+HTMLParamElement.prototype.valueType;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-31006348
+ */
+function HTMLAppletElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-8049912
+ */
+HTMLAppletElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-58610064
+ */
+HTMLAppletElement.prototype.alt;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-14476360
+ */
+HTMLAppletElement.prototype.archive;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-61509645
+ */
+HTMLAppletElement.prototype.code;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6581160
+ */
+HTMLAppletElement.prototype.codeBase;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-90184867
+ */
+HTMLAppletElement.prototype.height;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-1567197
+ */
+HTMLAppletElement.prototype.hspace;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-39843695
+ */
+HTMLAppletElement.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-93681523
+ */
+HTMLAppletElement.prototype.object;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-22637173
+ */
+HTMLAppletElement.prototype.vspace;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-16526327
+ */
+HTMLAppletElement.prototype.width;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-94109203
+ */
+function HTMLMapElement() {}
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-71838730
+ */
+HTMLMapElement.prototype.areas;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-52696514
+ */
+HTMLMapElement.prototype.name;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-26019118
+ */
+function HTMLAreaElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-57944457
+ */
+HTMLAreaElement.prototype.accessKey;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-39775416
+ */
+HTMLAreaElement.prototype.alt;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-66021476
+ */
+HTMLAreaElement.prototype.coords;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-34672936
+ */
+HTMLAreaElement.prototype.href;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-61826871
+ */
+HTMLAreaElement.prototype.noHref;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-85683271
+ */
+HTMLAreaElement.prototype.shape;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-8722121
+ */
+HTMLAreaElement.prototype.tabIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-46054682
+ */
+HTMLAreaElement.prototype.target;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-81598695
+ */
+function HTMLScriptElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-35305677
+ */
+HTMLScriptElement.prototype.charset;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-93788534
+ */
+HTMLScriptElement.prototype.defer;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-56700403
+ */
+HTMLScriptElement.prototype.event;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-66979266
+ */
+HTMLScriptElement.prototype.htmlFor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-75147231
+ */
+HTMLScriptElement.prototype.src;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-46872999
+ */
+HTMLScriptElement.prototype.text;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-30534818
+ */
+HTMLScriptElement.prototype.type;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-64060425
+ */
+function HTMLTableElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-23180977
+ */
+HTMLTableElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-83532985
+ */
+HTMLTableElement.prototype.bgColor;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-50969400
+ */
+HTMLTableElement.prototype.border;
+
+/**
+ * @type {HTMLTableCaptionElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-14594520
+ */
+HTMLTableElement.prototype.caption;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-59162158
+ */
+HTMLTableElement.prototype.cellPadding;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-68907883
+ */
+HTMLTableElement.prototype.cellSpacing;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-64808476
+ */
+HTMLTableElement.prototype.frame;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6156016
+ */
+HTMLTableElement.prototype.rows;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-26347553
+ */
+HTMLTableElement.prototype.rules;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-44998528
+ */
+HTMLTableElement.prototype.summary;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-63206416
+ */
+HTMLTableElement.prototype.tBodies;
+
+/**
+ * @type {HTMLTableSectionElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-64197097
+ */
+HTMLTableElement.prototype.tFoot;
+
+/**
+ * @type {HTMLTableSectionElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-9530944
+ */
+HTMLTableElement.prototype.tHead;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-77447361
+ */
+HTMLTableElement.prototype.width;
+
+/**
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-96920263
+ */
+HTMLTableElement.prototype.createCaption = function() {};
+
+/**
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-8453710
+ */
+HTMLTableElement.prototype.createTFoot = function() {};
+
+/**
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70313345
+ */
+HTMLTableElement.prototype.createTHead = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-22930071
+ */
+HTMLTableElement.prototype.deleteCaption = function() {};
+
+/**
+ * @param {number} index
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-13114938
+ */
+HTMLTableElement.prototype.deleteRow = function(index) {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-78363258
+ */
+HTMLTableElement.prototype.deleteTFoot = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-38310198
+ */
+HTMLTableElement.prototype.deleteTHead = function() {};
+
+/**
+ * @param {number} index
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-39872903
+ */
+HTMLTableElement.prototype.insertRow = function(index) {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-12035137
+ */
+function HTMLTableCaptionElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79875068
+ */
+HTMLTableCaptionElement.prototype.align;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-84150186
+ */
+function HTMLTableColElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-31128447
+ */
+HTMLTableColElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-9447412
+ */
+HTMLTableColElement.prototype.ch;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-57779225
+ */
+HTMLTableColElement.prototype.chOff;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-96511335
+ */
+HTMLTableColElement.prototype.span;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-83291710
+ */
+HTMLTableColElement.prototype.vAlign;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-25196799
+ */
+HTMLTableColElement.prototype.width;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-67417573
+ */
+function HTMLTableSectionElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-40530119
+ */
+HTMLTableSectionElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-83470012
+ */
+HTMLTableSectionElement.prototype.ch;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-53459732
+ */
+HTMLTableSectionElement.prototype.chOff;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-52092650
+ */
+HTMLTableSectionElement.prototype.rows;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-4379116
+ */
+HTMLTableSectionElement.prototype.vAlign;
+
+/**
+ * @param {number} index
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-5625626
+ */
+HTMLTableSectionElement.prototype.deleteRow = function(index) {};
+
+/**
+ * @param {number} index
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-93995626
+ */
+HTMLTableSectionElement.prototype.insertRow = function(index) {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-6986576
+ */
+function HTMLTableRowElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-74098257
+ */
+HTMLTableRowElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-18161327
+ */
+HTMLTableRowElement.prototype.bgColor;
+
+/**
+ * @type {HTMLCollection}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-67349879
+ */
+HTMLTableRowElement.prototype.cells;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-16230502
+ */
+HTMLTableRowElement.prototype.ch;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-68207461
+ */
+HTMLTableRowElement.prototype.chOff;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-67347567
+ */
+HTMLTableRowElement.prototype.rowIndex;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-79105901
+ */
+HTMLTableRowElement.prototype.sectionRowIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-90000058
+ */
+HTMLTableRowElement.prototype.vAlign;
+
+/**
+ * @param {number} index
+ * @return {undefined}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-11738598
+ */
+HTMLTableRowElement.prototype.deleteCell = function(index) {};
+
+/**
+ * @param {number} index
+ * @return {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-68927016
+ */
+HTMLTableRowElement.prototype.insertCell = function(index) {};
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-82915075
+ */
+function HTMLTableCellElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-74444037
+ */
+HTMLTableCellElement.prototype.abbr;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-98433879
+ */
+HTMLTableCellElement.prototype.align;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-76554418
+ */
+HTMLTableCellElement.prototype.axis;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-88135431
+ */
+HTMLTableCellElement.prototype.bgColor;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-80748363
+ */
+HTMLTableCellElement.prototype.cellIndex;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-30914780
+ */
+HTMLTableCellElement.prototype.ch;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-20144310
+ */
+HTMLTableCellElement.prototype.chOff;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-84645244
+ */
+HTMLTableCellElement.prototype.colSpan;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-89104817
+ */
+HTMLTableCellElement.prototype.headers;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-83679212
+ */
+HTMLTableCellElement.prototype.height;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-62922045
+ */
+HTMLTableCellElement.prototype.noWrap;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-48237625
+ */
+HTMLTableCellElement.prototype.rowSpan;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-36139952
+ */
+HTMLTableCellElement.prototype.scope;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-58284221
+ */
+HTMLTableCellElement.prototype.vAlign;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-27480795
+ */
+HTMLTableCellElement.prototype.width;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-43829095
+ */
+function HTMLFrameSetElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-98869594
+ */
+HTMLFrameSetElement.prototype.cols;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-19739247
+ */
+HTMLFrameSetElement.prototype.rows;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-97790553
+ */
+function HTMLFrameElement() {}
+
+/**
+ * @type {Document}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-78799536
+ */
+HTMLFrameElement.prototype.contentDocument;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-11858633
+ */
+HTMLFrameElement.prototype.frameBorder;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-7836998
+ */
+HTMLFrameElement.prototype.longDesc;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-55569778
+ */
+HTMLFrameElement.prototype.marginHeight;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-8369969
+ */
+HTMLFrameElement.prototype.marginWidth;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-91128709
+ */
+HTMLFrameElement.prototype.name;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-80766578
+ */
+HTMLFrameElement.prototype.noResize;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-45411424
+ */
+HTMLFrameElement.prototype.scrolling;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-78799535
+ */
+HTMLFrameElement.prototype.src;
+
+/**
+ * @constructor
+ * @extends {HTMLElement}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-50708718
+ */
+function HTMLIFrameElement() {}
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-11309947
+ */
+HTMLIFrameElement.prototype.align;
+
+/**
+ * @type {Document}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-67133006
+ */
+HTMLIFrameElement.prototype.contentDocument;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-22463410
+ */
+HTMLIFrameElement.prototype.frameBorder;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-1678118
+ */
+HTMLIFrameElement.prototype.height;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-70472105
+ */
+HTMLIFrameElement.prototype.longDesc;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-91371294
+ */
+HTMLIFrameElement.prototype.marginHeight;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-66486595
+ */
+HTMLIFrameElement.prototype.marginWidth;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-96819659
+ */
+HTMLIFrameElement.prototype.name;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-36369822
+ */
+HTMLIFrameElement.prototype.scrolling;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-43933957
+ */
+HTMLIFrameElement.prototype.src;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/2000/CR-DOM-Level-2-20000510/html.html#ID-67133005
+ */
+HTMLIFrameElement.prototype.width;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
+ */
+DOMException.INVALID_STATE_ERR = 11;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
+ */
+DOMException.SYNTAX_ERR = 12;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
+ */
+DOMException.INVALID_MODIFICATION_ERR = 13;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
+ */
+DOMException.NAMESPACE_ERR = 14;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-258A00AF
+ */
+DOMException.INVALID_ACCESS_ERR = 15;

--- a/sdk/tests/deqp/temp_externs/w3c_dom3.js
+++ b/sdk/tests/deqp/temp_externs/w3c_dom3.js
@@ -1,0 +1,854 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's DOM Level 3 specification.
+ *  This file depends on w3c_dom2.js.
+ *  The whole file has been fully type annotated.
+ *  Created from
+ *   http://www.w3.org/TR/DOM-Level-3-Core/ecma-script-binding.html
+ *
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ */
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-258A00AF
+ */
+DOMException.prototype.code;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-258A00AF
+ */
+DOMException.VALIDATION_ERR = 16;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-258A00AF
+ */
+DOMException.TYPE_MISMATCH_ERR = 17;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMStringList
+ */
+function DOMStringList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMStringList-length
+ */
+DOMStringList.prototype.length;
+
+/**
+ * @param {string} str
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMStringList-contains
+ */
+DOMStringList.prototype.contains = function(str) {};
+
+/**
+ * @param {number} index
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMStringList-item
+ */
+DOMStringList.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList
+ */
+function NameList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-length
+ */
+NameList.prototype.length;
+
+/**
+ * @param {string} str
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-contains
+ * @nosideeffects
+ */
+NameList.prototype.contains = function(str) {};
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} name
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-containsNS
+ * @nosideeffects
+ */
+NameList.prototype.containsNS = function(namespaceURI, name) {};
+
+/**
+ * @param {number} index
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-getName
+ * @nosideeffects
+ */
+NameList.prototype.getName = function(index) {};
+
+/**
+ * @param {number} index
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#NameList-getNamespaceURI
+ * @nosideeffects
+ */
+NameList.prototype.getNamespaceURI = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMImplementationList
+ */
+function DOMImplementationList() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMImplementationList-length
+ */
+DOMImplementationList.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {DOMImplementation}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMImplementationList-item
+ * @nosideeffects
+ */
+DOMImplementationList.prototype.item = function(index) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMImplementationSource
+ */
+function DOMImplementationSource() {}
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} publicId
+ * @param {DocumentType} doctype
+ * @return {Document}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Level-2-Core-DOM-createDocument
+ * @nosideeffects
+ */
+DOMImplementation.prototype.createDocument = function(namespaceURI, publicId, doctype) {};
+
+/**
+ * @param {string} qualifiedName
+ * @param {string} publicId
+ * @param {string} systemId
+ * @return {DocumentType}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Level-2-Core-DOM-createDocType
+ * @nosideeffects
+ */
+DOMImplementation.prototype.createDocumentType = function(qualifiedName, publicId, systemId) {};
+
+/**
+ * @param {string} features
+ * @return {DOMImplementation}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-getDOMImpl
+ * @nosideeffects
+ */
+DOMImplementationSource.prototype.getDOMImplementation = function(features) {};
+
+/**
+ * @param {string} features
+ * @return {DOMImplementationList}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-getDOMImpls
+ * @nosideeffects
+ */
+DOMImplementationSource.prototype.getDOMImplementationList = function(features) {};
+
+/**
+ * @param {string} feature
+ * @param {string} version
+ * @return {Object}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMImplementation3-getFeature
+ * @nosideeffects
+ */
+DOMImplementation.prototype.getFeature = function(feature, version) {};
+
+/**
+ * @param {Node} externalNode
+ * @return {Node}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-adoptNode
+ */
+Document.prototype.adoptNode = function(externalNode) {};
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-documentURI
+ */
+Document.prototype.documentURI;
+
+/**
+ * @type {DOMConfiguration}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-domConfig
+ */
+Document.prototype.domConfig;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-inputEncoding
+ */
+Document.prototype.inputEncoding;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-strictErrorChecking
+ */
+Document.prototype.strictErrorChecking;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-encoding
+ */
+Document.prototype.xmlEncoding;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-standalone
+ */
+Document.prototype.xmlStandalone;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-version
+ */
+Document.prototype.xmlVersion;
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-normalizeDocument
+ */
+Document.prototype.normalizeDocument = function() {};
+
+/**
+ * @param {Node} n
+ * @param {string} namespaceURI
+ * @param {string} qualifiedName
+ * @return {Node}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-renameNode
+ */
+Document.prototype.renameNode = function(n, namespaceURI, qualifiedName) {};
+
+/**
+ * @type {?string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-baseURI
+ */
+Node.prototype.baseURI;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-NodeNSLocalN
+ */
+Node.prototype.localName;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-NodeNSname
+ */
+Node.prototype.namespaceURI;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-NodeNSPrefix
+ */
+Node.prototype.prefix;
+
+/**
+ * @type {string}
+ * @implicitCast
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-textContent
+ */
+Node.prototype.textContent;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node-DOCUMENT_POSITION_DISCONNECTED
+ */
+Node.DOCUMENT_POSITION_DISCONNECTED = 0x01;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node-DOCUMENT_POSITION_PRECEDING
+ */
+Node.DOCUMENT_POSITION_PRECEDING    = 0x02;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node-DOCUMENT_POSITION_FOLLOWING
+ */
+Node.DOCUMENT_POSITION_FOLLOWING    = 0x04;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node-DOCUMENT_POSITION_CONTAINS
+ */
+Node.DOCUMENT_POSITION_CONTAINS     = 0x08;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node-DOCUMENT_POSITION_CONTAINED_BY
+ */
+Node.DOCUMENT_POSITION_CONTAINED_BY = 0x10;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node-DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+ */
+Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
+
+/**
+ * @param {Node} other
+ * @return {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-compareDocumentPosition
+ * @nosideeffects
+ */
+Node.prototype.compareDocumentPosition = function(other) {};
+
+/**
+ * @param {string} feature
+ * @param {string} version
+ * @return {Object}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-getFeature
+ * @nosideeffects
+ */
+Node.prototype.getFeature = function(feature, version) {};
+
+/**
+ * @param {string} key
+ * @return {Object}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-getUserData
+ * @nosideeffects
+ */
+Node.prototype.getUserData = function(key) {};
+
+/**
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-NodeHasAttrs
+ * @nosideeffects
+ */
+Node.prototype.hasAttributes = function() {};
+
+/**
+ * @param {string} namespaceURI
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-isDefaultNamespace
+ * @nosideeffects
+ */
+Node.prototype.isDefaultNamespace = function(namespaceURI) {};
+
+/**
+ * @param {Node} arg
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-isEqualNode
+ * @nosideeffects
+ */
+Node.prototype.isEqualNode = function(arg) {};
+
+/**
+ * @param {Node} other
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-isSameNode
+ * @nosideeffects
+ */
+Node.prototype.isSameNode = function(other) {};
+
+/**
+ * @param {string} feature
+ * @param {string} version
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Level-2-Core-Node-supports
+ * @nosideeffects
+ */
+Node.prototype.isSupported = function(feature, version) {};
+
+/**
+ * @param {string} prefix
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespaceURI
+ * @nosideeffects
+ */
+Node.prototype.lookupNamespaceURI = function(prefix) {};
+
+/**
+ * @param {string} namespaceURI
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespacePrefix
+ * @nosideeffects
+ */
+Node.prototype.lookupPrefix = function(namespaceURI) {};
+
+/**
+ * @return undefined
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-normalize
+ */
+Node.prototype.normalize = function() {};
+
+/**
+ * @param {Object} key
+ * @param {Object} data
+ * @param {UserDataHandler} handler
+ * @return {Object}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-setUserData'
+ */
+Node.prototype.setUserData = function(key, data, handler) {};
+
+/**
+ * @param {string} query
+ * @return {Node}
+ * @see http://www.w3.org/TR/selectors-api/#queryselector
+ * @nosideeffects
+ */
+Node.prototype.querySelector = function(query) {};
+
+/**
+ * @param {string} query
+ * @return {!NodeList}
+ * @see http://www.w3.org/TR/selectors-api/#queryselectorall
+ * @nosideeffects
+ */
+Node.prototype.querySelectorAll = function(query) {};
+
+/**
+ * @type {Element}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Attr-ownerElement
+ */
+Attr.prototype.ownerElement;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Attr-isId
+ */
+Attr.prototype.isId;
+
+/**
+ * @type {TypeInfo}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Attr-schemaTypeInfo
+ */
+Attr.prototype.schemaTypeInfo;
+
+/**
+ * @type {TypeInfo}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Element-schemaTypeInfo
+ */
+Element.prototype.schemaTypeInfo;
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} localName
+ * @return {Attr}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElGetAtNodeNS
+ * @nosideeffects
+ */
+Element.prototype.getAttributeNodeNS = function(namespaceURI, localName) {};
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} localName
+ * @return {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElGetAttrNS
+ * @nosideeffects
+ */
+Element.prototype.getAttributeNS = function(namespaceURI, localName) {};
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} localName
+ * @return {!NodeList}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-A6C90942
+ * @nosideeffects
+ */
+Element.prototype.getElementsByTagNameNS = function(namespaceURI, localName) {};
+
+/**
+ * @param {string} name
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElHasAttr
+ * @nosideeffects
+ */
+Element.prototype.hasAttribute = function(name) {};
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} localName
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElHasAttrNS
+ * @nosideeffects
+ */
+Element.prototype.hasAttributeNS = function(namespaceURI, localName) {};
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} localName
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElRemAtNS
+ */
+Element.prototype.removeAttributeNS = function(namespaceURI, localName) {};
+
+/**
+ * @param {Attr} newAttr
+ * @return {Attr}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetAtNodeNS
+ */
+Element.prototype.setAttributeNodeNS = function(newAttr) {};
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} qualifiedName
+ * @param {string|number|boolean} value Values are converted to strings with
+ *     ToString, so we accept number and boolean since both convert easily to
+ *     strings.
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetAttrNS
+ */
+Element.prototype.setAttributeNS = function(namespaceURI, qualifiedName, value) {};
+
+/**
+ * @param {string} name
+ * @param {boolean} isId
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetIdAttr
+ */
+Element.prototype.setIdAttribute = function(name, isId) {};
+
+/**
+ * @param {Attr} idAttr
+ * @param {boolean} isId
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetIdAttrNode
+ */
+Element.prototype.setIdAttributeNode = function(idAttr, isId) {};
+
+/**
+ * @param {string} namespaceURI
+ * @param {string} localName
+ * @param {boolean} isId
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ElSetIdAttrNS
+ */
+Element.prototype.setIdAttributeNS = function(namespaceURI, localName, isId) {};
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Text3-wholeText
+ */
+Text.prototype.wholeText;
+
+/**
+ * @param {string} newText
+ * @return {Text}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Text3-replaceWholeText
+ */
+Text.prototype.replaceWholeText = function(newText) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo
+ */
+function TypeInfo() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo-DERIVATION_EXTENSION
+ */
+TypeInfo.prototype.DERIVATION_EXTENSION;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo-DERIVATION_LIST
+ */
+TypeInfo.prototype.DERIVATION_LIST;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo-DERIVATION_RESTRICTION
+ */
+TypeInfo.prototype.DERIVATION_RESTRICTION;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo-DERIVATION_UNION
+ */
+TypeInfo.prototype.DERIVATION_UNION;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo-typeName
+ */
+TypeInfo.prototype.typeName;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo-typeNamespace
+ */
+TypeInfo.prototype.typeNamespace;
+
+/**
+ * @param {string} typeNamespaceArg
+ * @param {string} typeNameArg
+ * @param {number} derivationMethod
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#TypeInfo-isDerivedFrom
+ * @nosideeffects
+ */
+TypeInfo.prototype.isDerivedFrom = function(typeNamespaceArg, typeNameArg, derivationMethod) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler
+ */
+function UserDataHandler() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-CLONED
+ */
+UserDataHandler.prototype.NODE_CLONED = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-IMPORTED
+ */
+UserDataHandler.prototype.NODE_IMPORTED = 2;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-DELETED
+ */
+UserDataHandler.prototype.NODE_DELETED = 3;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-RENAMED
+ */
+UserDataHandler.prototype.NODE_RENAMED = 4;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#UserDataHandler-ADOPTED
+ */
+UserDataHandler.prototype.NODE_ADOPTED = 5;
+
+/**
+ * @param {number} operation
+ * @param {string} key
+ * @param {*=} opt_data
+ * @param {?Node=} opt_src
+ * @param {?Node=} opt_dst
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-handleUserDataEvent
+ */
+UserDataHandler.prototype.handle = function(operation, key, opt_data,
+  opt_src, opt_dst) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-Interfaces-DOMError
+ */
+function DOMError() {}
+
+/**
+ * @type {DOMLocator}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-location
+ */
+DOMError.prototype.location;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-message
+ */
+DOMError.prototype.message;
+
+/**
+ * @type {Object}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-relatedData
+ */
+DOMError.prototype.relatedData;
+
+/**
+ * @type {Object}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-relatedException
+ */
+DOMError.prototype.relatedException;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-severity-warning
+ */
+DOMError.SEVERITY_WARNING = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-severity-error
+ */
+DOMError.SEVERITY_ERROR = 2;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-severity-fatal-error
+ */
+DOMError.SEVERITY_FATAL_ERROR = 3;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-severity
+ */
+DOMError.prototype.severity;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-DOMError-type
+ */
+DOMError.prototype.type;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/dom/#domerror
+ */
+DOMError.prototype.name;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ERROR-Interfaces-DOMErrorHandler
+ */
+function DOMErrorHandler() {}
+
+/**
+ * @param {DOMError} error
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-ERRORS-DOMErrorHandler-handleError
+ */
+DOMErrorHandler.prototype.handleError = function(error) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Interfaces-DOMLocator
+ */
+function DOMLocator() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMLocator-byteOffset
+ */
+DOMLocator.prototype.byteOffset;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMLocator-column-number
+ */
+DOMLocator.prototype.columnNumber;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMLocator-line-number
+ */
+DOMLocator.prototype.lineNumber;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMLocator-node
+ */
+DOMLocator.prototype.relatedNode;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMLocator-uri
+ */
+DOMLocator.prototype.uri;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMLocator-utf16Offset
+ */
+DOMLocator.prototype.utf16Offset;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMConfiguration
+ */
+function DOMConfiguration() {}
+
+/**
+ * @type {DOMStringList}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMConfiguration-parameterNames
+ */
+DOMConfiguration.prototype.parameterNames;
+
+/**
+ * @param {string} name
+ * @return {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMConfiguration-canSetParameter
+ * @nosideeffects
+ */
+DOMConfiguration.prototype.canSetParameter = function(name) {};
+
+/**
+ * @param {string} name
+ * @return {*}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMConfiguration-getParameter
+ * @nosideeffects
+ */
+DOMConfiguration.prototype.getParameter = function(name) {};
+
+/**
+ * @param {string} name
+ * @param {*} value
+ * @return {*}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#DOMConfiguration-property
+ */
+DOMConfiguration.prototype.setParameter = function(name, value) {};
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-Core-DocType-internalSubset
+ */
+DocumentType.prototype.internalSubset;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-Core-DocType-publicId
+ */
+DocumentType.prototype.publicId;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#ID-Core-DocType-systemId
+ */
+DocumentType.prototype.systemId;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Entity3-inputEncoding
+ */
+Entity.prototype.inputEncoding;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Entity3-encoding
+ */
+Entity.prototype.xmlEncoding;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/DOM-Level-3-Core/core.html#Entity3-version
+ */
+Entity.prototype.xmlVersion;

--- a/sdk/tests/deqp/temp_externs/w3c_elementtraversal.js
+++ b/sdk/tests/deqp/temp_externs/w3c_elementtraversal.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2009 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for DOM Element Traversal interface.
+ *  This file depends on w3c_dom1.js.
+ *  The whole file has been fully type annotated.
+ *  Created from:
+ *    http://www.w3.org/TR/ElementTraversal/#ecmascript-bindings
+ *
+ * @externs
+ * @author arv@google.com (Erik Arvidsson)
+ */
+
+/**
+ * @type {Element}
+ * @see https://developer.mozilla.org/En/DOM/Element.firstElementChild
+ */
+Element.prototype.firstElementChild;
+
+/**
+ * @type {Element}
+ * @see https://developer.mozilla.org/En/DOM/Element.lastElementChild
+ */
+Element.prototype.lastElementChild;
+
+/**
+ * @type {Element}
+ * @see https://developer.mozilla.org/En/DOM/Element.previousElementSibling
+ */
+Element.prototype.previousElementSibling;
+
+/**
+ * @type {Element}
+ * @see https://developer.mozilla.org/En/DOM/Element.nextElementSibling
+ */
+Element.prototype.nextElementSibling;
+
+/**
+ * @type {number}
+ * @see https://developer.mozilla.org/En/DOM/Element.childElementCount
+ */
+Element.prototype.childElementCount;

--- a/sdk/tests/deqp/temp_externs/w3c_encoding.js
+++ b/sdk/tests/deqp/temp_externs/w3c_encoding.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's Encoding specification
+ *     https://encoding.spec.whatwg.org
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @param {string=} encoding
+ * @param {Object=} options
+ */
+function TextDecoder(encoding, options) {}
+
+/** @type {string} **/ TextDecoder.prototype.encoding;
+/** @type {boolean} **/ TextDecoder.prototype.fatal;
+/** @type {boolean} **/ TextDecoder.prototype.ignoreBOM;
+
+/**
+ * @param {!Uint8Array} input
+ * @param {Object=} options
+ * @return {string}
+ */
+TextDecoder.prototype.decode = function decode(input, options) {};
+
+/**
+ * @constructor
+ * @param {string=} encoding
+ * @param {Object=} options
+ */
+function TextEncoder(encoding, options) {}
+
+/** @type {string} **/ TextEncoder.prototype.encoding;
+
+/**
+ * @param {string} input
+ * @return {!Uint8Array}
+ */
+TextEncoder.prototype.encode = function(input) {};

--- a/sdk/tests/deqp/temp_externs/w3c_event.js
+++ b/sdk/tests/deqp/temp_externs/w3c_event.js
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's event specification.
+ *  The whole file has been fully type annotated.
+ *  Created from
+ *   http://www.w3.org/TR/DOM-Level-2-Events/ecma-script-binding.html
+ *
+ * @externs
+ */
+
+
+/**
+ * @interface
+ */
+function EventTarget() {}
+
+/**
+ * @param {string} type
+ * @param {EventListener|function(!Event):(boolean|undefined)} listener
+ * @param {boolean} useCapture
+ * @return {undefined}
+ */
+EventTarget.prototype.addEventListener = function(type, listener, useCapture)
+    {};
+
+/**
+ * @param {string} type
+ * @param {EventListener|function(!Event):(boolean|undefined)} listener
+ * @param {boolean} useCapture
+ * @return {undefined}
+ */
+EventTarget.prototype.removeEventListener = function(type, listener, useCapture)
+    {};
+
+/**
+ * @param {!Event} evt
+ * @return {boolean}
+ */
+EventTarget.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * @interface
+ */
+function EventListener() {}
+
+/**
+ * @param {!Event} evt
+ * @return {undefined}
+ */
+EventListener.prototype.handleEvent = function(evt) {};
+
+// The EventInit interface and the parameters to the Event constructor are part
+// of DOM Level 3 (suggested) and the DOM "Living Standard" (mandated). They are
+// included here as externs cannot be redefined. The same applies to other
+// *EventInit interfaces and *Event constructors throughout this file. See:
+// http://www.w3.org/TR/DOM-Level-3-Events/#event-initializers
+// http://dom.spec.whatwg.org/#constructing-events
+// https://dvcs.w3.org/hg/d4e/raw-file/tip/source_respec.htm#event-constructors
+
+/**
+ * @typedef {{
+ *   bubbles: (boolean|undefined),
+ *   cancelable: (boolean|undefined)
+ * }}
+ */
+var EventInit;
+
+/**
+ * @constructor
+ * @param {string} type
+ * @param {EventInit=} opt_eventInitDict
+ */
+function Event(type, opt_eventInitDict) {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Events/ecma-script-binding.html
+ */
+Event.AT_TARGET;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Events/ecma-script-binding.html
+ */
+Event.BUBBLING_PHASE;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Events/ecma-script-binding.html
+ */
+Event.CAPTURING_PHASE;
+
+
+/** @type {string} */
+Event.prototype.type;
+
+/** @type {EventTarget} */
+Event.prototype.target;
+
+/** @type {EventTarget} */
+Event.prototype.currentTarget;
+
+/** @type {number} */
+Event.prototype.eventPhase;
+
+/** @type {boolean} */
+Event.prototype.bubbles;
+
+/** @type {boolean} */
+Event.prototype.cancelable;
+
+/** @type {number} */
+Event.prototype.timeStamp;
+
+/**
+ * Present for events spawned in browsers that support shadow dom.
+ * @type {Array.<!Element>|undefined}
+ */
+Event.prototype.path;
+
+/**
+ * @return {undefined}
+ */
+Event.prototype.stopPropagation = function() {};
+
+/**
+ * @return {undefined}
+ */
+Event.prototype.preventDefault = function() {};
+
+/**
+ * @param {string} eventTypeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @return {undefined}
+ */
+Event.prototype.initEvent = function(eventTypeArg, canBubbleArg, cancelableArg) {};
+
+/**
+ * @typedef {{
+ *   bubbles: (boolean|undefined),
+ *   cancelable: (boolean|undefined),
+ *   detail: *
+ * }}
+ */
+var CustomEventInit;
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @param {string} type
+ * @param {CustomEventInit=} opt_eventInitDict
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#interface-CustomEvent
+ */
+function CustomEvent(type, opt_eventInitDict) {}
+
+/**
+ * @param {string} eventType
+ * @param {boolean} bubbles
+ * @param {boolean} cancelable
+ * @param {*} detail
+ */
+CustomEvent.prototype.initCustomEvent = function(
+    eventType, bubbles, cancelable, detail) {};
+
+/**
+ * @type {*}
+ */
+CustomEvent.prototype.detail;
+
+/**
+ * @interface
+ */
+function DocumentEvent() {}
+
+/**
+ * @param {string} eventType
+ * @return {!Event}
+ */
+DocumentEvent.prototype.createEvent = function(eventType) {};
+
+/**
+ * @typedef {{
+ *   bubbles: (boolean|undefined),
+ *   cancelable: (boolean|undefined),
+ *   view: (Window|undefined),
+ *   detail: (number|undefined)
+ * }}
+ */
+var UIEventInit;
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @param {string} type
+ * @param {UIEventInit=} opt_eventInitDict
+ */
+function UIEvent(type, opt_eventInitDict) {}
+
+/** @type {number} */
+UIEvent.prototype.detail;
+
+/**
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {Window} viewArg
+ * @param {number} detailArg
+ * @return {undefined}
+ */
+UIEvent.prototype.initUIEvent = function(typeArg, canBubbleArg, cancelableArg,
+    viewArg, detailArg) {};
+
+/**
+ * @typedef {{
+ *   bubbles: (boolean|undefined),
+ *   cancelable: (boolean|undefined),
+ *   view: (Window|undefined),
+ *   detail: (number|undefined),
+ *   screenX: (number|undefined),
+ *   screenY: (number|undefined),
+ *   clientX: (number|undefined),
+ *   clientY: (number|undefined),
+ *   ctrlKey: (boolean|undefined),
+ *   shiftKey: (boolean|undefined),
+ *   altKey: (boolean|undefined),
+ *   metaKey: (boolean|undefined),
+ *   button: (number|undefined),
+ *   buttons: (number|undefined),
+ *   relatedTarget: (EventTarget|undefined)
+ * }}
+ */
+var MouseEventInit;
+
+/**
+ * @constructor
+ * @extends {UIEvent}
+ * @param {string} type
+ * @param {MouseEventInit=} opt_eventInitDict
+ */
+function MouseEvent(type, opt_eventInitDict) {}
+
+/** @type {number} */
+MouseEvent.prototype.screenX;
+
+/** @type {number} */
+MouseEvent.prototype.screenY;
+
+/** @type {number} */
+MouseEvent.prototype.clientX;
+
+/** @type {number} */
+MouseEvent.prototype.clientY;
+
+/** @type {boolean} */
+MouseEvent.prototype.ctrlKey;
+
+/** @type {boolean} */
+MouseEvent.prototype.shiftKey;
+
+/** @type {boolean} */
+MouseEvent.prototype.altKey;
+
+/** @type {boolean} */
+MouseEvent.prototype.metaKey;
+
+/** @type {number} */
+MouseEvent.prototype.button;
+
+/** @type {EventTarget} */
+MouseEvent.prototype.relatedTarget;
+
+
+/**
+ * @constructor
+ * @extends {Event}
+ */
+function MutationEvent() {}
+
+/** @type {Node} */
+MutationEvent.prototype.relatedNode;
+
+/** @type {string} */
+MutationEvent.prototype.prevValue;
+
+/** @type {string} */
+MutationEvent.prototype.newValue;
+
+/** @type {string} */
+MutationEvent.prototype.attrName;
+
+/** @type {number} */
+MutationEvent.prototype.attrChange;
+
+/**
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {Node} relatedNodeArg
+ * @param {string} prevValueArg
+ * @param {string} newValueArg
+ * @param {string} attrNameArg
+ * @param {number} attrChangeArg
+ * @return {undefined}
+ */
+MutationEvent.prototype.initMutationEvent = function(typeArg, canBubbleArg, cancelableArg, relatedNodeArg, prevValueArg, newValueArg, attrNameArg, attrChangeArg) {};
+
+
+// DOM3
+/**
+ * @typedef {{
+ *   bubbles: (boolean|undefined),
+ *   cancelable: (boolean|undefined),
+ *   view: (Window|undefined),
+ *   detail: (number|undefined),
+ *   char: (string|undefined),
+ *   key: (string|undefined),
+ *   code: (string|undefined),
+ *   location: (number|undefined),
+ *   ctrlKey: (boolean|undefined),
+ *   shiftKey: (boolean|undefined),
+ *   altKey: (boolean|undefined),
+ *   metaKey: (boolean|undefined),
+ *   repeat: (boolean|undefined),
+ *   locale: (string|undefined)
+ * }}
+ */
+var KeyboardEventInit;
+
+/**
+ * @constructor
+ * @extends {UIEvent}
+ * @param {string} type
+ * @param {KeyboardEventInit=} opt_eventInitDict
+ */
+function KeyboardEvent(type, opt_eventInitDict) {}
+
+/** @type {string} */
+KeyboardEvent.prototype.keyIdentifier;
+
+/** @type {boolean} */
+KeyboardEvent.prototype.ctrlKey;
+
+/** @type {boolean} */
+KeyboardEvent.prototype.shiftKey;
+
+/** @type {boolean} */
+KeyboardEvent.prototype.altKey;
+
+/** @type {boolean} */
+KeyboardEvent.prototype.metaKey;
+
+/**
+ * @param {string} keyIdentifierArg
+ * @return {boolean}
+ */
+KeyboardEvent.prototype.getModifierState = function(keyIdentifierArg) {};

--- a/sdk/tests/deqp/temp_externs/w3c_event3.js
+++ b/sdk/tests/deqp/temp_externs/w3c_event3.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's event Level 3 specification.
+ *  This file depends on w3c_event.js.
+ *  The whole file has been partially type annotated.
+ *  Created from
+ *   http://www.w3.org/TR/DOM-Level-3-Events/#ecma-script-binding-ecma-binding
+ *
+ * @externs
+ */
+
+/**
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {Window} viewArg
+ * @param {string} keyIdentifierArg
+ * @param {number} keyLocationArg
+ * @param {string} modifiersList
+ */
+KeyboardEvent.prototype.initKeyboardEvent = function(typeArg, canBubbleArg, cancelableArg, viewArg, keyIdentifierArg, keyLocationArg, modifiersList) {};
+
+/** @type {string} */
+KeyboardEvent.prototype.char;
+
+/** @type {string} */
+KeyboardEvent.prototype.key;
+
+/** @type {number} */
+KeyboardEvent.prototype.location;
+
+/** @type {boolean} */
+KeyboardEvent.prototype.repeat;
+
+/** @type {string} */
+KeyboardEvent.prototype.locale;
+
+/** @type {number} */
+MouseEvent.prototype.buttons;
+
+/** @type {boolean} */
+Event.prototype.defaultPrevented;
+
+/** @type {string} */
+Event.prototype.namespaceURI;
+
+/** @return {undefined} */
+Event.prototype.stopImmediatePropagation = function() {};

--- a/sdk/tests/deqp/temp_externs/w3c_geolocation.js
+++ b/sdk/tests/deqp/temp_externs/w3c_geolocation.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2009 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's Geolocation specification
+ *     http://www.w3.org/TR/geolocation-API/
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/geolocation-API/#geolocation
+ */
+function Geolocation() {}
+
+/**
+ * @param {function(GeolocationPosition)} successCallback
+ * @param {(function(GeolocationPositionError)|null)=} opt_errorCallback
+ * @param {GeolocationPositionOptions=} opt_options
+ */
+Geolocation.prototype.getCurrentPosition = function(successCallback,
+                                                       opt_errorCallback,
+                                                       opt_options) {};
+
+/**
+ * @param {function(GeolocationPosition)} successCallback
+ * @param {(function(GeolocationPositionError)|null)=} opt_errorCallback
+ * @param {GeolocationPositionOptions=} opt_options
+ * @return {number}
+ */
+Geolocation.prototype.watchPosition = function(successCallback,
+                                                  opt_errorCallback,
+                                                  opt_options) {};
+
+/** @param {number} watchId */
+Geolocation.prototype.clearWatch = function(watchId) {};
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/geolocation-API/#coordinates
+ */
+function GeolocationCoordinates() {}
+/** @type {number} */ GeolocationCoordinates.prototype.latitude;
+/** @type {number} */ GeolocationCoordinates.prototype.longitude;
+/** @type {number} */ GeolocationCoordinates.prototype.accuracy;
+/** @type {number} */ GeolocationCoordinates.prototype.altitude;
+/** @type {number} */ GeolocationCoordinates.prototype.altitudeAccuracy;
+/** @type {number} */ GeolocationCoordinates.prototype.heading;
+/** @type {number} */ GeolocationCoordinates.prototype.speed;
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/geolocation-API/#position
+ */
+function GeolocationPosition() {}
+/** @type {GeolocationCoordinates} */
+GeolocationPosition.prototype.coords;
+/** @type {Date} */ GeolocationPosition.prototype.timestamp;
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/geolocation-API/#position-options
+ */
+function GeolocationPositionOptions() {}
+/** @type {boolean} */
+GeolocationPositionOptions.prototype.enableHighAccuracy;
+/** @type {number} */ GeolocationPositionOptions.prototype.maximumAge;
+/** @type {number} */ GeolocationPositionOptions.prototype.timeout;
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/geolocation-API/#position-error
+ */
+function GeolocationPositionError() {}
+/** @type {number} */ GeolocationPositionError.prototype.code;
+/** @type {string} */ GeolocationPositionError.prototype.message;
+/** @type {number} */ GeolocationPositionError.prototype.UNKNOWN_ERROR;
+/** @type {number} */ GeolocationPositionError.prototype.PERMISSION_DENIED;
+/** @type {number} */
+GeolocationPositionError.prototype.POSITION_UNAVAILABLE;
+/** @type {number} */ GeolocationPositionError.prototype.TIMEOUT;
+
+/** @type {Geolocation} */
+Navigator.prototype.geolocation;

--- a/sdk/tests/deqp/temp_externs/w3c_indexeddb.js
+++ b/sdk/tests/deqp/temp_externs/w3c_indexeddb.js
@@ -1,0 +1,914 @@
+/*
+ * Copyright 2011 The Closure Compiler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's IndexedDB API. In Chrome all the
+ * IndexedDB classes are prefixed with 'webkit'. In order to access constants
+ * and static methods of these classes they must be duplicated with the
+ * prefix here.
+ * @see http://www.w3.org/TR/IndexedDB/
+ *
+ * @externs
+ * @author guido.tapia@picnet.com.au (Guido Tapia)
+ */
+
+/** @type {IDBFactory} */
+Window.prototype.moz_indexedDB;
+
+/** @type {IDBFactory} */
+Window.prototype.mozIndexedDB;
+
+/** @type {IDBFactory} */
+Window.prototype.webkitIndexedDB;
+
+/** @type {IDBFactory} */
+Window.prototype.msIndexedDB;
+
+/** @type {IDBFactory} */
+Window.prototype.indexedDB;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBFactory
+ */
+function IDBFactory() {}
+
+/**
+ * @param {string} name The name of the database to open.
+ * @param {number=} opt_version The version at which to open the database.
+ * @return {!IDBOpenDBRequest} The IDBRequest object.
+ */
+IDBFactory.prototype.open = function(name, opt_version) {};
+
+/**
+ * @param {string} name The name of the database to delete.
+ * @return {!IDBOpenDBRequest} The IDBRequest object.
+ */
+IDBFactory.prototype.deleteDatabase = function(name) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBDatabaseException
+ */
+function IDBDatabaseException() {}
+
+/**
+ * @constructor
+ * @extends {IDBDatabaseException}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBDatabaseException
+ */
+function webkitIDBDatabaseException() {}
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.UNKNOWN_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.UNKNOWN_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.NON_TRANSIENT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.NON_TRANSIENT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.NOT_FOUND_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.NOT_FOUND_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.CONSTRAINT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.CONSTRAINT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.DATA_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.DATA_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.NOT_ALLOWED_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.NOT_ALLOWED_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.TRANSACTION_INACTIVE_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.TRANSACTION_INACTIVE_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.ABORT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.ABORT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.READ_ONLY_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.READ_ONLY_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.TIMEOUT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.TIMEOUT_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.QUOTA_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.QUOTA_ERR;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBDatabaseException.prototype.code;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBDatabaseException.prototype.code;
+
+/**
+ * @const
+ * @type {string}
+ */
+IDBDatabaseException.prototype.message;
+
+/**
+ * @const
+ * @type {string}
+ */
+webkitIDBDatabaseException.prototype.message;
+
+/**
+ * @constructor
+ * @implements {EventTarget}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBRequest
+ */
+function IDBRequest() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+IDBRequest.prototype.addEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+IDBRequest.prototype.removeEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/** @override */
+IDBRequest.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * @constructor
+ * @extends {IDBRequest}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBRequest
+ */
+function webkitIDBRequest() {}
+
+/**
+ * @type {number}
+ * @const
+ */
+IDBRequest.LOADING;
+
+/**
+ * @type {number}
+ * @const
+ */
+webkitIDBRequest.LOADING;
+
+/**
+ * @type {number}
+ * @const
+ */
+IDBRequest.DONE;
+
+/**
+ * @type {number}
+ * @const
+ */
+webkitIDBRequest.DONE;
+
+/** @type {number} */
+IDBRequest.prototype.readyState; // readonly
+
+/** @type {function(!Event)} */
+IDBRequest.prototype.onsuccess = function(e) {};
+
+/** @type {function(!Event)} */
+IDBRequest.prototype.onerror = function(e) {};
+
+/** @type {*} */
+IDBRequest.prototype.result;  // readonly
+
+/**
+ * @type {number}
+ * @deprecated Use "error"
+ */
+IDBRequest.prototype.errorCode;  // readonly
+
+
+/** @type {!DOMError} */
+IDBRequest.prototype.error; // readonly
+
+/** @type {Object} */
+IDBRequest.prototype.source; // readonly
+
+/** @type {IDBTransaction} */
+IDBRequest.prototype.transaction; // readonly
+
+/**
+ * @constructor
+ * @extends {IDBRequest}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBOpenDBRequest
+ */
+function IDBOpenDBRequest() {}
+
+/**
+ * @type {function(!IDBVersionChangeEvent)}
+ */
+IDBOpenDBRequest.prototype.onblocked = function(e) {};
+
+/**
+ * @type {function(!IDBVersionChangeEvent)}
+ */
+IDBOpenDBRequest.prototype.onupgradeneeded = function(e) {};
+
+/**
+ * @constructor
+ * @implements {EventTarget}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBDatabase
+ */
+function IDBDatabase() {}
+
+/**
+ * @type {string}
+ * @const
+ */
+IDBDatabase.prototype.name;
+
+/**
+ * @type {string}
+ * @const
+ */
+IDBDatabase.prototype.description;
+
+/**
+ * @type {string}
+ * @const
+ */
+IDBDatabase.prototype.version;
+
+/**
+ * @type {DOMStringList}
+ * @const
+ */
+IDBDatabase.prototype.objectStoreNames;
+
+/**
+ * @param {string} name The name of the object store.
+ * @param {Object=} opt_parameters Parameters to be passed
+ *     creating the object store.
+ * @return {!IDBObjectStore} The created/open object store.
+ */
+IDBDatabase.prototype.createObjectStore =
+    function(name, opt_parameters)  {};
+
+/**
+ * @param {string} name The name of the object store to remove.
+ */
+IDBDatabase.prototype.deleteObjectStore = function(name) {};
+
+/**
+ * @param {string} version The new version of the database.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBDatabase.prototype.setVersion = function(version) {};
+
+/**
+ * @param {Array.<string>} storeNames The stores to open in this transaction.
+ * @param {(number|string)=} mode The mode for opening the object stores.
+ * @return {!IDBTransaction} The IDBRequest object.
+ */
+IDBDatabase.prototype.transaction = function(storeNames, mode) {};
+
+/**
+ * Closes the database connection.
+ */
+IDBDatabase.prototype.close = function() {};
+
+/**
+ * @type {Function}
+ */
+IDBDatabase.prototype.onabort = function() {};
+
+/**
+ * @type {Function}
+ */
+IDBDatabase.prototype.onerror = function() {};
+
+/**
+ * @type {Function}
+ */
+IDBDatabase.prototype.onversionchange = function() {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+IDBDatabase.prototype.addEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+IDBDatabase.prototype.removeEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/** @override */
+IDBDatabase.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * Typedef for valid key types according to the w3 specification. Note that this
+ * is slightly wider than what is actually allowed, as all Array elements must
+ * have a valid key type.
+ * @see http://www.w3.org/TR/IndexedDB/#key-construct
+ * @typedef {number|string|!Date|!Array.<?>}
+ */
+var IDBKeyType;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBObjectStore
+ */
+function IDBObjectStore() {}
+
+/**
+ * @type {string}
+ */
+IDBObjectStore.prototype.name;
+
+/**
+ * @type {string}
+ */
+IDBObjectStore.prototype.keyPath;
+
+/**
+ * @type {DOMStringList}
+ */
+IDBObjectStore.prototype.indexNames;
+
+/** @type {IDBTransaction} */
+IDBObjectStore.prototype.transaction;
+
+/** @type {boolean} */
+IDBObjectStore.prototype.autoIncrement;
+
+/**
+ * @param {*} value The value to put into the object store.
+ * @param {IDBKeyType=} key The key of this value.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBObjectStore.prototype.put = function(value, key) {};
+
+/**
+ * @param {*} value The value to add into the object store.
+ * @param {IDBKeyType=} key The key of this value.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBObjectStore.prototype.add = function(value, key) {};
+
+/**
+ * @param {IDBKeyType} key The key of this value.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBObjectStore.prototype.delete = function(key) {};
+
+/**
+ * @param {IDBKeyType|!IDBKeyRange} key The key of the document to retrieve.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBObjectStore.prototype.get = function(key) {};
+
+/**
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBObjectStore.prototype.clear = function() {};
+
+/**
+ * @param {IDBKeyRange=} range The range of the cursor.
+ * @param {(number|string)=} direction The direction of cursor enumeration.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBObjectStore.prototype.openCursor = function(range, direction) {};
+
+/**
+ * @param {string} name The name of the index.
+ * @param {string|!Array.<string>} keyPath The path to the index key.
+ * @param {Object=} opt_paramters Optional parameters
+ *     for the created index.
+ * @return {!IDBIndex} The IDBIndex object.
+ */
+IDBObjectStore.prototype.createIndex = function(name, keyPath, opt_paramters) {};
+
+/**
+ * @param {string} name The name of the index to retrieve.
+ * @return {!IDBIndex} The IDBIndex object.
+ */
+IDBObjectStore.prototype.index = function(name) {};
+
+/**
+ * @param {string} indexName The name of the index to remove.
+ */
+IDBObjectStore.prototype.deleteIndex = function(indexName) {};
+
+/**
+ * @param {(IDBKeyType|IDBKeyRange)=} key The key of this value.
+ * @return {!IDBRequest} The IDBRequest object.
+ * @see http://www.w3.org/TR/IndexedDB/#widl-IDBObjectStore-count
+ */
+IDBObjectStore.prototype.count = function(key) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBIndex
+ */
+function IDBIndex() {}
+
+/**
+ * @type {string}
+ * @const
+ */
+IDBIndex.prototype.name;
+
+/**
+ * @type {!IDBObjectStore}
+ * @const
+ */
+IDBIndex.prototype.objectStore;
+
+/**
+ * @type {string}
+ * @const
+ */
+IDBIndex.prototype.keyPath;
+
+/**
+ * @type {boolean}
+ * @const
+ */
+IDBIndex.prototype.unique;
+
+/**
+ * @param {IDBKeyRange=} range The range of the cursor.
+ * @param {(number|string)=} direction The direction of cursor enumeration.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBIndex.prototype.openCursor = function(range, direction) {};
+
+/**
+ * @param {IDBKeyRange=} range The range of the cursor.
+ * @param {(number|string)=} direction The direction of cursor enumeration.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBIndex.prototype.openKeyCursor = function(range, direction) {};
+
+/**
+ * @param {IDBKeyType|!IDBKeyRange} key The id of the object to retrieve.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBIndex.prototype.get = function(key) {};
+
+/**
+ * @param {IDBKeyType|!IDBKeyRange} key The id of the object to retrieve.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBIndex.prototype.getKey = function(key) {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBCursor
+ */
+function IDBCursor() {}
+
+/**
+ * @constructor
+ * @extends {IDBCursor}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBCursor
+ */
+function webkitIDBCursor() {}
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBCursor.NEXT;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBCursor.NEXT;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBCursor.NEXT_NO_DUPLICATE;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBCursor.NEXT_NO_DUPLICATE;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBCursor.PREV;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBCursor.PREV;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBCursor.PREV_NO_DUPLICATE;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBCursor.PREV_NO_DUPLICATE;
+
+/**
+ * @type {*}
+ * @const
+ */
+IDBCursor.prototype.source;
+
+/**
+ * @type {number}
+ * @const
+ */
+IDBCursor.prototype.direction;
+
+/**
+ * @type {IDBKeyType}
+ * @const
+ */
+IDBCursor.prototype.key;
+
+/**
+ * @type {number}
+ * @const
+ */
+IDBCursor.prototype.primaryKey;
+
+/**
+ * @param {*} value The new value for the current object in the cursor.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBCursor.prototype.update = function(value) {};
+
+/**
+ * Note: Must be quoted to avoid parse error.
+ * @param {IDBKeyType=} key Continue enumerating the cursor from the specified
+ *     key (or next).
+ */
+IDBCursor.prototype.continue = function(key) {};
+
+/**
+ * @param {number} count Number of times to iterate the cursor.
+ */
+IDBCursor.prototype.advance = function(count) {};
+
+/**
+ * Note: Must be quoted to avoid parse error.
+ * @return {!IDBRequest} The IDBRequest object.
+ */
+IDBCursor.prototype.delete = function() {};
+
+/**
+ * @constructor
+ * @extends {IDBCursor}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBCursorWithValue
+ */
+function IDBCursorWithValue() {}
+
+/** @type {*} */
+IDBCursorWithValue.prototype.value; // readonly
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBTransaction
+ */
+function IDBTransaction() {}
+
+/**
+ * @constructor
+ * @extends {IDBTransaction}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBTransaction
+ */
+function webkitIDBTransaction() {}
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBTransaction.READ_WRITE;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBTransaction.READ_WRITE;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBTransaction.READ_ONLY;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBTransaction.READ_ONLY;
+
+/**
+ * @const
+ * @type {number}
+ */
+IDBTransaction.VERSION_CHANGE;
+
+/**
+ * @const
+ * @type {number}
+ */
+webkitIDBTransaction.VERSION_CHANGE;
+
+/**
+ * @type {number|string}
+ * @const
+ */
+IDBTransaction.prototype.mode;
+
+/**
+ * @type {IDBDatabase}
+ * @const
+ */
+IDBTransaction.prototype.db;
+
+/**
+ * @param {string} name The name of the object store to retrieve.
+ * @return {!IDBObjectStore} The object store.
+ */
+IDBTransaction.prototype.objectStore = function(name) {};
+
+/**
+ * Aborts the transaction.
+ */
+IDBTransaction.prototype.abort = function() {};
+
+/**
+ * @type {Function}
+ */
+IDBTransaction.prototype.onabort = function() {};
+
+/**
+ * @type {Function}
+ */
+IDBTransaction.prototype.oncomplete = function() {};
+
+/**
+ * @type {Function}
+ */
+IDBTransaction.prototype.onerror = function() {};
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBKeyRange
+ */
+function IDBKeyRange() {}
+
+/**
+ * @constructor
+ * @extends {IDBKeyRange}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBKeyRange
+ */
+function webkitIDBKeyRange() {}
+
+/**
+ * @type {*}
+ * @const
+ */
+IDBKeyRange.prototype.lower;
+
+/**
+ * @type {*}
+ * @const
+ */
+IDBKeyRange.prototype.upper;
+
+/**
+ * @type {*}
+ * @const
+ */
+IDBKeyRange.prototype.lowerOpen;
+
+/**
+ * @type {*}
+ * @const
+ */
+IDBKeyRange.prototype.upperOpen;
+
+/**
+ * @param {IDBKeyType} value The single key value of this range.
+ * @return {!IDBKeyRange} The key range.
+ */
+IDBKeyRange.only = function(value) {};
+
+/**
+ * @param {IDBKeyType} value The single key value of this range.
+ * @return {!IDBKeyRange} The key range.
+ */
+webkitIDBKeyRange.only = function(value) {};
+
+/**
+ * @param {IDBKeyType} bound Creates a lower bound key range.
+ * @param {boolean=} open Open the key range.
+ * @return {!IDBKeyRange} The key range.
+ */
+IDBKeyRange.lowerBound = function(bound, open) {};
+
+/**
+ * @param {IDBKeyType} bound Creates a lower bound key range.
+ * @param {boolean=} open Open the key range.
+ * @return {!IDBKeyRange} The key range.
+ */
+webkitIDBKeyRange.lowerBound = function(bound, open) {};
+
+/**
+ * @param {IDBKeyType} bound Creates an upper bound key range.
+ * @param {boolean=} open Open the key range.
+ * @return {!IDBKeyRange} The key range.
+ */
+IDBKeyRange.upperBound = function(bound, open) {};
+
+/**
+ * @param {IDBKeyType} bound Creates an upper bound key range.
+ * @param {boolean=} open Open the key range.
+ * @return {!IDBKeyRange} The key range.
+ */
+webkitIDBKeyRange.upperBound = function(bound, open) {};
+
+/**
+ * @param {IDBKeyType} left The left bound value.
+ * @param {IDBKeyType} right The right bound value.
+ * @param {boolean=} openLeft Whether the left bound value should be excluded.
+ * @param {boolean=} openRight Whether the right bound value should be excluded.
+ * @return {!IDBKeyRange} The key range.
+ */
+IDBKeyRange.bound = function(left, right, openLeft, openRight) {};
+
+/**
+ * @param {IDBKeyType} left The left bound value.
+ * @param {IDBKeyType} right The right bound value.
+ * @param {boolean=} openLeft Whether the left bound value should be excluded.
+ * @param {boolean=} openRight Whether the right bound value should be excluded.
+ * @return {!IDBKeyRange} The key range.
+ */
+webkitIDBKeyRange.bound = function(left, right, openLeft, openRight) {};
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBVersionChangeEvent
+ */
+function IDBVersionChangeEvent() {}
+
+/**
+ * @type {number}
+ * @const
+ */
+IDBVersionChangeEvent.prototype.oldVersion;
+
+/**
+ * @type {?number}
+ * @const
+ */
+IDBVersionChangeEvent.prototype.newVersion;
+
+/**
+ * @constructor
+ * @extends {IDBVersionChangeEvent}
+ * @see http://www.w3.org/TR/IndexedDB/#idl-def-IDBVersionChangeEvent
+ */
+function webkitIDBVersionChangeEvent() {}
+
+/**
+ * @type {string}
+ * @const
+ */
+webkitIDBVersionChangeEvent.prototype.version;

--- a/sdk/tests/deqp/temp_externs/w3c_navigation_timing.js
+++ b/sdk/tests/deqp/temp_externs/w3c_navigation_timing.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2011 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's Navigation Timing specification.
+ *
+ * Created from
+ * @see http://dvcs.w3.org/hg/webperf/raw-file/tip/specs/NavigationTiming/Overview.html
+ * @see http://w3c-test.org/webperf/specs/ResourceTiming
+ * @see http://www.w3.org/TR/performance-timeline
+ *
+ * @externs
+ */
+
+/** @constructor */
+function PerformanceTiming() {}
+/** @type {number} */ PerformanceTiming.prototype.navigationStart;
+/** @type {number} */ PerformanceTiming.prototype.unloadEventStart;
+/** @type {number} */ PerformanceTiming.prototype.unloadEventEnd;
+/** @type {number} */ PerformanceTiming.prototype.redirectStart;
+/** @type {number} */ PerformanceTiming.prototype.redirectEnd;
+/** @type {number} */ PerformanceTiming.prototype.fetchStart;
+/** @type {number} */ PerformanceTiming.prototype.domainLookupStart;
+/** @type {number} */ PerformanceTiming.prototype.domainLookupEnd;
+/** @type {number} */ PerformanceTiming.prototype.connectStart;
+/** @type {number} */ PerformanceTiming.prototype.connectEnd;
+/** @type {number} */ PerformanceTiming.prototype.secureConnectionStart;
+/** @type {number} */ PerformanceTiming.prototype.requestStart;
+/** @type {number} */ PerformanceTiming.prototype.responseStart;
+/** @type {number} */ PerformanceTiming.prototype.responseEnd;
+/** @type {number} */ PerformanceTiming.prototype.domLoading;
+/** @type {number} */ PerformanceTiming.prototype.domInteractive;
+/** @type {number} */ PerformanceTiming.prototype.domContentLoadedEventStart;
+/** @type {number} */ PerformanceTiming.prototype.domContentLoadedEventEnd;
+/** @type {number} */ PerformanceTiming.prototype.domComplete;
+/** @type {number} */ PerformanceTiming.prototype.loadEventStart;
+/** @type {number} */ PerformanceTiming.prototype.loadEventEnd;
+
+/** @constructor */
+function PerformanceEntry() {}
+/** @type {string} */ PerformanceEntry.prototype.name;
+/** @type {string} */ PerformanceEntry.prototype.entryType;
+/** @type {number} */ PerformanceEntry.prototype.startTime;
+/** @type {number} */ PerformanceEntry.prototype.duration;
+
+/**
+ * @constructor
+ * @extends {PerformanceEntry}
+ */
+function PerformanceResourceTiming() {}
+/** @type {number} */ PerformanceResourceTiming.prototype.redirectStart;
+/** @type {number} */ PerformanceResourceTiming.prototype.redirectEnd;
+/** @type {number} */ PerformanceResourceTiming.prototype.fetchStart;
+/** @type {number} */ PerformanceResourceTiming.prototype.domainLookupStart;
+/** @type {number} */ PerformanceResourceTiming.prototype.domainLookupEnd;
+/** @type {number} */ PerformanceResourceTiming.prototype.connectStart;
+/** @type {number} */ PerformanceResourceTiming.prototype.connectEnd;
+/** @type {number} */
+PerformanceResourceTiming.prototype.secureConnectionStart;
+/** @type {number} */ PerformanceResourceTiming.prototype.requestStart;
+/** @type {number} */ PerformanceResourceTiming.prototype.responseStart;
+/** @type {number} */ PerformanceResourceTiming.prototype.responseEnd;
+/** @type {string} */ PerformanceResourceTiming.prototype.initiatorType;
+
+/** @constructor */
+function PerformanceNavigation() {}
+/** @type {number} */ PerformanceNavigation.prototype.TYPE_NAVIGATE = 0;
+/** @type {number} */ PerformanceNavigation.prototype.TYPE_RELOAD = 1;
+/** @type {number} */ PerformanceNavigation.prototype.TYPE_BACK_FORWARD = 2;
+/** @type {number} */ PerformanceNavigation.prototype.TYPE_RESERVED = 255;
+/** @type {number} */ PerformanceNavigation.prototype.type;
+/** @type {number} */ PerformanceNavigation.prototype.redirectCount;
+
+// Only available in WebKit, and only with the --enable-memory-info flag.
+/** @constructor */
+function PerformanceMemory() {}
+/** @type {number} */ PerformanceMemory.prototype.jsHeapSizeLimit;
+/** @type {number} */ PerformanceMemory.prototype.totalJSHeapSize;
+/** @type {number} */ PerformanceMemory.prototype.usedJSHeapSize;
+
+/** @constructor */
+function Performance() {}
+/** @type {PerformanceTiming} */ Performance.prototype.timing;
+/** @type {PerformanceNavigation} */ Performance.prototype.navigation;
+
+/**
+ * Clears the buffer used to store the current list of
+ * PerformanceResourceTiming resources.
+ * @return {undefined}
+ */
+Performance.prototype.clearResourceTimings = function() {};
+
+/**
+ * Clear out the buffer of performance timing events for webkit browsers.
+ * @return {undefined}
+ */
+Performance.prototype.webkitClearResourceTimings = function() {};
+
+/**
+ * Set the maximum number of PerformanceResourceTiming resources that may be
+ * stored in the buffer.
+ * @param {number} maxSize
+ */
+Performance.prototype.setResourceTimingBufferSize = function(maxSize) {};
+
+/**
+ * @return {Array.<PerformanceEntry>} A copy of the PerformanceEntry list,
+ *     in chronological order with respect to startTime.
+ * @nosideeffects
+ */
+Performance.prototype.getEntries = function() {};
+
+/**
+ * @param {string} entryType Only return {@code PerformanceEntry}s with this
+ *     entryType.
+ * @return {Array.<PerformanceEntry>} A copy of the PerformanceEntry list,
+ *     in chronological order with respect to startTime.
+ * @nosideeffects
+ */
+Performance.prototype.getEntriesByType = function(entryType) {};
+
+/**
+ * @param {string} name Only return {@code PerformanceEntry}s with this name.
+ * @param {string=} opt_entryType Only return {@code PerformanceEntry}s with
+ *     this entryType.
+ * @return {Array.<PerformanceEntry>} PerformanceEntry list in chronological
+ *     order with respect to startTime.
+ * @nosideeffects
+ */
+Performance.prototype.getEntriesByName = function(name, opt_entryType) {};
+
+// Only available in WebKit, and only with the --enable-memory-info flag.
+/** @type {PerformanceMemory} */ Performance.prototype.memory;
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+Performance.prototype.now = function() {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+Performance.prototype.webkitNow = function() {};
+
+/** @type {Performance} */
+Window.prototype.performance;

--- a/sdk/tests/deqp/temp_externs/w3c_range.js
+++ b/sdk/tests/deqp/temp_externs/w3c_range.js
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's range specification.
+ *  This file depends on w3c_dom2.js.
+ *  The whole file has been fully type annotated.
+ *  Created from
+ *   http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html
+ *
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ */
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-Range-Interface
+ */
+function Range() {}
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-Range-attr-startParent
+ */
+Range.prototype.startContainer;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-Range-attr-startOffset
+ */
+Range.prototype.startOffset;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-Range-attr-endParent
+ */
+Range.prototype.endContainer;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-Range-attr-endOffset
+ */
+Range.prototype.endOffset;
+
+/**
+ * @type {boolean}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-Range-attr-collapsed
+ */
+Range.prototype.collapsed;
+
+/**
+ * @type {Node}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-Range-attr-commonParent
+ */
+Range.prototype.commonAncestorContainer;
+
+/**
+ * @param {Node} refNode
+ * @param {number} offset
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-setStart
+ */
+Range.prototype.setStart = function(refNode, offset) {};
+
+/**
+ * @param {Node} refNode
+ * @param {number} offset
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-setEnd
+ */
+Range.prototype.setEnd = function(refNode, offset) {};
+
+/**
+ * @param {Node} refNode
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-setStartBefore
+ */
+Range.prototype.setStartBefore = function(refNode) {};
+
+/**
+ * @param {Node} refNode
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-setStartAfter
+ */
+Range.prototype.setStartAfter = function(refNode) {};
+
+/**
+ * @param {Node} refNode
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-setEndBefore
+ */
+Range.prototype.setEndBefore = function(refNode) {};
+
+/**
+ * @param {Node} refNode
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-setEndAfter
+ */
+Range.prototype.setEndAfter = function(refNode) {};
+
+/**
+ * @param {boolean} toStart
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-collapse
+ */
+Range.prototype.collapse = function(toStart) {};
+
+/**
+ * @param {Node} refNode
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-selectNode
+ */
+Range.prototype.selectNode = function(refNode) {};
+
+/**
+ * @param {Node} refNode
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-selectNodeContents
+ */
+Range.prototype.selectNodeContents = function(refNode) {};
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-compareHow
+ */
+Range.prototype.START_TO_START = 0;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-compareHow
+ */
+Range.prototype.START_TO_END = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-compareHow
+ */
+Range.prototype.END_TO_END = 2;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-compareHow
+ */
+Range.prototype.END_TO_START = 3;
+
+/**
+ * @param {number} how
+ * @param {Range} sourceRange
+ * @return {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-compareBoundaryPoints
+ */
+Range.prototype.compareBoundaryPoints = function(how, sourceRange) {};
+
+/**
+ * @return {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-deleteContents
+ */
+Range.prototype.deleteContents = function() {};
+
+/**
+ * @return {DocumentFragment}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-extractContents
+ */
+Range.prototype.extractContents = function() {};
+
+/**
+ * @return {DocumentFragment}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-cloneContents
+ */
+Range.prototype.cloneContents = function() {};
+
+/**
+ * @param {Node} newNode
+ * @return {DocumentFragment}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-insertNode
+ */
+Range.prototype.insertNode = function(newNode) {};
+
+/**
+ * @param {Node} newParent
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-surroundContents
+ */
+Range.prototype.surroundContents = function(newParent) {};
+
+/**
+ * @return {Range}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-clone
+ */
+Range.prototype.cloneRange = function() {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-Range-method-detach
+ */
+Range.prototype.detach = function() {};
+
+// Introduced in DOM Level 2:
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level-2-DocumentRange-idl
+ */
+function DocumentRange() {}
+
+/**
+ * @return {Range}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#Level2-DocumentRange-method-createRange
+ */
+DocumentRange.prototype.createRange = function() {};
+
+// Introduced in DOM Level 2:
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#RangeException
+ */
+function RangeException() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#RangeExceptionCode
+ */
+RangeException.prototype.code;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#RangeExceptionCode
+ */
+RangeException.prototype.BAD_BOUNDARYPOINTS_ERR = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-2-Traversal-Range/ranges.html#RangeExceptionCode
+ */
+RangeException.prototype.INVALID_NODE_TYPE_ERR = 2;

--- a/sdk/tests/deqp/temp_externs/w3c_rtc.js
+++ b/sdk/tests/deqp/temp_externs/w3c_rtc.js
@@ -1,0 +1,1002 @@
+/*
+ * Copyright 2012 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for components of the WebRTC browser API.
+ * @see http://dev.w3.org/2011/webrtc/editor/webrtc.html
+ * @see http://tools.ietf.org/html/draft-ietf-rtcweb-jsep-01
+ * @see http://www.w3.org/TR/mediacapture-streams/
+ *
+ * @externs
+ * @author bemasc@google.com (Benjamin M. Schwartz)
+ */
+
+/**
+ * @typedef {string}
+ * @see {http://dev.w3.org/2011/webrtc/editor/getusermedia.html
+ *     #idl-def-MediaStreamTrackState}
+ * In WebIDL this is an enum with values 'live', 'mute', and 'ended',
+ * but there is no mechanism in Closure for describing a specialization of
+ * the string type.
+ */
+var MediaStreamTrackState;
+
+/**
+ * @interface
+ */
+function SourceInfo() {}
+
+/** @const {string} */
+SourceInfo.prototype.kind;
+
+/** @const {string} */
+SourceInfo.prototype.id;
+
+/** @const {?string} */
+SourceInfo.prototype.label;
+
+/** @const {boolean} */
+SourceInfo.prototype.facing;
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/mediacapture-streams/#mediastreamtrack
+ */
+function MediaStreamTrack() {}
+
+/**
+ * @param {!function(!Array.<!SourceInfo>)} callback
+ */
+MediaStreamTrack.getSources = function(callback) {};
+
+/**
+ * @type {string}
+ * @const
+ */
+MediaStreamTrack.prototype.kind;
+
+/**
+ * @type {string}
+ * @const
+ */
+MediaStreamTrack.prototype.id;
+
+/**
+ * @type {string}
+ * @const
+ */
+MediaStreamTrack.prototype.label;
+
+/**
+ * @type {boolean}
+ */
+MediaStreamTrack.prototype.enabled;
+
+/**
+ * @type {MediaStreamTrackState}
+ * Read only.
+ */
+MediaStreamTrack.prototype.readyState;
+
+/**
+ * @type {?function(!Event)}
+ */
+MediaStreamTrack.prototype.onmute;
+
+/**
+ * @type {?function(!Event)}
+ */
+MediaStreamTrack.prototype.onunmute;
+
+/**
+ * @type {?function(!Event)}
+ */
+MediaStreamTrack.prototype.onended;
+
+/**
+ * @return {!MediaStreamTrack}
+ */
+MediaStreamTrack.prototype.clone = function() {};
+
+/** @return {void} */
+MediaStreamTrack.prototype.stop = function() {};
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @private
+ * @see http://dev.w3.org/2011/webrtc/editor/
+ * webrtc-20120720.html#mediastreamtrackevent
+ * TODO(bemasc): Update this link to the final definition once one exists
+ * (https://www.w3.org/Bugs/Public/show_bug.cgi?id=19568)
+ */
+function MediaStreamTrackEvent() {}
+
+/**
+ * @type {!MediaStreamTrack}
+ * @const
+ */
+MediaStreamTrackEvent.prototype.track;
+
+/**
+ * @param {!MediaStream|!Array.<!MediaStreamTrack>=} streamOrTracks
+ * @constructor
+ * @implements {EventTarget}
+ * @see http://www.w3.org/TR/mediacapture-streams/#mediastream
+ */
+function MediaStream(streamOrTracks) {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+MediaStream.prototype.addEventListener = function(type, listener,
+    opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+MediaStream.prototype.removeEventListener = function(type, listener,
+    opt_useCapture) {};
+
+/** @override */
+MediaStream.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * TODO(bemasc): Remove this property.
+ * @deprecated
+ * @type {string}
+ * @const
+ */
+MediaStream.prototype.label;
+
+/**
+ * @type {string}
+ * @const
+ */
+MediaStream.prototype.id;
+
+/**
+ * @return {!Array.<!MediaStreamTrack>}
+ */
+MediaStream.prototype.getAudioTracks = function() {};
+
+/**
+ * @return {!Array.<!MediaStreamTrack>}
+ */
+MediaStream.prototype.getVideoTracks = function() {};
+
+/**
+ * @param {string} trackId
+ * @return {MediaStreamTrack}
+ */
+MediaStream.prototype.getTrackById = function(trackId) {};
+
+/**
+ * @param {!MediaStreamTrack} track
+ */
+MediaStream.prototype.addTrack = function(track) {};
+
+/**
+ * @param {!MediaStreamTrack} track
+ */
+MediaStream.prototype.removeTrack = function(track) {};
+
+/**
+ * @type {boolean}
+ */
+MediaStream.prototype.ended;
+
+/**
+ * @type {?function(!Event)}
+ */
+MediaStream.prototype.onended;
+
+/**
+ * @type {?function(!MediaStreamTrackEvent)}
+ */
+MediaStream.prototype.onaddtrack;
+
+/**
+ * @type {?function(!MediaStreamTrackEvent)}
+ */
+MediaStream.prototype.onremovetrack;
+
+/**
+ * @deprecated
+ * TODO(bemasc): Remove this method once browsers have updated to
+ * MediaStreamTrack.stop().
+ */
+MediaStream.prototype.stop = function() {};
+
+/**
+ * @type {function(new: MediaStream,
+ *                 (!MediaStream|!Array.<!MediaStreamTrack>)=)}
+ */
+var webkitMediaStream;
+
+/**
+ * This interface defines the available constraint attributes.  These are the
+ * attributes defined in
+ * {@see http://tools.ietf.org/html/draft-alvestrand-constraints-resolution-01}.
+ * Note that although that draft refers to "Media Constraints", the W3C uses
+ * the terms "Media[Stream|Track]Constraints" for this type, and
+ * defines a different type (for RTCPeerConnection) called "MediaConstraints".
+ *
+ * This interface type is not part of any standard, so it is marked as private.
+ * It is defined here in order to reserve the property names, which would
+ * otherwise be rewritten when the compiler processes an object literal.
+ * Several subsequent interfaces are defined in the same pattern.
+ *
+ * Note that although this list includes all the properties supported by
+ * libjingle (and hence by Chromium), browsers are permitted to offer other
+ * properties as well ({
+ * @see http://tools.ietf.org/html/draft-burnett-rtcweb-constraints-registry-02
+ * }), and browsers are expected to silently ignore unknown properties.  This
+ * creates the potential for a very confusing situation in which properties
+ * not listed here are renamed by the compiler and then ignored by the browser.
+ *
+ * @interface
+ * @private
+ */
+function MediaTrackConstraintSetInterface_() {}
+
+/**
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.minWidth;
+
+/**
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.maxWidth;
+
+/**
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.minHeight;
+
+/**
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.maxHeight;
+
+/**
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.minAspectRatio;
+
+/**
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.maxAspectRatio;
+
+/**
+ * Due to a typo, this is called "minFramerate" in the -01 draft.
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.minFrameRate;
+
+/**
+ * @type {?number}
+ */
+MediaTrackConstraintSetInterface_.prototype.maxFrameRate;
+
+/**
+ * This type and two more below are defined as unions with Object because they
+ * are normally used as record types by constructing an Object literal, but all
+ * of their properties are optional.
+ * @typedef {Object|MediaTrackConstraintSetInterface_}
+ */
+var MediaTrackConstraintSet;
+
+/**
+ * @interface
+ * @private
+ */
+function MediaTrackConstraintsInterface_() {}
+
+/**
+ * @type {?MediaTrackConstraintSet}
+ */
+MediaTrackConstraintsInterface_.prototype.mandatory;
+
+/**
+ * @type {?Array.<!MediaTrackConstraintSet>}
+ */
+MediaTrackConstraintsInterface_.prototype.optional;
+
+/**
+ * @typedef {Object|MediaTrackConstraintsInterface_}
+ */
+var MediaTrackConstraints;
+
+/**
+ * @interface
+ * @private
+ */
+function MediaStreamConstraintsInterface_() {}
+
+/**
+ * @type {boolean|MediaTrackConstraints}
+ */
+MediaStreamConstraintsInterface_.prototype.audio;
+
+/**
+ * @type {boolean|MediaTrackConstraints}
+ */
+MediaStreamConstraintsInterface_.prototype.video;
+
+/**
+ * @typedef {Object|MediaStreamConstraintsInterface_}
+ */
+var MediaStreamConstraints;
+
+/**
+ * @see {http://dev.w3.org/2011/webrtc/editor/getusermedia.html#
+ *     navigatorusermediaerror-and-navigatorusermediaerrorcallback}
+ * @interface
+ */
+function NavigatorUserMediaError() {}
+
+/**
+ * @type {number}
+ * @deprecated Removed from the standard and some browsers.
+ * @const
+ */
+NavigatorUserMediaError.prototype.PERMISSION_DENIED;  /** 1 */
+
+/**
+ * @type {number}
+ * @deprecated Removed from the standard and some browsers.
+ * Read only.
+ */
+NavigatorUserMediaError.prototype.code;
+
+/**
+ * @type {string}
+ * Read only.
+ */
+NavigatorUserMediaError.prototype.name;
+
+/**
+ * @type {?string}
+ * Read only.
+ */
+NavigatorUserMediaError.prototype.message;
+
+/**
+ * @type {?string}
+ * Read only.
+ */
+NavigatorUserMediaError.prototype.constraintName;
+
+/**
+ * @param {MediaStreamConstraints} constraints A MediaStreamConstraints object.
+ * @param {function(!MediaStream)} successCallback
+ *     A NavigatorUserMediaSuccessCallback function.
+ * @param {function(!NavigatorUserMediaError)=} errorCallback A
+ *     NavigatorUserMediaErrorCallback function.
+ * @see http://dev.w3.org/2011/webrtc/editor/getusermedia.html
+ * @see http://www.w3.org/TR/mediacapture-streams/
+ */
+Navigator.prototype.webkitGetUserMedia =
+  function(constraints, successCallback, errorCallback) {};
+
+/**
+ * @param {string} type
+ * @param {!Object} eventInitDict
+ * @constructor
+ */
+function MediaStreamEvent(type, eventInitDict) {}
+
+/**
+ * @type {?MediaStream}
+ * @const
+ */
+MediaStreamEvent.prototype.stream;
+
+/**
+ * @typedef {string}
+ * @see http://www.w3.org/TR/webrtc/#rtcsdptype
+ * In WebIDL this is an enum with values 'offer', 'pranswer', and 'answer',
+ * but there is no mechanism in Closure for describing a specialization of
+ * the string type.
+ */
+var RTCSdpType;
+
+/**
+ * @param {!Object=} descriptionInitDict The RTCSessionDescriptionInit
+ * dictionary.  This optional argument may have type
+ * {type:RTCSdpType, sdp:string}, but neither of these keys are required to be
+ * present, and other keys are ignored, so the closest Closure type is Object.
+ * @constructor
+ * @see http://dev.w3.org/2011/webrtc/editor/webrtc.html#rtcsessiondescription-class
+ */
+function RTCSessionDescription(descriptionInitDict) {}
+
+/**
+ * @type {?RTCSdpType}
+ * @see http://www.w3.org/TR/webrtc/#widl-RTCSessionDescription-type
+ */
+RTCSessionDescription.prototype.type;
+
+/**
+ * @type {?string}
+ * @see http://www.w3.org/TR/webrtc/#widl-RTCSessionDescription-sdp
+ */
+RTCSessionDescription.prototype.sdp;
+
+/**
+ * TODO(bemasc): Remove this definition once it is removed from the browser.
+ * @param {string} label The label index (audio/video/data -> 0,1,2)
+ * @param {string} sdp The ICE candidate in SDP text form
+ * @constructor
+ */
+function IceCandidate(label, sdp) {}
+
+/**
+ * @return {string}
+ */
+IceCandidate.prototype.toSdp = function() {};
+
+/**
+ * @type {?string}
+ */
+IceCandidate.prototype.label;
+
+/**
+ * @param {!Object=} candidateInitDict  The RTCIceCandidateInit dictionary.
+ * This optional argument may have type
+ * {candidate: string, sdpMid: string, sdpMLineIndex:number}, but none of
+ * these keys are required to be present, and other keys are ignored, so the
+ * closest Closure type is Object.
+ * @constructor
+ * @see http://www.w3.org/TR/webrtc/#rtcicecandidate-type
+ */
+function RTCIceCandidate(candidateInitDict) {}
+
+/**
+ * @type {?string}
+ */
+RTCIceCandidate.prototype.candidate;
+
+/**
+ * @type {?string}
+ */
+RTCIceCandidate.prototype.sdpMid;
+
+/**
+ * @type {?number}
+ */
+RTCIceCandidate.prototype.sdpMLineIndex;
+
+/**
+ * @typedef {{url: string}}
+ * @private
+ * @see http://www.w3.org/TR/webrtc/#rtciceserver-type
+ * This dictionary type also has an optional key {credential: ?string}.
+ */
+var RTCIceServerRecord_;
+
+/**
+ * @interface
+ * @private
+ */
+function RTCIceServerInterface_() {}
+
+/**
+ * @type {string}
+ */
+RTCIceServerInterface_.prototype.url;
+
+/**
+ * @type {?string}
+ */
+RTCIceServerInterface_.prototype.credential;
+
+/**
+ * This type, and several below it, are constructed as unions between records
+ *
+ * @typedef {RTCIceServerRecord_|RTCIceServerInterface_}
+ * @private
+ */
+var RTCIceServer;
+
+/**
+ * @typedef {{iceServers: !Array.<!RTCIceServer>}}
+ * @private
+ */
+var RTCConfigurationRecord_;
+
+/**
+ * @interface
+ * @private
+ */
+function RTCConfigurationInterface_() {}
+
+/**
+ * @type {!Array.<!RTCIceServer>}
+ */
+RTCConfigurationInterface_.prototype.iceServers;
+
+/**
+ * @typedef {RTCConfigurationRecord_|RTCConfigurationInterface_}
+ */
+var RTCConfiguration;
+
+/**
+ * @typedef {function(!RTCSessionDescription)}
+ */
+var RTCSessionDescriptionCallback;
+
+/**
+ * @typedef {function(string)}
+ */
+var RTCPeerConnectionErrorCallback;
+
+/**
+ * @typedef {function()}
+ */
+var RTCVoidCallback;
+
+/**
+ * @typedef {string}
+ */
+var RTCSignalingState;
+
+/**
+ * @typedef {string}
+ */
+var RTCIceConnectionState;
+
+/**
+ * @typedef {string}
+ */
+var RTCIceGatheringState;
+
+/**
+ * @param {string} type
+ * @param {!Object} eventInitDict
+ * @constructor
+ */
+function RTCPeerConnectionIceEvent(type, eventInitDict) {}
+
+/**
+ * @type {RTCIceCandidate}
+ * @const
+ */
+RTCPeerConnectionIceEvent.prototype.candidate;
+
+// Note: The specification of RTCStats types is still under development.
+// Declarations here will be updated and removed to follow the development of
+// modern browsers, breaking compatibility with older versions as they become
+// obsolete.
+/**
+ * @interface
+ */
+function RTCStatsReport() {}
+
+/**
+ * @type {Date}
+ * @const
+ */
+RTCStatsReport.prototype.timestamp;
+
+/**
+ * @return {!Array.<!string>}
+ */
+RTCStatsReport.prototype.names = function() {};
+
+/**
+ * @param {string} name
+ * @return {string}
+ */
+RTCStatsReport.prototype.stat = function(name) {};
+
+/**
+ * @deprecated
+ * @type {RTCStatsReport}
+ * @const
+ */
+RTCStatsReport.prototype.local;
+
+/**
+ * @deprecated
+ * @type {RTCStatsReport}
+ * @const
+ */
+RTCStatsReport.prototype.remote;
+
+/**
+ * @type {string}
+ * @const
+ */
+RTCStatsReport.prototype.type;
+
+/**
+ * @type {string}
+ * @const
+ */
+RTCStatsReport.prototype.id;
+
+/**
+ * TODO(bemasc): Remove this type once it is no longer in use.  It has already
+ * been removed from the specification.
+ * @typedef {RTCStatsReport}
+ * @deprecated
+ */
+var RTCStatsElement;
+
+/**
+ * @interface
+ */
+function RTCStatsResponse() {}
+
+/**
+ * @return {!Array.<!RTCStatsReport>}
+ */
+RTCStatsResponse.prototype.result = function() {};
+
+/**
+ * @typedef {function(!RTCStatsResponse, MediaStreamTrack=)}
+ */
+var RTCStatsCallback;
+
+/**
+ * This type is not yet standardized, so the properties here only represent
+ * the current capabilities of libjingle (and hence Chromium).
+ * TODO(bemasc): Add a link to the relevant standard once MediaConstraint has a
+ * standard definition.
+ *
+ * @interface
+ * @private
+ */
+function MediaConstraintSetInterface_() {}
+
+/**
+ * @type {?boolean}
+ */
+MediaConstraintSetInterface_.prototype.OfferToReceiveAudio;
+
+/**
+ * @type {?boolean}
+ */
+MediaConstraintSetInterface_.prototype.OfferToReceiveVideo;
+
+/**
+ * @type {?boolean}
+ */
+MediaConstraintSetInterface_.prototype.DtlsSrtpKeyAgreement;
+
+/**
+ * @type {?boolean}
+ */
+MediaConstraintSetInterface_.prototype.RtpDataChannels;
+
+/**
+ * TODO(bemasc): Make this type public once it is defined in a standard.
+ *
+ * @typedef {Object|MediaConstraintSetInterface_}
+ * @private
+ */
+var MediaConstraintSet_;
+
+/**
+ * @interface
+ * @private
+ */
+function MediaConstraintsInterface_() {}
+
+/**
+ * @type {?MediaConstraintSet_}
+ */
+MediaConstraintsInterface_.prototype.mandatory;
+
+/**
+ * @type {?Array.<!MediaConstraintSet_>}
+ */
+MediaConstraintsInterface_.prototype.optional;
+
+/**
+ * This type is used extensively in
+ * {@see http://dev.w3.org/2011/webrtc/editor/webrtc.html} but is not yet
+ * defined.
+ *
+ * @typedef {Object|MediaConstraintsInterface_}
+ */
+var MediaConstraints;
+
+/**
+ * @interface
+ */
+function RTCDataChannel() {}
+
+/**
+ * @type {string}
+ * @const
+ */
+RTCDataChannel.prototype.label;
+
+/**
+ * @type {boolean}
+ * @const
+ */
+RTCDataChannel.prototype.reliable;
+
+/**
+ * An enumerated string type (RTCDataChannelState) with values:
+ * "connecting", "open", "closing", and "closed".
+ * @type {string}
+ * Read only.
+ */
+RTCDataChannel.prototype.readyState;
+
+/**
+ * @type {number}
+ * Read only.
+ */
+RTCDataChannel.prototype.bufferedAmount;
+
+/**
+ * @type {?function(!Event)}
+ */
+RTCDataChannel.prototype.onopen;
+
+/**
+ * @type {?function(!Event)}
+ */
+RTCDataChannel.prototype.onerror;
+
+/**
+ * @type {?function(!Event)}
+ */
+RTCDataChannel.prototype.onclose;
+
+RTCDataChannel.prototype.close = function() {};
+
+/**
+ * @type {?function(!MessageEvent.<*>)}
+ */
+RTCDataChannel.prototype.onmessage;
+
+/**
+ * @type {string}
+ */
+RTCDataChannel.prototype.binaryType;
+
+/**
+ * @param {string|!Blob|!ArrayBuffer|!ArrayBufferView} data
+ */
+RTCDataChannel.prototype.send = function(data) {};
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @private
+ */
+function RTCDataChannelEvent() {}
+
+/**
+ * @type {!RTCDataChannel}
+ * Read only.
+ */
+RTCDataChannelEvent.prototype.channel;
+
+/**
+ * @typedef {{reliable: boolean}}
+ */
+var RTCDataChannelInitRecord_;
+
+/**
+ * @interface
+ * @private
+ */
+function RTCDataChannelInitInterface_() {}
+
+/**
+ * @type {boolean}
+ */
+RTCDataChannelInitInterface_.prototype.reliable;
+
+/**
+ * @typedef {RTCDataChannelInitInterface_|RTCDataChannelInitRecord_}
+ */
+var RTCDataChannelInit;
+
+/**
+ * @param {RTCConfiguration} configuration
+ * @param {!MediaConstraints=} constraints
+ * @constructor
+ * @implements {EventTarget}
+ */
+function RTCPeerConnection(configuration, constraints) {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+RTCPeerConnection.prototype.addEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+RTCPeerConnection.prototype.removeEventListener = function(
+    type, listener, opt_useCapture) {};
+
+/** @override */
+RTCPeerConnection.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * @param {!RTCSessionDescriptionCallback} successCallback
+ * @param {!RTCPeerConnectionErrorCallback=} failureCallback
+ * @param {!MediaConstraints=} constraints
+ */
+RTCPeerConnection.prototype.createOffer = function(successCallback,
+    failureCallback, constraints) {};
+
+/**
+ * @param {RTCSessionDescriptionCallback} successCallback
+ * @param {?RTCPeerConnectionErrorCallback=} failureCallback
+ * @param {!MediaConstraints=} constraints
+ */
+RTCPeerConnection.prototype.createAnswer = function(successCallback,
+    failureCallback, constraints) {};
+
+/**
+ * @param {!RTCSessionDescription} description
+ * @param {!RTCVoidCallback=} successCallback
+ * @param {!RTCPeerConnectionErrorCallback=} failureCallback
+ */
+RTCPeerConnection.prototype.setLocalDescription = function(description,
+    successCallback, failureCallback) {};
+
+/**
+ * @param {!RTCSessionDescription} description
+ * @param {!RTCVoidCallback=} successCallback
+ * @param {!RTCPeerConnectionErrorCallback=} failureCallback
+ */
+RTCPeerConnection.prototype.setRemoteDescription = function(description,
+    successCallback, failureCallback) {};
+
+/**
+ * @type {?RTCSessionDescription}
+ * Read only.
+ */
+RTCPeerConnection.prototype.localDescription;
+
+/**
+ * @type {?RTCSessionDescription}
+ * Read only.
+ */
+RTCPeerConnection.prototype.remoteDescription;
+
+/**
+ * @type {RTCSignalingState}
+ * Read only.
+ */
+RTCPeerConnection.prototype.signalingState;
+
+/**
+ * @param {?RTCConfiguration=} configuration
+ * @param {?MediaConstraints=} constraints
+ */
+RTCPeerConnection.prototype.updateIce = function(configuration, constraints) {};
+
+/**
+ * @param {!RTCIceCandidate} candidate
+ */
+RTCPeerConnection.prototype.addIceCandidate = function(candidate) {};
+
+/**
+ * @type {!RTCIceGatheringState}
+ * Read only.
+ */
+RTCPeerConnection.prototype.iceGatheringState;
+
+/**
+ * @type {!RTCIceConnectionState}
+ * Read only.
+ */
+RTCPeerConnection.prototype.iceConnectionState;
+
+/**
+ * @return {!Array.<!MediaStream>}
+ */
+RTCPeerConnection.prototype.getLocalStreams = function() {};
+
+/**
+ * @return {!Array.<!MediaStream>}
+ */
+RTCPeerConnection.prototype.getRemoteStreams = function() {};
+
+/**
+ * @param {string} streamId
+ * @return {MediaStream}
+ */
+RTCPeerConnection.prototype.getStreamById = function(streamId) {};
+
+/**
+ * @param {?string} label
+ * @param {RTCDataChannelInit=} dataChannelDict
+ * @return {!RTCDataChannel}
+ */
+RTCPeerConnection.prototype.createDataChannel =
+    function(label, dataChannelDict) {};
+/**
+ * @param {!MediaStream} stream
+ * @param {!MediaConstraints=} constraints
+ */
+RTCPeerConnection.prototype.addStream = function(stream, constraints) {};
+
+/**
+ * @param {!MediaStream} stream
+ */
+RTCPeerConnection.prototype.removeStream = function(stream) {};
+
+// TODO(bemasc): Add identity provider stuff once implementations exist
+
+/**
+ * @param {!RTCStatsCallback} successCallback
+ * @param {MediaStreamTrack=} selector
+ */
+RTCPeerConnection.prototype.getStats = function(successCallback, selector) {};
+
+RTCPeerConnection.prototype.close = function() {};
+
+/**
+ * @type {?function(!Event)}
+ */
+RTCPeerConnection.prototype.onnegotiationneeded;
+
+/**
+ * @type {?function(!RTCPeerConnectionIceEvent)}
+ */
+RTCPeerConnection.prototype.onicecandidate;
+
+/**
+ * @type {?function(!Event)}
+ */
+RTCPeerConnection.prototype.onsignalingstatechange;
+
+/**
+ * @type {?function(!MediaStreamEvent)}
+ */
+RTCPeerConnection.prototype.onaddstream;
+
+/**
+ * @type {?function(!MediaStreamEvent)}
+ */
+RTCPeerConnection.prototype.onremovestream;
+
+/**
+ * @type {?function(!Event)}
+ */
+RTCPeerConnection.prototype.oniceconnectionstatechange;
+
+/**
+ * @type {?function(!RTCDataChannelEvent)}
+ */
+RTCPeerConnection.prototype.ondatachannel;
+
+/**
+ * @type {function(new: RTCPeerConnection, RTCConfiguration,
+ *     !MediaConstraints=)}
+ */
+var webkitRTCPeerConnection;

--- a/sdk/tests/deqp/temp_externs/w3c_selectors.js
+++ b/sdk/tests/deqp/temp_externs/w3c_selectors.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's Selectors API.
+ *  This file depends on w3c_dom1.js.
+ *  @see http://www.w3.org/TR/selectors-api2/
+ *
+ * @externs
+ */
+
+/**
+ * @param {string} selectors
+ * @return {Element}
+ * @override
+ */
+Document.prototype.querySelector = function(selectors) {};
+
+/**
+ * @param {string} selectors
+ * @return {!NodeList}
+ * @override
+ */
+Document.prototype.querySelectorAll = function(selectors) {};
+
+/**
+ * @param {string} selectors
+ * @return {Element}
+ * @override
+ */
+Element.prototype.querySelector = function(selectors) {};
+
+/**
+ * @param {string} selectors
+ * @return {!NodeList}
+ * @override
+ */
+Element.prototype.querySelectorAll = function(selectors) {};
+
+/**
+ * https://dom.spec.whatwg.org/#dom-element-matches
+ * https://developer.mozilla.org/en-US/docs/Web/API/Element.matches
+ * @param {string} selectors
+ * @return {boolean}
+ */
+Element.prototype.matches = function(selectors) {};
+
+/**
+ * @param {string} selectors
+ * @param {(Node|NodeList)=} refNodes
+ * @return {boolean}
+ */
+Element.prototype.matchesSelector = function(selectors, refNodes) {};
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/Node.mozMatchesSelector
+ * @param {string} selectors
+ * @return {boolean}
+ */
+Element.prototype.mozMatchesSelector = function(selectors) {};
+
+/**
+ * @see http://developer.apple.com/library/safari/documentation/WebKit/Reference/ElementClassRef/Element/Element.html
+ * @param {string} selectors
+ * @return {boolean}
+ */
+Element.prototype.webkitMatchesSelector = function(selectors) {};
+
+/**
+ * @see http://msdn.microsoft.com/en-us/library/ff975201.aspx
+ * @param {string} selectors
+ * @return {boolean}
+ */
+Element.prototype.msMatchesSelector = function(selectors) {};
+
+/**
+ * @see http://www.opera.com/docs/changelogs/windows/1150/
+ * @param {string} selectors
+ * @return {boolean}
+ */
+Element.prototype.oMatchesSelector = function(selectors) {};

--- a/sdk/tests/deqp/temp_externs/w3c_xml.js
+++ b/sdk/tests/deqp/temp_externs/w3c_xml.js
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for W3C's XML related specifications.
+ *  This file depends on w3c_dom2.js.
+ *  The whole file has been fully type annotated.
+ *
+ *  Provides the XML standards from W3C.
+ *   Includes:
+ *    XPath          - Fully type annotated
+ *    XMLHttpRequest - Fully type annotated
+ *
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html
+ * @see http://www.w3.org/TR/XMLHttpRequest/
+ * @see http://www.w3.org/TR/XMLHttpRequest2/
+ *
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ */
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathException
+ */
+function XPathException() {}
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#INVALID_EXPRESSION_ERR
+ */
+XPathException.INVALID_EXPRESSION_ERR = 52;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#TYPE_ERR
+ */
+XPathException.TYPE_ERR = 52;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#
+ */
+XPathException.prototype.code;
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator
+ */
+function XPathEvaluator() {}
+
+/**
+ * @param {string} expr
+ * @param {?XPathNSResolver=} opt_resolver
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-createExpression
+ * @throws XPathException
+ * @throws DOMException
+ */
+XPathEvaluator.prototype.createExpression = function(expr, opt_resolver) {};
+
+/**
+ * @param {Node} nodeResolver
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-createNSResolver
+ */
+XPathEvaluator.prototype.createNSResolver = function(nodeResolver) {};
+
+/**
+ * @param {string} expr
+ * @param {Node} contextNode
+ * @param {?XPathNSResolver=} opt_resolver
+ * @param {?number=} opt_type
+ * @param {*=} opt_result
+ * @return {XPathResult}
+ * @throws XPathException
+ * @throws DOMException
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathEvaluator-evaluate
+ */
+XPathEvaluator.prototype.evaluate = function(expr, contextNode, opt_resolver,
+    opt_type, opt_result) {};
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathExpression
+ */
+function XPathExpression() {}
+
+/**
+ * @param {Node} contextNode
+ * @param {number=} opt_type
+ * @param {*=} opt_result
+ * @return {*}
+ * @throws XPathException
+ * @throws DOMException
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathExpression-evaluate
+ */
+XPathExpression.prototype.evaluate = function(contextNode, opt_type,
+    opt_result) {};
+
+
+/**
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathNSResolver
+ */
+function XPathNSResolver() {}
+
+/**
+ * @param {string} prefix
+ * @return {?string}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathNSResolver-lookupNamespaceURI
+ */
+XPathNSResolver.prototype.lookupNamespaceURI = function(prefix) {};
+
+/**
+ * From http://www.w3.org/TR/xpath
+ *
+ * XPath is a language for addressing parts of an XML document, designed to be
+ * used by both XSLT and XPointer.
+ *
+ * @noalias
+ * @constructor
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult
+ */
+function XPathResult() {}
+
+/**
+ * @type {boolean} {@see XPathException.TYPE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-booleanValue
+ */
+XPathResult.prototype.booleanValue;
+
+/**
+ * @type {boolean} {@see XPathException.TYPE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-invalid-iterator-state
+ */
+XPathResult.prototype.invalidInteratorState;
+
+/**
+ * @type {number}
+ * @throws XPathException {@see XPathException.TYPE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-numberValue
+ */
+XPathResult.prototype.numberValue;
+
+/**
+ * @type {number}
+ * @throws XPathException {@see XPathException.TYPE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-resultType
+ */
+XPathResult.prototype.resultType;
+
+/**
+ * @type {Node}
+ * @throws XPathException {@see XPathException.TYPE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-singleNodeValue
+ */
+XPathResult.prototype.singleNodeValue;
+
+/**
+ * @type {number}
+ * @throws XPathException {@see XPathException.TYPE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-snapshot-length
+ */
+XPathResult.prototype.snapshotLength;
+
+/**
+ * @type {string}
+ * @throws XPathException {@see XPathException.TYPE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-stringValue
+ */
+XPathResult.prototype.stringValue;
+
+/**
+ * @return {Node}
+ * @throws XPathException {@see XPathException.TYPE_ERR}
+ * @throws DOMException {@see DOMException.INVALID_STATE_ERR}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-iterateNext
+ */
+XPathResult.prototype.iterateNext = function() {};
+
+/**
+ * @param {number} index
+ * @return {Node}
+ * @throws XPathException
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-snapshotItem
+ */
+XPathResult.prototype.snapshotItem = function(index) {};
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ANY-TYPE
+ */
+XPathResult.ANY_TYPE = 0;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-NUMBER-TYPE
+ */
+XPathResult.NUMBER_TYPE = 1;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-STRING-TYPE
+ */
+XPathResult.STRING_TYPE = 2;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-BOOLEAN-TYPE
+ */
+XPathResult.BOOLEAN_TYPE = 3;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-UNORDERED-NODE-ITERATOR-TYPE
+ */
+XPathResult.UNORDERED_NODE_ITERATOR_TYPE = 4;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ORDERED-NODE-ITERATOR-TYPE
+ */
+XPathResult.ORDERED_NODE_ITERATOR_TYPE = 5;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-UNORDERED-NODE-SNAPSHOT-TYPE
+ */
+XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE = 6;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ORDERED-NODE-SNAPSHOT-TYPE
+ */
+XPathResult.ORDERED_NODE_SNAPSHOT_TYPE = 7;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-ANY-UNORDERED-NODE-TYPE
+ */
+XPathResult.ANY_UNORDERED_NODE_TYPE = 8;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult-FIRST-ORDERED-NODE-TYPE
+ */
+XPathResult.FIRST_ORDERED_NODE_TYPE = 9;
+
+/**
+ * @constructor
+ * @extends {Node}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathNamespace
+ */
+function XPathNamespace() {}
+
+/**
+ * @type {Element}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathNamespace-ownerElement
+ */
+XPathNamespace.prototype.ownerElement;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPATH_NAMESPACE_NODE
+ */
+XPathNamespace.XPATH_NAMESPACE_NODE = 13;
+
+/**
+ * From http://www.w3.org/TR/XMLHttpRequest/
+ *
+ * (Draft)
+ *
+ * The XMLHttpRequest Object specification defines an API that provides
+ * scripted client functionality for transferring data between a client and a
+ * server.
+ *
+ * @constructor
+ * @implements {EventTarget}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#xmlhttprequest-object
+ */
+function XMLHttpRequest() {}
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+XMLHttpRequest.prototype.addEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+XMLHttpRequest.prototype.removeEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/** @override */
+XMLHttpRequest.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * @param {string} method
+ * @param {string} url
+ * @param {?boolean=} opt_async
+ * @param {?string=} opt_user
+ * @param {?string=} opt_password
+ * @return {undefined}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-open()-method
+ */
+XMLHttpRequest.prototype.open = function(method, url, opt_async, opt_user,
+    opt_password) {};
+
+/**
+ * @param {string} header
+ * @param {string} value
+ * @return {undefined}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-setrequestheader()-method
+ */
+XMLHttpRequest.prototype.setRequestHeader = function(header, value) {};
+
+/**
+ * @param {ArrayBuffer|ArrayBufferView|Blob|Document|FormData|string=} opt_data
+ * @return {undefined}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-send()-method
+ */
+XMLHttpRequest.prototype.send = function(opt_data) {};
+
+/**
+ * @return {undefined}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-abort()-method
+ */
+XMLHttpRequest.prototype.abort = function() {};
+
+/**
+ * @return {string}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-getallresponseheaders()-method
+ */
+XMLHttpRequest.prototype.getAllResponseHeaders = function() {};
+
+/**
+ * @param {string} header
+ * @return {string}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-getresponseheader()-method
+ */
+XMLHttpRequest.prototype.getResponseHeader = function(header) {};
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-responsetext-attribute
+ */
+XMLHttpRequest.prototype.responseText;
+
+/**
+ * @type {Document}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-responsexml-attribute
+ */
+XMLHttpRequest.prototype.responseXML;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-readystate-attribute
+ */
+XMLHttpRequest.prototype.readyState;
+
+/**
+ * @type {number}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-status-attribute
+ */
+XMLHttpRequest.prototype.status;
+
+/**
+ * @type {string}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#the-statustext-attribute
+ */
+XMLHttpRequest.prototype.statusText;
+
+/**
+ * @type {Function}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#handler-xhr-onreadystatechange
+ */
+XMLHttpRequest.prototype.onreadystatechange;
+
+/**
+ * @type {Function}
+ * @see http://www.w3.org/TR/XMLHttpRequest/#handler-xhr-onerror
+ */
+XMLHttpRequest.prototype.onerror;
+
+/**
+ * The FormData object represents an ordered collection of entries. Each entry
+ * has a name and value.
+ *
+ * @param {?Element=} opt_form An optional form to use for constructing the form
+ *     data set.
+ * @constructor
+ * @see http://www.w3.org/TR/XMLHttpRequest2/#the-formdata-interface
+ */
+function FormData(opt_form) {}
+
+/**
+ * @param {string} name
+ * @param {Blob|string} value
+ */
+FormData.prototype.append = function(name, value) {};

--- a/sdk/tests/deqp/temp_externs/webkit_css.js
+++ b/sdk/tests/deqp/temp_externs/webkit_css.js
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for WebKit's custom CSS properties. Copied from:
+ * {@link
+ * http://trac.webkit.org/browser/trunk/Source/WebCore/css/CSSPropertyNames.in}
+ *
+ * If you make changes to this file, notice that every property appears
+ * twice: once as an uppercase name and once as a lowercase name.
+ * WebKit allows both. The uppercase version is preferred.
+ *
+ * @externs
+ * @author nicksantos@google.com (Nick Santos)
+ */
+
+/** @type {string} */ CSSProperties.prototype.WebkitAlignContent;
+/** @type {string} */ CSSProperties.prototype.WebkitAlignItems;
+/** @type {string} */ CSSProperties.prototype.WebkitAlignSelf;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimation;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationDelay;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationDirection;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationDuration;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationFillMode;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationIterationCount;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationName;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationPlayState;
+/** @type {string} */ CSSProperties.prototype.WebkitAnimationTimingFunction;
+/** @type {string} */ CSSProperties.prototype.WebkitAppearance;
+/** @type {string} */ CSSProperties.prototype.WebkitAppRegion;
+/** @type {string} */ CSSProperties.prototype.WebkitAspectRatio;
+/** @type {string} */ CSSProperties.prototype.WebkitBackfaceVisibility;
+/** @type {string} */ CSSProperties.prototype.WebkitBackgroundClip;
+/** @type {string} */ CSSProperties.prototype.WebkitBackgroundComposite;
+/** @type {string} */ CSSProperties.prototype.WebkitBackgroundOrigin;
+/** @type {string} */ CSSProperties.prototype.WebkitBackgroundSize;
+/** @type {string} */ CSSProperties.prototype.WebkitBinding;
+/** @type {string} */ CSSProperties.prototype.WebkitBlendMode;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderAfter;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderAfterColor;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderAfterStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderAfterWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderBefore;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderBeforeColor;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderBeforeStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderBeforeWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderBottomLeftRadius;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderBottomRightRadius;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderEnd;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderEndColor;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderEndStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderEndWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderFit;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderHorizontalSpacing;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderImage;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderRadius;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderStart;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderStartColor;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderStartStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderStartWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderTopLeftRadius;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderTopRightRadius;
+/** @type {string} */ CSSProperties.prototype.WebkitBorderVerticalSpacing;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxAlign;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxDecorationBreak;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxDirection;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxFlex;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxFlexGroup;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxLines;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxOrdinalGroup;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxOrient;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxPack;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxReflect;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxShadow;
+/** @type {string} */ CSSProperties.prototype.WebkitBoxSizing;
+/** @type {string} */ CSSProperties.prototype.WebkitColorCorrection;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnAxis;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnBreakAfter;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnBreakBefore;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnBreakInside;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnCount;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnGap;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnProgression;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnRule;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnRuleColor;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnRuleStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnRuleWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitColumns;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnSpan;
+/** @type {string} */ CSSProperties.prototype.WebkitColumnWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitDashboardRegion;
+/** @type {string} */ CSSProperties.prototype.WebkitFilter;
+/** @type {string} */ CSSProperties.prototype.WebkitFlex;
+/** @type {string} */ CSSProperties.prototype.WebkitFlexBasis;
+/** @type {string} */ CSSProperties.prototype.WebkitFlexDirection;
+/** @type {string} */ CSSProperties.prototype.WebkitFlexFlow;
+/** @type {string} */ CSSProperties.prototype.WebkitFlexGrow;
+/** @type {string} */ CSSProperties.prototype.WebkitFlexShrink;
+/** @type {string} */ CSSProperties.prototype.WebkitFlexWrap;
+/** @type {string} */ CSSProperties.prototype.WebkitFlowFrom;
+/** @type {string} */ CSSProperties.prototype.WebkitFlowInto;
+/** @type {string} */ CSSProperties.prototype.WebkitFontSizeDelta;
+/** @type {string} */ CSSProperties.prototype.WebkitFontSmoothing;
+/** @type {string} */ CSSProperties.prototype.WebkitGridColumn;
+/** @type {string} */ CSSProperties.prototype.WebkitGridColumns;
+/** @type {string} */ CSSProperties.prototype.WebkitGridRow;
+/** @type {string} */ CSSProperties.prototype.WebkitGridRows;
+/** @type {string} */ CSSProperties.prototype.WebkitHighlight;
+/** @type {string} */ CSSProperties.prototype.WebkitHyphenateCharacter;
+/** @type {string} */ CSSProperties.prototype.WebkitHyphenateLimitAfter;
+/** @type {string} */ CSSProperties.prototype.WebkitHyphenateLimitBefore;
+/** @type {string} */ CSSProperties.prototype.WebkitHyphenateLimitLines;
+/** @type {string} */ CSSProperties.prototype.WebkitHyphens;
+/** @type {string} */ CSSProperties.prototype.WebkitJustifyContent;
+/** @type {string} */ CSSProperties.prototype.WebkitLineAlign;
+/** @type {string} */ CSSProperties.prototype.WebkitLineBoxContain;
+/** @type {string} */ CSSProperties.prototype.WebkitLineBreak;
+/** @type {string} */ CSSProperties.prototype.WebkitLineClamp;
+/** @type {string} */ CSSProperties.prototype.WebkitLineGrid;
+/** @type {string} */ CSSProperties.prototype.WebkitLineSnap;
+/** @type {string} */ CSSProperties.prototype.WebkitLocale;
+/** @type {string} */ CSSProperties.prototype.WebkitLogicalHeight;
+/** @type {string} */ CSSProperties.prototype.WebkitLogicalWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginAfter;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginAfterCollapse;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginBefore;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginBeforeCollapse;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginBottomCollapse;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginCollapse;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginEnd;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginStart;
+/** @type {string} */ CSSProperties.prototype.WebkitMarginTopCollapse;
+/** @type {string} */ CSSProperties.prototype.WebkitMarquee;
+/** @type {string} */ CSSProperties.prototype.WebkitMarqueeDirection;
+/** @type {string} */ CSSProperties.prototype.WebkitMarqueeIncrement;
+/** @type {string} */ CSSProperties.prototype.WebkitMarqueeRepetition;
+/** @type {string} */ CSSProperties.prototype.WebkitMarqueeSpeed;
+/** @type {string} */ CSSProperties.prototype.WebkitMarqueeStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitMask;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskAttachment;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskBoxImage;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskBoxImageOutset;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskBoxImageRepeat;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskBoxImageSlice;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskBoxImageSource;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskBoxImageWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskClip;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskComposite;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskImage;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskOrigin;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskPosition;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskPositionX;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskPositionY;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskRepeat;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskRepeatX;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskRepeatY;
+/** @type {string} */ CSSProperties.prototype.WebkitMaskSize;
+/** @type {string} */
+CSSProperties.prototype.WebkitMatchNearestMailBlockquoteColor;
+/** @type {string} */ CSSProperties.prototype.WebkitMaxLogicalHeight;
+/** @type {string} */ CSSProperties.prototype.WebkitMaxLogicalWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitMinLogicalHeight;
+/** @type {string} */ CSSProperties.prototype.WebkitMinLogicalWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitNbspMode;
+/** @type {string} */ CSSProperties.prototype.WebkitOrder;
+/** @type {string} */ CSSProperties.prototype.WebkitOverflowScrolling;
+/** @type {string} */ CSSProperties.prototype.WebkitPaddingAfter;
+/** @type {string} */ CSSProperties.prototype.WebkitPaddingBefore;
+/** @type {string} */ CSSProperties.prototype.WebkitPaddingEnd;
+/** @type {string} */ CSSProperties.prototype.WebkitPaddingStart;
+/** @type {string} */ CSSProperties.prototype.WebkitPerspective;
+/** @type {string} */ CSSProperties.prototype.WebkitPerspectiveOrigin;
+/** @type {string} */ CSSProperties.prototype.WebkitPerspectiveOriginX;
+/** @type {string} */ CSSProperties.prototype.WebkitPerspectiveOriginY;
+/** @type {string} */ CSSProperties.prototype.WebkitPrintColorAdjust;
+/** @type {string} */ CSSProperties.prototype.WebkitRegionBreakAfter;
+/** @type {string} */ CSSProperties.prototype.WebkitRegionBreakBefore;
+/** @type {string} */ CSSProperties.prototype.WebkitRegionBreakInside;
+/** @type {string} */ CSSProperties.prototype.WebkitRegionOverflow;
+/** @type {string} */ CSSProperties.prototype.WebkitRtlOrdering;
+/** @type {string} */ CSSProperties.prototype.WebkitRubyPosition;
+/** @type {string} */ CSSProperties.prototype.WebkitShapeInside;
+/** @type {string} */ CSSProperties.prototype.WebkitShapeMargin;
+/** @type {string} */ CSSProperties.prototype.WebkitShapeOutside;
+/** @type {string} */ CSSProperties.prototype.WebkitShapePadding;
+/** @type {string} */ CSSProperties.prototype.WebkitTapHighlightColor;
+/** @type {string} */ CSSProperties.prototype.WebkitTextAlignLast;
+/** @type {string} */ CSSProperties.prototype.WebkitTextCombine;
+/** @type {string} */ CSSProperties.prototype.WebkitTextDecorationLine;
+/** @type {string} */ CSSProperties.prototype.WebkitTextDecorationsInEffect;
+/** @type {string} */ CSSProperties.prototype.WebkitTextDecorationStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitTextEmphasis;
+/** @type {string} */ CSSProperties.prototype.WebkitTextEmphasisColor;
+/** @type {string} */ CSSProperties.prototype.WebkitTextEmphasisPosition;
+/** @type {string} */ CSSProperties.prototype.WebkitTextEmphasisStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitTextFillColor;
+/** @type {string} */ CSSProperties.prototype.WebkitTextOrientation;
+/** @type {string} */ CSSProperties.prototype.WebkitTextSecurity;
+/** @type {string} */ CSSProperties.prototype.WebkitTextSizeAdjust;
+/** @type {string} */ CSSProperties.prototype.WebkitTextStroke;
+/** @type {string} */ CSSProperties.prototype.WebkitTextStrokeColor;
+/** @type {string} */ CSSProperties.prototype.WebkitTextStrokeWidth;
+/** @type {string} */ CSSProperties.prototype.WebkitTransform;
+/** @type {string} */ CSSProperties.prototype.WebkitTransformOrigin;
+/** @type {string} */ CSSProperties.prototype.WebkitTransformOriginX;
+/** @type {string} */ CSSProperties.prototype.WebkitTransformOriginY;
+/** @type {string} */ CSSProperties.prototype.WebkitTransformOriginZ;
+/** @type {string} */ CSSProperties.prototype.WebkitTransformStyle;
+/** @type {string} */ CSSProperties.prototype.WebkitTransition;
+/** @type {string} */ CSSProperties.prototype.WebkitTransitionDelay;
+/** @type {string} */ CSSProperties.prototype.WebkitTransitionDuration;
+/** @type {string} */ CSSProperties.prototype.WebkitTransitionProperty;
+/** @type {string} */ CSSProperties.prototype.WebkitTransitionRepeatCount;
+/** @type {string} */ CSSProperties.prototype.WebkitTransitionTimingFunction;
+/** @type {string} */ CSSProperties.prototype.WebkitUserDrag;
+/** @type {string} */ CSSProperties.prototype.WebkitUserModify;
+/** @type {string} */ CSSProperties.prototype.WebkitUserSelect;
+/** @type {string} */ CSSProperties.prototype.WebkitWrap;
+/** @type {string} */ CSSProperties.prototype.WebkitWrapFlow;
+/** @type {string} */ CSSProperties.prototype.WebkitWrapThrough;
+/** @type {string} */ CSSProperties.prototype.WebkitWritingMode;
+
+// WebKit also adds bindings for the lowercase versions of these properties.
+// The uppercase version is preferred.
+
+/** @type {string} */ CSSProperties.prototype.webkitAlignContent;
+/** @type {string} */ CSSProperties.prototype.webkitAlignItems;
+/** @type {string} */ CSSProperties.prototype.webkitAlignSelf;
+/** @type {string} */ CSSProperties.prototype.webkitAnimation;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationDelay;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationDirection;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationDuration;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationFillMode;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationIterationCount;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationName;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationPlayState;
+/** @type {string} */ CSSProperties.prototype.webkitAnimationTimingFunction;
+/** @type {string} */ CSSProperties.prototype.webkitAppearance;
+/** @type {string} */ CSSProperties.prototype.webkitAppRegion;
+/** @type {string} */ CSSProperties.prototype.webkitAspectRatio;
+/** @type {string} */ CSSProperties.prototype.webkitBackfaceVisibility;
+/** @type {string} */ CSSProperties.prototype.webkitBackgroundClip;
+/** @type {string} */ CSSProperties.prototype.webkitBackgroundComposite;
+/** @type {string} */ CSSProperties.prototype.webkitBackgroundOrigin;
+/** @type {string} */ CSSProperties.prototype.webkitBackgroundSize;
+/** @type {string} */ CSSProperties.prototype.webkitBinding;
+/** @type {string} */ CSSProperties.prototype.webkitBlendMode;
+/** @type {string} */ CSSProperties.prototype.webkitBorderAfter;
+/** @type {string} */ CSSProperties.prototype.webkitBorderAfterColor;
+/** @type {string} */ CSSProperties.prototype.webkitBorderAfterStyle;
+/** @type {string} */ CSSProperties.prototype.webkitBorderAfterWidth;
+/** @type {string} */ CSSProperties.prototype.webkitBorderBefore;
+/** @type {string} */ CSSProperties.prototype.webkitBorderBeforeColor;
+/** @type {string} */ CSSProperties.prototype.webkitBorderBeforeStyle;
+/** @type {string} */ CSSProperties.prototype.webkitBorderBeforeWidth;
+/** @type {string} */ CSSProperties.prototype.webkitBorderBottomLeftRadius;
+/** @type {string} */ CSSProperties.prototype.webkitBorderBottomRightRadius;
+/** @type {string} */ CSSProperties.prototype.webkitBorderEnd;
+/** @type {string} */ CSSProperties.prototype.webkitBorderEndColor;
+/** @type {string} */ CSSProperties.prototype.webkitBorderEndStyle;
+/** @type {string} */ CSSProperties.prototype.webkitBorderEndWidth;
+/** @type {string} */ CSSProperties.prototype.webkitBorderFit;
+/** @type {string} */ CSSProperties.prototype.webkitBorderHorizontalSpacing;
+/** @type {string} */ CSSProperties.prototype.webkitBorderImage;
+/** @type {string} */ CSSProperties.prototype.webkitBorderRadius;
+/** @type {string} */ CSSProperties.prototype.webkitBorderStart;
+/** @type {string} */ CSSProperties.prototype.webkitBorderStartColor;
+/** @type {string} */ CSSProperties.prototype.webkitBorderStartStyle;
+/** @type {string} */ CSSProperties.prototype.webkitBorderStartWidth;
+/** @type {string} */ CSSProperties.prototype.webkitBorderTopLeftRadius;
+/** @type {string} */ CSSProperties.prototype.webkitBorderTopRightRadius;
+/** @type {string} */ CSSProperties.prototype.webkitBorderVerticalSpacing;
+/** @type {string} */ CSSProperties.prototype.webkitBoxAlign;
+/** @type {string} */ CSSProperties.prototype.webkitBoxDecorationBreak;
+/** @type {string} */ CSSProperties.prototype.webkitBoxDirection;
+/** @type {string} */ CSSProperties.prototype.webkitBoxFlex;
+/** @type {string} */ CSSProperties.prototype.webkitBoxFlexGroup;
+/** @type {string} */ CSSProperties.prototype.webkitBoxLines;
+/** @type {string} */ CSSProperties.prototype.webkitBoxOrdinalGroup;
+/** @type {string} */ CSSProperties.prototype.webkitBoxOrient;
+/** @type {string} */ CSSProperties.prototype.webkitBoxPack;
+/** @type {string} */ CSSProperties.prototype.webkitBoxReflect;
+/** @type {string} */ CSSProperties.prototype.webkitBoxShadow;
+/** @type {string} */ CSSProperties.prototype.webkitBoxSizing;
+/** @type {string} */ CSSProperties.prototype.webkitColorCorrection;
+/** @type {string} */ CSSProperties.prototype.webkitColumnAxis;
+/** @type {string} */ CSSProperties.prototype.webkitColumnBreakAfter;
+/** @type {string} */ CSSProperties.prototype.webkitColumnBreakBefore;
+/** @type {string} */ CSSProperties.prototype.webkitColumnBreakInside;
+/** @type {string} */ CSSProperties.prototype.webkitColumnCount;
+/** @type {string} */ CSSProperties.prototype.webkitColumnGap;
+/** @type {string} */ CSSProperties.prototype.webkitColumnProgression;
+/** @type {string} */ CSSProperties.prototype.webkitColumnRule;
+/** @type {string} */ CSSProperties.prototype.webkitColumnRuleColor;
+/** @type {string} */ CSSProperties.prototype.webkitColumnRuleStyle;
+/** @type {string} */ CSSProperties.prototype.webkitColumnRuleWidth;
+/** @type {string} */ CSSProperties.prototype.webkitColumns;
+/** @type {string} */ CSSProperties.prototype.webkitColumnSpan;
+/** @type {string} */ CSSProperties.prototype.webkitColumnWidth;
+/** @type {string} */ CSSProperties.prototype.webkitDashboardRegion;
+/** @type {string} */ CSSProperties.prototype.webkitFilter;
+/** @type {string} */ CSSProperties.prototype.webkitFlex;
+/** @type {string} */ CSSProperties.prototype.webkitFlexBasis;
+/** @type {string} */ CSSProperties.prototype.webkitFlexDirection;
+/** @type {string} */ CSSProperties.prototype.webkitFlexFlow;
+/** @type {string} */ CSSProperties.prototype.webkitFlexGrow;
+/** @type {string} */ CSSProperties.prototype.webkitFlexShrink;
+/** @type {string} */ CSSProperties.prototype.webkitFlexWrap;
+/** @type {string} */ CSSProperties.prototype.webkitFlowFrom;
+/** @type {string} */ CSSProperties.prototype.webkitFlowInto;
+/** @type {string} */ CSSProperties.prototype.webkitFontSizeDelta;
+/** @type {string} */ CSSProperties.prototype.webkitFontSmoothing;
+/** @type {string} */ CSSProperties.prototype.webkitGridColumn;
+/** @type {string} */ CSSProperties.prototype.webkitGridColumns;
+/** @type {string} */ CSSProperties.prototype.webkitGridRow;
+/** @type {string} */ CSSProperties.prototype.webkitGridRows;
+/** @type {string} */ CSSProperties.prototype.webkitHighlight;
+/** @type {string} */ CSSProperties.prototype.webkitHyphenateCharacter;
+/** @type {string} */ CSSProperties.prototype.webkitHyphenateLimitAfter;
+/** @type {string} */ CSSProperties.prototype.webkitHyphenateLimitBefore;
+/** @type {string} */ CSSProperties.prototype.webkitHyphenateLimitLines;
+/** @type {string} */ CSSProperties.prototype.webkitHyphens;
+/** @type {string} */ CSSProperties.prototype.webkitJustifyContent;
+/** @type {string} */ CSSProperties.prototype.webkitLineAlign;
+/** @type {string} */ CSSProperties.prototype.webkitLineBoxContain;
+/** @type {string} */ CSSProperties.prototype.webkitLineBreak;
+/** @type {string} */ CSSProperties.prototype.webkitLineClamp;
+/** @type {string} */ CSSProperties.prototype.webkitLineGrid;
+/** @type {string} */ CSSProperties.prototype.webkitLineSnap;
+/** @type {string} */ CSSProperties.prototype.webkitLocale;
+/** @type {string} */ CSSProperties.prototype.webkitLogicalHeight;
+/** @type {string} */ CSSProperties.prototype.webkitLogicalWidth;
+/** @type {string} */ CSSProperties.prototype.webkitMarginAfter;
+/** @type {string} */ CSSProperties.prototype.webkitMarginAfterCollapse;
+/** @type {string} */ CSSProperties.prototype.webkitMarginBefore;
+/** @type {string} */ CSSProperties.prototype.webkitMarginBeforeCollapse;
+/** @type {string} */ CSSProperties.prototype.webkitMarginBottomCollapse;
+/** @type {string} */ CSSProperties.prototype.webkitMarginCollapse;
+/** @type {string} */ CSSProperties.prototype.webkitMarginEnd;
+/** @type {string} */ CSSProperties.prototype.webkitMarginStart;
+/** @type {string} */ CSSProperties.prototype.webkitMarginTopCollapse;
+/** @type {string} */ CSSProperties.prototype.webkitMarquee;
+/** @type {string} */ CSSProperties.prototype.webkitMarqueeDirection;
+/** @type {string} */ CSSProperties.prototype.webkitMarqueeIncrement;
+/** @type {string} */ CSSProperties.prototype.webkitMarqueeRepetition;
+/** @type {string} */ CSSProperties.prototype.webkitMarqueeSpeed;
+/** @type {string} */ CSSProperties.prototype.webkitMarqueeStyle;
+/** @type {string} */ CSSProperties.prototype.webkitMask;
+/** @type {string} */ CSSProperties.prototype.webkitMaskAttachment;
+/** @type {string} */ CSSProperties.prototype.webkitMaskBoxImage;
+/** @type {string} */ CSSProperties.prototype.webkitMaskBoxImageOutset;
+/** @type {string} */ CSSProperties.prototype.webkitMaskBoxImageRepeat;
+/** @type {string} */ CSSProperties.prototype.webkitMaskBoxImageSlice;
+/** @type {string} */ CSSProperties.prototype.webkitMaskBoxImageSource;
+/** @type {string} */ CSSProperties.prototype.webkitMaskBoxImageWidth;
+/** @type {string} */ CSSProperties.prototype.webkitMaskClip;
+/** @type {string} */ CSSProperties.prototype.webkitMaskComposite;
+/** @type {string} */ CSSProperties.prototype.webkitMaskImage;
+/** @type {string} */ CSSProperties.prototype.webkitMaskOrigin;
+/** @type {string} */ CSSProperties.prototype.webkitMaskPosition;
+/** @type {string} */ CSSProperties.prototype.webkitMaskPositionX;
+/** @type {string} */ CSSProperties.prototype.webkitMaskPositionY;
+/** @type {string} */ CSSProperties.prototype.webkitMaskRepeat;
+/** @type {string} */ CSSProperties.prototype.webkitMaskRepeatX;
+/** @type {string} */ CSSProperties.prototype.webkitMaskRepeatY;
+/** @type {string} */ CSSProperties.prototype.webkitMaskSize;
+/** @type {string} */
+CSSProperties.prototype.webkitMatchNearestMailBlockquoteColor;
+/** @type {string} */ CSSProperties.prototype.webkitMaxLogicalHeight;
+/** @type {string} */ CSSProperties.prototype.webkitMaxLogicalWidth;
+/** @type {string} */ CSSProperties.prototype.webkitMinLogicalHeight;
+/** @type {string} */ CSSProperties.prototype.webkitMinLogicalWidth;
+/** @type {string} */ CSSProperties.prototype.webkitNbspMode;
+/** @type {string} */ CSSProperties.prototype.webkitOrder;
+/** @type {string} */ CSSProperties.prototype.webkitOverflowScrolling;
+/** @type {string} */ CSSProperties.prototype.webkitPaddingAfter;
+/** @type {string} */ CSSProperties.prototype.webkitPaddingBefore;
+/** @type {string} */ CSSProperties.prototype.webkitPaddingEnd;
+/** @type {string} */ CSSProperties.prototype.webkitPaddingStart;
+/** @type {string} */ CSSProperties.prototype.webkitPerspective;
+/** @type {string} */ CSSProperties.prototype.webkitPerspectiveOrigin;
+/** @type {string} */ CSSProperties.prototype.webkitPerspectiveOriginX;
+/** @type {string} */ CSSProperties.prototype.webkitPerspectiveOriginY;
+/** @type {string} */ CSSProperties.prototype.webkitPrintColorAdjust;
+/** @type {string} */ CSSProperties.prototype.webkitRegionBreakAfter;
+/** @type {string} */ CSSProperties.prototype.webkitRegionBreakBefore;
+/** @type {string} */ CSSProperties.prototype.webkitRegionBreakInside;
+/** @type {string} */ CSSProperties.prototype.webkitRegionOverflow;
+/** @type {string} */ CSSProperties.prototype.webkitRtlOrdering;
+/** @type {string} */ CSSProperties.prototype.webkitRubyPosition;
+/** @type {string} */ CSSProperties.prototype.webkitShapeInside;
+/** @type {string} */ CSSProperties.prototype.webkitShapeMargin;
+/** @type {string} */ CSSProperties.prototype.webkitShapeOutside;
+/** @type {string} */ CSSProperties.prototype.webkitShapePadding;
+/** @type {string} */ CSSProperties.prototype.webkitTapHighlightColor;
+/** @type {string} */ CSSProperties.prototype.webkitTextAlignLast;
+/** @type {string} */ CSSProperties.prototype.webkitTextCombine;
+/** @type {string} */ CSSProperties.prototype.webkitTextDecorationLine;
+/** @type {string} */ CSSProperties.prototype.webkitTextDecorationsInEffect;
+/** @type {string} */ CSSProperties.prototype.webkitTextDecorationStyle;
+/** @type {string} */ CSSProperties.prototype.webkitTextEmphasis;
+/** @type {string} */ CSSProperties.prototype.webkitTextEmphasisColor;
+/** @type {string} */ CSSProperties.prototype.webkitTextEmphasisPosition;
+/** @type {string} */ CSSProperties.prototype.webkitTextEmphasisStyle;
+/** @type {string} */ CSSProperties.prototype.webkitTextFillColor;
+/** @type {string} */ CSSProperties.prototype.webkitTextOrientation;
+/** @type {string} */ CSSProperties.prototype.webkitTextSecurity;
+/** @type {string} */ CSSProperties.prototype.webkitTextSizeAdjust;
+/** @type {string} */ CSSProperties.prototype.webkitTextStroke;
+/** @type {string} */ CSSProperties.prototype.webkitTextStrokeColor;
+/** @type {string} */ CSSProperties.prototype.webkitTextStrokeWidth;
+/** @type {string} */ CSSProperties.prototype.webkitTransform;
+/** @type {string} */ CSSProperties.prototype.webkitTransformOrigin;
+/** @type {string} */ CSSProperties.prototype.webkitTransformOriginX;
+/** @type {string} */ CSSProperties.prototype.webkitTransformOriginY;
+/** @type {string} */ CSSProperties.prototype.webkitTransformOriginZ;
+/** @type {string} */ CSSProperties.prototype.webkitTransformStyle;
+/** @type {string} */ CSSProperties.prototype.webkitTransition;
+/** @type {string} */ CSSProperties.prototype.webkitTransitionDelay;
+/** @type {string} */ CSSProperties.prototype.webkitTransitionDuration;
+/** @type {string} */ CSSProperties.prototype.webkitTransitionProperty;
+/** @type {string} */ CSSProperties.prototype.webkitTransitionRepeatCount;
+/** @type {string} */ CSSProperties.prototype.webkitTransitionTimingFunction;
+/** @type {string} */ CSSProperties.prototype.webkitUserDrag;
+/** @type {string} */ CSSProperties.prototype.webkitUserModify;
+/** @type {string} */ CSSProperties.prototype.webkitUserSelect;
+/** @type {string} */ CSSProperties.prototype.webkitWrap;
+/** @type {string} */ CSSProperties.prototype.webkitWrapFlow;
+/** @type {string} */ CSSProperties.prototype.webkitWrapThrough;
+/** @type {string} */ CSSProperties.prototype.webkitWritingMode;
+
+/**
+ * @constructor
+ * @param {number} x
+ * @param {number} y
+ */
+function WebKitPoint(x, y) {}
+
+/** @type {number} */
+WebKitPoint.prototype.x;
+
+/** @type {number} */
+WebKitPoint.prototype.y;

--- a/sdk/tests/deqp/temp_externs/webkit_dom.js
+++ b/sdk/tests/deqp/temp_externs/webkit_dom.js
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for all the extensions over W3C's DOM
+ *  specification by WebKit. This file depends on w3c_dom2.js.
+ *  All the provided definitions has been type annotated
+ *
+ * @externs
+ */
+
+
+/**
+ * @param {boolean=} opt_center
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=403510
+ */
+Element.prototype.scrollIntoViewIfNeeded = function(opt_center) {};
+
+/**
+ * @constructor
+ * @see http://trac.webkit.org/browser/trunk/Source/WebCore/page/MemoryInfo.idl
+ * @see http://trac.webkit.org/browser/trunk/Source/WebCore/page/MemoryInfo.cpp
+ */
+function MemoryInfo() {};
+
+/** @type {number} */
+MemoryInfo.prototype.totalJSHeapSize;
+
+/** @type {number} */
+MemoryInfo.prototype.usedJSHeapSize;
+
+/** @type {number} */
+MemoryInfo.prototype.jsHeapSizeLimit;
+
+/**
+ * @constructor
+ * @see http://trac.webkit.org/browser/trunk/Source/WebCore/inspector/ScriptProfileNode.idl
+ */
+function ScriptProfileNode() {};
+
+/** @type {string} */
+ScriptProfileNode.prototype.functionName;
+
+/** @type {string} */
+ScriptProfileNode.prototype.url;
+
+/** @type {number} */
+ScriptProfileNode.prototype.lineNumber;
+
+/** @type {number} */
+ScriptProfileNode.prototype.totalTime;
+
+/** @type {number} */
+ScriptProfileNode.prototype.selfTime;
+
+/** @type {number} */
+ScriptProfileNode.prototype.numberOfCalls;
+
+/** @type {Array.<ScriptProfileNode>} */
+ScriptProfileNode.prototype.children;
+
+/** @type {boolean} */
+ScriptProfileNode.prototype.visible;
+
+/** @type {number} */
+ScriptProfileNode.prototype.callUID;
+
+/**
+ * @constructor
+ * @see http://trac.webkit.org/browser/trunk/Source/WebCore/inspector/ScriptProfile.idl
+ */
+function ScriptProfile() {};
+
+/** @type {string} */
+ScriptProfile.prototype.title;
+
+/** @type {number} */
+ScriptProfile.prototype.uid;
+
+/** @type {ScriptProfileNode} */
+ScriptProfile.prototype.head;
+
+/**
+ * @constructor
+ * @see http://trac.webkit.org/browser/trunk/Source/WebCore/page/Console.idl
+ * @see http://trac.webkit.org/browser/trunk/Source/WebCore/page/Console.cpp
+ */
+function Console() {};
+
+/**
+ * @param {*} condition
+ * @param {...*} var_args
+ */
+Console.prototype.assert = function(condition, var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.error = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.info = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.log = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.warn = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.debug = function(var_args) {};
+
+/**
+ * @param {*} value
+ */
+Console.prototype.dir = function(value) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.dirxml = function(var_args) {};
+
+/**
+ * @param {!Object} data
+ * @param {*=} opt_columns
+ */
+Console.prototype.table = function(data, opt_columns) {};
+
+/**
+ * @return {undefined}
+ */
+Console.prototype.trace = function() {};
+
+/**
+ * @param {*} value
+ */
+Console.prototype.count = function(value) {};
+
+/**
+ * @param {*} value
+ */
+Console.prototype.markTimeline = function(value) {};
+
+/**
+ * @param {string=} opt_title
+ */
+Console.prototype.profile = function(opt_title) {};
+
+/** @type {Array.<ScriptProfile>} */
+Console.prototype.profiles;
+
+/**
+ * @param {string=} opt_title
+ */
+Console.prototype.profileEnd = function(opt_title) {};
+
+/**
+ * @param {string} name
+ */
+Console.prototype.time = function(name) {};
+
+/**
+ * @param {string} name
+ */
+Console.prototype.timeEnd = function(name) {};
+
+/**
+ * @param {*} value
+ */
+Console.prototype.timeStamp = function(value) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.group = function(var_args) {};
+
+/**
+ * @param {...*} var_args
+ */
+Console.prototype.groupCollapsed = function(var_args) {};
+
+Console.prototype.groupEnd = function() {};
+
+Console.prototype.clear = function() {};
+
+/** @type {MemoryInfo} */
+Console.prototype.memory;
+
+/** @type {!Console} */
+Window.prototype.console;
+
+/**
+ * @type {!Console}
+ * @suppress {duplicate}
+ */
+var console;
+
+/**
+ * @type {number}
+ * @see http://developer.android.com/reference/android/webkit/WebView.html
+ */
+Window.prototype.devicePixelRatio;
+
+/** @type {Node} */
+Selection.prototype.baseNode;
+
+/** @type {number} */
+Selection.prototype.baseOffset;
+
+/** @type {Node} */
+Selection.prototype.extentNode;
+
+/** @type {number} */
+Selection.prototype.extentOffset;
+
+/** @type {string} */
+Selection.prototype.type;
+
+/**
+ * @return {undefined}
+ */
+Selection.prototype.empty = function() {};
+
+/**
+ * @param {Node} baseNode
+ * @param {number} baseOffset
+ * @param {Node} extentNode
+ * @param {number} extentOffset
+ * @return {undefined}
+ */
+Selection.prototype.setBaseAndExtent =
+ function(baseNode, baseOffset, extentNode, extentOffset) {};
+
+/**
+ * @param {string} alter
+ * @param {string} direction
+ * @param {string} granularity
+ * @return {undefined}
+ */
+Selection.prototype.modify = function(alter, direction, granularity) {};
+
+/**
+ * @param {Element} element
+ * @param {string} pseudoElement
+ * @param {boolean=} opt_authorOnly
+ * @return {CSSRuleList}
+ * @nosideeffects
+ */
+ViewCSS.prototype.getMatchedCSSRules =
+    function(element, pseudoElement, opt_authorOnly) {};
+
+/**
+ * @param {string} contextId
+ * @param {string} name
+ * @param {number} width
+ * @param {number} height
+ * @nosideeffects
+ */
+Document.prototype.getCSSCanvasContext =
+    function(contextId, name, width, height) {};

--- a/sdk/tests/deqp/temp_externs/webkit_event.js
+++ b/sdk/tests/deqp/temp_externs/webkit_event.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2009 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Definitions for all the extensions over W3C's
+ *  event specification by WebKit. This file depends on w3c_event.js.
+ *  All the provided definitions have been type annotated
+ *
+ * @externs
+ */
+
+/** @type {number} */
+Event.prototype.wheelDeltaX;
+
+/** @type {number} */
+Event.prototype.wheelDeltaY;
+
+/**
+ * @constructor
+ * @extends {Event}
+ * @see http://developer.apple.com/library/safari/documentation/AudioVideo/Reference/WebKitAnimationEventClassReference/WebKitAnimationEvent/WebKitAnimationEvent.html
+ */
+function WebKitAnimationEvent() {}
+
+/**
+ * @type {string}
+ * @const
+ */
+WebKitAnimationEvent.prototype.animationName;
+
+/**
+ * @type {number}
+ * @const
+ */
+WebKitAnimationEvent.prototype.elapsedTime;

--- a/sdk/tests/deqp/temp_externs/webkit_notifications.js
+++ b/sdk/tests/deqp/temp_externs/webkit_notifications.js
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2010 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for W3C's Notifications specification.
+ * @externs
+ */
+
+/**
+ * @typedef {{dir: (string|undefined), lang: (string|undefined),
+ *            body: (string|undefined), tag: (string|undefined),
+ *            icon: (string|undefined)}}
+ * @see http://notifications.spec.whatwg.org/#notificationoptions
+ */
+var NotificationOptions;
+
+/** @interface */
+var NotificationOptionsInterface_;
+/** @type {string} */ NotificationOptionsInterface_.prototype.dir;
+/** @type {string} */ NotificationOptionsInterface_.prototype.lang;
+/** @type {string} */ NotificationOptionsInterface_.prototype.body;
+/** @type {string} */ NotificationOptionsInterface_.prototype.tag;
+/** @type {string} */ NotificationOptionsInterface_.prototype.icon;
+
+/**
+ * @param {string} title
+ * @param {NotificationOptions=} opt_options
+ * @constructor
+ * @implements {EventTarget}
+ * @see http://notifications.spec.whatwg.org/#notification
+ */
+function Notification(title, opt_options) {}
+
+/**
+ * @type {string}
+ */
+Notification.permission;
+
+/**
+ * @param {NotificationPermissionCallback=} opt_callback
+ */
+Notification.requestPermission = function(opt_callback) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Notification.prototype.addEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/**
+ * @param {boolean=} opt_useCapture
+ * @override
+ */
+Notification.prototype.removeEventListener =
+    function(type, listener, opt_useCapture) {};
+
+/** @override */
+Notification.prototype.dispatchEvent = function(evt) {};
+
+/**
+ * The ID used by clients to uniquely identify notifications to eliminate
+ * duplicate notifications.
+ * @type {string}
+ * @deprecated Use NotificationOptions.tag instead.
+ */
+Notification.prototype.replaceId;
+
+/**
+ * The string used by clients to specify the directionality (rtl/ltr) of the
+ * notification.
+ * @type {string}
+ * @deprecated Use NotificationOptions.titleDir and bodyDir instead.
+ */
+Notification.prototype.dir;
+
+/**
+ * Displays the notification.
+ */
+Notification.prototype.show = function() {};
+
+/**
+ * Prevents the notification from being displayed, or closes it if it is already
+ * displayed.
+ */
+Notification.prototype.cancel = function() {};
+
+/**
+ * Prevents the notification from being displayed, or closes it if it is already
+ * displayed.
+ */
+Notification.prototype.close = function() {};
+
+/**
+ * An event handler called when notification is closed.
+ * @type {?function(Event)}
+ */
+Notification.prototype.onclose;
+
+/**
+ * An event handler called if the notification could not be displayed due to
+ * an error (i.e. resource could not be loaded).
+ * @type {?function(Event)}
+ */
+Notification.prototype.onerror;
+
+/**
+ * An event handler called when the notification has become visible.
+ * @type {?function(Event)}
+ * @deprecated Use onshow instead.
+ */
+Notification.prototype.ondisplay;
+
+/**
+ * An event handler called when the notification has become visible.
+ * @type {?function(Event)}
+ */
+Notification.prototype.onshow;
+
+/**
+ * An event handler called when the notification has been clicked on.
+ * @type {?function(Event)}
+ */
+Notification.prototype.onclick;
+
+/**
+ * @constructor
+ */
+window.Notification = Notification;
+
+/**
+ * @type {string}
+ */
+window.Notification.permission;
+
+/**
+ * @param {NotificationPermissionCallback=} opt_callback
+ */
+window.Notification.requestPermission = function(opt_callback) {};
+
+/**
+ * @typedef {function(string)}
+ * @see http://notifications.spec.whatwg.org/#notificationpermissioncallback
+ */
+var NotificationPermissionCallback;
+
+/**
+ * @constructor
+ * @see http://dev.w3.org/2006/webapi/WebNotifications/publish/#dialog-if
+ * @deprecated Use Notification instead.
+ */
+function NotificationCenter() {}
+
+/**
+ * Creates a text+icon notification and displays it to the user.
+ * @param {string} iconUrl
+ * @param {string} title
+ * @param {string} body
+ * @return {Notification}
+ */
+NotificationCenter.prototype.createNotification =
+    function(iconUrl, title, body) {};
+
+/**
+ * Creates an HTML notification and displays it to the user.
+ * @param {string} url
+ * @return {Notification}
+ */
+NotificationCenter.prototype.createHTMLNotification = function(url) {};
+
+/**
+ * Checks if the user has permission to display notifications.
+ * @return {number}
+ */
+NotificationCenter.prototype.checkPermission = function() {};
+
+/**
+ * Requests permission from the user to display notifications.
+ * @param {Function=} opt_callback
+ * @return {void}
+ */
+NotificationCenter.prototype.requestPermission = function(opt_callback) {};
+
+/**
+ * WebKit browsers expose the NotificationCenter API through
+ * window.webkitNotifications.
+ * @type {NotificationCenter}
+ */
+Window.prototype.webkitNotifications;

--- a/sdk/tests/deqp/temp_externs/webstorage.js
+++ b/sdk/tests/deqp/temp_externs/webstorage.js
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2009 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @fileoverview Definitions for W3C's WebStorage specification.
+ * This file depends on html5.js.
+ * @externs
+ */
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/2011/CR-webstorage-20111208/#the-storage-interface
+ */
+function Storage() {}
+
+/**
+ * @type {number}
+ * @const
+ */
+Storage.prototype.length;
+
+/**
+ * @param {number} index
+ * @return {?string}
+ */
+Storage.prototype.key = function(index) {};
+
+/**
+ * @param {string} key
+ * @return {?string}
+ */
+Storage.prototype.getItem = function(key) {};
+
+/**
+ * @param {string} key
+ * @param {string} data
+ * @return {void}
+ */
+Storage.prototype.setItem = function(key, data) {};
+
+/**
+ * @param {string} key
+ * @return {void}
+ */
+Storage.prototype.removeItem = function(key) {};
+
+/**
+ * @return {void}
+ */
+Storage.prototype.clear = function() {};
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/2011/CR-webstorage-20111208/#the-sessionstorage-attribute
+ */
+function WindowSessionStorage() {}
+
+/**
+ * @type {Storage}
+ */
+WindowSessionStorage.prototype.sessionStorage;
+
+/**
+ * Window implements WindowSessionStorage
+ *
+ * @type {Storage}
+ */
+Window.prototype.sessionStorage;
+
+/**
+ * @interface
+ * @see http://www.w3.org/TR/2011/CR-webstorage-20111208/#the-localstorage-attribute
+ */
+function WindowLocalStorage() {}
+
+/**
+ * @type {Storage}
+ */
+WindowLocalStorage.prototype.localStorage;
+
+/**
+ * Window implements WindowLocalStorage
+ *
+ * @type {Storage}
+ */
+Window.prototype.localStorage;
+
+/**
+ * This is the storage event interface.
+ * @see http://www.w3.org/TR/2011/CR-webstorage-20111208/#the-storage-event
+ * @extends {Event}
+ * @constructor
+ */
+function StorageEvent() {}
+
+/**
+ * @type {string}
+ */
+StorageEvent.prototype.key;
+
+/**
+ * @type {?string}
+ */
+StorageEvent.prototype.oldValue;
+
+/**
+ * @type {?string}
+ */
+StorageEvent.prototype.newValue;
+
+/**
+ * @type {string}
+ */
+StorageEvent.prototype.url;
+
+/**
+ * @type {?Storage}
+ */
+StorageEvent.prototype.storageArea;
+
+/**
+ * @param {string} typeArg
+ * @param {boolean} canBubbleArg
+ * @param {boolean} cancelableArg
+ * @param {string} keyArg
+ * @param {?string} oldValueArg
+ * @param {?string} newValueArg
+ * @param {string} urlArg
+ * @param {?Storage} storageAreaArg
+ * @return {void}
+ */
+StorageEvent.prototype.initStorageEvent = function(typeArg, canBubbleArg,
+                                                   cancelableArg, keyArg,
+                                                   oldValueArg, newValueArg,
+                                                   urlArg, storageAreaArg) {};
+

--- a/sdk/tests/deqp/temp_externs/window.js
+++ b/sdk/tests/deqp/temp_externs/window.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2008 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview JavaScript Built-Ins for windows properties.
+ *
+ * @externs
+ * @author stevey@google.com (Steve Yegge)
+ */
+
+// Window properties
+// Only common properties are here.  Others such as open()
+// should be used with an explicit Window object.
+
+/**
+ * @type {!Window}
+ * @see https://developer.mozilla.org/en/DOM/window.top
+ * @const
+ */
+var top;
+
+/**
+ * @type {Navigator}
+ * @see https://developer.mozilla.org/en/DOM/window.navigator
+ * @const
+ */
+var navigator;
+
+/**
+ * @type {!HTMLDocument}
+ * @see https://developer.mozilla.org/en/DOM/window.document
+ * @const
+ */
+var document;
+
+/**
+ * @type {Location}
+ * @see https://developer.mozilla.org/en/DOM/window.location
+ * @const
+ * @suppress {duplicate}
+ * @implicitCast
+ */
+var location;
+
+/**
+ * @type {!Screen}
+ * @see https://developer.mozilla.org/En/DOM/window.screen
+ * @const
+ */
+var screen;
+
+/**
+ * @type {!Window}
+ * @see https://developer.mozilla.org/En/DOM/Window.self
+ * @const
+ */
+var self;
+
+// Magic functions for Firefox's LiveConnect.
+// We'll probably never use these in practice. But redefining them
+// will fire up the JVM, so we want to reserve the symbol names.
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/JavaArray
+ */
+var JavaArray;
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/JavaClass
+ */
+var JavaClass;
+
+// We just ripped this from the FF source; it doesn't appear to be
+// publicly documented.
+var JavaMember;
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/JavaObject
+ */
+var JavaObject;
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/JavaPackage
+ */
+var JavaPackage;
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Packages
+ */
+var Packages;
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/java
+ */
+var java;
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/netscape
+ */
+var netscape;
+
+/**
+ * @see https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/sun
+ */
+var sun;
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/window.alert
+ */
+function alert(x) {}
+
+/**
+ * @param {number|undefined|null} immediateID
+ * @see https://developer.mozilla.org/en-US/docs/DOM/window.clearImmediate
+ * @see http://msdn.microsoft.com/en-us/library/ie/hh924825(v=vs.85).aspx
+ */
+function clearImmediate(immediateID) {}
+
+/**
+ * @param {number|undefined?} intervalID
+ * @see https://developer.mozilla.org/en/DOM/window.clearInterval
+ * @suppress {duplicate}
+ */
+function clearInterval(intervalID) {}
+
+/**
+ * @param {number|undefined?} timeoutID
+ * @see https://developer.mozilla.org/en/DOM/window.clearTimeout
+ * @suppress {duplicate}
+ */
+function clearTimeout(timeoutID) {}
+
+/**
+ * @param {*} message
+ * @return {boolean}
+ * @see https://developer.mozilla.org/en/DOM/window.confirm
+ */
+function confirm(message) {}
+
+/**
+ * @see https://developer.mozilla.org/en/DOM/window.dump
+ */
+function dump(x) {}
+
+/**
+ * @param {string} message
+ * @param {string=} opt_value
+ * @return {?string}
+ * @see https://developer.mozilla.org/en/DOM/window.prompt
+ */
+function prompt(message, opt_value) {}
+
+/**
+ * @param {function()} callback
+ * @return {number}
+ * @see https://developer.mozilla.org/en-US/docs/DOM/window.setImmediate
+ * @see http://msdn.microsoft.com/en-us/library/ie/hh773176(v=vs.85).aspx
+ */
+function setImmediate(callback) {}
+
+/**
+ * @param {Function|string} callback
+ * @param {number=} opt_delay
+ * @return {number}
+ * @see https://developer.mozilla.org/en/DOM/window.setInterval
+ * @see https://html.spec.whatwg.org/multipage/webappapis.html#timers
+ */
+function setInterval(callback, opt_delay) {}
+
+/**
+ * @param {Function|string} callback
+ * @param {number=} opt_delay
+ * @param {...*} var_args
+ * @return {number}
+ * @see https://developer.mozilla.org/en/DOM/window.setTimeout
+ * @see https://html.spec.whatwg.org/multipage/webappapis.html#timers
+ */
+function setTimeout(callback, opt_delay, var_args) {}

--- a/sdk/tests/deqp/test-webgl2.js
+++ b/sdk/tests/deqp/test-webgl2.js
@@ -1,0 +1,2 @@
+/** @type {WebGL2RenderingContext} */ var myContext;
+console.log(myContext.READ_BUFFER);

--- a/sdk/tests/deqp/test-webgl2.js
+++ b/sdk/tests/deqp/test-webgl2.js
@@ -1,2 +1,4 @@
 /** @type {WebGL2RenderingContext} */ var myContext;
 console.log(myContext.READ_BUFFER);
+// See whether WebGL 1.0 properties are correctly type checked.
+console.log(myContext.DEPTH_BUFFER_BIT);

--- a/sdk/tests/deqp/test-webgl2.sh
+++ b/sdk/tests/deqp/test-webgl2.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+: ${JAVA:=java}
+
+# Temporary shell script to help shake out the bugs to webgl2.js until
+# it's folded back into the Closure workspace.
+$JAVA -jar ../../../../closure/compiler.jar \
+  --use_only_custom_externs \
+  --js test-webgl2.js \
+  --externs temp_externs/chrome.js \
+  --externs temp_externs/deprecated.js \
+  --externs temp_externs/es3.js \
+  --externs temp_externs/es5.js \
+  --externs temp_externs/es6.js \
+  --externs temp_externs/es6_collections.js \
+  --externs temp_externs/fileapi.js \
+  --externs temp_externs/flash.js \
+  --externs temp_externs/gecko_css.js \
+  --externs temp_externs/gecko_dom.js \
+  --externs temp_externs/gecko_event.js \
+  --externs temp_externs/gecko_xml.js \
+  --externs temp_externs/google.js \
+  --externs temp_externs/html5.js \
+  --externs temp_externs/ie_css.js \
+  --externs temp_externs/ie_dom.js \
+  --externs temp_externs/ie_event.js \
+  --externs temp_externs/ie_vml.js \
+  --externs temp_externs/intl.js \
+  --externs temp_externs/iphone.js \
+  --externs temp_externs/mediasource.js \
+  --externs temp_externs/page_visibility.js \
+  --externs temp_externs/v8.js \
+  --externs temp_externs/w3c_anim_timing.js \
+  --externs temp_externs/w3c_css.js \
+  --externs temp_externs/w3c_css3d.js \
+  --externs temp_externs/w3c_device_sensor_event.js \
+  --externs temp_externs/w3c_dom1.js \
+  --externs temp_externs/w3c_dom2.js \
+  --externs temp_externs/w3c_dom3.js \
+  --externs temp_externs/w3c_elementtraversal.js \
+  --externs temp_externs/w3c_encoding.js \
+  --externs temp_externs/w3c_event.js \
+  --externs temp_externs/w3c_event3.js \
+  --externs temp_externs/w3c_geolocation.js \
+  --externs temp_externs/w3c_indexeddb.js \
+  --externs temp_externs/w3c_navigation_timing.js \
+  --externs temp_externs/w3c_range.js \
+  --externs temp_externs/w3c_rtc.js \
+  --externs temp_externs/w3c_selectors.js \
+  --externs temp_externs/w3c_xml.js \
+  --externs temp_externs/webkit_css.js \
+  --externs temp_externs/webkit_dom.js \
+  --externs temp_externs/webkit_event.js \
+  --externs temp_externs/webkit_notifications.js \
+  --externs temp_externs/webstorage.js \
+  --externs temp_externs/window.js \
+  --externs webgl2.js \
+  --compilation_level ADVANCED \
+  --warning_level VERBOSE \
+  --js_output_file /dev/null

--- a/sdk/tests/deqp/webgl2.js
+++ b/sdk/tests/deqp/webgl2.js
@@ -1,0 +1,5595 @@
+/*
+ * Copyright 2010 The Closure Compiler Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WebGL 2.0 portions:
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+/**
+ * @fileoverview Definitions for WebGL functions as described at
+ * http://www.khronos.org/registry/webgl/specs/latest/1.0 and
+ * http://www.khronos.org/registry/webgl/specs/latest/2.0
+ *
+ * This file is current up to the WebGL 2.0 spec, including extensions.
+ *
+ * This relies on html5.js being included for Canvas and Typed Array support.
+ *
+ * This includes some extensions defined at
+ * http://www.khronos.org/registry/webgl/extensions/
+ *
+ * This file will be merged back into the Closure workspace as soon as
+ * the WebGL 2.0 changes have been fully tested.
+ *
+ * @externs
+ */
+
+/**
+ * @constructor
+ * @noalias
+ * @private
+ */
+function WebGLRenderingContextBase() {}
+
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_BUFFER_BIT;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BUFFER_BIT;
+
+/** @type {number} */
+WebGLRenderingContextBase.COLOR_BUFFER_BIT;
+
+/** @type {number} */
+WebGLRenderingContextBase.POINTS;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINES;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINE_LOOP;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINE_STRIP;
+
+/** @type {number} */
+WebGLRenderingContextBase.TRIANGLES;
+
+/** @type {number} */
+WebGLRenderingContextBase.TRIANGLE_STRIP;
+
+/** @type {number} */
+WebGLRenderingContextBase.TRIANGLE_FAN;
+
+/** @type {number} */
+WebGLRenderingContextBase.ZERO;
+
+/** @type {number} */
+WebGLRenderingContextBase.ONE;
+
+/** @type {number} */
+WebGLRenderingContextBase.SRC_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.ONE_MINUS_SRC_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.SRC_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.ONE_MINUS_SRC_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.DST_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.ONE_MINUS_DST_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.DST_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.ONE_MINUS_DST_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.SRC_ALPHA_SATURATE;
+
+/** @type {number} */
+WebGLRenderingContextBase.FUNC_ADD;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_EQUATION;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_EQUATION_RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_EQUATION_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.FUNC_SUBTRACT;
+
+/** @type {number} */
+WebGLRenderingContextBase.FUNC_REVERSE_SUBTRACT;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_DST_RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_SRC_RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_DST_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_SRC_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.CONSTANT_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.ONE_MINUS_CONSTANT_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.CONSTANT_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.ONE_MINUS_CONSTANT_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.ARRAY_BUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.ELEMENT_ARRAY_BUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.ARRAY_BUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.ELEMENT_ARRAY_BUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.STREAM_DRAW;
+
+/** @type {number} */
+WebGLRenderingContextBase.STATIC_DRAW;
+
+/** @type {number} */
+WebGLRenderingContextBase.DYNAMIC_DRAW;
+
+/** @type {number} */
+WebGLRenderingContextBase.BUFFER_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.BUFFER_USAGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.CURRENT_VERTEX_ATTRIB;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRONT;
+
+/** @type {number} */
+WebGLRenderingContextBase.BACK;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRONT_AND_BACK;
+
+/** @type {number} */
+WebGLRenderingContextBase.CULL_FACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLEND;
+
+/** @type {number} */
+WebGLRenderingContextBase.DITHER;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_TEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_TEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.SCISSOR_TEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.POLYGON_OFFSET_FILL;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLE_ALPHA_TO_COVERAGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLE_COVERAGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.NO_ERROR;
+
+/** @type {number} */
+WebGLRenderingContextBase.INVALID_ENUM;
+
+/** @type {number} */
+WebGLRenderingContextBase.INVALID_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.INVALID_OPERATION;
+
+/** @type {number} */
+WebGLRenderingContextBase.OUT_OF_MEMORY;
+
+/** @type {number} */
+WebGLRenderingContextBase.CW;
+
+/** @type {number} */
+WebGLRenderingContextBase.CCW;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINE_WIDTH;
+
+/** @type {number} */
+WebGLRenderingContextBase.ALIASED_POINT_SIZE_RANGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.ALIASED_LINE_WIDTH_RANGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.CULL_FACE_MODE;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRONT_FACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_RANGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_CLEAR_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_FUNC;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_CLEAR_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_FUNC;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_PASS_DEPTH_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_PASS_DEPTH_PASS;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_REF;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_VALUE_MASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BACK_FUNC;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BACK_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BACK_PASS_DEPTH_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BACK_PASS_DEPTH_PASS;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BACK_REF;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BACK_VALUE_MASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BACK_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.VIEWPORT;
+
+/** @type {number} */
+WebGLRenderingContextBase.SCISSOR_BOX;
+
+/** @type {number} */
+WebGLRenderingContextBase.COLOR_CLEAR_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.COLOR_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNPACK_ALIGNMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.PACK_ALIGNMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_TEXTURE_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_VIEWPORT_DIMS;
+
+/** @type {number} */
+WebGLRenderingContextBase.SUBPIXEL_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.RED_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.GREEN_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.BLUE_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.ALPHA_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.POLYGON_OFFSET_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.POLYGON_OFFSET_FACTOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_BINDING_2D;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLE_BUFFERS;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLES;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLE_COVERAGE_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLE_COVERAGE_INVERT;
+
+/** @type {number} */
+WebGLRenderingContextBase.COMPRESSED_TEXTURE_FORMATS;
+
+/** @type {number} */
+WebGLRenderingContextBase.DONT_CARE;
+
+/** @type {number} */
+WebGLRenderingContextBase.FASTEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.NICEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.GENERATE_MIPMAP_HINT;
+
+/** @type {number} */
+WebGLRenderingContextBase.BYTE;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNSIGNED_BYTE;
+
+/** @type {number} */
+WebGLRenderingContextBase.SHORT;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNSIGNED_SHORT;
+
+/** @type {number} */
+WebGLRenderingContextBase.INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNSIGNED_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_COMPONENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.RGBA;
+
+/** @type {number} */
+WebGLRenderingContextBase.LUMINANCE;
+
+/** @type {number} */
+WebGLRenderingContextBase.LUMINANCE_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNSIGNED_SHORT_4_4_4_4;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNSIGNED_SHORT_5_5_5_1;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNSIGNED_SHORT_5_6_5;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAGMENT_SHADER;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_SHADER;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_VERTEX_ATTRIBS;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_VERTEX_UNIFORM_VECTORS;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_VARYING_VECTORS;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_COMBINED_TEXTURE_IMAGE_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_VERTEX_TEXTURE_IMAGE_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_TEXTURE_IMAGE_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_FRAGMENT_UNIFORM_VECTORS;
+
+/** @type {number} */
+WebGLRenderingContextBase.SHADER_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.DELETE_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINK_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.VALIDATE_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.ATTACHED_SHADERS;
+
+/** @type {number} */
+WebGLRenderingContextBase.ACTIVE_UNIFORMS;
+
+/** @type {number} */
+WebGLRenderingContextBase.ACTIVE_ATTRIBUTES;
+
+/** @type {number} */
+WebGLRenderingContextBase.SHADING_LANGUAGE_VERSION;
+
+/** @type {number} */
+WebGLRenderingContextBase.CURRENT_PROGRAM;
+
+/** @type {number} */
+WebGLRenderingContextBase.NEVER;
+
+/** @type {number} */
+WebGLRenderingContextBase.LESS;
+
+/** @type {number} */
+WebGLRenderingContextBase.EQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.LEQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.GREATER;
+
+/** @type {number} */
+WebGLRenderingContextBase.NOTEQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.GEQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.ALWAYS;
+
+/** @type {number} */
+WebGLRenderingContextBase.KEEP;
+
+/** @type {number} */
+WebGLRenderingContextBase.REPLACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.INCR;
+
+/** @type {number} */
+WebGLRenderingContextBase.DECR;
+
+/** @type {number} */
+WebGLRenderingContextBase.INVERT;
+
+/** @type {number} */
+WebGLRenderingContextBase.INCR_WRAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.DECR_WRAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.VENDOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERER;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERSION;
+
+/** @type {number} */
+WebGLRenderingContextBase.NEAREST;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINEAR;
+
+/** @type {number} */
+WebGLRenderingContextBase.NEAREST_MIPMAP_NEAREST;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINEAR_MIPMAP_NEAREST;
+
+/** @type {number} */
+WebGLRenderingContextBase.NEAREST_MIPMAP_LINEAR;
+
+/** @type {number} */
+WebGLRenderingContextBase.LINEAR_MIPMAP_LINEAR;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_MAG_FILTER;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_MIN_FILTER;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_WRAP_S;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_WRAP_T;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_2D;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_CUBE_MAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_BINDING_CUBE_MAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_CUBE_MAP_POSITIVE_X;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_CUBE_MAP_NEGATIVE_X;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_CUBE_MAP_POSITIVE_Y;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_CUBE_MAP_NEGATIVE_Y;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_CUBE_MAP_POSITIVE_Z;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE_CUBE_MAP_NEGATIVE_Z;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_CUBE_MAP_TEXTURE_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE0;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE1;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE2;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE3;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE4;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE5;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE6;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE7;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE8;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE9;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE10;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE11;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE12;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE13;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE14;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE15;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE16;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE17;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE18;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE19;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE20;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE21;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE22;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE23;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE24;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE25;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE26;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE27;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE28;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE29;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE30;
+
+/** @type {number} */
+WebGLRenderingContextBase.TEXTURE31;
+
+/** @type {number} */
+WebGLRenderingContextBase.ACTIVE_TEXTURE;
+
+/** @type {number} */
+WebGLRenderingContextBase.REPEAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.CLAMP_TO_EDGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.MIRRORED_REPEAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.FLOAT_VEC2;
+
+/** @type {number} */
+WebGLRenderingContextBase.FLOAT_VEC3;
+
+/** @type {number} */
+WebGLRenderingContextBase.FLOAT_VEC4;
+
+/** @type {number} */
+WebGLRenderingContextBase.INT_VEC2;
+
+/** @type {number} */
+WebGLRenderingContextBase.INT_VEC3;
+
+/** @type {number} */
+WebGLRenderingContextBase.INT_VEC4;
+
+/** @type {number} */
+WebGLRenderingContextBase.BOOL;
+
+/** @type {number} */
+WebGLRenderingContextBase.BOOL_VEC2;
+
+/** @type {number} */
+WebGLRenderingContextBase.BOOL_VEC3;
+
+/** @type {number} */
+WebGLRenderingContextBase.BOOL_VEC4;
+
+/** @type {number} */
+WebGLRenderingContextBase.FLOAT_MAT2;
+
+/** @type {number} */
+WebGLRenderingContextBase.FLOAT_MAT3;
+
+/** @type {number} */
+WebGLRenderingContextBase.FLOAT_MAT4;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLER_2D;
+
+/** @type {number} */
+WebGLRenderingContextBase.SAMPLER_CUBE;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_ATTRIB_ARRAY_ENABLED;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_ATTRIB_ARRAY_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_ATTRIB_ARRAY_STRIDE;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_ATTRIB_ARRAY_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_ATTRIB_ARRAY_NORMALIZED;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_ATTRIB_ARRAY_POINTER;
+
+/** @type {number} */
+WebGLRenderingContextBase.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.IMPLEMENTATION_COLOR_READ_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.IMPLEMENTATION_COLOR_READ_FORMAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.COMPILE_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.LOW_FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.MEDIUM_FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.HIGH_FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.LOW_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.MEDIUM_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.HIGH_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.RGBA4;
+
+/** @type {number} */
+WebGLRenderingContextBase.RGB5_A1;
+
+/** @type {number} */
+WebGLRenderingContextBase.RGB565;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_COMPONENT16;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_INDEX;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_INDEX8;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_STENCIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_WIDTH;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_HEIGHT;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_INTERNAL_FORMAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_RED_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_GREEN_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_BLUE_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_ALPHA_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_DEPTH_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_STENCIL_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.COLOR_ATTACHMENT0;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.STENCIL_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.DEPTH_STENCIL_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.NONE;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_COMPLETE;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_INCOMPLETE_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_INCOMPLETE_DIMENSIONS;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_UNSUPPORTED;
+
+/** @type {number} */
+WebGLRenderingContextBase.FRAMEBUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.RENDERBUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.MAX_RENDERBUFFER_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.INVALID_FRAMEBUFFER_OPERATION;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNPACK_FLIP_Y_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNPACK_PREMULTIPLY_ALPHA_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.CONTEXT_LOST_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.UNPACK_COLORSPACE_CONVERSION_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.BROWSER_DEFAULT_WEBGL;
+
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_BUFFER_BIT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BUFFER_BIT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.COLOR_BUFFER_BIT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.POINTS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINES;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINE_LOOP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINE_STRIP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TRIANGLES;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TRIANGLE_STRIP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TRIANGLE_FAN;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ZERO;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ONE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SRC_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ONE_MINUS_SRC_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SRC_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ONE_MINUS_SRC_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DST_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ONE_MINUS_DST_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DST_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ONE_MINUS_DST_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SRC_ALPHA_SATURATE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FUNC_ADD;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_EQUATION;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_EQUATION_RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_EQUATION_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FUNC_SUBTRACT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FUNC_REVERSE_SUBTRACT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_DST_RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_SRC_RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_DST_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_SRC_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CONSTANT_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ONE_MINUS_CONSTANT_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CONSTANT_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ONE_MINUS_CONSTANT_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND_COLOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ARRAY_BUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ELEMENT_ARRAY_BUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ARRAY_BUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ELEMENT_ARRAY_BUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STREAM_DRAW;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STATIC_DRAW;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DYNAMIC_DRAW;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BUFFER_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BUFFER_USAGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CURRENT_VERTEX_ATTRIB;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRONT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BACK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRONT_AND_BACK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CULL_FACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLEND;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DITHER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_TEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_TEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SCISSOR_TEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.POLYGON_OFFSET_FILL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLE_ALPHA_TO_COVERAGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLE_COVERAGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NO_ERROR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INVALID_ENUM;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INVALID_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INVALID_OPERATION;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.OUT_OF_MEMORY;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CW;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CCW;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINE_WIDTH;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ALIASED_POINT_SIZE_RANGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ALIASED_LINE_WIDTH_RANGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CULL_FACE_MODE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRONT_FACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_RANGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_CLEAR_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_FUNC;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_CLEAR_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_FUNC;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_PASS_DEPTH_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_PASS_DEPTH_PASS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_REF;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_VALUE_MASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BACK_FUNC;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BACK_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BACK_PASS_DEPTH_FAIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BACK_PASS_DEPTH_PASS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BACK_REF;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BACK_VALUE_MASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BACK_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VIEWPORT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SCISSOR_BOX;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.COLOR_CLEAR_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.COLOR_WRITEMASK;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNPACK_ALIGNMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.PACK_ALIGNMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_TEXTURE_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_VIEWPORT_DIMS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SUBPIXEL_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RED_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.GREEN_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BLUE_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ALPHA_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_BITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.POLYGON_OFFSET_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.POLYGON_OFFSET_FACTOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_BINDING_2D;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLE_BUFFERS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLES;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLE_COVERAGE_VALUE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLE_COVERAGE_INVERT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.COMPRESSED_TEXTURE_FORMATS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DONT_CARE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FASTEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NICEST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.GENERATE_MIPMAP_HINT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BYTE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNSIGNED_BYTE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SHORT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNSIGNED_SHORT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNSIGNED_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_COMPONENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RGB;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RGBA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LUMINANCE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LUMINANCE_ALPHA;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNSIGNED_SHORT_4_4_4_4;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNSIGNED_SHORT_5_5_5_1;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNSIGNED_SHORT_5_6_5;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAGMENT_SHADER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_SHADER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_VERTEX_ATTRIBS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_VERTEX_UNIFORM_VECTORS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_VARYING_VECTORS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_COMBINED_TEXTURE_IMAGE_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_VERTEX_TEXTURE_IMAGE_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_TEXTURE_IMAGE_UNITS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_FRAGMENT_UNIFORM_VECTORS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SHADER_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DELETE_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINK_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VALIDATE_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ATTACHED_SHADERS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ACTIVE_UNIFORMS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ACTIVE_ATTRIBUTES;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SHADING_LANGUAGE_VERSION;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CURRENT_PROGRAM;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NEVER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LESS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.EQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LEQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.GREATER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NOTEQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.GEQUAL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ALWAYS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.KEEP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.REPLACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INCR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DECR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INVERT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INCR_WRAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DECR_WRAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VENDOR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERSION;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NEAREST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINEAR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NEAREST_MIPMAP_NEAREST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINEAR_MIPMAP_NEAREST;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NEAREST_MIPMAP_LINEAR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LINEAR_MIPMAP_LINEAR;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_MAG_FILTER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_MIN_FILTER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_WRAP_S;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_WRAP_T;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_2D;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_CUBE_MAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_BINDING_CUBE_MAP;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_CUBE_MAP_POSITIVE_X;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_CUBE_MAP_NEGATIVE_X;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_CUBE_MAP_POSITIVE_Y;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_CUBE_MAP_NEGATIVE_Y;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_CUBE_MAP_POSITIVE_Z;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE_CUBE_MAP_NEGATIVE_Z;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_CUBE_MAP_TEXTURE_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE0;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE1;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE2;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE3;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE4;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE5;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE6;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE7;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE8;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE9;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE10;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE11;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE12;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE13;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE14;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE15;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE16;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE17;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE18;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE19;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE20;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE21;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE22;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE23;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE24;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE25;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE26;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE27;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE28;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE29;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE30;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.TEXTURE31;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.ACTIVE_TEXTURE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.REPEAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CLAMP_TO_EDGE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MIRRORED_REPEAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FLOAT_VEC2;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FLOAT_VEC3;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FLOAT_VEC4;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INT_VEC2;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INT_VEC3;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INT_VEC4;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BOOL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BOOL_VEC2;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BOOL_VEC3;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BOOL_VEC4;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FLOAT_MAT2;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FLOAT_MAT3;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FLOAT_MAT4;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLER_2D;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.SAMPLER_CUBE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_ENABLED;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_STRIDE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_NORMALIZED;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_POINTER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.IMPLEMENTATION_COLOR_READ_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.IMPLEMENTATION_COLOR_READ_FORMAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.COMPILE_STATUS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LOW_FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MEDIUM_FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.HIGH_FLOAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.LOW_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MEDIUM_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.HIGH_INT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RGBA4;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RGB5_A1;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RGB565;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_COMPONENT16;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_INDEX;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_INDEX8;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_STENCIL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_WIDTH;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_HEIGHT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_INTERNAL_FORMAT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_RED_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_GREEN_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_BLUE_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_ALPHA_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_DEPTH_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_STENCIL_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.COLOR_ATTACHMENT0;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.STENCIL_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.DEPTH_STENCIL_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.NONE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_COMPLETE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_INCOMPLETE_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_INCOMPLETE_DIMENSIONS;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_UNSUPPORTED;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.FRAMEBUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.RENDERBUFFER_BINDING;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.MAX_RENDERBUFFER_SIZE;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.INVALID_FRAMEBUFFER_OPERATION;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNPACK_FLIP_Y_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNPACK_PREMULTIPLY_ALPHA_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.CONTEXT_LOST_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.UNPACK_COLORSPACE_CONVERSION_WEBGL;
+
+/** @type {number} */
+WebGLRenderingContextBase.prototype.BROWSER_DEFAULT_WEBGL;
+
+
+/**
+ * @type {!HTMLCanvasElement}
+ */
+WebGLRenderingContextBase.prototype.canvas;
+
+/**
+ * @type {number}
+ */
+WebGLRenderingContextBase.prototype.drawingBufferWidth;
+
+/**
+ * @type {number}
+ */
+WebGLRenderingContextBase.prototype.drawingBufferHeight;
+
+/**
+ * @return {!WebGLContextAttributes}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getContextAttributes = function() {};
+
+/**
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isContextLost = function() {};
+
+/**
+ * @return {!Array.<string>}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getSupportedExtensions = function() {};
+
+/**
+ * Note that this has side effects by enabling the extension even if the
+ * result is not used.
+ * @param {string} name
+ * @return {Object}
+ */
+WebGLRenderingContextBase.prototype.getExtension = function(name) {};
+
+/**
+ * @param {number} texture
+ */
+WebGLRenderingContextBase.prototype.activeTexture = function(texture) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {WebGLShader} shader
+ */
+WebGLRenderingContextBase.prototype.attachShader = function(program, shader) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} index
+ * @param {string} name
+ */
+WebGLRenderingContextBase.prototype.bindAttribLocation = function(
+    program, index, name) {};
+
+/**
+ * @param {number} target
+ * @param {WebGLBuffer} buffer
+ */
+WebGLRenderingContextBase.prototype.bindBuffer = function(target, buffer) {};
+
+/**
+ * @param {number} target
+ * @param {WebGLFramebuffer} buffer
+ */
+WebGLRenderingContextBase.prototype.bindFramebuffer = function(target, buffer) {};
+
+/**
+ * @param {number} target
+ * @param {WebGLRenderbuffer} buffer
+ */
+WebGLRenderingContextBase.prototype.bindRenderbuffer = function(target, buffer) {};
+
+/**
+ * @param {number} target
+ * @param {WebGLTexture} texture
+ */
+WebGLRenderingContextBase.prototype.bindTexture = function(target, texture) {};
+
+/**
+ * @param {number} red
+ * @param {number} green
+ * @param {number} blue
+ * @param {number} alpha
+ */
+WebGLRenderingContextBase.prototype.blendColor = function(
+    red, blue, green, alpha) {};
+
+/**
+ * @param {number} mode
+ */
+WebGLRenderingContextBase.prototype.blendEquation = function(mode) {};
+
+/**
+ * @param {number} modeRGB
+ * @param {number} modeAlpha
+ */
+WebGLRenderingContextBase.prototype.blendEquationSeparate = function(
+    modeRGB, modeAlpha) {};
+
+/**
+ * @param {number} sfactor
+ * @param {number} dfactor
+ */
+WebGLRenderingContextBase.prototype.blendFunc = function(sfactor, dfactor) {};
+
+/**
+ * @param {number} srcRGB
+ * @param {number} dstRGB
+ * @param {number} srcAlpha
+ * @param {number} dstAlpha
+ */
+WebGLRenderingContextBase.prototype.blendFuncSeparate = function(
+    srcRGB, dstRGB, srcAlpha, dstAlpha) {};
+
+/**
+ * @param {number} target
+ * @param {ArrayBufferView|ArrayBuffer|number} data
+ * @param {number} usage
+ */
+WebGLRenderingContextBase.prototype.bufferData = function(target, data, usage) {};
+
+/**
+ * @param {number} target
+ * @param {number} offset
+ * @param {ArrayBufferView|ArrayBuffer} data
+ */
+WebGLRenderingContextBase.prototype.bufferSubData = function(
+    target, offset, data) {};
+
+/**
+ * @param {number} target
+ * @return {number}
+ */
+WebGLRenderingContextBase.prototype.checkFramebufferStatus = function(target) {};
+
+/**
+ * @param {number} mask
+ */
+WebGLRenderingContextBase.prototype.clear = function(mask) {};
+
+/**
+ * @param {number} red
+ * @param {number} green
+ * @param {number} blue
+ * @param {number} alpha
+ */
+WebGLRenderingContextBase.prototype.clearColor = function(
+    red, green, blue, alpha) {};
+
+/**
+ * @param {number} depth
+ */
+WebGLRenderingContextBase.prototype.clearDepth = function(depth) {};
+
+/**
+ * @param {number} s
+ */
+WebGLRenderingContextBase.prototype.clearStencil = function(s) {};
+
+/**
+ * @param {boolean} red
+ * @param {boolean} green
+ * @param {boolean} blue
+ * @param {boolean} alpha
+ */
+WebGLRenderingContextBase.prototype.colorMask = function(
+    red, green, blue, alpha) {};
+
+/**
+ * @param {WebGLShader} shader
+ */
+WebGLRenderingContextBase.prototype.compileShader = function(shader) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} internalformat
+ * @param {number} width
+ * @param {number} height
+ * @param {number} border
+ * @param {ArrayBufferView} data
+ */
+WebGLRenderingContextBase.prototype.compressedTexImage2D = function(
+    target, level, internalformat, width, height, border, data) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} xoffset
+ * @param {number} yoffset
+ * @param {number} width
+ * @param {number} height
+ * @param {number} format
+ * @param {ArrayBufferView} data
+ */
+WebGLRenderingContextBase.prototype.compressedTexSubImage2D = function(
+    target, level, xoffset, yoffset, width, height, format, data) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} format
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ * @param {number} border
+ */
+WebGLRenderingContextBase.prototype.copyTexImage2D = function(
+    target, level, format, x, y, width, height, border) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} xoffset
+ * @param {number} yoffset
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ */
+WebGLRenderingContextBase.prototype.copyTexSubImage2D = function(
+    target, level, xoffset, yoffset, x, y, width, height) {};
+
+/**
+ * @return {!WebGLBuffer}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.createBuffer = function() {};
+
+/**
+ * @return {!WebGLFramebuffer}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.createFramebuffer = function() {};
+
+/**
+ * @return {!WebGLProgram}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.createProgram = function() {};
+
+/**
+ * @return {!WebGLRenderbuffer}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.createRenderbuffer = function() {};
+
+/**
+ * @param {number} type
+ * @return {!WebGLShader}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.createShader = function(type) {};
+
+/**
+ * @return {!WebGLTexture}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.createTexture = function() {};
+
+/**
+ * @param {number} mode
+ */
+WebGLRenderingContextBase.prototype.cullFace = function(mode) {};
+
+/**
+ * @param {WebGLBuffer} buffer
+ */
+WebGLRenderingContextBase.prototype.deleteBuffer = function(buffer) {};
+
+/**
+ * @param {WebGLFramebuffer} buffer
+ */
+WebGLRenderingContextBase.prototype.deleteFramebuffer = function(buffer) {};
+
+/**
+ * @param {WebGLProgram} program
+ */
+WebGLRenderingContextBase.prototype.deleteProgram = function(program) {};
+
+/**
+ * @param {WebGLRenderbuffer} buffer
+ */
+WebGLRenderingContextBase.prototype.deleteRenderbuffer = function(buffer) {};
+
+/**
+ * @param {WebGLShader} shader
+ */
+WebGLRenderingContextBase.prototype.deleteShader = function(shader) {};
+
+/**
+ * @param {WebGLTexture} texture
+ */
+WebGLRenderingContextBase.prototype.deleteTexture = function(texture) {};
+
+/**
+ * @param {number} func
+ */
+WebGLRenderingContextBase.prototype.depthFunc = function(func) {};
+
+/**
+ * @param {boolean} flag
+ */
+WebGLRenderingContextBase.prototype.depthMask = function(flag) {};
+
+/**
+ * @param {number} nearVal
+ * @param {number} farVal
+ */
+WebGLRenderingContextBase.prototype.depthRange = function(nearVal, farVal) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {WebGLShader} shader
+ */
+WebGLRenderingContextBase.prototype.detachShader = function(program, shader) {};
+
+/**
+ * @param {number} flags
+ */
+WebGLRenderingContextBase.prototype.disable = function(flags) {};
+
+/**
+ * @param {number} index
+ */
+WebGLRenderingContextBase.prototype.disableVertexAttribArray = function(
+    index) {};
+
+/**
+ * @param {number} mode
+ * @param {number} first
+ * @param {number} count
+ */
+WebGLRenderingContextBase.prototype.drawArrays = function(mode, first, count) {};
+
+/**
+ * @param {number} mode
+ * @param {number} count
+ * @param {number} type
+ * @param {number} offset
+ */
+WebGLRenderingContextBase.prototype.drawElements = function(
+    mode, count, type, offset) {};
+
+/**
+ * @param {number} cap
+ */
+WebGLRenderingContextBase.prototype.enable = function(cap) {};
+
+/**
+ * @param {number} index
+ */
+WebGLRenderingContextBase.prototype.enableVertexAttribArray = function(
+    index) {};
+
+WebGLRenderingContextBase.prototype.finish = function() {};
+
+WebGLRenderingContextBase.prototype.flush = function() {};
+
+/**
+ * @param {number} target
+ * @param {number} attachment
+ * @param {number} renderbuffertarget
+ * @param {WebGLRenderbuffer} renderbuffer
+ */
+WebGLRenderingContextBase.prototype.framebufferRenderbuffer = function(
+    target, attachment, renderbuffertarget, renderbuffer) {};
+
+/**
+ * @param {number} target
+ * @param {number} attachment
+ * @param {number} textarget
+ * @param {WebGLTexture} texture
+ * @param {number} level
+ */
+WebGLRenderingContextBase.prototype.framebufferTexture2D = function(
+    target, attachment, textarget, texture, level) {};
+
+/**
+ * @param {number} mode
+ */
+WebGLRenderingContextBase.prototype.frontFace = function(mode) {};
+
+/**
+ * @param {number} target
+ */
+WebGLRenderingContextBase.prototype.generateMipmap = function(target) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} index
+ * @return {WebGLActiveInfo}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getActiveAttrib = function(program, index) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} index
+ * @return {WebGLActiveInfo}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getActiveUniform = function(program, index) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @return {!Array.<WebGLShader>}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getAttachedShaders = function(program) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {string} name
+ * @return {number}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getAttribLocation = function(program, name) {};
+
+/**
+ * @param {number} target
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getBufferParameter = function(target, pname) {};
+
+/**
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getParameter = function(pname) {};
+
+/**
+ * @return {number}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getError = function() {};
+
+/**
+ * @param {number} target
+ * @param {number} attachment
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getFramebufferAttachmentParameter = function(
+    target, attachment, pname) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getProgramParameter = function(
+    program, pname) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @return {string}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getProgramInfoLog = function(program) {};
+
+/**
+ * @param {number} target
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getRenderbufferParameter = function(
+    target, pname) {};
+
+/**
+ * @param {WebGLShader} shader
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getShaderParameter = function(shader, pname) {};
+
+/**
+ * @param {number} shadertype
+ * @param {number} precisiontype
+ * @return {WebGLShaderPrecisionFormat}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getShaderPrecisionFormat = function(shadertype,
+    precisiontype) {};
+
+/**
+ * @param {WebGLShader} shader
+ * @return {string}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getShaderInfoLog = function(shader) {};
+
+/**
+ * @param {WebGLShader} shader
+ * @return {string}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getShaderSource = function(shader) {};
+
+/**
+ * @param {number} target
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getTexParameter = function(target, pname) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {WebGLUniformLocation} location
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getUniform = function(program, location) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {string} name
+ * @return {WebGLUniformLocation}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getUniformLocation = function(program, name) {};
+
+/**
+ * @param {number} index
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getVertexAttrib = function(index, pname) {};
+
+/**
+ * @param {number} index
+ * @param {number} pname
+ * @return {number}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.getVertexAttribOffset = function(
+    index, pname) {};
+
+/**
+ * @param {number} target
+ * @param {number} mode
+ */
+WebGLRenderingContextBase.prototype.hint = function(target, mode) {};
+
+/**
+ * @param {WebGLObject} buffer
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isBuffer = function(buffer) {};
+
+/**
+ * @param {number} cap
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isEnabled = function(cap) {};
+
+/**
+ * @param {WebGLObject} framebuffer
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isFramebuffer = function(framebuffer) {};
+
+/**
+ * @param {WebGLObject} program
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isProgram = function(program) {};
+
+/**
+ * @param {WebGLObject} renderbuffer
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isRenderbuffer = function(renderbuffer) {};
+
+/**
+ * @param {WebGLObject} shader
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isShader = function(shader) {};
+
+/**
+ * @param {WebGLObject} texture
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGLRenderingContextBase.prototype.isTexture = function(texture) {};
+
+/**
+ * @param {number} width
+ */
+WebGLRenderingContextBase.prototype.lineWidth = function(width) {};
+
+/**
+ * @param {WebGLProgram} program
+ */
+WebGLRenderingContextBase.prototype.linkProgram = function(program) {};
+
+/**
+ * @param {number} pname
+ * @param {number} param
+ */
+WebGLRenderingContextBase.prototype.pixelStorei = function(pname, param) {};
+
+/**
+ * @param {number} factor
+ * @param {number} units
+ */
+WebGLRenderingContextBase.prototype.polygonOffset = function(factor, units) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ * @param {number} format
+ * @param {number} type
+ * @param {ArrayBufferView} pixels
+ */
+WebGLRenderingContextBase.prototype.readPixels = function(
+    x, y, width, height, format, type, pixels) {};
+
+/**
+ * @param {number} target
+ * @param {number} internalformat
+ * @param {number} width
+ * @param {number} height
+ */
+WebGLRenderingContextBase.prototype.renderbufferStorage = function(
+    target, internalformat, width, height) {};
+
+/**
+ * @param {number} coverage
+ * @param {boolean} invert
+ */
+WebGLRenderingContextBase.prototype.sampleCoverage = function(coverage, invert) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ */
+WebGLRenderingContextBase.prototype.scissor = function(x, y, width, height) {};
+
+/**
+ * @param {WebGLShader} shader
+ * @param {string} source
+ */
+WebGLRenderingContextBase.prototype.shaderSource = function(shader, source) {};
+
+/**
+ * @param {number} func
+ * @param {number} ref
+ * @param {number} mask
+ */
+WebGLRenderingContextBase.prototype.stencilFunc = function(func, ref, mask) {};
+
+/**
+ * @param {number} face
+ * @param {number} func
+ * @param {number} ref
+ * @param {number} mask
+ */
+WebGLRenderingContextBase.prototype.stencilFuncSeparate = function(
+    face, func, ref, mask) {};
+
+/**
+ * @param {number} mask
+ */
+WebGLRenderingContextBase.prototype.stencilMask = function(mask) {};
+
+/**
+ * @param {number} face
+ * @param {number} mask
+ */
+WebGLRenderingContextBase.prototype.stencilMaskSeparate = function(face, mask) {};
+
+/**
+ * @param {number} fail
+ * @param {number} zfail
+ * @param {number} zpass
+ */
+WebGLRenderingContextBase.prototype.stencilOp = function(fail, zfail, zpass) {};
+
+/**
+ * @param {number} face
+ * @param {number} fail
+ * @param {number} zfail
+ * @param {number} zpass
+ */
+WebGLRenderingContextBase.prototype.stencilOpSeparate = function(
+    face, fail, zfail, zpass) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} internalformat
+ * @param {number} format or width
+ * @param {number} type or height
+ * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|
+ *     number} img or border
+ * @param {number=} opt_format
+ * @param {number=} opt_type
+ * @param {ArrayBufferView=} opt_pixels
+ */
+WebGLRenderingContextBase.prototype.texImage2D = function(
+    target, level, internalformat, format, type, img, opt_format, opt_type,
+    opt_pixels) {};
+
+/**
+ * @param {number} target
+ * @param {number} pname
+ * @param {number} param
+ */
+WebGLRenderingContextBase.prototype.texParameterf = function(
+    target, pname, param) {};
+
+/**
+ * @param {number} target
+ * @param {number} pname
+ * @param {number} param
+ */
+WebGLRenderingContextBase.prototype.texParameteri = function(
+    target, pname, param) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} xoffset
+ * @param {number} yoffset
+ * @param {number} format or width
+ * @param {number} type or height
+ * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|
+ *     number} data or format
+ * @param {number=} opt_type
+ * @param {ArrayBufferView=} opt_pixels
+ */
+WebGLRenderingContextBase.prototype.texSubImage2D = function(
+    target, level, xoffset, yoffset, format, type, data, opt_type,
+    opt_pixels) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value
+ */
+WebGLRenderingContextBase.prototype.uniform1f = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform1fv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value
+ */
+WebGLRenderingContextBase.prototype.uniform1i = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Int32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform1iv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value1
+ * @param {number} value2
+ */
+WebGLRenderingContextBase.prototype.uniform2f = function(
+    location, value1, value2) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform2fv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value1
+ * @param {number} value2
+ */
+WebGLRenderingContextBase.prototype.uniform2i = function(
+    location, value1, value2) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Int32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform2iv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value1
+ * @param {number} value2
+ * @param {number} value3
+ */
+WebGLRenderingContextBase.prototype.uniform3f = function(
+    location, value1, value2, value3) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform3fv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value1
+ * @param {number} value2
+ * @param {number} value3
+ */
+WebGLRenderingContextBase.prototype.uniform3i = function(
+    location, value1, value2, value3) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Int32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform3iv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value1
+ * @param {number} value2
+ * @param {number} value3
+ * @param {number} value4
+ */
+WebGLRenderingContextBase.prototype.uniform4f = function(
+    location, value1, value2, value3, value4) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform4fv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} value1
+ * @param {number} value2
+ * @param {number} value3
+ * @param {number} value4
+ */
+WebGLRenderingContextBase.prototype.uniform4i = function(
+    location, value1, value2, value3, value4) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Int32Array|Array.<number>} value
+ */
+WebGLRenderingContextBase.prototype.uniform4iv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} data
+ */
+WebGLRenderingContextBase.prototype.uniformMatrix2fv = function(
+    location, transpose, data) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} data
+ */
+WebGLRenderingContextBase.prototype.uniformMatrix3fv = function(
+    location, transpose, data) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} data
+ */
+WebGLRenderingContextBase.prototype.uniformMatrix4fv = function(
+    location, transpose, data) {};
+
+/**
+ * @param {WebGLProgram} program
+ */
+WebGLRenderingContextBase.prototype.useProgram = function(program) {};
+
+/**
+ * @param {WebGLProgram} program
+ */
+WebGLRenderingContextBase.prototype.validateProgram = function(program) {};
+
+/**
+ * @param {number} indx
+ * @param {number} x
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib1f = function(indx, x) {};
+
+/**
+ * @param {number} indx
+ * @param {Float32Array|Array.<number>} values
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib1fv = function(indx, values) {};
+
+/**
+ * @param {number} indx
+ * @param {number} x
+ * @param {number} y
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib2f = function(
+    indx, x, y) {};
+
+/**
+ * @param {number} indx
+ * @param {Float32Array|Array.<number>} values
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib2fv = function(
+    indx, values) {};
+
+/**
+ * @param {number} indx
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib3f = function(
+    indx, x, y, z) {};
+
+/**
+ * @param {number} indx
+ * @param {Float32Array|Array.<number>} values
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib3fv = function(indx, values) {};
+
+/**
+ * @param {number} indx
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @param {number} w
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib4f = function(
+    indx, x, y, z, w) {};
+
+/**
+ * @param {number} indx
+ * @param {Float32Array|Array.<number>} values
+ */
+WebGLRenderingContextBase.prototype.vertexAttrib4fv = function(indx, values) {};
+
+/**
+ * @param {number} indx
+ * @param {number} size
+ * @param {number} type
+ * @param {boolean} normalized
+ * @param {number} stride
+ * @param {number} offset
+ */
+WebGLRenderingContextBase.prototype.vertexAttribPointer = function(
+    indx, size, type, normalized, stride, offset) {};
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ */
+WebGLRenderingContextBase.prototype.viewport = function(x, y, width, height) {};
+
+
+/**
+ * @constructor
+ * @noalias
+ */
+function WebGLContextAttributes() {}
+
+/**
+ * @type {boolean}
+ */
+WebGLContextAttributes.prototype.alpha;
+
+/**
+ * @type {boolean}
+ */
+WebGLContextAttributes.prototype.depth;
+
+/**
+ * @type {boolean}
+ */
+WebGLContextAttributes.prototype.stencil;
+
+/**
+ * @type {boolean}
+ */
+WebGLContextAttributes.prototype.antialias;
+
+/**
+ * @type {boolean}
+ */
+WebGLContextAttributes.prototype.premultipliedAlpha;
+
+/**
+ * @type {boolean}
+ */
+WebGLContextAttributes.prototype.preserveDrawingBuffer;
+
+
+/**
+ * @param {string} eventType
+ * @constructor
+ * @noalias
+ * @extends {Event}
+ */
+function WebGLContextEvent(eventType) {}
+
+/**
+ * @type {string}
+ */
+WebGLContextEvent.prototype.statusMessage;
+
+
+/**
+ * @constructor
+ * @noalias
+ */
+function WebGLShaderPrecisionFormat() {}
+
+/**
+ * @type {number}
+ */
+WebGLShaderPrecisionFormat.prototype.rangeMin;
+
+/**
+ * @type {number}
+ */
+WebGLShaderPrecisionFormat.prototype.rangeMax;
+
+/**
+ * @type {number}
+ */
+WebGLShaderPrecisionFormat.prototype.precision;
+
+
+/**
+ * @constructor
+ * @noalias
+ */
+function WebGLObject() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLBuffer() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLFramebuffer() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLProgram() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLRenderbuffer() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLShader() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLTexture() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ */
+function WebGLActiveInfo() {}
+
+/** @type {number} */
+WebGLActiveInfo.prototype.size;
+
+/** @type {number} */
+WebGLActiveInfo.prototype.type;
+
+/** @type {string} */
+WebGLActiveInfo.prototype.name;
+
+
+/**
+ * @constructor
+ * @noalias
+ */
+function WebGLUniformLocation() {}
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/OES_texture_float/
+ * @constructor
+ * @noalias
+ */
+function OES_texture_float() {}
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/
+ * @constructor
+ * @noalias
+ */
+function OES_texture_half_float() {}
+
+/** @type {number} */
+OES_texture_half_float.prototype.HALF_FLOAT_OES;
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/
+ * @constructor
+ * @noalias
+ */
+function WEBGL_lose_context() {}
+
+WEBGL_lose_context.prototype.loseContext = function() {};
+
+WEBGL_lose_context.prototype.restoreContext = function() {};
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/
+ * @constructor
+ * @noalias
+ */
+function OES_standard_derivatives() {}
+
+/** @type {number} */
+OES_standard_derivatives.prototype.FRAGMENT_SHADER_DERIVATIVE_HINT_OES;
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLVertexArrayObjectOES() {}
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/
+ * @constructor
+ * @noalias
+ */
+function OES_vertex_array_object() {}
+
+/** @type {number} */
+OES_vertex_array_object.prototype.VERTEX_ARRAY_BINDING_OES;
+
+/**
+ * @return {WebGLVertexArrayObjectOES}
+ * @nosideeffects
+ */
+OES_vertex_array_object.prototype.createVertexArrayOES = function() {};
+
+/**
+ * @param {WebGLVertexArrayObjectOES} arrayObject
+ */
+OES_vertex_array_object.prototype.deleteVertexArrayOES =
+    function(arrayObject) {};
+
+/**
+ * @param {WebGLVertexArrayObjectOES} arrayObject
+ * @return {boolean}
+ * @nosideeffects
+ */
+OES_vertex_array_object.prototype.isVertexArrayOES = function(arrayObject) {};
+
+/**
+ * @param {WebGLVertexArrayObjectOES} arrayObject
+ */
+OES_vertex_array_object.prototype.bindVertexArrayOES = function(arrayObject) {};
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/
+ * @constructor
+ * @noalias
+ */
+function WEBGL_debug_renderer_info() {}
+
+/** @type {number} */
+WEBGL_debug_renderer_info.prototype.UNMASKED_VENDOR_WEBGL;
+
+/** @type {number} */
+WEBGL_debug_renderer_info.prototype.UNMASKED_RENDERER_WEBGL;
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/
+ * @constructor
+ * @noalias
+ */
+function WEBGL_debug_shaders() {}
+
+/**
+ * @param {WebGLShader} shader
+ * @return {string}
+ * @nosideeffects
+ */
+WEBGL_debug_shaders.prototype.getTranslatedShaderSource = function(shader) {};
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
+ * @constructor
+ * @noalias
+ */
+function WEBGL_compressed_texture_s3tc() {}
+
+/** @type {number} */
+WEBGL_compressed_texture_s3tc.prototype.COMPRESSED_RGB_S3TC_DXT1_EXT;
+
+/** @type {number} */
+WEBGL_compressed_texture_s3tc.prototype.COMPRESSED_RGBA_S3TC_DXT1_EXT;
+
+/** @type {number} */
+WEBGL_compressed_texture_s3tc.prototype.COMPRESSED_RGBA_S3TC_DXT3_EXT;
+
+/** @type {number} */
+WEBGL_compressed_texture_s3tc.prototype.COMPRESSED_RGBA_S3TC_DXT5_EXT;
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/OES_depth_texture/
+ * @constructor
+ * @noalias
+ */
+function OES_depth_texture() {}
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/
+ * @constructor
+ * @noalias
+ */
+function OES_element_index_uint() {}
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/
+ * @constructor
+ * @noalias
+ */
+function EXT_texture_filter_anisotropic() {}
+
+/** @type {number} */
+EXT_texture_filter_anisotropic.prototype.TEXTURE_MAX_ANISOTROPY_EXT;
+
+/** @type {number} */
+EXT_texture_filter_anisotropic.prototype.MAX_TEXTURE_MAX_ANISOTROPY_EXT;
+
+
+
+/**
+ * @see http://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
+ * @constructor
+ * @noalias
+ */
+function ANGLE_instanced_arrays() {}
+
+
+/** @type {number} */
+ANGLE_instanced_arrays.prototype.VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE;
+
+
+/**
+ * @param {number} mode Primitive type.
+ * @param {number} first First vertex.
+ * @param {number} count Number of vertices per instance.
+ * @param {number} primcount Number of instances.
+ */
+ANGLE_instanced_arrays.prototype.drawArraysInstancedANGLE = function(
+    mode, first, count, primcount) {};
+
+
+/**
+ * @param {number} mode Primitive type.
+ * @param {number} count Number of vertex indices per instance.
+ * @param {number} type Type of a vertex index.
+ * @param {number} offset Offset to the first vertex index.
+ * @param {number} primcount Number of instances.
+ */
+ANGLE_instanced_arrays.prototype.drawElementsInstancedANGLE = function(
+    mode, count, type, offset, primcount) {};
+
+
+/**
+ * @param {number} index Attribute index.
+ * @param {number} divisor Instance divisor.
+ */
+ANGLE_instanced_arrays.prototype.vertexAttribDivisorANGLE = function(
+    index, divisor) {};
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLRenderingContextBase}
+ */
+function WebGLRenderingContext() {}
+
+
+/**
+ * @constructor
+ * @private
+ * @noalias
+ * @extends {WebGLRenderingContextBase}
+ */
+function WebGL2RenderingContextBase() {}
+
+
+/** @type {number} */
+WebGL2RenderingContextBase.READ_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNPACK_ROW_LENGTH;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNPACK_SKIP_ROWS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNPACK_SKIP_PIXELS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.PACK_ROW_LENGTH;
+
+/** @type {number} */
+WebGL2RenderingContextBase.PACK_SKIP_ROWS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.PACK_SKIP_PIXELS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DEPTH;
+
+/** @type {number} */
+WebGL2RenderingContextBase.STENCIL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB10_A2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_BINDING_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNPACK_SKIP_IMAGES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNPACK_IMAGE_HEIGHT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_WRAP_R;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_3D_TEXTURE_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_2_10_10_10_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_ELEMENTS_VERTICES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_ELEMENTS_INDICES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_MIN_LOD;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_MAX_LOD;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_BASE_LEVEL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_MAX_LEVEL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MIN;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DEPTH_COMPONENT24;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_TEXTURE_LOD_BIAS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_COMPARE_MODE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_COMPARE_FUNC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.CURRENT_QUERY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.QUERY_RESULT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.QUERY_RESULT_AVAILABLE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.STREAM_READ;
+
+/** @type {number} */
+WebGL2RenderingContextBase.STREAM_COPY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.STATIC_READ;
+
+/** @type {number} */
+WebGL2RenderingContextBase.STATIC_COPY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DYNAMIC_READ;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DYNAMIC_COPY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_DRAW_BUFFERS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER0;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER1;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER5;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER6;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER7;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER9;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER10;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER11;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER12;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER13;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER14;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_BUFFER15;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_FRAGMENT_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_VERTEX_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SAMPLER_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SAMPLER_2D_SHADOW;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAGMENT_SHADER_DERIVATIVE_HINT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.PIXEL_PACK_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.PIXEL_UNPACK_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.PIXEL_PACK_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.PIXEL_UNPACK_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FLOAT_MAT2x3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FLOAT_MAT2x4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FLOAT_MAT3x2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FLOAT_MAT3x4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FLOAT_MAT4x2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FLOAT_MAT4x3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SRGB;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SRGB8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SRGB8_ALPHA8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPARE_REF_TO_TEXTURE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.VERTEX_ATTRIB_ARRAY_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_ARRAY_TEXTURE_LAYERS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MIN_PROGRAM_TEXEL_OFFSET;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_PROGRAM_TEXEL_OFFSET;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_VARYING_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_BINDING_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R11F_G11F_B10F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_10F_11F_11F_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB9_E5;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_5_9_9_9_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_BUFFER_MODE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_VARYINGS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_BUFFER_START;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_BUFFER_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RASTERIZER_DISCARD;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.INTERLEAVED_ATTRIBS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SEPARATE_ATTRIBS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RED_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SAMPLER_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SAMPLER_2D_ARRAY_SHADOW;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SAMPLER_CUBE_SHADOW;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_VEC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_VEC3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_VEC4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.INT_SAMPLER_2D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.INT_SAMPLER_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.INT_SAMPLER_CUBE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.INT_SAMPLER_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_SAMPLER_2D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_SAMPLER_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_SAMPLER_CUBE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_SAMPLER_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DEPTH_COMPONENT32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DEPTH32F_STENCIL8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FLOAT_32_UNSIGNED_INT_24_8_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_RED_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_GREEN_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_DEFAULT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DEPTH_STENCIL_ATTACHMENT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DEPTH_STENCIL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_INT_24_8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DEPTH24_STENCIL8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNED_NORMALIZED;
+
+// Same as FRAMEBUFFER_BINDING
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_FRAMEBUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.READ_FRAMEBUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.DRAW_FRAMEBUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.READ_FRAMEBUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RENDERBUFFER_SAMPLES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_COLOR_ATTACHMENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT1;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT5;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT6;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT7;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT9;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT10;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT11;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT12;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT13;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT14;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COLOR_ATTACHMENT15;
+
+/** @type {number} */
+WebGL2RenderingContextBase.FRAMEBUFFER_INCOMPLETE_MULTISAMPLE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_SAMPLES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.HALF_FLOAT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.VERTEX_ARRAY_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.R8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RG8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGBA8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SIGNED_NORMALIZED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COPY_READ_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COPY_WRITE_BUFFER;
+
+// Same as COPY_READ_BUFFER
+/** @type {number} */
+WebGL2RenderingContextBase.COPY_READ_BUFFER_BINDING;
+
+// Same as COPY_WRITE_BUFFER
+/** @type {number} */
+WebGL2RenderingContextBase.COPY_WRITE_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BUFFER_START;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BUFFER_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_VERTEX_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_FRAGMENT_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_COMBINED_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_UNIFORM_BUFFER_BINDINGS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_UNIFORM_BLOCK_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BUFFER_OFFSET_ALIGNMENT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.ACTIVE_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_TYPE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BLOCK_INDEX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_OFFSET;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_ARRAY_STRIDE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_MATRIX_STRIDE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_IS_ROW_MAJOR;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BLOCK_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BLOCK_DATA_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BLOCK_ACTIVE_UNIFORMS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.INVALID_INDEX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_VERTEX_OUTPUT_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_FRAGMENT_INPUT_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_SERVER_WAIT_TIMEOUT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.OBJECT_TYPE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SYNC_CONDITION;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SYNC_STATUS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SYNC_FLAGS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SYNC_FENCE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SYNC_GPU_COMMANDS_COMPLETE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.UNSIGNALED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SIGNALED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.ALREADY_SIGNALED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TIMEOUT_EXPIRED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.CONDITION_SATISFIED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.WAIT_FAILED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SYNC_FLUSH_COMMANDS_BIT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.VERTEX_ATTRIB_ARRAY_DIVISOR;
+
+/** @type {number} */
+WebGL2RenderingContextBase.ANY_SAMPLES_PASSED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.ANY_SAMPLES_PASSED_CONSERVATIVE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.SAMPLER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.RGB10_A2UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.INT_2_10_10_10_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_PAUSED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_ACTIVE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TRANSFORM_FEEDBACK_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_R11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_SIGNED_R11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_RG11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_SIGNED_RG11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_RGB8_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_SRGB8_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_RGBA8_ETC2_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_IMMUTABLE_FORMAT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.MAX_ELEMENT_INDEX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.NUM_SAMPLE_COUNTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TEXTURE_IMMUTABLE_LEVELS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.TIMEOUT_IGNORED;
+
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.READ_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNPACK_ROW_LENGTH;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNPACK_SKIP_ROWS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNPACK_SKIP_PIXELS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.PACK_ROW_LENGTH;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.PACK_SKIP_ROWS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.PACK_SKIP_PIXELS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DEPTH;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.STENCIL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB10_A2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_BINDING_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNPACK_SKIP_IMAGES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNPACK_IMAGE_HEIGHT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_WRAP_R;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_3D_TEXTURE_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_2_10_10_10_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_ELEMENTS_VERTICES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_ELEMENTS_INDICES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_MIN_LOD;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_MAX_LOD;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_BASE_LEVEL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_MAX_LEVEL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MIN;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DEPTH_COMPONENT24;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_TEXTURE_LOD_BIAS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_COMPARE_MODE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_COMPARE_FUNC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.CURRENT_QUERY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.QUERY_RESULT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.QUERY_RESULT_AVAILABLE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.STREAM_READ;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.STREAM_COPY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.STATIC_READ;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.STATIC_COPY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DYNAMIC_READ;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DYNAMIC_COPY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_DRAW_BUFFERS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER0;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER1;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER5;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER6;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER7;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER9;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER10;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER11;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER12;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER13;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER14;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_BUFFER15;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_FRAGMENT_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_VERTEX_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SAMPLER_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SAMPLER_2D_SHADOW;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAGMENT_SHADER_DERIVATIVE_HINT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.PIXEL_PACK_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.PIXEL_UNPACK_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.PIXEL_PACK_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.PIXEL_UNPACK_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FLOAT_MAT2x3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FLOAT_MAT2x4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FLOAT_MAT3x2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FLOAT_MAT3x4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FLOAT_MAT4x2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FLOAT_MAT4x3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SRGB;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SRGB8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SRGB8_ALPHA8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPARE_REF_TO_TEXTURE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_ARRAY_TEXTURE_LAYERS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MIN_PROGRAM_TEXEL_OFFSET;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_PROGRAM_TEXEL_OFFSET;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_VARYING_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_BINDING_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R11F_G11F_B10F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_10F_11F_11F_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB9_E5;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_5_9_9_9_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_BUFFER_MODE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_VARYINGS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_BUFFER_START;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_BUFFER_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RASTERIZER_DISCARD;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.INTERLEAVED_ATTRIBS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SEPARATE_ATTRIBS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RED_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SAMPLER_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SAMPLER_2D_ARRAY_SHADOW;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SAMPLER_CUBE_SHADOW;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_VEC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_VEC3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_VEC4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.INT_SAMPLER_2D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.INT_SAMPLER_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.INT_SAMPLER_CUBE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.INT_SAMPLER_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_SAMPLER_2D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_SAMPLER_3D;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_SAMPLER_CUBE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_SAMPLER_2D_ARRAY;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DEPTH_COMPONENT32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DEPTH32F_STENCIL8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FLOAT_32_UNSIGNED_INT_24_8_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_RED_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_GREEN_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_DEFAULT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DEPTH_STENCIL_ATTACHMENT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DEPTH_STENCIL;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_INT_24_8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DEPTH24_STENCIL8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNED_NORMALIZED;
+
+// Same as FRAMEBUFFER_BINDING
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_FRAMEBUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.READ_FRAMEBUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.DRAW_FRAMEBUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.READ_FRAMEBUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RENDERBUFFER_SAMPLES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_COLOR_ATTACHMENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT1;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT3;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT4;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT5;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT6;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT7;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT9;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT10;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT11;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT12;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT13;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT14;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COLOR_ATTACHMENT15;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.FRAMEBUFFER_INCOMPLETE_MULTISAMPLE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_SAMPLES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.HALF_FLOAT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG_INTEGER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG8;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG16F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG32F;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG8I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG8UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG16I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG16UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG32I;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG32UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.VERTEX_ARRAY_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.R8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RG8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGBA8_SNORM;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SIGNED_NORMALIZED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COPY_READ_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COPY_WRITE_BUFFER;
+
+// Same as COPY_READ_BUFFER
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COPY_READ_BUFFER_BINDING;
+
+// Same as COPY_WRITE_BUFFER
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COPY_WRITE_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BUFFER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BUFFER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BUFFER_START;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BUFFER_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_VERTEX_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_FRAGMENT_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_COMBINED_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_UNIFORM_BUFFER_BINDINGS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_UNIFORM_BLOCK_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BUFFER_OFFSET_ALIGNMENT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.ACTIVE_UNIFORM_BLOCKS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_TYPE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BLOCK_INDEX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_OFFSET;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_ARRAY_STRIDE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_MATRIX_STRIDE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_IS_ROW_MAJOR;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BLOCK_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BLOCK_DATA_SIZE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BLOCK_ACTIVE_UNIFORMS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.INVALID_INDEX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_VERTEX_OUTPUT_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_FRAGMENT_INPUT_COMPONENTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_SERVER_WAIT_TIMEOUT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.OBJECT_TYPE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SYNC_CONDITION;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SYNC_STATUS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SYNC_FLAGS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SYNC_FENCE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SYNC_GPU_COMMANDS_COMPLETE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.UNSIGNALED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SIGNALED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.ALREADY_SIGNALED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TIMEOUT_EXPIRED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.CONDITION_SATISFIED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.WAIT_FAILED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SYNC_FLUSH_COMMANDS_BIT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.VERTEX_ATTRIB_ARRAY_DIVISOR;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.ANY_SAMPLES_PASSED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.ANY_SAMPLES_PASSED_CONSERVATIVE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.SAMPLER_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.RGB10_A2UI;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.INT_2_10_10_10_REV;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_PAUSED;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_ACTIVE;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TRANSFORM_FEEDBACK_BINDING;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_R11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_SIGNED_R11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_RG11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_SIGNED_RG11_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_RGB8_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_SRGB8_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_RGBA8_ETC2_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_IMMUTABLE_FORMAT;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.MAX_ELEMENT_INDEX;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.NUM_SAMPLE_COUNTS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TEXTURE_IMMUTABLE_LEVELS;
+
+/** @type {number} */
+WebGL2RenderingContextBase.prototype.TIMEOUT_IGNORED;
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLQuery() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLSampler() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLSync() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLTransformFeedback() {}
+
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGLObject}
+ */
+function WebGLVertexArrayObject() {}
+
+
+/**
+ * @param {number} target
+ * @param {WebGLQuery} query
+ */
+WebGL2RenderingContextBase.prototype.beginQuery = function(target, query) {};
+
+/**
+ * @param {number} primitiveMode
+ */
+WebGL2RenderingContextBase.prototype.beginTransformFeedback = function(primitiveMode) {};
+
+/**
+ * @param {number} target
+ * @param {number} index
+ * @param {WebGLBuffer} buffer
+ */
+WebGL2RenderingContextBase.prototype.bindBufferBase = function(target, index, buffer) {};
+
+/**
+ * @param {number} target
+ * @param {number} index
+ * @param {WebGLBuffer} buffer
+ * @param {number} offset
+ * @param {number} size
+ */
+WebGL2RenderingContextBase.prototype.bindBufferRange = function(target, index, buffer, offset, size) {};
+
+/**
+ * @param {number} unit
+ * @param {WebGLSampler} sampler
+ */
+WebGL2RenderingContextBase.prototype.bindSampler = function(unit, sampler) {};
+
+/**
+ * @param {number} target
+ * @param {WebGLTransformFeedback} id
+ */
+WebGL2RenderingContextBase.prototype.bindTransformFeedback = function(target, id) {};
+
+/**
+ * @param {WebGLVertexArrayObject} array
+ */
+WebGL2RenderingContextBase.prototype.bindVertexArray = function(array) {};
+
+/**
+ * @param {number} srcX0
+ * @param {number} srcY0
+ * @param {number} srcX1
+ * @param {number} srcY1
+ * @param {number} dstX0
+ * @param {number} dstY0
+ * @param {number} dstX1
+ * @param {number} dstY1
+ * @param {number} mask
+ * @param {number} filter
+ */
+WebGL2RenderingContextBase.prototype.blitFramebuffer = function(
+    srcX0, srcY0, srcX1, srcY1, dstX0, dstY0,
+    dstX1, dstY1, mask, filter) {};
+
+/**
+ * @param {number} buffer
+ * @param {number} drawbuffer
+ * @param {Int32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.clearBufferiv = function(buffer, drawbuffer, value) {};
+
+/**
+ * @param {number} buffer
+ * @param {number} drawbuffer
+ * @param {Uint32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.clearBufferuiv = function(buffer, drawbuffer, value) {};
+
+/**
+ * @param {number} buffer
+ * @param {number} drawbuffer
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.clearBufferfv = function(buffer, drawbuffer, value) {};
+
+/**
+ * @param {number} buffer
+ * @param {number} drawbuffer
+ * @param {number} depth
+ * @param {number} stencil
+ */
+WebGL2RenderingContextBase.prototype.clearBufferfi = function(buffer, drawbuffer, depth, stencil) {};
+
+/**
+ * @param {WebGLSync} sync
+ * @param {number} flags
+ * @param {number} timeout
+ * @return {number}
+ */
+WebGL2RenderingContextBase.prototype.clientWaitSync = function(sync, flags, timeout) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} internalformat
+ * @param {number} width
+ * @param {number} height
+ * @param {number} depth
+ * @param {number} border
+ * @param {ArrayBufferView} data
+ */
+WebGL2RenderingContextBase.prototype.compressedTexImage3D = function(
+    target, level, internalformat, width, height, depth, border, data) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} xoffset
+ * @param {number} yoffset
+ * @param {number} zoffset
+ * @param {number} width
+ * @param {number} height
+ * @param {number} depth
+ * @param {number} format
+ * @param {ArrayBufferView} data
+ */
+WebGL2RenderingContextBase.prototype.compressedTexSubImage3D = function(
+    target, level, xoffset, yoffset, zoffset, width, height, depth, format, data) {};
+
+/**
+ * @param {number} readTarget
+ * @param {number} writeTarget
+ * @param {number} readOffset
+ * @param {number} writeOffset
+ * @param {number} size
+ */
+WebGL2RenderingContextBase.prototype.copyBufferSubData = function(
+    readTarget, writeTarget, readOffset, writeOffset, size) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} xoffset
+ * @param {number} yoffset
+ * @param {number} zoffset
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ */
+WebGL2RenderingContextBase.prototype.copyTexSubImage3D = function(
+    target, level, xoffset, yoffset, zoffset, x, y, width, height) {};
+
+/**
+ * @return {!WebGLQuery}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.createQuery = function() {};
+
+/**
+ * @return {!WebGLSampler}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.createSampler = function() {};
+
+/**
+ * @return {!WebGLTransformFeedback}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.createTransformFeedback = function() {};
+
+/**
+ * @return {!WebGLVertexArrayObject}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.createVertexArray = function() {};
+
+
+/**
+ * @param {WebGLQuery} query
+ */
+WebGL2RenderingContextBase.prototype.deleteQuery = function(query) {};
+
+/**
+ * @param {WebGLQuery} sampler
+ */
+WebGL2RenderingContextBase.prototype.deleteSampler = function(sampler) {};
+
+/**
+ * @param {WebGLQuery} sync
+ */
+WebGL2RenderingContextBase.prototype.deleteSync = function(sync) {};
+
+/**
+ * @param {WebGLQuery} feedback
+ */
+WebGL2RenderingContextBase.prototype.deleteTransformFeedback = function(feedback) {};
+
+/**
+ * @param {WebGLQuery} vertexArray
+ */
+WebGL2RenderingContextBase.prototype.deleteVertexArray = function(vertexArray) {};
+
+/**
+ * @param {number} mode
+ * @param {number} first
+ * @param {number} count
+ * @param {number} instanceCount
+ */
+WebGL2RenderingContextBase.prototype.drawArraysInstanced = function(mode, first, count, instanceCount) {};
+
+/**
+ * @param {number} mode
+ * @param {number} count
+ * @param {number} type
+ * @param {number} offset
+ * @param {number} instanceCount
+ */
+WebGL2RenderingContextBase.prototype.drawElementsInstanced = function(mode, count, type, offset, instanceCount) {};
+
+/**
+ * @param {number} mode
+ * @param {number} start
+ * @param {number} end
+ * @param {number} count
+ * @param {number} type
+ * @param {number} offset
+ */
+WebGL2RenderingContextBase.prototype.drawRangeElements = function(mode, start, end, count, type, offset) {};
+
+/**
+ * @param {Array.<number>} buffers
+ */
+WebGL2RenderingContextBase.prototype.drawBuffers = function(buffers) {};
+
+/**
+ * @param {number} target
+ */
+WebGL2RenderingContextBase.prototype.endQuery = function(target) {};
+
+/**
+ */
+WebGL2RenderingContextBase.prototype.endTransformFeedback = function() {};
+
+/**
+ * @param {number} condition
+ * @param {number} flags
+ * @return {WebGLSync}
+ */
+WebGL2RenderingContextBase.prototype.fenceSync = function(condition, flags) {};
+
+/**
+ * @param {number} target
+ * @param {number} attachment
+ * @param {number} texture
+ * @param {number} level
+ * @param {number} layer
+ */
+WebGL2RenderingContextBase.prototype.framebufferTextureLayer = function(
+    target, attachment, texture, level, layer) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} uniformBlockIndex
+ * @return {string}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getActiveUniformBlockName = function(program, uniformBlockIndex) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} uniformBlockIndex
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getActiveUniformBlockParameter = function(
+    program, uniformBlockIndex, pname) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {Array.<number>} uniformIndices
+ * @param {number} pname
+ * @return {Array.<number>}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getActiveUniforms = function(
+    program, uniformIndices, pname) {};
+
+/**
+ * @param {number} target
+ * @param {number} offset
+ * @param {ArrayBuffer} returnedData
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getBufferSubData = function(
+    target, offset, returnedData) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {string} name
+ * @return {number}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getFragDataLocation = function(program, name) {};
+
+/**
+ * @param {number} target
+ * @param {number} index
+ * @return {*}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getIndexedParameter = function(target, index) {};
+
+/**
+ * @param {number} target
+ * @param {number} internalformat
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getInternalformatParameter = function(target, internalformat, pname) {};
+
+/**
+ * @param {number} target
+ * @param {number} pname
+ * @return {WebGLQuery}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getQuery = function(target, pname) {};
+
+/**
+ * @param {WebGLQuery} query
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getQueryParameter = function(query, pname) {};
+
+/**
+ * @param {WebGLSampler} sampler
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getSamplerParameter = function(sampler, pname) {};
+
+/**
+ * @param {WebGLSync} sync
+ * @param {number} pname
+ * @return {*}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getSyncParameter = function(sync, pname) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} index
+ * @return {WebGLActiveInfo}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getTransformFeedbackVarying = function(program, index) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {string} uniformBlockName
+ * @return {number}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getUniformBlockIndex = function(program, uniformBlockName) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {Array.<string>} uniformNames
+ * @return {Array.<number>}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.getUniformIndices = function(program, uniformNames) {};
+
+/**
+ * @param {number} target
+ * @param {Array.<number>} attachments
+ */
+WebGL2RenderingContextBase.prototype.invalidateFramebuffer = function(target, attachments) {};
+
+/**
+ * @param {number} target
+ * @param {Array.<number>} attachments
+ * @param {number} x
+ * @param {number} y
+ * @param {number} width
+ * @param {number} height
+ */
+WebGL2RenderingContextBase.prototype.invalidateSubFramebuffer = function(
+    target, attachments, x, y, width, height) {};
+
+/**
+ * @param {WebGLQuery} query
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.isQuery = function(query) {};
+
+/**
+ * @param {WebGLSampler} sampler
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.isSampler = function(sampler) {};
+
+/**
+ * @param {WebGLSync} sync
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.isSync = function(sync) {};
+
+/**
+ * @param {WebGLTransformFeedback} feedback
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.isTransformFeedback = function(feedback) {};
+
+/**
+ * @param {WebGLVertexArrayObject} vertexArray
+ * @return {boolean}
+ * @nosideeffects
+ */
+WebGL2RenderingContextBase.prototype.isVertexArray = function(vertexArray) {};
+
+/**
+ */
+WebGL2RenderingContextBase.prototype.pauseTransformFeedback = function() {};
+
+/**
+ * @param {number} src
+ */
+WebGL2RenderingContextBase.prototype.readBuffer = function(src) {};
+
+/**
+ * @param {number} target
+ * @param {number} samples
+ * @param {number} internalformat
+ * @param {number} width
+ * @param {number} height
+ */
+WebGL2RenderingContextBase.prototype.renderbufferStorageMultisample = function(
+    target, samples, internalformat, width, height) {};
+
+/**
+ */
+WebGL2RenderingContextBase.prototype.resumeTransformFeedback = function() {};
+
+/**
+ * @param {WebGLSampler} sampler
+ * @param {number} pname
+ * @param {number} param
+ */
+WebGL2RenderingContextBase.prototype.samplerParameteri = function(sampler, pname, param) {};
+
+/**
+ * @param {WebGLSampler} sampler
+ * @param {number} pname
+ * @param {number} param
+ */
+WebGL2RenderingContextBase.prototype.samplerParameterf = function(sampler, pname, param) {};
+
+/**
+ * @param {number} target
+ * @param {number} levels
+ * @param {number} internalformat
+ * @param {number} width
+ * @param {number} height
+ */
+WebGL2RenderingContextBase.prototype.texStorage2D = function(target, levels, internalformat, width, height) {};
+
+/**
+ * @param {number} target
+ * @param {number} levels
+ * @param {number} internalformat
+ * @param {number} width
+ * @param {number} height
+ * @param {number} depth
+ */
+WebGL2RenderingContextBase.prototype.texStorage3D = function(target, levels, internalformat, width, height, depth) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} internalformat
+ * @param {number} width
+ * @param {number} height
+ * @param {number} depth
+ * @param {number} border
+ * @param {number} format
+ * @param {number} type
+ * @param {ArrayBufferView} pixels
+ */
+WebGL2RenderingContextBase.prototype.texImage3D = function(
+    target, level, internalformat, width, height, depth, border, format, type, pixels) {};
+
+/**
+ * @param {number} target
+ * @param {number} level
+ * @param {number} xoffset
+ * @param {number} yoffset
+ * @param {number} zoffset
+ * @param {number} format or width
+ * @param {number} type or height
+ * @param {ImageData|HTMLImageElement|HTMLCanvasElement|HTMLVideoElement|
+ *     number} source or depth
+ * @param {number=} opt_format
+ * @param {number=} opt_type
+ * @param {ArrayBufferView=} opt_pixels
+ */
+WebGL2RenderingContextBase.prototype.texSubImage3D = function(
+    target, level, xoffset, yoffset, zoffset, format, type, source, opt_format, opt_type, opt_pixels) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {Array.<string>} varyings
+ * @param {number} bufferMode
+ */
+WebGL2RenderingContextBase.prototype.transformFeedbackVaryings = function(program, varyings, bufferMode) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} v0
+ */
+WebGL2RenderingContextBase.prototype.uniform1ui = function(location, v0) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} v0
+ * @param {number} v1
+ */
+WebGL2RenderingContextBase.prototype.uniform2ui = function(location, v0, v1) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} v0
+ * @param {number} v1
+ * @param {number} v2
+ */
+WebGL2RenderingContextBase.prototype.uniform3ui = function(location, v0, v1, v2) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {number} v0
+ * @param {number} v1
+ * @param {number} v2
+ * @param {number} v3
+ */
+WebGL2RenderingContextBase.prototype.uniform4ui = function(location, v0, v1, v2, v3) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Uint32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniform1uiv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Uint32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniform2uiv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Uint32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniform3uiv = function(location, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {Uint32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniform4uiv = function(location, value) {};
+
+/**
+ * @param {WebGLProgram} program
+ * @param {number} uniformBlockIndex
+ * @param {number} uniformBlockBinding
+ */
+WebGL2RenderingContextBase.prototype.uniformBlockBinding = function(program, uniformBlockIndex, uniformBlockBinding) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniformMatrix2x3fv = function(location, transpose, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniformMatrix3x2fv = function(location, transpose, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniformMatrix2x4fv = function(location, transpose, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniformMatrix4x2fv = function(location, transpose, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniformMatrix3x4fv = function(location, transpose, value) {};
+
+/**
+ * @param {WebGLUniformLocation} location
+ * @param {boolean} transpose
+ * @param {Float32Array|Array.<number>} value
+ */
+WebGL2RenderingContextBase.prototype.uniformMatrix4x3fv = function(location, transpose, value) {};
+
+/**
+ * @param {number} index
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @param {number} w
+ */
+WebGL2RenderingContextBase.prototype.vertexAttribI4i = function(index, x, y, z, w) {};
+
+/**
+ * @param {number} index
+ * @param {Array.<number>} v
+ */
+WebGL2RenderingContextBase.prototype.vertexAttribI4iv = function(index, v) {};
+
+/**
+ * @param {number} index
+ * @param {number} x
+ * @param {number} y
+ * @param {number} z
+ * @param {number} w
+ */
+WebGL2RenderingContextBase.prototype.vertexAttribI4ui = function(index, x, y, z, w) {};
+
+/**
+ * @param {number} index
+ * @param {Array.<number>} v
+ */
+WebGL2RenderingContextBase.prototype.vertexAttribI4uiv = function(index, v) {};
+
+/**
+ * @param {number} index
+ * @param {number} size
+ * @param {number} type
+ * @param {number} stride
+ * @param {number} offset
+ */
+WebGL2RenderingContextBase.prototype.vertexAttribIPointer = function(index, size, type, stride, offset) {};
+
+/**
+ * @param {number} index
+ * @param {number} divisor
+ */
+WebGL2RenderingContextBase.prototype.vertexAttribDivisor = function(index, divisor) {};
+
+/**
+ * @param {WebGLSync} sync
+ * @param {number} flags
+ * @param {number} timeout
+ */
+WebGL2RenderingContextBase.prototype.waitSync = function(sync, flags, timeout) {};
+
+/**
+ * @constructor
+ * @noalias
+ * @extends {WebGL2RenderingContextBase}
+ */
+function WebGL2RenderingContext() {}


### PR DESCRIPTION
..., based on the WebGL 1.0 externs.

Temporarily copied in all of the Closure compiler's externs, modulo webgl.js, in order to test overriding of the compiler's built-in WebGL externs.

The new externs parse, but have not been tested against the ported dEQP tests yet.