### PR TITLE
Add WebGL version to GLSL conformance test parameters

### DIFF
--- a/sdk/tests/conformance/resources/glsl-conformance-test.js
+++ b/sdk/tests/conformance/resources/glsl-conformance-test.js
@@ -214,12 +214,12 @@ function runOneTest(gl, info) {
   wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
 }
 
-function runTests(shaderInfos) {
+function runTests(shaderInfos, opt_contextVersion) {
   var wtu = WebGLTestUtils;
   var canvas = document.createElement('canvas');
   canvas.width = 32;
   canvas.height = 32;
-  var gl = wtu.create3DContext(canvas);
+  var gl = wtu.create3DContext(canvas, undefined, opt_contextVersion);
   if (!gl) {
     testFailed("context does not exist");
     finishTest();

--- a/sdk/tests/conformance2/glsl3/misplaced-version-directive.html
+++ b/sdk/tests/conformance2/glsl3/misplaced-version-directive.html
@@ -125,7 +125,7 @@ GLSLConformanceTester.runTests([
     linkSuccess: false,
     passMsg: "Fragment shader with a newline before the version directive should fail."
   }
-]);
+], 2);
 var successfullyParsed = true;
 </script>
 </body>

--- a/sdk/tests/conformance2/glsl3/shader-linking.html
+++ b/sdk/tests/conformance2/glsl3/shader-linking.html
@@ -98,7 +98,7 @@ GLSLConformanceTester.runTests([
     linkSuccess: false,
     passMsg: "OpenGL ES Shading Language 1.00 vertex shader should not link with OpenGL ES Shading Language 3.00 fragment shader."
   }
-]);
+], 2);
 var successfullyParsed = true;
 </script>
 </body>


### PR DESCRIPTION
This makes the WebGL 2 GLSL tests easier to use, since specifying the
context version separately with webglVersion=2 is no longer necessary.