### PR TITLE
Set dEQP-based GLES3 tests to use WebGL 2 contexts by default

### DIFF
--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1398,6 +1398,17 @@ var getUrlOptions = function() {
   return options;
 };
 
+var default3DContextVersion = 1;
+
+/**
+ * Set the default context version for create3DContext.
+ * Initially the default version is 1.
+ * @param {number} Default version of WebGL contexts.
+ */
+var setDefault3DContextVersion = function(version) {
+    default3DContextVersion = version;
+};
+
 /**
  * Creates a webgl context.
  * @param {!Canvas|string} opt_canvas The canvas tag to get
@@ -1405,7 +1416,8 @@ var getUrlOptions = function() {
  *     created. If it's a string it's assumed to be the id of a
  *     canvas.
  * @param {Object} opt_attributes Context attributes.
- * @param {!number} opt_version Version of WebGL context to create
+ * @param {!number} opt_version Version of WebGL context to create.
+ *     The default version can be set by calling setDefault3DContextVersion.
  * @return {!WebGLRenderingContext} The created context.
  */
 var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
@@ -1417,7 +1429,7 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
     attributes.antialias = false;
   }
   if (!opt_version) {
-    opt_version = parseInt(getUrlOptions().webglVersion, 10) || 1;
+    opt_version = parseInt(getUrlOptions().webglVersion, 10) || default3DContextVersion;
   }
   opt_canvas = opt_canvas || document.createElement("canvas");
   if (typeof opt_canvas == 'string') {
@@ -2898,6 +2910,7 @@ return {
   makeVideo: makeVideo,
   error: error,
   shallowCopyObject: shallowCopyObject,
+  setDefault3DContextVersion: setDefault3DContextVersion,
   setupColorQuad: setupColorQuad,
   setupProgram: setupProgram,
   setupQuad: setupQuad,

--- a/sdk/tests/deqp/data/gles3/shaders/arrays.html
+++ b/sdk/tests/deqp/data/gles3/shaders/arrays.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'arrays';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/conditionals.html
+++ b/sdk/tests/deqp/data/gles3/shaders/conditionals.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'conditionals';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/constant_expressions.html
+++ b/sdk/tests/deqp/data/gles3/shaders/constant_expressions.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'constant_expressions';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/constants.html
+++ b/sdk/tests/deqp/data/gles3/shaders/constants.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'constants';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/conversions.html
+++ b/sdk/tests/deqp/data/gles3/shaders/conversions.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'conversions';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/declarations.html
+++ b/sdk/tests/deqp/data/gles3/shaders/declarations.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'declarations';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/fragdata.html
+++ b/sdk/tests/deqp/data/gles3/shaders/fragdata.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'fragdata';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/functions.html
+++ b/sdk/tests/deqp/data/gles3/shaders/functions.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'functions';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/invalid_texture_functions.html
+++ b/sdk/tests/deqp/data/gles3/shaders/invalid_texture_functions.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'invalid_texture_functions';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/keywords.html
+++ b/sdk/tests/deqp/data/gles3/shaders/keywords.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'keywords';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/linkage.html
+++ b/sdk/tests/deqp/data/gles3/shaders/linkage.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'linkage';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/negative.html
+++ b/sdk/tests/deqp/data/gles3/shaders/negative.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'negative';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/preprocessor.html
+++ b/sdk/tests/deqp/data/gles3/shaders/preprocessor.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'preprocessor';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/qualification_order.html
+++ b/sdk/tests/deqp/data/gles3/shaders/qualification_order.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'qualification_order';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/scoping.html
+++ b/sdk/tests/deqp/data/gles3/shaders/scoping.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'scoping';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/switch.html
+++ b/sdk/tests/deqp/data/gles3/shaders/switch.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'switch';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/swizzles.html
+++ b/sdk/tests/deqp/data/gles3/shaders/swizzles.html
@@ -17,6 +17,7 @@
 <script>
 testName = 'swizzles';
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');

--- a/sdk/tests/deqp/data/gles3/shaders/template.html
+++ b/sdk/tests/deqp/data/gles3/shaders/template.html
@@ -17,6 +17,7 @@
 <script>
 testName = ___TEST_NAME___;
 description("Shader test: " + testName + ".");
+WebGLTestUtils.setDefault3DContextVersion(2);
 
 var getFilter = function() {
     var queryVars = window.location.search.substring(1).split('&');


### PR DESCRIPTION
This removes the need to supply ?webglVersion=2 in the URL when running
one of these tests by itself. A function is added to WebGLTestUtils to
set the default context version, since it is a lot simpler than passing
the context version through the fairly complex test framework.