### PR TITLE
Improve error handling of UNPACK_COLORSPACE_CONVERSION_WEBGL.

### DIFF
--- a/sdk/tests/conformance/context/premultiplyalpha-test.html
+++ b/sdk/tests/conformance/context/premultiplyalpha-test.html
@@ -177,6 +177,9 @@ function doNextTest() {
     shouldBeTrue('gl.getContextAttributes().preserveDrawingBuffer');
 
     wtu.log(gl.getContextAttributes());
+    // not needed as it's the default
+    // gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);");
     var program = wtu.setupTexturedQuad(gl);
 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
@@ -195,9 +198,6 @@ function doNextTest() {
     var loadTexture = function() {
       debug("loadTexture called");
       var pngTex = gl.createTexture();
-      // not needed as it's the default
-      // gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-      gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
       gl.bindTexture(gl.TEXTURE_2D, pngTex);
       if (test.imageFormat) {
          // create texture from image

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
@@ -37,6 +37,8 @@ function generateTest(pixelFormat, pixelType, prologue) {
             return;
         }
 
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);");
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -105,8 +107,6 @@ function generateTest(pixelFormat, pixelType, prologue) {
         }
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
-        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
@@ -40,6 +40,8 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
             return;
         }
 
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);");
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -63,8 +65,6 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
         gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
-        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
@@ -40,6 +40,8 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
             return;
         }
 
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);");
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -62,8 +64,6 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
         gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
-        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -37,6 +37,8 @@ function generateTest(pixelFormat, pixelType, prologue) {
             return;
         }
 
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+        wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);");
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -97,8 +99,6 @@ function generateTest(pixelFormat, pixelType, prologue) {
         }
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
-        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/textures/gl-teximage.html
+++ b/sdk/tests/conformance/textures/gl-teximage.html
@@ -84,6 +84,7 @@ function runTests(imgs) {
 
   gl.disable(gl.BLEND);
   gl.disable(gl.DEPTH_TEST);
+  wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);");
 
   var width = gl.canvas.width;
   var height = gl.canvas.height;
@@ -173,7 +174,6 @@ function runTests(imgs) {
 
   debug("");
   debug("Check that gamma settings don't effect 8bit pngs");
-  gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE,
                 imgs['../resources/gray-ramp-default-gamma.png']);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
@@ -333,7 +333,6 @@ function runTests(imgs) {
   debug("check uploading of images with ICC profiles");
   gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
   gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-  gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
 
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE,
                 imgs['../resources/small-square-with-colorspin-profile.jpg']);


### PR DESCRIPTION
Internet Explorer does not support the UNPACK_COLORSPACE_CONVERSION_WEBGL
pixelStorei parameter. To inform developers the enum is unsupported, it flags an
INVALID_VALUE WebGL error.

Various tests in the conformance suite set UNPACK_COLORSPACE_CONVERSION_WEBGL to
gl.NONE and then fail to check the error code on the context. This causes subsequent
operations be misreported as failing when they, in fact, succeed. Much frustrating time
has been devoted to debugging root causes of conformance failures due to this issue.

This change:
- Checks and clears the WebGL error code when setting the
UNPACK_COLORSPACE_CONVERSION_WEBGL pixelStoreI parameter. Errors are now correctly
attributed to the source of the failure.
- Moves pixelStoreI calls to the beginning of the test to avoid needless and duplicate
calls to testPassed/testFailed.