### PR TITLE
Add a WebGL 2 test for array length expressions that have side effects

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -1,5 +1,6 @@
 array-assign.html
 array-assign-constructor.html
 array-equality.html
+array-length-side-effects.html
 misplaced-version-directive.html
 shader-linking.html

--- a/sdk/tests/conformance2/glsl3/array-length-side-effects.html
+++ b/sdk/tests/conformance2/glsl3/array-length-side-effects.html
@@ -86,6 +86,7 @@ void main() {
 <script type="text/javascript">
 "use strict";
 description();
+debug("These restrictions come from ESSL 3.00 section 5.9 definition of expression, which only allows length to be called on array names, not on arbitrary expressions returning an array.");
 GLSLConformanceTester.runTests([
   {
     vShaderId: "vshader",

--- a/sdk/tests/conformance2/glsl3/array-length-side-effects.html
+++ b/sdk/tests/conformance2/glsl3/array-length-side-effects.html
@@ -1,0 +1,118 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL: test that length() method called on a complex expression does not compile</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../conformance/resources/glsl-feature-tests.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../conformance/resources/webgl-test-utils.js"></script>
+<script src="../../conformance/resources/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+
+void main() {
+    gl_Position = vec4(aPosition, 1);
+}
+</script>
+<script id="fshaderLengthOfAssignment" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+void main() {
+    int a[3];
+    int b[3];
+    int c = (a = b).length();
+    my_FragColor = vec4(float(c));
+}
+</script>
+<script id="fshaderLengthOfFunctionCall" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+int[2] func() {
+    int a[2];
+    return a;
+}
+
+void main() {
+    int b = (func()).length();
+    my_FragColor = vec4(float(b));
+}
+</script>
+<script id="fshaderLengthOfConstructor" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+void main() {
+    int a = (int[1](0)).length();
+    my_FragColor = vec4(float(a));
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description();
+GLSLConformanceTester.runTests([
+  {
+    vShaderId: "vshader",
+    vShaderSuccess: true,
+    fShaderId: "fshaderLengthOfAssignment",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Fragment shader which tries to evaluate the length of an assignment operation should fail."
+  },
+  {
+    vShaderId: "vshader",
+    vShaderSuccess: true,
+    fShaderId: "fshaderLengthOfFunctionCall",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Fragment shader which tries to evaluate the length of a return value should fail."
+  },
+  {
+    vShaderId: "vshader",
+    vShaderSuccess: true,
+    fShaderId: "fshaderLengthOfConstructor",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Fragment shader which tries to evaluate the length of a newly constructed array should fail."
+  }
+], 2);
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
ESSL3 defines expressions in section 5.9 so that the length() method is
only allowed to be called on array names, not on complex expressions that
return arrays. Enforce this restriction, which simplifies constant
folding of length() method calls.