### PR TITLE
add test cases for read/draw binding points for framebuffer related APIs against webgl 2.0

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/framebuffer-test.html
+++ b/sdk/tests/conformance2/renderbuffers/framebuffer-test.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../../resources/webgl-test-utils.js"></script>
-<script src="../../resources/desktop-gl-constants.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -63,6 +62,12 @@ if (!gl) {
      gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
   wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
             "calling getFramebufferAttachmentParameter with attachment = COLOR_ATTACHMENT0 on the default framebuffer should generate INVALID_ENUM.");
+  gl.getFramebufferAttachmentParameter(
+     gl.FRAMEBUFFER,
+     gl.BACK,
+     gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "calling getFramebufferAttachmentParameter with attachment = GL_BACK on the default framebuffer should succeed.");
   gl.checkFramebufferStatus(gl.FRAMEBUFFER);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,
             "calling checkFramebufferStatus on the default framebuffer should succeed");
@@ -122,7 +127,7 @@ if (!gl) {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,
             "binding a newly created framebuffer should succeed.");
 
-  var target = desktopGL.READ_FRAMEBUFFER
+  var target = gl.READ_FRAMEBUFFER
   gl.getFramebufferAttachmentParameter(
      target,
      gl.COLOR_ATTACHMENT0,
@@ -153,18 +158,20 @@ if (!gl) {
 
   var colorAttachmentsNum = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
   if (colorAttachmentsNum >= 2) {
-    var attachment = desktopGL.COLOR_ATTACHMENT1
+    var attachment = gl.COLOR_ATTACHMENT1
     gl.framebufferTexture2D(gl.FRAMEBUFFER, attachment, gl.TEXTURE_2D, fbtex, 0);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR,
             "calling framebufferTexImage2D with attachment = COLOR_ATTACHMENT1 should succeed.");
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, attachment, gl.TEXTURE_2D, null, 0);
     gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachment, gl.RENDERBUFFER, rb);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR,
             "calling framebufferRenderbuffer with attachment = COLOR_ATTACHMENT1 should succeed.");
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachment, gl.RENDERBUFFER, null);
   }
 
   gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
                                        gl.COLOR_ATTACHMENT0,
-                                       desktopGL.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
             "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING without any attachment should generate INVALID_OPERATION.");
 
@@ -191,6 +198,131 @@ if (!gl) {
   gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,
             "binding default (null) framebuffer should succeed.");
