### PR TITLE
Add 1.0.4 --min-version for ported GLES2 dEQP tests.

### DIFF
--- a/sdk/tests/00_test_list.txt
+++ b/sdk/tests/00_test_list.txt
@@ -3,7 +3,7 @@
 
 conformance/00_test_list.txt
 conformance/more/00_test_list.txt
-deqp/data/gles2/shaders/00_test_list.txt
+--min-version 1.0.4 deqp/data/gles2/shaders/00_test_list.txt
 --min-version 2.0.0 deqp/data/gles3/shaders/00_test_list.txt
 --min-version 2.0.0 deqp/functional/gles3/00_test_list.txt
 --min-version 2.0.0 conformance2/00_test_list.txt


### PR DESCRIPTION
These tests were introduced in that version of the conformance suite, so the bookkeeping should reflect that fact.