### PR TITLE
Relax dEQP compilation error checks (consistent with other tests)

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsShaderLibraryCase.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderLibraryCase.js
@@ -919,13 +919,14 @@ glsShaderLibraryCase.execute = function() {
 
     if (failReason != null) {
         // \todo [2010-06-07 petri] These should be handled in the test case?
-        bufferedLogToConsole('ERROR: ' + failReason);
 
         // If implementation parses shader at link time, report it as quality warning.
         if (spec.expectResult === glsShaderLibraryCase.expectResult.EXPECT_COMPILE_FAIL && allCompilesOk && !allLinksOk)
-            bufferedLogToConsole('Quality warning: implementation parses shader at link time');
-
-        testFailedOptions(failReason, true);
+            bufferedLogToConsole('Quality warning: implementation parses shader at link time: ' + failReason);
+        else {
+            bufferedLogToConsole('ERROR: ' + failReason);
+            testFailedOptions(failReason, true);
+        }
         return false;
     }
 


### PR DESCRIPTION
Compilation failures are not guaranteed to be detected at compile time,
so dEQP tests should not require that. Other tests, like ones using
tests/conformance/resources/glsl-conformance-test.js are already built
to only check for link errors in case compilation errors are expected.