### PR TITLE
Move conformance2/textures tests into conformance2/textures/misc

### DIFF
--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgb565.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgb565.html
@@ -33,16 +33,18 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
 <script>
 "use strict";
 function testPrologue(gl) {
     return true;
 }
+
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue)();
 </script>
-</head>
-<body onload='generateTest("RGB", "UNSIGNED_SHORT_5_6_5", testPrologue)()'>
-<canvas id="example" width="32" height="32"></canvas>
-<div id="description"></div>
-<div id="console"></div>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba4444.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba4444.html
@@ -33,16 +33,18 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
 <script>
 "use strict";
 function testPrologue(gl) {
     return true;
 }
+
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue)();
 </script>
-</head>
-<body onload='generateTest("RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue)()'>
-<canvas id="example" width="32" height="32"></canvas>
-<div id="description"></div>
-<div id="console"></div>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba5551.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas-rgba5551.html
@@ -33,16 +33,18 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
 <script>
 "use strict";
 function testPrologue(gl) {
     return true;
 }
+
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue)();
 </script>
-</head>
-<body onload='generateTest("RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue)()'>
-<canvas id="example" width="32" height="32"></canvas>
-<div id="description"></div>
-<div id="console"></div>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas.html
+++ b/sdk/tests/conformance/textures/tex-image-and-sub-image-2d-with-canvas.html
@@ -33,16 +33,18 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
 <script>
 "use strict";
 function testPrologue(gl) {
     return true;
 }
+
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue)();
 </script>
-</head>
-<body onload='generateTest("RGBA", "UNSIGNED_BYTE", testPrologue)()'>
-<canvas id="example" width="32" height="32"></canvas>
-<div id="description"></div>
-<div id="console"></div>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/00_test_list.txt
@@ -1,8 +1,1 @@
-gl-get-tex-parameter.html
-tex-input-validation.html
-tex-mipmap-levels.html
-tex-new-formats.html
-tex-storage-2d.html
-tex-storage-and-subimage-3d.html
-texel-fetch-undefined.html
-texture-npot.html
+misc/00_test_list.txt

--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -1,0 +1,8 @@
+gl-get-tex-parameter.html
+tex-input-validation.html
+tex-mipmap-levels.html
+tex-new-formats.html
+tex-storage-2d.html
+tex-storage-and-subimage-3d.html
+texel-fetch-undefined.html
+texture-npot.html

--- a/sdk/tests/conformance2/textures/misc/gl-get-tex-parameter.html
+++ b/sdk/tests/conformance2/textures/misc/gl-get-tex-parameter.html
@@ -29,17 +29,20 @@
 <html>
 <head>
 <meta charset="utf-8">
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"></script>
+<title>WebGL getTexParameter test</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"> </script>
 </head>
 <body>
+<canvas id="example" width="4" height="4" style="width: 40px; height: 30px;"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>
 var contextVersion = 2;
 </script>
-<script src="../../js/tests/tex-input-validation.js"></script>
-<script src="../../js/js-test-post.js"></script>
+<script src="../../../js/tests/gl-get-tex-parameter.js"></script>
+<script src="../../../js/js-test-post.js"></script>
+
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/tex-input-validation.html
+++ b/sdk/tests/conformance2/textures/misc/tex-input-validation.html
@@ -29,20 +29,17 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL getTexParameter test</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"> </script>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
 </head>
 <body>
-<canvas id="example" width="4" height="4" style="width: 40px; height: 30px;"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>
 var contextVersion = 2;
 </script>
-<script src="../../js/tests/gl-get-tex-parameter.js"></script>
-<script src="../../js/js-test-post.js"></script>
-
+<script src="../../../js/tests/tex-input-validation.js"></script>
+<script src="../../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/tex-mipmap-levels.html
+++ b/sdk/tests/conformance2/textures/misc/tex-mipmap-levels.html
@@ -30,9 +30,9 @@
 <head>
 <meta charset="utf-8">
 <title>WebGL2 Non-Power of 2 texture conformance test.</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"></script>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
 </head>
 <body>
 <canvas id="example" width="2" height="2" style="width: 2px; height: 2px;"></canvas>
@@ -127,7 +127,7 @@ wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
 var successfullyParsed = true;
 
 </script>
-<script src="../../js/js-test-post.js"></script>
+<script src="../../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/tex-new-formats.html
+++ b/sdk/tests/conformance2/textures/misc/tex-new-formats.html
@@ -30,9 +30,9 @@
 <head>
 <meta charset="utf-8">
 <title>Conformance test for WebGL2 texture image formats specification</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"></script>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -523,7 +523,7 @@ function runTexFormatsTest()
 debug("");
 var successfullyParsed = true;
 </script>