+
+  // attach/detach a 2d texture to one framebuffer binding point, while no attachment to the other binding point.
+  function attachAndDetachTexture(targetA, targetB) {
+    gl.framebufferTexture2D(targetA, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbtex, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "attaching a texture to read/draw framebuffer binding point should succeed.");
+    gl.getFramebufferAttachmentParameter(targetA,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING on read/draw framebuffer should succeed.");
+    gl.getFramebufferAttachmentParameter(targetB,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING on read/draw framebuffer without any attachment should generate INVALID_OPERATION.");
+    gl.framebufferTexture2D(targetA, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, null, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "detaching a texture from read/draw framebuffer should succeed.");
+  }
+
+  var readFBWithTexture = gl.createFramebuffer();
+  var drawFBWithTexture = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFBWithTexture);
+  gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, drawFBWithTexture);
+  attachAndDetachTexture(gl.READ_FRAMEBUFFER, gl.DRAW_FRAMEBUFFER);
+  attachAndDetachTexture(gl.DRAW_FRAMEBUFFER, gl.READ_FRAMEBUFFER);
+
+  // attach different textures as color attachment to read and draw framebuffer respectively, then detach these attachments.
+  var fbtex1 = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, fbtex1);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG8, canvas.width, canvas.height, 0, gl.RG, gl.UNSIGNED_BYTE, null);
+  gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbtex1, 0);
+  gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbtex, 0);
+  shouldBeNonZero('gl.getFramebufferAttachmentParameter(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE)');
+  shouldBe('gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_BLUE_SIZE)', '0');
+
+  gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, null, 0);
+  gl.getFramebufferAttachmentParameter(gl.READ_FRAMEBUFFER,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING on read framebuffer without any attachment should generate INVALID_OPERATION.");
+  gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING on draw framebuffer should succeed.");
+  gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, null, 0);
+  gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING on draw framebuffer without any attachment should generate INVALID_OPERATION.");
+
+  // attach/detach a renderbuffer to one framebuffer binding point, while no attachment to the other binding point.
+  function attachAndDetachRenderbuffer(targetA, targetB) {
+    gl.framebufferRenderbuffer(targetA, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rb);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "attaching a renderbuffer to a read/draw framebuffer should succeed.");
+    gl.getFramebufferAttachmentParameter(targetA,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING on read/draw framebuffer should succeed.");
+    gl.getFramebufferAttachmentParameter(targetB,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING on read/draw framebuffer without any attachment should generate INVALID_OPERATION.");
+    gl.framebufferRenderbuffer(targetA, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, null);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "detaching a renderbuffer from a read/draw framebuffer should succeed.");
+  }
+
+  var readFBWithRenderbuffer = gl.createFramebuffer();
+  var drawFBWithRenderbuffer = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFBWithRenderbuffer);
+  gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, drawFBWithRenderbuffer);
+  attachAndDetachRenderbuffer(gl.READ_FRAMEBUFFER, gl.DRAW_FRAMEBUFFER);
+  attachAndDetachRenderbuffer(gl.DRAW_FRAMEBUFFER, gl.READ_FRAMEBUFFER);
+
+  // attach different renderbuffers to read and draw framebuffer respectively, then detach these attachments.
+  var depthRB = gl.createRenderbuffer();
+  gl.bindRenderbuffer(gl.RENDERBUFFER, depthRB);
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, canvas.width, canvas.height);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "allocating renderbuffer storage of a newly created renderbuffer should succeed.");
+  gl.framebufferRenderbuffer(gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthRB);
+  gl.framebufferRenderbuffer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rb);
+  shouldBeNonZero('gl.getFramebufferAttachmentParameter(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_RED_SIZE)');
+  gl.getFramebufferAttachmentParameter(gl.READ_FRAMEBUFFER,
+                                       gl.DEPTH_ATTACHMENT,
+                                       gl.FRAMEBUFFER_DEPTH_SIZE);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE on read framebuffer without depth attachment should generate INVALID_OPERATION.");
+  shouldBeNonZero('gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE)');
+  gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_RED_SIZE);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE on draw framebuffer without color attachment should generate INVALID_OPERATION.");
+
+  gl.framebufferRenderbuffer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, null);
+  gl.getFramebufferAttachmentParameter(gl.READ_FRAMEBUFFER,
+                                       gl.COLOR_ATTACHMENT0,
+                                       gl.FRAMEBUFFER_RED_SIZE);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_RED_SIZE on read framebuffer without any attachment should generate INVALID_OPERATION.");
+  shouldBeNonZero('gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE)');
+  gl.framebufferRenderbuffer(gl.DRAW_FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, null);
+  gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER,
+                                       gl.DEPTH_ATTACHMENT,
+                                       gl.FRAMEBUFFER_DEPTH_SIZE);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+            "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE on draw framebuffer without any attachment should generate INVALID_OPERATION.");
+
+  // binding read/draw framebuffer to default framebuffer
+  gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "binding read framebuffer to default (null) framebuffer should succeed.");
+
+  gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "binding draw framebuffer to default (null) framebuffer should succeed.");
 }
 
 debug("");


### PR DESCRIPTION
Chromium failed on several tests. My patch (https://codereview.chromium.org/1120953002/) can fix some (NOT all) failures in chromium. The other failed cases can be passed in firefox nightly build, although firefox has some other failures too. 

I think the conformance test itself is OK. We should fix the failures in browsers. PTAL.