### PR TITLE
Fix default shaders in ESSL3 shaders with WebGL 1.0 test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/essl3-shaders-with-webgl1.html
+++ b/sdk/tests/conformance/glsl/bugs/essl3-shaders-with-webgl1.html
@@ -39,6 +39,21 @@
 <body>
 <div id="description"></div>
 <div id="console"></div>
+<script id="ES1VertexShader" type="x-shader/x-vertex">
+precision mediump float;
+attribute vec4 aPosition;
+
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+<script id="ES1FragmentShader" type="x-shader/x-fragment">
+precision mediump float;
+
+void main() {
+    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+}
+</script>
 <!-- Note that the version directive should be on the very first line in ESSL 3, see ESSL 3 section 3.3 -->
 <script id="ES3VertexShader" type="x-shader/x-vertex">#version 300 es
 precision mediump float;
@@ -84,16 +99,22 @@ GLSLConformanceTester.runTests([
   {
     vShaderId: "ES3VertexShader",
     vShaderSuccess: false,
+    fShaderId: "ES1FragmentShader",
+    fShaderSuccess: true,
     linkSuccess: false,
     passMsg: "OpenGL ES 3 shading language vertex shader with an in variable should not be accepted by WebGL 1."
   },
   {
+    vShaderId: "ES1VertexShader",
+    vShaderSuccess: true,
     fShaderId: "ES3FragmentShader",
     fShaderSuccess: false,
     linkSuccess: false,
     passMsg: "OpenGL ES 3 shading language fragment shader with an out variable should not be accepted by WebGL 1."
   },
   {
+    vShaderId: "ES1VertexShader",
+    vShaderSuccess: true,
     fShaderId: "emptyES3FragmentShader",
     fShaderSuccess: false,
     linkSuccess: false,
@@ -118,10 +139,14 @@ GLSLConformanceTester.runTests([
   {
     vShaderId: "vertexShaderWithInQualifier",
     vShaderSuccess: false,
+    fShaderId: "ES1FragmentShader",
+    fShaderSuccess: true,
     linkSuccess: false,
     passMsg: "Vertex shader with an in qualifier on a global variable should not be accepted by WebGL 1."
   },
   {
+    vShaderId: "ES1VertexShader",
+    vShaderSuccess: true,
     fShaderId: "fragmentShaderWithOutQualifier",
     fShaderSuccess: false,
     linkSuccess: false,


### PR DESCRIPTION
GLSLConformanceTester was recently updated to support default ESSL3
shaders. This unintentionally affected some subtests in
essl3-shaders-with-webgl1.html. Restore the intended testing of
mixing ESSL1 shaders with ESSL3 shaders.