### PR TITLE
Add test for arrays being returned inside complex expressions

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -1,6 +1,7 @@
 array-assign.html
 array-assign-constructor.html
 array-equality.html
+array-in-complex-expression.html
 array-length-side-effects.html
 misplaced-version-directive.html
 shader-linking.html

--- a/sdk/tests/conformance2/glsl3/array-in-complex-expression.html
+++ b/sdk/tests/conformance2/glsl3/array-in-complex-expression.html
@@ -1,0 +1,183 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL array in complex expression test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../conformance/resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="64" height="64"> </canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in vec3 aPosition;
+
+void main() {
+    gl_Position = vec4(aPosition, 1);
+}
+</script>
+<script id="fshaderAndShortCircuits" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+int g = 0;
+
+int[2] plus() {
+    ++g;
+    return int[2](g, g);
+}
+
+bool minus() {
+    --g;
+    return false;
+}
+
+void main() {
+    int a[2] = int[2](0, 0);
+    // The function call must not be evaluated, since && short-circuits
+    minus() && (a == plus());
+    my_FragColor = vec4(0.0, ((g == -1) ? 1.0 : 0.0), 0.0, 1.0);
+}
+</script>
+<script id="fshaderOrShortCircuits" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+int g = 0;
+
+int[2] plus() {
+    ++g;
+    return int[2](g, g);
+}
+
+bool minus() {
+    --g;
+    return true;
+}
+
+void main() {
+    int a[2] = int[2](0, 0);
+    // The function call must not be evaluated, since || short-circuits.
+    minus() || (a == plus());
+    my_FragColor = vec4(0.0, ((g == -1) ? 1.0 : 0.0), 0.0, 1.0);
+}
+</script>
+<script id="fshaderTernaryOnlyEvaluatesOneOperand" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+int g = 0;
+
+int[2] plus() {
+    ++g;
+    return int[2](g, g);
+}
+
+void main() {
+    int a[2] = int[2](0, 0);
+    // The function call must not be evaluated, since the condition is true.
+    (g == 0) ? true : (a == plus());
+    my_FragColor = vec4(0.0, ((g == 0) ? 1.0 : 0.0), 0.0, 1.0);
+}
+</script>
+<script id="fshaderSequenceSideEffectsAffectingComparedArrayContent" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+int[2] func(int param) {
+    return int[2](param, param);
+}
+
+void main() {
+    int a[2];
+    for (int i = 0; i < 2; ++i) {
+        a[i] = 1;
+    }
+    int j = 0;
+    // Sequence operator evaluates operands from left to right (ESSL 3.00 section 5.9).
+    // The function call that returns the array needs to be evaluated after ++j
+    // for the expression to return the correct value (true).
+    bool result = ((++j), (a == func(j)));
+    my_FragColor = vec4(0.0, (result ? 1.0 : 0.0), 0.0, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Arrays in complex expressions should work");
+debug("");
+debug("This test is targeted to stress syntax tree transformations that might need to be done in shader translation when the platform doesn't natively support arrays as return values.");
+var wtu = WebGLTestUtils;
+function test() {
+  var gl = wtu.create3DContext("canvas", undefined, 2);
+  if (!gl) {
+    testFailed("WebGL 2 context does not exist");
+    return;
+  }
+  wtu.setupUnitQuad(gl);
+
+  debug("");
+  debug("Expression where an array is returned from a function call inside an operand to && that doesn't get evaluated as result of short-circuiting");
+  wtu.setupProgram(gl, ["vshader", "fshaderAndShortCircuits"], ["aPosition"], undefined, true);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+
+  debug("");
+  debug("Expression where an array is returned from a function call inside an operand to || that doesn't get evaluated as result of short-circuiting");
+  wtu.setupProgram(gl, ["vshader", "fshaderOrShortCircuits"], ["aPosition"], undefined, true);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+
+  debug("");
+  debug("Expression where an array is returned from a function call in an operand of a ternary operator that doesn't get evaluated");
+  wtu.setupProgram(gl, ["vshader", "fshaderTernaryOnlyEvaluatesOneOperand"], ["aPosition"], undefined, true);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+
+  debug("");
+  debug("Expression where first operand of a sequence operator has side effects which affect the second operand that returns an array");
+  wtu.setupProgram(gl, ["vshader", "fshaderSequenceSideEffectsAffectingComparedArrayContent"], ["aPosition"], undefined, true);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+
+};
+
+test();
+var successfullyParsed = true;
+finishTest();
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
HLSL doesn't natively support arrays as return values. To translate
shaders to HLSL, expressions where arrays are being returned need to be
converted into a form where arrays are not being returned. There are some
cases where implementing this is somewhat tricky, and should be tested.

All the new tests already pass on Chrome's current WebGL 2 prototype on
Linux/NVIDIA.