### PR TITLE
Clean up small issues in some ESSL and WebGL 2 tests

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
+++ b/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
@@ -75,7 +75,7 @@ function test() {
   var uniformLoc = gl.getUniformLocation(program, 'uCount');
   gl.uniform1i(uniformLoc, 5);
   wtu.drawUnitQuad(gl);
-  wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
 };
 
 test();

--- a/sdk/tests/conformance2/buffers/buffer-copying-contents.html
+++ b/sdk/tests/conformance2/buffers/buffer-copying-contents.html
@@ -31,10 +31,8 @@
 <meta charset="utf-8">
 <title>WebGL buffer copying contents test.</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<link rel="stylesheet" href="../../conformance/resources/glsl-feature-tests.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
-<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>

--- a/sdk/tests/conformance2/buffers/buffer-copying-restrictions.html
+++ b/sdk/tests/conformance2/buffers/buffer-copying-restrictions.html
@@ -31,10 +31,8 @@
 <meta charset="utf-8">
 <title>WebGL buffer copying restrictions test.</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<link rel="stylesheet" href="../../conformance/resources/glsl-feature-tests.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
-<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>

--- a/sdk/tests/conformance2/buffers/buffer-type-restrictions.html
+++ b/sdk/tests/conformance2/buffers/buffer-type-restrictions.html
@@ -31,10 +31,8 @@
 <meta charset="utf-8">
 <title>WebGL buffer binding restrictions test.</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<link rel="stylesheet" href="../../conformance/resources/glsl-feature-tests.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
-<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>

--- a/sdk/tests/conformance2/buffers/getBufferSubData.html
+++ b/sdk/tests/conformance2/buffers/getBufferSubData.html
@@ -31,10 +31,8 @@
 <meta charset="utf-8">
 <title>WebGL getBufferSubData test.</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<link rel="stylesheet" href="../../conformance/resources/glsl-feature-tests.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
-<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>

--- a/sdk/tests/conformance2/core/frag-depth.html
+++ b/sdk/tests/conformance2/core/frag-depth.html
@@ -161,12 +161,12 @@ function runOutputTests() {
     // Draw 1: Greater than clear depth
     gl.uniform1f(depthUniform, 1.0);
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.checkCanvasRect(gl, 0, 0, canvas.width, canvas.height, [255, 255, 255, 255]);
+    wtu.checkCanvas(gl, [255, 255, 255, 255]);
 
     // Draw 2: Less than clear depth
     gl.uniform1f(depthUniform, 0.0);
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.checkCanvasRect(gl, 0, 0, canvas.width, canvas.height, [255, 0, 0, 255]);
+    wtu.checkCanvas(gl, [255, 0, 0, 255]);
 }
 
 debug("");

--- a/sdk/tests/conformance2/glsl3/array-assign.html
+++ b/sdk/tests/conformance2/glsl3/array-assign.html
@@ -47,7 +47,6 @@ void main() {
 </script>
 <script id="fshaderSimple" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
-uniform int uCount;
 
 out vec4 my_FragColor;
 
@@ -72,7 +71,6 @@ void main() {
 </script>
 <script id="fshaderArrayOfStructs" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
-uniform int uCount;
 
 out vec4 my_FragColor;
 

--- a/sdk/tests/conformance2/glsl3/array-equality.html
+++ b/sdk/tests/conformance2/glsl3/array-equality.html
@@ -47,7 +47,6 @@ void main() {
 </script>
 <script id="fshaderSimple" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
-uniform int uCount;
 
 out vec4 my_FragColor;
 
@@ -68,7 +67,6 @@ void main() {
 </script>
 <script id="fshaderArrayOfStructs" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
-uniform int uCount;
 
 out vec4 my_FragColor;
 


### PR DESCRIPTION
Prefer checkCanvas to checkCanvasRect, and remove unnecessary script tags
and an unnecessary uniform that were left over to tests from copy-pasted
code.