### PR TITLE
Clarify error msg in expando test

### DIFF
--- a/sdk/tests/conformance/misc/expando-loss.html
+++ b/sdk/tests/conformance/misc/expando-loss.html
@@ -58,7 +58,7 @@ function setTestExpandos(instance) {
 }
 function verifyTestExpandos(instance, msg) {
     assertMsg(instance.expando1 === expandoValue, msg + ": Expect basic expando to survive despite GC.");
-    assertMsg(instance.expando2.subvalue === expandoValue, msg + ": Expect subobject expando to survive despite GC.");
+    assertMsg(instance.expando2 && instance.expando2.subvalue === expandoValue, msg + ": Expect subobject expando to survive despite GC.");
 }
 
 // Tests that we don't get expando loss for bound resources where the


### PR DESCRIPTION
Without this patch the expando test fails in a peculiar way in Chrome by
generating an exception, which prevents it from running into completion
and marking successfullyParsed = true. Make sure that expando2 property
is set before querying its properties to generate a better error message.