### PR TITLE
Fixed erronious removal of some enums from getParameter table

### DIFF
--- a/sdk/tests/conformance2/state/gl-get-calls.html
+++ b/sdk/tests/conformance2/state/gl-get-calls.html
@@ -83,7 +83,10 @@ else {
     shouldBe('context.getParameter(context.TEXTURE_BINDING_2D_ARRAY)', 'null');
     shouldBe('context.getParameter(context.TEXTURE_BINDING_3D)', 'null');
     shouldBe('context.getParameter(context.TRANSFORM_FEEDBACK_ACTIVE)', 'false');
+    shouldBe('context.getParameter(context.TRANSFORM_FEEDBACK_BINDING)', 'null');
+    shouldBe('context.getParameter(context.TRANSFORM_FEEDBACK_BUFFER_BINDING)', 'null');
     shouldBe('context.getParameter(context.TRANSFORM_FEEDBACK_PAUSED)', 'false');
+    shouldBe('context.getParameter(context.UNIFORM_BUFFER_BINDING)', 'null');
 
     shouldBe('context.getParameter(context.UNPACK_IMAGE_HEIGHT)', '0');
     shouldBe('context.getParameter(context.UNPACK_ROW_LENGTH)', '0');

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -889,7 +889,10 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
                 <tr><td>TEXTURE_BINDING_2D_ARRAY</td><td>WebGLTexture</td></tr>
                 <tr><td>TEXTURE_BINDING_3D</td><td>WebGLTexture</td></tr>
                 <tr><td>TRANSFORM_FEEDBACK_ACTIVE</td><td>GLboolean</td></tr>
+                <tr><td>TRANSFORM_FEEDBACK_BINDING</td><td>WebGLTransformFeedback</td></tr>
+                <tr><td>TRANSFORM_FEEDBACK_BUFFER_BINDING</td><td>WebGLBuffer</td></tr>
                 <tr><td>TRANSFORM_FEEDBACK_PAUSED</td><td>GLboolean</td></tr>
+                <tr><td>UNIFORM_BUFFER_BINDING</td><td>WebGLBuffer</td></tr>
                 <tr><td>UNIFORM_BUFFER_OFFSET_ALIGNMENT</td><td>GLint</td></tr>
                 <tr><td>UNPACK_IMAGE_HEIGHT</td><td>GLint</td></tr>
                 <tr><td>UNPACK_ROW_LENGTH</td><td>GLint</td></tr>


### PR DESCRIPTION
I removed TRANSFORM_FEEDBACK_BUFFER_BINDING and UNIFORM_BUFFER_BINDING in a prior patch because they were indexed parameters. I didn't realize that it was also valid to query them non-indexed. Sorry for the confusion.

TRANSFORM_FEEDBACK_BINDING, on the other hand, seems to have simply been overlooked previously.