### PR TITLE
Allow multiple checkCanvasRectColor checks with one readPixels call

### DIFF
--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1092,8 +1092,8 @@ var makeCheckRect = function(x, y, width, height, color, msg, errorRange) {
     'errorRange': errorRange,
 
     'checkRect': function (buf, l, b, w) {
-      for (var px = (x - l) ; px < (width - l) ; ++px) {
-        for (var py = (y - b) ; py < (height - b) ; ++py) {
+      for (var px = (x - l) ; px < (x + width - l) ; ++px) {
+        for (var py = (y - b) ; py < (y + height - b) ; ++py) {
           var offset = (py * w + px) * 4;
           for (var j = 0; j < color.length; ++j) {
             if (Math.abs(buf[offset + j] - color[j]) > errorRange) {

--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html
@@ -192,7 +192,7 @@ function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premult
         // Check the top pixel and bottom pixel and make sure they have
         // the right color.
         var rects = [wtu.makeCheckRect(0, 0, testWidth, testHeight, bottomColor, "bottom pixel should be " + bottomColor, 0),
-                      wtu.makeCheckRect(0, testHeight, testWidth, testHeight, topColor, "top pixel should be " + topColor, 0)];
+                     wtu.makeCheckRect(0, testHeight, testWidth, testHeight, topColor, "top pixel should be " + topColor, 0)];
         wtu.checkCanvasRects(gl, rects);
       }
 

--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-array-buffer-view.html
@@ -191,9 +191,10 @@ function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premult
 
         // Check the top pixel and bottom pixel and make sure they have
         // the right color.
-        wtu.checkCanvasRect(gl, 0, 0, testWidth, testHeight, bottomColor, "bottom pixel should be " + bottomColor);
-        wtu.checkCanvasRect(gl, 0, testHeight, testWidth, testHeight, topColor, "top pixel should be " + topColor);
-    }
+        var rects = [wtu.makeCheckRect(0, 0, testWidth, testHeight, bottomColor, "bottom pixel should be " + bottomColor, 0),
+                      wtu.makeCheckRect(0, testHeight, testWidth, testHeight, topColor, "top pixel should be " + topColor, 0)];
+        wtu.checkCanvasRects(gl, rects);
+      }
 
     // Change part of the texture.
     var partWidth = 16;
@@ -225,11 +226,13 @@ function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premult
         }
 
         wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-        wtu.checkCanvasRect(gl, 0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0);
-        wtu.checkCanvasRect(gl, 0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1);
-        wtu.checkCanvasRect(gl, halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom right pixels should be " + bottomColor);
-        wtu.checkCanvasRect(gl, 0, halfHeight, testWidth, halfHeight, topColor, "top pixels should be " + topColor);
-    }
+        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+        var rects = [wtu.makeCheckRect(0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0, 0),
+                     wtu.makeCheckRect(0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1, 0),
+                     wtu.makeCheckRect(halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom right pixels should be " + bottomColor, 0),
+                     wtu.makeCheckRect(0, halfHeight, testWidth, halfHeight, topColor, "top pixels should be " + topColor, 0)];
+        wtu.checkCanvasRects(gl, rects);
+      }
 
     // set far corner.
     for (var tt = 0; tt < targets.length; ++tt) {
@@ -241,13 +244,14 @@ function runOneIteration(useTexSubImage2D, type, unpackAlignment, flipY, premult
         }
 
         wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-        wtu.checkCanvasRect(gl, 0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0);
-        wtu.checkCanvasRect(gl, 0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1);
-        wtu.checkCanvasRect(gl, halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom left pixels should be " + bottomColor);
-        wtu.checkCanvasRect(gl, 0, halfHeight, halfWidth, halfHeight, topColor, "top right pixels should be " + topColor);
-        wtu.checkCanvasRect(gl, halfWidth, halfHeight, halfWidth, quarterHeight, tcolor0, "top right bottom pixels should be " + tcolor0);
-        wtu.checkCanvasRect(gl, halfWidth, halfHeight + quarterHeight, halfWidth, quarterHeight, tcolor1, "top right top pixels should be " + tcolor1);
-    }
+        var rects = [wtu.makeCheckRect(0, 0, halfWidth, quarterHeight, tcolor0, "bottom left bottom pixels should be " + tcolor0, 0),
+                     wtu.makeCheckRect(0, quarterHeight, halfWidth, quarterHeight, tcolor1, "bottom left top pixels should be " + tcolor1, 0),
+                     wtu.makeCheckRect(halfWidth, 0, halfWidth, halfHeight, bottomColor, "bottom left pixels should be " + bottomColor, 0),
+                     wtu.makeCheckRect(0, halfHeight, halfWidth, halfHeight, topColor, "top right pixels should be " + topColor, 0),
+                     wtu.makeCheckRect(halfWidth, halfHeight, halfWidth, quarterHeight, tcolor0, "top right bottom pixels should be " + tcolor0, 0),
+                     wtu.makeCheckRect(halfWidth, halfHeight + quarterHeight, halfWidth, quarterHeight, tcolor1, "top right top pixels should be " + tcolor1, 0)];
+        wtu.checkCanvasRects(gl, rects);
+      }
 }
 
 function runTest(bindingTarget, program)


### PR DESCRIPTION
Quick optimization to make the test run faster.  readPixels can be slow, so call readPixels once on a union of the rects, and check each subrect for matching color.