### PR TITLE
Change 'WebGL GLSL ES 3.0' to 'WebGL GLSL ES 3.00' for WebGL 2 spec

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -912,7 +912,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
               <tr><td>VERSION</td>
                   <td>Returns a version or release number of the form <code>WebGL&lt;space&gt;2.0&lt;space&gt;&lt;vendor-specific information&gt;</code>.</td></tr>
               <tr><td>SHADING_LANGUAGE_VERSION</td>
-                  <td>Returns a version or release number of the form <code>WebGL&lt;space&gt;GLSL&lt;space&gt;ES&lt;space&gt;3.0&lt;space&gt;&lt;vendor-specific information&gt;</code>.</td></tr>
+                  <td>Returns a version or release number of the form <code>WebGL&lt;space&gt;GLSL&lt;space&gt;ES&lt;space&gt;3.00&lt;space&gt;&lt;vendor-specific information&gt;</code>.</td></tr>
             </table><br>
 
         <dt class="idl-code">any getIndexedParameter(GLenum target, GLuint index)


### PR DESCRIPTION
This makes WebGL 2 shading language version number consistent with GLSL
ES 3.00.