### PR TITLE
Don't remove non-whitespace characters when stripping indentations

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsShaderLibrary.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderLibrary.js
@@ -100,7 +100,8 @@ var gluShaderUtil = framework.opengl.gluShaderUtil;
             for (var i = 0; i < arr.length; ++i) {
             /** @type {number} */ var removed = 0;
             /** @type {number} */ var j;
-                for (j = 0; removed < numIndentChars && j < arr[i].length; ++j) {
+                // Some tests are indented inconsistently, so we have to check for non-whitespace characters here.
+                for (j = 0; removed < numIndentChars && j < arr[i].length && glsShaderLibrary.isWhitespace(arr[i].charAt(j)); ++j) {
                     removed += (arr[i].charAt(j) === '\t' ? 4 : 1);
                 }
 


### PR DESCRIPTION
Some dEQP test shaders are indented in an inconsistent way: for example,
some lines might be indented with \<tab\>\<tab\> whereas others have
\<tab\>\<space\>\<tab\>. These two indentations may look the same in an editor,
but when the framework indentation removal function looks at the
indentations, it counts <tab> as indentation by 4 and <space> as
indentation by one. The first line is used as reference and the rest of
the lines get the same amount of indentation removed. With inconsistent
indentation in the source, this could remove some meaningful characters,
like turning "void main()" into "oid main()" unless it is separately
checked that no non-whitespace characters are removed.

This fixes several shader tests, particularly in
deqp/data/gles2/shaders/constants.html.