### PR TITLE
Fix the gl_DepthRange vertex shader test.

### DIFF
--- a/sdk/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
+++ b/sdk/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
@@ -46,25 +46,25 @@ OpenGLESTestRunner.run({
   "tests": [
     {
       "referenceProgram": {
-        "vertexShader": "../default/default.vert", 
+        "vertexShader": "../default/default.vert",
         "uniforms": {
           "result": {
-            "count": 1, 
-            "type": "uniform4fv", 
+            "count": 1,
+            "type": "uniform4fv",
             "value": [
-              0.25, 
-              0.75, 
-              0.5, 
+              0.25,
+              0.75,
+              0.5,
               1.0
             ]
           }
         },
         "fragmentShader": "../default/expected.frag"
-      }, 
-      "name": "DepthRange_frag.test.html", 
-      "pattern": "compare", 
+      },
+      "name": "DepthRange_frag.test.html",
+      "pattern": "compare",
       "testProgram": {
-        "vertexShader": "../default/default.vert", 
+        "vertexShader": "../default/default.vert",
         "fragmentShader": "DepthRange_frag.frag",
         "builtin_uniforms": {
           "min_required": 2,
@@ -74,52 +74,52 @@ OpenGLESTestRunner.run({
             "gl_DepthRange.diff"
           ],
         }
-      }, 
+      },
       "state": {
         "depthrange": {
-          "far": "0.75", 
+          "far": "0.75",
           "near": "0.25"
         }
-      }, 
+      },
       "model": null
-    }, 
+    },
     {
       "referenceProgram": {
-        "vertexShader": "../default/default.vert", 
+        "vertexShader": "../default/default.vert",
         "uniforms": {
           "result": {
-            "count": 1, 
-            "type": "uniform4fv", 
+            "count": 1,
+            "type": "uniform4fv",
             "value": [
-              0.25, 
-              0.75, 
-              0.5, 
+              0.25,
+              0.75,
+              0.5,
               1.0
             ]
           }
-        }, 
+        },
+        "fragmentShader": "../default/expected.frag"
+      },
+      "name": "DepthRange_vert.test.html",
+      "pattern": "compare",
+      "testProgram": {
+        "vertexShader": "DepthRange_vert.vert",
+        "fragmentShader": "../default/default.frag",
         "builtin_uniforms": {
           "min_required": 2,
           "valid_values": [
             "gl_DepthRange.near",
             "gl_DepthRange.far",
             "gl_DepthRange.diff"
-          ],
-        },
-        "fragmentShader": "../default/expected.frag"
-      }, 
-      "name": "DepthRange_vert.test.html", 
-      "pattern": "compare", 
-      "testProgram": {
-        "vertexShader": "DepthRange_vert.vert", 
-        "fragmentShader": "../default/default.frag"
-      }, 
+          ]
+        }
+      },
       "state": {
         "depthrange": {
-          "far": "0.75", 
+          "far": "0.75",
           "near": "0.25"
         }
-      }, 
+      },
       "model": "grid"
     }
   ]


### PR DESCRIPTION
This test was accidentally checking the reference shader for the
presence of the gl_DepthRange built-in uniform. Modify the check
to happen on the expected shader instead.