### PR TITLE
WebGL2 Conformance - state/gl-get-calls fixes

### DIFF
--- a/sdk/tests/conformance2/state/gl-get-calls.html
+++ b/sdk/tests/conformance2/state/gl-get-calls.html
@@ -105,7 +105,7 @@ else {
     shouldBeType('context.getParameter(context.MAX_ARRAY_TEXTURE_LAYERS)', 'Number');
 
     shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_CLIENT_WAIT_TIMEOUT_WEBGL)', '0');
-    shouldBeType('context.getParameter(context.MAX_ARRAY_TEXTURE_LAYERS)', 'Number');
+    shouldBeType('context.getParameter(context.MAX_CLIENT_WAIT_TIMEOUT_WEBGL)', 'Number');
 
     shouldBeGreaterThanOrEqual('context.getParameter(context.MAX_COLOR_ATTACHMENTS)', '4');
     shouldBeType('context.getParameter(context.MAX_COLOR_ATTACHMENTS)', 'Number');

--- a/sdk/tests/conformance2/state/gl-get-calls.html
+++ b/sdk/tests/conformance2/state/gl-get-calls.html
@@ -75,7 +75,7 @@ else {
 
     shouldBe('context.getParameter(context.PIXEL_UNPACK_BUFFER_BINDING)', 'null');
     shouldBe('context.getParameter(context.RASTERIZER_DISCARD)', 'false');
-    shouldBe('context.getParameter(context.READ_BUFFER)', 'context.NONE');
+    shouldBe('context.getParameter(context.READ_BUFFER)', 'context.BACK');
     shouldBe('context.getParameter(context.READ_FRAMEBUFFER_BINDING)', 'null');
     shouldBe('context.getParameter(context.SAMPLE_ALPHA_TO_COVERAGE)', 'false');
     shouldBe('context.getParameter(context.SAMPLE_COVERAGE)', 'false');


### PR DESCRIPTION
I found a couple of bugs in this test:
1. The default value for gl.getParameter(gl.READ_BUFFER) should be gl.BACK not gl.NONE 
```
The initial value of the read framebuffer for the default framebuffer is BACK
if there is a default framebuffer associated with the context, otherwise it is 
NONE. (GL ES 3 3.0.4, Section 4.3.1, page 191)
```
2. An instance of `context.MAX_ARRAY_TEXTURE_LAYERS` that should have been `context.MAX_CLIENT_WAIT_TIMEOUT_WEBGL`