### PR TITLE
Unbind PIXEL_UNPACK_BUFFER after testing.

### DIFF
--- a/sdk/tests/js/tests/gl-object-get-calls.js
+++ b/sdk/tests/js/tests/gl-object-get-calls.js
@@ -95,6 +95,7 @@ for (var bb = 0; bb < bufferTypes.length; ++bb) {
       return gl.getBufferParameter(bufferType, parameter);
     };
   }(bufferType));
+  gl.bindBuffer(bufferType, null);
 }
 testInvalidArgument(
     "getBufferParameter",


### PR DESCRIPTION
Leaving PIXEL_UNPACK_BUFFER bound causes gl.texImage2D(...) to fail in
`getFramebufferAttachmentParameter` section.