### PR TITLE
Change Buffer Object Binding rule

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -2390,8 +2390,10 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         In the WebGL 2 API, buffers have their WebGL buffer type initially set to <em>undefined</em>. Calling
         <code>bindBuffer</code>, <code>bindBufferRange</code> or <code>bindBufferBase</code> with the
         <code>target</code> argument set to any buffer binding point except <code>COPY_READ_BUFFER</code> or
-        <code>COPY_WRITE_BUFFER</code> will then set the WebGL buffer type of the buffer being bound according
-        to the table above.
+        <code>COPY_WRITE_BUFFER</code> will then set the WebGL buffer type of the buffer being bound
+        according to the table above. Binding a buffer with type <em>undefined</em> to
+        the <code>COPY_READ_BUFFER</code> or <code>COPY_WRITE_BUFFER</code> binding points will set
+        its type to <em>other data</em>.
     </p>
 
     <p>


### PR DESCRIPTION
So that binding a buffer object has been bound to COPY_READ_BUFFER or COPY_WRITE_BUFFER to ELEMENT_ARRAY_BUFFER will also generate INVALID_OPERATION.

This is because we can upload data directly to a buffer object bound to these
two binding points, so they are no different from other non ELEMENT_ARRAY_BUFFER
binding points.