### PR TITLE
Make depth/stencil/antialias drawing buffer attributes required

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -223,6 +223,14 @@
         </ol>
     </p>
 
+    <h3><a name="CONTEXT_CREATION">The Drawing Buffer</a></h3>
+
+    <p>
+    Different from WebGL 1.0, the <code>depth</code>, <code>stencil</code>, and
+    <code>antialias</code> attributes in WebGL 2.0 must be obeyed by the WebGL
+    implementation.
+    </p>
+
 <!-- ======================================================================================================= -->
 
     <h2>DOM Interfaces</h2>


### PR DESCRIPTION
With an ES3 capable GPU/driver, I don't think it's possible that such requests can't be honored.