### PR TITLE
Fix a precision issue in nested loop test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/nested-loops-with-break-and-continue.html
+++ b/sdk/tests/conformance/glsl/bugs/nested-loops-with-break-and-continue.html
@@ -50,31 +50,32 @@
         uniform int uCount;
 
         void main() {
-            float a = 1.0 / 1020.0;
+            int a = 0;
             for (int i = 0; i < 10; ++i) {
                 if (i >= uCount) { break; }
                 for (int j = 0; j < 10; ++j) {
                     if (j >= uCount) { continue; }
-                    a += 0.002;
+                    a += 1;
                 }
                 for (int j = 0; j < 10; ++j) {
                     if (j >= uCount) { break; }
-                    a += 0.002;
+                    a += 1;
                 }
                 for (int j = 0; j < 10; ++j) {
                     if (j >= uCount) { continue; }
-                    a += 0.002;
+                    a += 1;
                 }
                 for (int j = 0; j < 10; ++j) {
                     if (j >= uCount) { break; }
-                    a += 0.002;
+                    a += 1;
                 }
                 for (int j = 0; j < 10; ++j) {
                     if (j >= uCount) { continue; }
-                    a += 0.002;
+                    a += 1;
                 }
             }
-            gl_FragColor = vec4(a, 1.0 - a, 0.0, 1.0);
+            float b = (float(a) / 125.0) * (64.0 / 255.0);
+            gl_FragColor = vec4(b, 1.0 - b, 0.0, 1.0);
         }
     </script>
     <script type="text/javascript">


### PR DESCRIPTION
Adding together floating point values of different magnitude and without
exact representations could cause error to accumulate in the previous
version of the test. The test failed when being run with
--emulate-shader-precision flag of Chromium, for example. Add integers
instead of floats so that precision issues can be avoided.