### PR TITLE
Add a test for ternary operator affected by earlier operand in sequence

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -21,3 +21,4 @@
 --min-version 1.0.4 undefined-index-should-not-crash.html
 --min-version 1.0.4 pow-of-small-constant-in-user-defined-function.html
 --min-version 1.0.4 sampler-struct-function-arg.html
+--min-version 1.0.4 sequence-operator-evaluation-order.html

--- a/sdk/tests/conformance/glsl/bugs/sequence-operator-evaluation-order.html
+++ b/sdk/tests/conformance/glsl/bugs/sequence-operator-evaluation-order.html
@@ -1,0 +1,100 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL ternary operator should be evaluated after previous operands in a sequence</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../conformance/resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="64" height="64"> </canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">
+attribute vec3 aPosition;
+
+void main() {
+    gl_Position = vec4(aPosition, 1);
+}
+</script>
+<script id="fshaderSequenceSideEffectsAffectTernary" type="x-shader/x-fragment">
+precision mediump float;
+
+bool correct = true;
+
+uniform float u;
+
+float wrong() {
+    correct = false;
+    return 0.0;
+}
+
+void main() {
+    // ESSL 1.00 section 5.9, about sequence operator:
+    // "All expressions are evaluated, in order, from left to right"
+    // Also use a ternary operator where the third operand has side effects to make sure
+    // only the second operand is evaluated.
+    float a = u; // Expected to be -0.5
+    float green = (a++, a > 0.0 ? 1.0 : wrong());
+    gl_FragColor = vec4(0.0, correct ? green : 0.0, 0.0, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Ternary operator should be evaluated after previous operands in a sequence");
+debug("");
+debug("This test is targeted to stress syntax tree transformations that might need to be done in shader translation to unfold operators.");
+var wtu = WebGLTestUtils;
+function test() {
+  var gl = wtu.create3DContext("canvas");
+  if (!gl) {
+    testFailed("WebGL context does not exist");
+    return;
+  }
+  wtu.setupUnitQuad(gl);
+
+  debug("");
+  debug("Expression where first operand of a sequence operator has side effects which affect the second operand that is a ternary operator");
+  var prog = wtu.setupProgram(gl, ["vshader", "fshaderSequenceSideEffectsAffectTernary"], ["aPosition"], undefined, true);
+  var u = gl.getUniformLocation(prog, 'u');
+  gl.uniform1f(u, -0.5);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [0, 255, 0, 255]);
+
+};
+
+test();
+var successfullyParsed = true;
+finishTest();
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
This reveals a bug in ANGLE's HLSL translation.

The test passes in Chrome on Linux/NVIDIA and also in current version of
IE.