### PR TITLE
Fix incorrect position of glsl3 directive

### DIFF
--- a/sdk/tests/conformance2/attribs/gl-vertex-attrib-i-render.html
+++ b/sdk/tests/conformance2/attribs/gl-vertex-attrib-i-render.html
@@ -32,8 +32,7 @@
     <link rel="stylesheet" href="../../resources/js-test-style.css"/>
     <script src="../../resources/js-test-pre.js"></script>
     <script src="../../resources/webgl-test-utils.js"></script>
-    <script id='vshader' type='x-shader'>
-        #version 300 es
+    <script id='vshader' type='x-shader/x-vertex'>#version 300 es
         layout(location=0) in ivec2 p;
         layout(location=1) in ivec4 a;
         void main()
@@ -41,8 +40,7 @@
             gl_Position = vec4(p.x + a.x + a.y + a.z + a.w, p.y, 0.0, 10.0);
         }
     </script>
-    <script id='fshader' type='x-shader'>
-        #version 300 es
+    <script id='fshader' type='x-shader/x-fragment'>#version 300 es
         precision mediump float;
         layout(location=0) out vec4 oColor;
         void main()

--- a/sdk/tests/conformance2/attribs/gl-vertexattribipointer-offsets.html
+++ b/sdk/tests/conformance2/attribs/gl-vertexattribipointer-offsets.html
@@ -40,8 +40,7 @@ There is supposed to be an example drawing here, but it's not important.
 </canvas>
 <div id="description"></div>
 <div id="console"></div>
-    <script id="vshader" type="x-shader/x-vertex">
-        #version 300 es
+    <script id="vshader" type="x-shader/x-vertex">#version 300 es
         layout(location=0) in ivec4 aPosition;
         layout(location=1) in vec4 aColor;
         out vec4 vColor;
@@ -52,8 +51,7 @@ There is supposed to be an example drawing here, but it's not important.
         }
     </script>
 
-    <script id="fshader" type="x-shader/x-fragment">
-        #version 300 es
+    <script id="fshader" type="x-shader/x-fragment">#version 300 es
         precision mediump float;
         in vec4 vColor;
         layout(location=0) out vec4 oColor;


### PR DESCRIPTION
Fix compile error of directive `#version 300 es` not on the first line.
1. sdk/tests/conformance2/attribs/gl-vertex-attrib-i-render.html
2. sdk/tests/conformance2/attribs/gl-vertexattribipointer-offsets.html