-<script src="../../js/js-test-post.js"></script>
+<script src="../../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
@@ -30,9 +30,9 @@
 <head>
 <meta charset="utf-8">
 <title>texStorage2D conformance test</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"></script>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -253,7 +253,7 @@ function runTexStorage2DTest()
 debug("");
 var successfullyParsed = true;
 </script>
-<script src="../../js/js-test-post.js"></script>
+<script src="../../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/tex-storage-and-subimage-3d.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-and-subimage-3d.html
@@ -30,9 +30,9 @@
 <head>
 <meta charset="utf-8">
 <title>texStorage3D and texSubImage3D conformance test</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"></script>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -222,7 +222,7 @@ function runTexStorageAndSubImage3DTest()
 debug("");
 var successfullyParsed = true;
 </script>
-<script src="../../js/js-test-post.js"></script>
+<script src="../../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/texel-fetch-undefined.html
+++ b/sdk/tests/conformance2/textures/misc/texel-fetch-undefined.html
@@ -30,11 +30,11 @@
 <head>
 <meta charset="utf-8">
 <title>WebGL texel fetch test.</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="c" width="256" height="256"></canvas>
@@ -99,8 +99,6 @@ testFetchAt(0, -1, [0, 0, 0, 0]);
 testFetchAt(-1, 1, [0, 0, 0, 0]);
 
 finishTest();
-
-var successfullyParsed = true;
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/texture-npot.html
+++ b/sdk/tests/conformance2/textures/misc/texture-npot.html
@@ -30,9 +30,9 @@
 <head>
 <meta charset="utf-8">
 <title>WebGL2 Non-Power of 2 texture conformance test.</title>
-<link rel="stylesheet" href="../../resources/js-test-style.css"/>
-<script src="../../js/js-test-pre.js"></script>
-<script src="../../js/webgl-test-utils.js"></script>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
 </head>
 <body>
 <canvas id="example" width="5" height="3" style="width: 40px; height: 30px;"></canvas>
@@ -174,7 +174,7 @@ tests.forEach(function(test) {
 var successfullyParsed = true;
 
 </script>
-<script src="../../js/js-test-post.js"></script>
+<script src="../../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
@@ -21,14 +21,14 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(pixelFormat, pixelType, prologue) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue) {
     var wtu = WebGLTestUtils;
     var gl = null;
     var successfullyParsed = false;
 
     var init = function()
     {
-        description('Verify texImage2D and texSubImage2D code paths taking canvas elements (' + pixelFormat + '/' + pixelType + ')');
+        description('Verify texImage2D and texSubImage2D code paths taking canvas elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
         gl = wtu.create3DContext("example");
 
@@ -120,11 +120,11 @@ function generateTest(pixelFormat, pixelType, prologue) {
         for (var tt = 0; tt < targets.length; ++tt) {
             // Initialize the texture to black first
             if (useTexSubImage2D) {
-                gl.texImage2D(targets[tt], 0, gl[pixelFormat], canvas.width, canvas.height, 0,
+                gl.texImage2D(targets[tt], 0, gl[internalFormat], canvas.width, canvas.height, 0,
                               gl[pixelFormat], gl[pixelType], null);
                 gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], canvas);
             } else {
-                gl.texImage2D(targets[tt], 0, gl[pixelFormat], gl[pixelFormat], gl[pixelType], canvas);
+                gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], canvas);
             }
         }
 
@@ -182,7 +182,7 @@ function generateTest(pixelFormat, pixelType, prologue) {
                     var pixels = new Float32Array([1000.0, 1000.0, 1000.0, 1000.0]);
                     gl.texSubImage2D(targets[tt], 0, 0, 0, 1, 1, gl[pixelFormat], gl[pixelType], pixels);
                     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Texture should be backed by floats");
-                } else if (pixelType == "HALF_FLOAT_OES") {
+                } else if (pixelType == "HALF_FLOAT_OES" || pixelType == "HALF_FLOAT") {
                     // Attempt to set a pixel in the texture to ensure the texture was
                     // actually created with half-floats. Regression test for http://crbug.com/484968
                     var halfFloatTenK = 0x70E2; // Half float 10000


### PR DESCRIPTION
So we can put tests for canvas/image/video into sub folders.

Also, refactor tex-image-and-sub-image-2d-with-canvas to accordomate ES3 needs.