### PR TITLE
Add test for global variable init order.

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -99,6 +99,7 @@ struct-nesting-under-maximum.html
 uniform-location-length-limits.html
 --min-version 1.0.2 shader-with-short-circuiting-operators.html
 --min-version 1.0.2 shader-with-global-variable-precision-mismatch.html
+--min-version 1.0.4 shader-with-global-varying-assign.html
 --min-version 1.0.2 large-loop-compile.html
 --min-version 1.0.3 struct-equals.html
 --min-version 1.0.4 struct-assign.html

--- a/sdk/tests/conformance/glsl/misc/shader-with-global-varying-assign.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-global-varying-assign.html
@@ -1,0 +1,89 @@
+
+
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL Varying Assignment at Global Scope</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../resources/webgl-test-utils.js"> </script>
+<script src="../../resources/glsl-conformance-test.js"></script>
+
+<script id="vs" type="x-shader/x-vertex">
+attribute vec4 a_position;
+varying float v;
+void main() {
+  gl_Position = a_position;
+  v = 1.0;
+}
+</script>
+<script id="fs" type="x-shader/x-fragment">
+precision highp float;
+varying float v;
+float x = v;
+float global_v = x;
+void main() {
+  if (global_v == 1.0) {
+      gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+  } else {
+      gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+  }
+}
+</script>
+</head>
+<body>
+<canvas id="canvas" width="50" height="50"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Testing varying assignment in global scope");
+
+var wtu = WebGLTestUtils;
+GLSLConformanceTester.runTests([
+  {
+    vShaderId: "vs",
+    vShaderSuccess: true,
+    fShaderId: "fs",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Varying assignment at global scope",
+  },
+]);
+debug("");
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
In some cases, ANGLE would miss initializing variables at global
scope in the correct order. This bug is already fixed in ANGLE.