### PR TITLE
Allow both ES5 and ES6 behavior in typed array unit test.

### DIFF
--- a/conformance-suites/1.0.3/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.3/conformance/typedarrays/array-unit-tests.html
@@ -195,16 +195,30 @@ function testInheritanceHierarchy() {
   // case, assert the new behavior.
   shouldBe('new Uint8ClampedArray(1) instanceof Uint8Array', 'false');
 
-  shouldBe('Object.getPrototypeOf(Int8Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Uint8Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Uint8ClampedArray.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Int16Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Uint16Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Int32Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Uint32Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Float32Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Float64Array.prototype)', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(DataView.prototype)', 'Object.prototype');
+  if (Object.getPrototypeOf(Int8Array.prototype) == Object.prototype) {
+    // ES5 behavior.
+    shouldBe('Object.getPrototypeOf(Int8Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint8Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint8ClampedArray.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Int16Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint16Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Int32Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint32Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Float32Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Float64Array.prototype)', 'Object.prototype');
+  } else {
+    // As of ES6, the prototypes for typed array constructors point to an intrinsic object whose internal
+    // prototype is Object.prototype. Relevant spec section is 22.2.5.2: TypedArray.prototype.
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int8Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint8Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint8ClampedArray.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int16Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint16Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int32Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint32Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Float32Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Float64Array.prototype))', 'Object.prototype');
+  }
 }
 
 //

--- a/sdk/tests/conformance/typedarrays/array-unit-tests.html
+++ b/sdk/tests/conformance/typedarrays/array-unit-tests.html
@@ -195,17 +195,30 @@ function testInheritanceHierarchy() {
   // case, assert the new behavior.
   shouldBe('new Uint8ClampedArray(1) instanceof Uint8Array', 'false');
 
-  // As of ES6, the prototypes for typed array constructors point to an intrinsic object whose internal
-  // prototype is Object.prototype. Relevant spec section is 22.2.5.2: TypedArray.prototype.
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int8Array.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint8Array.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint8ClampedArray.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int16Array.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint16Array.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int32Array.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint32Array.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Float32Array.prototype))', 'Object.prototype');
-  shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Float64Array.prototype))', 'Object.prototype');
+  if (Object.getPrototypeOf(Int8Array.prototype) == Object.prototype) {
+    // ES5 behavior.
+    shouldBe('Object.getPrototypeOf(Int8Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint8Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint8ClampedArray.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Int16Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint16Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Int32Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Uint32Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Float32Array.prototype)', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Float64Array.prototype)', 'Object.prototype');
+  } else {
+    // As of ES6, the prototypes for typed array constructors point to an intrinsic object whose internal
+    // prototype is Object.prototype. Relevant spec section is 22.2.5.2: TypedArray.prototype.
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int8Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint8Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint8ClampedArray.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int16Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint16Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Int32Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Uint32Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Float32Array.prototype))', 'Object.prototype');
+    shouldBe('Object.getPrototypeOf(Object.getPrototypeOf(Float64Array.prototype))', 'Object.prototype');
+  }
 
   shouldBe('Object.getPrototypeOf(DataView.prototype)', 'Object.prototype');
 }


### PR DESCRIPTION
While the WebGL conformance suite doesn't focus on ECMAScript
behavior, this test is still useful, and should work with both ES
versions for the time being.

Related to #1052.