### PR TITLE
Convert WebGL 2 shader tests to use GLSLConformanceTester

### DIFF
--- a/sdk/tests/conformance2/glsl3/array-as-return-value.html
+++ b/sdk/tests/conformance2/glsl3/array-as-return-value.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
+<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="64" height="64"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">#version 300 es
-in vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderReturnedArrayNotUsed" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 
@@ -145,43 +138,33 @@ void main() {
 description("Arrays as return values should work");
 debug("");
 debug("This test is targeted to stress syntax tree transformations that might need to be done in shader translation when the platform doesn't natively support arrays as return values.");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas", undefined, 2);
-  if (!gl) {
-    testFailed("WebGL 2 context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
 
-  debug("");
-  debug("Expression where a returned array is not used");
-  wtu.setupProgram(gl, ["vshader", "fshaderReturnedArrayNotUsed"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Expression where a returned array is compared");
-  wtu.setupProgram(gl, ["vshader", "fshaderCompareReturnedArray"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Expression where a returned array is returned again");
-  wtu.setupProgram(gl, ["vshader", "fshaderReturnReturnedArray"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Expression where a returned array is passed as a parameter");
-  wtu.setupProgram(gl, ["vshader", "fshaderReturnedArrayAsParameter"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-};
-
-test();
-var successfullyParsed = true;
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderReturnedArrayNotUsed',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where a returned array is not used'
+},
+{
+  fShaderId: 'fshaderCompareReturnedArray',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where a returned array is compared'
+},
+{
+  fShaderId: 'fshaderReturnReturnedArray',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where a returned array is returned again'
+},
+{
+  fShaderId: 'fshaderReturnedArrayAsParameter',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where a returned array is passed as a parameter'
+}
+], 2);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/glsl3/array-assign.html
+++ b/sdk/tests/conformance2/glsl3/array-assign.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
+<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="64" height="64"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">#version 300 es
-in vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderSimple" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 
@@ -100,31 +93,21 @@ void main() {
 <script type="text/javascript">
 "use strict";
 description("Assigning arrays should work.");
-debug("");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas", undefined, 2);
-  if (!gl) {
-    testFailed("WebGL 2 context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
 
-  debug("Testing with arrays of integers");
-  wtu.setupProgram(gl, ["vshader", "fshaderSimple"], ["aPosition"], undefined, true);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Testing with arrays of structs");
-  wtu.setupProgram(gl, ["vshader", "fshaderArrayOfStructs"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-};
-
-test();
-var successfullyParsed = true;
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderSimple',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Arrays of integers'
+},
+{
+  fShaderId: 'fshaderArrayOfStructs',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Arrays of structs'
+}
+], 2);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/glsl3/array-equality.html
+++ b/sdk/tests/conformance2/glsl3/array-equality.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
+<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="64" height="64"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">#version 300 es
-in vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderSimple" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 
@@ -92,31 +85,21 @@ void main() {
 <script type="text/javascript">
 "use strict";
 description("Comparing arrays should work.");
-debug("");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas", undefined, 2);
-  if (!gl) {
-    testFailed("WebGL 2 context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
 
-  debug("Testing with arrays of integers");
-  wtu.setupProgram(gl, ["vshader", "fshaderSimple"], ["aPosition"], undefined, true);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Testing with arrays of structs");
-  wtu.setupProgram(gl, ["vshader", "fshaderArrayOfStructs"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-};
-
-test();
-var successfullyParsed = true;
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderSimple',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Arrays of integers'
+},
+{
+  fShaderId: 'fshaderArrayOfStructs',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Arrays of structs'
+}
+], 2);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/glsl3/array-in-complex-expression.html
+++ b/sdk/tests/conformance2/glsl3/array-in-complex-expression.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../conformance/resources/webgl-test-utils.js"></script>
+<script src="../../conformance/resources/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="64" height="64"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">#version 300 es
-in vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderAndShortCircuits" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 
@@ -139,44 +132,33 @@ void main() {
 description("Arrays in complex expressions should work");
 debug("");
 debug("This test is targeted to stress syntax tree transformations that might need to be done in shader translation when the platform doesn't natively support arrays as return values.");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas", undefined, 2);
-  if (!gl) {
-    testFailed("WebGL 2 context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
 
-  debug("");
-  debug("Expression where an array is returned from a function call inside an operand to && that doesn't get evaluated as result of short-circuiting");
-  wtu.setupProgram(gl, ["vshader", "fshaderAndShortCircuits"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Expression where an array is returned from a function call inside an operand to || that doesn't get evaluated as result of short-circuiting");
-  wtu.setupProgram(gl, ["vshader", "fshaderOrShortCircuits"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Expression where an array is returned from a function call in an operand of a ternary operator that doesn't get evaluated");
-  wtu.setupProgram(gl, ["vshader", "fshaderTernaryOnlyEvaluatesOneOperand"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Expression where first operand of a sequence operator has side effects which affect the second operand that returns an array");
-  wtu.setupProgram(gl, ["vshader", "fshaderSequenceSideEffectsAffectingComparedArrayContent"], ["aPosition"], undefined, true);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-};
-
-test();
-var successfullyParsed = true;
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderAndShortCircuits',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Expression where an array is returned from a function call inside an operand to && that doesn't get evaluated as result of short-circuiting"
+},
+{
+  fShaderId: 'fshaderOrShortCircuits',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Expression where an array is returned from a function call inside an operand to || that doesn't get evaluated as result of short-circuiting"
+},
+{
+  fShaderId: 'fshaderTernaryOnlyEvaluatesOneOperand',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Expression where an array is returned from a function call in an operand of a ternary operator that doesn't get evaluated"
+},
+{
+  fShaderId: 'fshaderSequenceSideEffectsAffectingComparedArrayContent',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where first operand of a sequence operator has side effects which affect the second operand that returns an array'
+}
+], 2);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/glsl3/array-length-side-effects.html
+++ b/sdk/tests/conformance2/glsl3/array-length-side-effects.html
@@ -39,13 +39,6 @@
 <body>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">#version 300 es
-in vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderLengthOfAssignment" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 
@@ -89,24 +82,18 @@ description();
 debug("These restrictions come from ESSL 3.00 section 5.9 definition of expression, which only allows length to be called on array names, not on arbitrary expressions returning an array.");
 GLSLConformanceTester.runTests([
   {
-    vShaderId: "vshader",
-    vShaderSuccess: true,
     fShaderId: "fshaderLengthOfAssignment",
     fShaderSuccess: false,
     linkSuccess: false,
     passMsg: "Fragment shader which tries to evaluate the length of an assignment operation should fail."
   },
   {
-    vShaderId: "vshader",
-    vShaderSuccess: true,
     fShaderId: "fshaderLengthOfFunctionCall",
     fShaderSuccess: false,
     linkSuccess: false,
     passMsg: "Fragment shader which tries to evaluate the length of a return value should fail."
   },
   {
-    vShaderId: "vshader",
-    vShaderSuccess: true,
     fShaderId: "fshaderLengthOfConstructor",
     fShaderSuccess: false,
     linkSuccess: false,


### PR DESCRIPTION
This includes adding default ESSL3 shaders to the GLSLConformanceTester and converting the test files to use that.