### PR TITLE
Global variable initializers should be constant expressions

### DIFF
--- a/conformance-suites/1.0.3/conformance/glsl/misc/ternary-operators-in-global-initializers.html
+++ b/conformance-suites/1.0.3/conformance/glsl/misc/ternary-operators-in-global-initializers.html
@@ -38,8 +38,8 @@
 <div id="console"></div>
 <script id="fragmentShader" type="text/something-not-javascript">
 precision mediump float;
-$(type) green = $(green);
-$(type) black = $(black);
+const $(type) green = $(green);
+const $(type) black = $(black);
 $(type) var = (true) ? green : black;
 void main() {
     gl_FragColor = $(asVec4);

--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -5,6 +5,7 @@ embedded-struct-definitions-forbidden.html
 --min-version 1.0.4 empty-declaration.html
 empty_main.vert.html
 --min-version 1.0.3 expression-list-in-declarator-initializer.html
+--min-version 1.0.4 global-init-with-non-const.html
 gl_position_unset.vert.html
 # this test is intentionally disabled as it is too strict and to hard to simulate
 # glsl-2types-of-textures-on-same-unit.html
@@ -108,3 +109,4 @@ uniform-location-length-limits.html
 --min-version 1.0.3 struct-unary-operators.html
 --min-version 1.0.3 ternary-operators-in-global-initializers.html
 --min-version 1.0.3 ternary-operators-in-initializers.html
+

--- a/sdk/tests/conformance/glsl/misc/global-init-with-non-const.html
+++ b/sdk/tests/conformance/glsl/misc/global-init-with-non-const.html
@@ -1,0 +1,83 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Global variables can only be initialized with constant expressions</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="VertexGlobalInitWithNonConstantGlobal" type="x-shader/x-vertex">
+precision mediump float;
+attribute vec4 aPosition;
+
+bool a = true;
+bool b = a;
+
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+<script id="FragmentGlobalInitWithNonConstantGlobal" type="x-shader/x-vertex">
+precision mediump float;
+
+bool a = true;
+bool b = a;
+
+void main() {
+    gl_FragColor = vec4(0.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("");
+GLSLConformanceTester.runTests([
+  {
+    vShaderId: "VertexGlobalInitWithNonConstantGlobal",
+    vShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "A global variable cannot be initialized with a non-constant global variable in a vertex shader."
+  },
+  {
+    fShaderId: "FragmentGlobalInitWithNonConstantGlobal",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "A global variable cannot be initialized with a non-constant global variable in a fragment shader."
+  }
+]);
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/glsl/misc/ternary-operators-in-global-initializers.html
+++ b/sdk/tests/conformance/glsl/misc/ternary-operators-in-global-initializers.html
@@ -38,8 +38,8 @@
 <div id="console"></div>
 <script id="fragmentShader" type="text/something-not-javascript">
 precision mediump float;
-$(type) green = $(green);
-$(type) black = $(black);
+const $(type) green = $(green);
+const $(type) black = $(black);
 $(type) var = (true) ? green : black;
 void main() {
     gl_FragColor = $(asVec4);


### PR DESCRIPTION
Global variable initializers need to be constant expressions (ESSL1.00
section 4.3). Global variables need to be qualified with const in order
to be constant expressions (ESSL1.00 section 5.10).

Fix the ternary operator in global initializer test by making the
other globals used in initialization constant.

Add a test that verifies that non-const global variables cannot be used
to initialize other globals.