### PR TITLE
Add test case to oes-texture-float-with-canvas to verify texture is actually backed by FLOATs.

### DIFF
--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
@@ -174,6 +174,14 @@ function generateTest(pixelFormat, pixelType, prologue) {
                 wtu.checkCanvasRect(gl, 0, top, width, halfHeight, green,
                                     "shouldBe " + green);
             }
+
+            if (!useTexSubImage2D && pixelType == "FLOAT") {
+                // Attempt to set a pixel in the texture to ensure the texture was
+                // actually created with floats. Regression test for http://crbug.com/484968
+                var pixels = new Float32Array([1000.0, 1000.0, 1000.0, 1000.0]);
+                gl.texSubImage2D(targets[tt], 0, 0, 0, 1, 1, gl[pixelFormat], gl[pixelType], pixels);
+                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Texture should be backed by floats");
+            }
         }
 
         if (false) {

--- a/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/conformance/resources/tex-image-and-sub-image-2d-with-canvas.js
@@ -175,7 +175,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
                                     "shouldBe " + green);
             }
 
-            if (!useTexSubImage2D && pixelType == "FLOAT") {
+            if (!useTexSubImage2D && pixelFormat == "RGBA" && pixelType == "FLOAT") {
                 // Attempt to set a pixel in the texture to ensure the texture was
                 // actually created with floats. Regression test for http://crbug.com/484968
                 var pixels = new Float32Array([1000.0, 1000.0, 1000.0, 1000.0]);


### PR DESCRIPTION
Redoing the change discussed at:

https://github.com/KhronosGroup/WebGL/pull/977#issuecomment-100169188

