### PR TITLE
Fix global initializer containing an uniform in conformance tests

### DIFF
--- a/conformance-suites/1.0.1/conformance/glsl/misc/shader-with-for-loop.html
+++ b/conformance-suites/1.0.1/conformance/glsl/misc/shader-with-for-loop.html
@@ -26,7 +26,7 @@ uniform float time;
 uniform vec2 resolution;
 
 // Saw-tooth function that is synced with the demo music (128bpm)
-float gBeat=fract(time*3.2/3.);
+float gBeat;
 
 // Calculate the surface color
 vec3 surfColor(vec2 p)
@@ -52,6 +52,7 @@ vec3 trace(vec3 o,vec3 d)
 
 void main()
 {
+    gBeat=fract(time*3.2/3.);
     // Screen setup
     vec2 p=(2.*gl_FragCoord.xy-resolution)/resolution.y,
          q=2.*gl_FragCoord.xy/resolution-1.;

--- a/conformance-suites/1.0.2/conformance/glsl/misc/shader-with-for-loop.html
+++ b/conformance-suites/1.0.2/conformance/glsl/misc/shader-with-for-loop.html
@@ -48,7 +48,7 @@ uniform float time;
 uniform vec2 resolution;
 
 // Saw-tooth function that is synced with the demo music (128bpm)
-float gBeat=fract(time*3.2/3.);
+float gBeat;
 
 // Calculate the surface color
 vec3 surfColor(vec2 p)
@@ -74,6 +74,7 @@ vec3 trace(vec3 o,vec3 d)
 
 void main()
 {
+    gBeat=fract(time*3.2/3.);
     // Screen setup
     vec2 p=(2.*gl_FragCoord.xy-resolution)/resolution.y,
          q=2.*gl_FragCoord.xy/resolution-1.;

--- a/conformance-suites/1.0.3/conformance/glsl/misc/shader-with-for-loop.html
+++ b/conformance-suites/1.0.3/conformance/glsl/misc/shader-with-for-loop.html
@@ -48,7 +48,7 @@ uniform float time;
 uniform vec2 resolution;
 
 // Saw-tooth function that is synced with the demo music (128bpm)
-float gBeat=fract(time*3.2/3.);
+float gBeat;
 
 // Calculate the surface color
 vec3 surfColor(vec2 p)
@@ -74,6 +74,7 @@ vec3 trace(vec3 o,vec3 d)
 
 void main()
 {
+    gBeat=fract(time*3.2/3.);
     // Screen setup
     vec2 p=(2.*gl_FragCoord.xy-resolution)/resolution.y,
          q=2.*gl_FragCoord.xy/resolution-1.;

--- a/sdk/tests/conformance/glsl/misc/shader-with-for-loop.html
+++ b/sdk/tests/conformance/glsl/misc/shader-with-for-loop.html
@@ -48,7 +48,7 @@ uniform float time;
 uniform vec2 resolution;
 
 // Saw-tooth function that is synced with the demo music (128bpm)
-float gBeat=fract(time*3.2/3.);
+float gBeat;
 
 // Calculate the surface color
 vec3 surfColor(vec2 p)
@@ -74,6 +74,7 @@ vec3 trace(vec3 o,vec3 d)
 
 void main()
 {
+    gBeat=fract(time*3.2/3.);
     // Screen setup
     vec2 p=(2.*gl_FragCoord.xy-resolution)/resolution.y,
          q=2.*gl_FragCoord.xy/resolution-1.;


### PR DESCRIPTION
ESSL 1.00 section 4.3 says that global initializers need to be constant
expressions. It is still being discussed how strictly this rule should
apply to WebGL, but initializing globals with uniforms is clearly not
allowed by the spec, so fix the conformance test doing that.

The fix is backported all the way to 1.0.1 conformance suite.