### PR TITLE
Add test case to oes-texture-float-with-canvas to verify texture is actually backed by FLOATs.

### DIFF
--- a/sdk/tests/conformance/extensions/oes-texture-float-with-canvas.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float-with-canvas.html
@@ -42,7 +42,53 @@ function testPrologue(gl) {
     }
 
     testPassed("Successfully enabled OES_texture_float extension");
+
+    verifyTexturesAreFloat(gl);
     return true;
+}
+
+function verifyTexturesAreFloat(gl) {
+    var canvas = document.createElement('canvas');
+    var ctx = canvas.getContext('2d');
+
+    var framebuffer = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+
+    var texture = gl.createTexture();
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+    function testForSize(width, height) {
+        canvas.width = width;
+        canvas.height = height;
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.FLOAT, canvas);
+
+        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) !== gl.FRAMEBUFFER_COMPLETE) {
+            testPassed("Can't read from FLOAT texture, skipping test");
+            return;
+        }
+
+        // Attempt to read a pixel as a Float and ensure there were no errors
+        gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, new Float32Array(4));
+
+        WebGLTestUtils.glErrorShouldBe(gl, gl.NO_ERROR, "Verify texture is FLOAT for size " + width + "x" + height);
+    };
+
+    // Test various sizes to catch bugs with size dependent optimizations
+    testForSize(1, 1);
+    testForSize(256, 256);
+    testForSize(512, 512);
+    testForSize(1024, 1024);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.deleteFramebuffer(framebuffer);
+    gl.deleteTexture(texture);
 }
 </script>
 </head>

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
@@ -174,6 +174,14 @@ function generateTest(pixelFormat, pixelType, prologue) {
                 wtu.checkCanvasRect(gl, 0, top, width, halfHeight, green,
                                     "shouldBe " + green);
             }
+
+            if (!useTexSubImage2D && pixelType == "FLOAT") {
+                // Attempt to set a pixel in the texture to ensure the texture was
+                // actually created with floats. Regression test for http://crbug.com/484968
+                var pixels = new Float32Array([1000.0, 1000.0, 1000.0, 1000.0]);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, 1, 1, gl[pixelFormat], gl[pixelType], pixels);
+                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Texture should be backed by floats");
+            }
         }
 
         if (false) {


### PR DESCRIPTION
Adding a test case at the request of the Chromium team. For some texture sizes, Chrome was failing to allocate the texture as FLOAT and only allocating it as UNSIGNED_BYTE.

Details on the bug at:
https://code.google.com/p/chromium/issues/detail?id=484968

The test creates textures from various 2D canvas sizes and verifies that it can read out a pixel of the texture as a FLOAT.  

Some possible concerns with this approach:
 * Could an implementation just store the texture as UNSIGNED_BYTE and only convert to FLOAT during the readPixels call?
 * Does OES_texture_float imply you should be able to readPixels with FLOAT?  Safari does not seem to support this but Chrome, FireFox and IE do support it.

Please let me know if there is a better way to test this. For example, in the original test case, I rendered an almost transparent color repeated to the texture. The FLOAT version would keep the transparency and eventually become visible but the UNSIGNED_BYTE one would stay transparent since it didn't have enough precision. 