### PR TITLE
Report errors when setting colorspace conversion unpack parameters.

### DIFF
--- a/sdk/tests/conformance/context/premultiplyalpha-test.html
+++ b/sdk/tests/conformance/context/premultiplyalpha-test.html
@@ -197,7 +197,7 @@ function doNextTest() {
       var pngTex = gl.createTexture();
       // not needed as it's the default
       // gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-      gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+      wtu.failIfGLError(gl, 'gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);');
       gl.bindTexture(gl.TEXTURE_2D, pngTex);
       if (test.imageFormat) {
          // create texture from image

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
@@ -106,7 +106,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        wtu.failIfGLError(gl, 'gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);');
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-image.js
@@ -64,7 +64,7 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        wtu.failIfGLError(gl, 'gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);');
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-svg-image.js
@@ -63,7 +63,7 @@ function generateTest(pixelFormat, pixelType, pathToTestRoot, prologue) {
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        wtu.failIfGLError(gl, 'gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);');
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -98,7 +98,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
-        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+        wtu.failIfGLError(gl, 'gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);');
         var targets = [gl.TEXTURE_2D];
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1528,7 +1528,6 @@ var shouldGenerateGLError = function(gl, glErrors, evalStr) {
 /**
  * Tests that an evaluated expression does not generate a GL error.
  * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
  * @param {string} evalStr The string to evaluate.
  */
 var failIfGLError = function(gl, evalStr) {

--- a/sdk/tests/conformance/resources/webgl-test-utils.js
+++ b/sdk/tests/conformance/resources/webgl-test-utils.js
@@ -1526,12 +1526,43 @@ var shouldGenerateGLError = function(gl, glErrors, evalStr) {
 };
 
 /**
+ * Tests that an evaluated expression does not generate a GL error.
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
+ * @param {string} evalStr The string to evaluate.
+ */
+var failIfGLError = function(gl, evalStr) {
+  var exception;
+  try {
+    eval(evalStr);
+  } catch (e) {
+    exception = e;
+  }
+  if (exception) {
+    testFailed(evalStr + " threw exception " + exception);
+  } else {
+    glErrorShouldBeImpl(gl, gl.NO_ERROR, false, "after evaluating: " + evalStr);
+  }
+};
+
+/**
  * Tests that the first error GL returns is the specified error.
  * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
  * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
  * @param {string} opt_msg Optional additional message.
  */
 var glErrorShouldBe = function(gl, glErrors, opt_msg) {
+  glErrorShouldBeImpl(gl, glErrors, true, opt_msg);
+};
+
+/**
+ * Tests that the first error GL returns is the specified error. Allows suppression of successes.
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
+ * @param {boolean} reportSuccesses Whether to report successes as passes, or to silently pass.
+ * @param {string} opt_msg Optional additional message.
+ */
+var glErrorShouldBeImpl = function(gl, glErrors, reportSuccesses, opt_msg) {
   if (!glErrors.length) {
     glErrors = [glErrors];
   }
@@ -1546,7 +1577,7 @@ var glErrorShouldBe = function(gl, glErrors, opt_msg) {
   if (ndx < 0) {
     var msg = "getError expected" + ((glErrors.length > 1) ? " one of: " : ": ");
     testFailed(msg + expected +  ". Was " + glEnumToString(gl, err) + " : " + opt_msg);
-  } else {
+  } else if (reportSuccesses) {
     var msg = "getError was " + ((glErrors.length > 1) ? "one of: " : "expected value: ");
     testPassed(msg + expected + " : " + opt_msg);
   }
@@ -2868,6 +2899,7 @@ return {
   drawFloatColorQuad: drawFloatColorQuad,
   dumpShadersInfo: dumpShadersInfo,
   endsWith: endsWith,
+  failIfGLError: failIfGLError,
   fillTexture: fillTexture,
   getBytesPerComponent: getBytesPerComponent,
   getExtensionPrefixedNames: getExtensionPrefixedNames,

--- a/sdk/tests/conformance/textures/gl-teximage.html
+++ b/sdk/tests/conformance/textures/gl-teximage.html
@@ -173,7 +173,7 @@ function runTests(imgs) {
 
   debug("");
   debug("Check that gamma settings don't effect 8bit pngs");
-  gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+  wtu.failIfGLError(gl, 'gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);');
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE,
                 imgs['../resources/gray-ramp-default-gamma.png']);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
@@ -333,7 +333,7 @@ function runTests(imgs) {
   debug("check uploading of images with ICC profiles");
   gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
   gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
-  gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
+  wtu.failIfGLError(gl, 'gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);');
 
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE,
                 imgs['../resources/small-square-with-colorspin-profile.jpg']);


### PR DESCRIPTION
Avoid overly-verbose logging when these calls generate no error.