### PR TITLE
Add different versions of constant-precision-qualifier test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
+++ b/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
@@ -67,6 +67,31 @@ void main() {
     gl_FragColor = vec4(0.0, 2.0 * a, 0.0, 1.0);
 }
 </script>
+<script id="fshaderNoConstants" type="x-shader/x-fragment">
+// This shader has the same functionality as the one above, but it doesn't contain
+// operations that can be constant folded at compile-time.
+// It's here to provide a point of comparison.
+uniform mediump float uTest;
+
+void main() {
+    highp float c = 4096.5 + uTest;
+    mediump float a = 0.0;
+    a = fract(c + uTest);
+    gl_FragColor = vec4(0.0, 2.0 * a, 0.0, 1.0);
+}
+</script>
+<script id="fshaderAllHighp" type="x-shader/x-fragment">
+// This shader has the same functionality as the one above, but it only uses highp.
+// It's here to provide a point of comparison.
+uniform highp float uTest;
+
+void main() {
+    highp float c = 4096.5 + uTest;
+    highp float a = 0.0;
+    a = fract(c + uTest);
+    gl_FragColor = vec4(0.0, 2.0 * a, 0.0, 1.0);
+}
+</script>
 <script type="text/javascript">
 "use strict";
 description();
@@ -82,8 +107,26 @@ function test() {
     testPassed("highp precision not supported");
   } else {
     wtu.setupUnitQuad(gl);
+
+    debug("Testing shader where the precision qualifier of a constant affects built-in function results");
     var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["aPosition"], undefined, true);
     var uniformLoc = gl.getUniformLocation(program, 'uTest');
+    gl.uniform1f(uniformLoc, 0);
+    wtu.drawUnitQuad(gl);
+    wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);
+
+    debug("");
+    debug("Testing shader where the precision qualifier of a variable affects built-in function results");
+    program = wtu.setupProgram(gl, ["vshader", "fshaderNoConstants"], ["aPosition"], undefined, true);
+    uniformLoc = gl.getUniformLocation(program, 'uTest');
+    gl.uniform1f(uniformLoc, 0);
+    wtu.drawUnitQuad(gl);
+    wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);
+
+    debug("");
+    debug("Testing shader where all variables are qualified as highp");
+    program = wtu.setupProgram(gl, ["vshader", "fshaderAllHighp"], ["aPosition"], undefined, true);
+    uniformLoc = gl.getUniformLocation(program, 'uTest');
     gl.uniform1f(uniformLoc, 0);
     wtu.drawUnitQuad(gl);
     wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);


### PR DESCRIPTION
After fixing the bug in ANGLE that made this test fail, it was discovered
that some NVIDIA mobile drivers also have a bug making this test fail.
Add two more versions of the test, one that doesn't use constants and one
that only uses highp variables, so it's easier to narrow down
platform-specific failures of this test.