### PR TITLE
Replace deprecated JavaScript media types with application/javascript

### DIFF
--- a/sdk/demos/google/high-dpi/index.html
+++ b/sdk/demos/google/high-dpi/index.html
@@ -32,12 +32,12 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
     <title>Teapot Test</title>
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-    <script type="text/javascript" src="../resources/moz/matrix4x4.js"></script>
-    <script type="text/javascript" src="../resources/cameracontroller.js"></script>
-    <script type="text/javascript" src="teapot-streams.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../resources/moz/matrix4x4.js"></script>
+    <script type="application/javascript" src="../resources/cameracontroller.js"></script>
+    <script type="application/javascript" src="teapot-streams.js"></script>
+    <script type="application/javascript" src="demo.js"></script>
     <style type="text/css">
       .canvascontainer {
         float: left; 

--- a/sdk/demos/google/image-texture-test/index.html
+++ b/sdk/demos/google/image-texture-test/index.html
@@ -31,10 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <html>
   <head>
     <title>Texture Test</title>
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-    <script type="text/javascript" src="../resources/moz/matrix4x4.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../resources/moz/matrix4x4.js"></script>
+    <script type="application/javascript" src="demo.js"></script>
   </head>
   <body onload="main()">
 <H1>Texture Test</H1>

--- a/sdk/demos/google/nvidia-vertex-buffer-object/index.html
+++ b/sdk/demos/google/nvidia-vertex-buffer-object/index.html
@@ -31,12 +31,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <html>
   <head>
     <title>NVIDIA Vertex Buffer Object demo</title>
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-    <script type="text/javascript" src="../resources/o3djs/base.js"></script>
-    <script type="text/javascript" src="../resources/fpscounter.js"></script>
-    <script type="text/javascript" src="PeriodicIterator.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../resources/o3djs/base.js"></script>
+    <script type="application/javascript" src="../resources/fpscounter.js"></script>
+    <script type="application/javascript" src="PeriodicIterator.js"></script>
+    <script type="application/javascript" src="demo.js"></script>
   </head>
   <body onload="main()">
 <H1>NVIDIA Vertex Buffer Object demo</H1>

--- a/sdk/demos/google/particles/index.html
+++ b/sdk/demos/google/particles/index.html
@@ -31,12 +31,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <html>
   <head>
     <title>Particles</title>
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-    <script type="text/javascript" src="../resources/o3djs/base.js"></script>
-    <script type="text/javascript" src="../resources/cameracontroller.js"></script>
-    <script type="text/javascript" src="../resources/fpscounter.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../resources/o3djs/base.js"></script>
+    <script type="application/javascript" src="../resources/cameracontroller.js"></script>
+    <script type="application/javascript" src="../resources/fpscounter.js"></script>
+    <script type="application/javascript" src="demo.js"></script>
   </head>
   <body onload="main()">
     <p>

--- a/sdk/demos/google/performance/uniformmatrix4fv-15.html
+++ b/sdk/demos/google/performance/uniformmatrix4fv-15.html
@@ -31,10 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <html>
 <head>
 <title>Test how many uniform matrix arrays we can update in a frame</title>
-<script type="text/javascript" src="../../common/webgl-utils.js"></script>
-<script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-<script type="text/javascript" src="../resources/webgl-boilerplate.js"></script>
-<script type="text/javascript" src="../resources/perf-harness.js"></script>
+<script type="application/javascript" src="../../common/webgl-utils.js"></script>
+<script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+<script type="application/javascript" src="../resources/webgl-boilerplate.js"></script>
+<script type="application/javascript" src="../resources/perf-harness.js"></script>
 <script>
 window.onload = main;
 

--- a/sdk/demos/google/performance/uniformmatrix4fv.html
+++ b/sdk/demos/google/performance/uniformmatrix4fv.html
@@ -31,10 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <html>
 <head>
 <title>Test how many uniform matrices we can update in a frame</title>
-<script type="text/javascript" src="../../common/webgl-utils.js"></script>
-<script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-<script type="text/javascript" src="../resources/webgl-boilerplate.js"></script>
-<script type="text/javascript" src="../resources/perf-harness.js"></script>
+<script type="application/javascript" src="../../common/webgl-utils.js"></script>
+<script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+<script type="application/javascript" src="../resources/webgl-boilerplate.js"></script>
+<script type="application/javascript" src="../resources/perf-harness.js"></script>
 <script>
 window.onload = main;
 

--- a/sdk/demos/google/procedural-texture-test/index.html
+++ b/sdk/demos/google/procedural-texture-test/index.html
@@ -31,10 +31,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <html>
   <head>
     <title>Texture Test</title>
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-    <script type="text/javascript" src="../resources/moz/matrix4x4.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../resources/moz/matrix4x4.js"></script>
+    <script type="application/javascript" src="demo.js"></script>
   </head>
   <body onload="main()">
 <H1>Texture Test</H1>

--- a/sdk/demos/google/resources/o3djs/base.js
+++ b/sdk/demos/google/resources/o3djs/base.js
@@ -279,7 +279,7 @@ o3djs.writeScriptTag_ = function(src) {
   if (typeof doc != 'undefined' &&
       !o3djs.dependencies_.written[src]) {
     o3djs.dependencies_.written[src] = true;
-    doc.write('<script type="text/javascript" src="' +
+    doc.write('<script type="application/javascript" src="' +
               src + '"></' + 'script>');
   }
 };

--- a/sdk/demos/google/san-angeles/box/box.html
+++ b/sdk/demos/google/san-angeles/box/box.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <title>Box</title>
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
-    <script type="text/javascript" src="box.js"></script>
+    <script type="application/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.3.2/jquery.min.js"></script>
+    <script type="application/javascript" src="box.js"></script>
   </head>
   <body>
     <div style="text-align: center">

--- a/sdk/demos/google/san-angeles/index.html
+++ b/sdk/demos/google/san-angeles/index.html
@@ -31,13 +31,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 <html>
   <head>
     <title>San Angeles Observation</title>
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-    <script type="text/javascript" src="../resources/log.js"></script>
-    <script type="text/javascript" src="../resources/moz/matrix4x4.js"></script>
-    <script type="text/javascript" src="../resources/OESVertexArrayObject.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
-    <script type="text/javascript" src="angeles.js"></script>
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../resources/log.js"></script>
+    <script type="application/javascript" src="../resources/moz/matrix4x4.js"></script>
+    <script type="application/javascript" src="../resources/OESVertexArrayObject.js"></script>
+    <script type="application/javascript" src="demo.js"></script>
+    <script type="application/javascript" src="angeles.js"></script>
   </head>
   <body onload="main()">
     <p>

--- a/sdk/demos/google/shiny-teapot/index.html
+++ b/sdk/demos/google/shiny-teapot/index.html
@@ -32,12 +32,12 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -->
     <title>Teapot Test</title>
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-    <script type="text/javascript" src="../resources/moz/matrix4x4.js"></script>
-    <script type="text/javascript" src="../resources/cameracontroller.js"></script>
-    <script type="text/javascript" src="teapot-streams.js"></script>
-    <script type="text/javascript" src="demo.js"></script>
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../resources/moz/matrix4x4.js"></script>
+    <script type="application/javascript" src="../resources/cameracontroller.js"></script>
+    <script type="application/javascript" src="teapot-streams.js"></script>
+    <script type="application/javascript" src="demo.js"></script>
     <style type="text/css">
       .centeredcanvas {
         margin: 0px auto;

--- a/sdk/demos/google/web-workers-typed-arrays/index.html
+++ b/sdk/demos/google/web-workers-typed-arrays/index.html
@@ -32,15 +32,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <head>
     <title>Multithreaded NVIDIA Vertex Buffer Object demo</title>
     <link rel="stylesheet" type="text/css" href="style.css" />
-    <script type="text/javascript" src="../../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../resources/o3djs/base.js"></script>
-    <script type="text/javascript" src="../resources/fpscounter.js"></script>
-    <script type="text/javascript" src="calculate.js"></script>
-    <script type="text/javascript" src="../nvidia-vertex-buffer-object/PeriodicIterator.js"></script>
-    <script type="text/javascript" src="benchmark.js"></script>
-    <script type="text/javascript" src="capabilities.js"></script>
-    <script type="text/javascript" src="demo-multicore.js"></script>
-    <script type="text/javascript">
+    <script type="application/javascript" src="../../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../resources/o3djs/base.js"></script>
+    <script type="application/javascript" src="../resources/fpscounter.js"></script>
+    <script type="application/javascript" src="calculate.js"></script>
+    <script type="application/javascript" src="../nvidia-vertex-buffer-object/PeriodicIterator.js"></script>
+    <script type="application/javascript" src="benchmark.js"></script>
+    <script type="application/javascript" src="capabilities.js"></script>
+    <script type="application/javascript" src="demo-multicore.js"></script>
+    <script type="application/javascript">
         function selectManual() {
             document.querySelector('#manual').style.display = "block";
             document.querySelector('#benchmark').style.display = "none";

--- a/sdk/demos/mozilla/spore/.htaccess
+++ b/sdk/demos/mozilla/spore/.htaccess
@@ -1,4 +1,4 @@
 AddOutputFilterByType DEFLATE text/xml
-AddOutputFilterByType DEFLATE application/x-javascript
+AddOutputFilterByType DEFLATE application/javascript
 
 

--- a/sdk/demos/mozilla/spore/index.html
+++ b/sdk/demos/mozilla/spore/index.html
@@ -27,14 +27,14 @@
 <head>
 <title>Spore Creature Viewer</title>
 
-<script type="text/javascript" src="../../common/webgl-utils.js"></script>
-<script type="text/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
-<script type="text/javascript" src="sylvester.js"></script>
-<script type="text/javascript" src="glUtils.js"></script>
+<script type="application/javascript" src="../../common/webgl-utils.js"></script>
+<script type="application/javascript" src="../../../devtools/src/debug/webgl-debug.js"></script>
+<script type="application/javascript" src="sylvester.js"></script>
+<script type="application/javascript" src="glUtils.js"></script>
 
-<script type="text/javascript" src="SporeFile.js"></script>
+<script type="application/javascript" src="SporeFile.js"></script>
 
-<script type="text/javascript" src="sporeview.js"></script>
+<script type="application/javascript" src="sporeview.js"></script>
 
 <!-- shaders -->
 <script id="shader-vs" type="x-shader/x-vertex">

--- a/sdk/demos/webkit/Earth.html
+++ b/sdk/demos/webkit/Earth.html
@@ -28,10 +28,10 @@
 <html>
   <head>
     <title>Earth and Mars</title>
-    <script type="text/javascript" src="../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
     <script src="resources/J3DI.js"> </script>
-    <script src="resources/J3DIMath.js" type="text/javascript"> </script>
+    <script src="resources/J3DIMath.js" type="application/javascript"> </script>
 
     <script id="vshader" type="x-shader/x-vertex">
         uniform mat4 u_modelViewProjMatrix;

--- a/sdk/demos/webkit/ManyPlanetsDeep.html
+++ b/sdk/demos/webkit/ManyPlanetsDeep.html
@@ -28,10 +28,10 @@
 <html>
   <head>
     <title>Many Planets Deep</title>
-    <script type="text/javascript" src="../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
     <script src="resources/J3DI.js"> </script>
-    <script src="resources/J3DIMath.js" type="text/javascript"> </script>
+    <script src="resources/J3DIMath.js" type="application/javascript"> </script>
 
     <script id="vshader" type="x-shader/x-vertex">
         uniform mat4 u_modelViewProjMatrix;

--- a/sdk/demos/webkit/MatrixTest.html
+++ b/sdk/demos/webkit/MatrixTest.html
@@ -30,10 +30,10 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>Matrix Tests</title>
 
-<script type="text/javascript" src="../common/webgl-utils.js"></script>
-<script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
-<script src="resources/J3DI.js" type="text/javascript"> </script>
-<script src="resources/J3DIMath.js" type="text/javascript"> </script>
+<script type="application/javascript" src="../common/webgl-utils.js"></script>
+<script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+<script src="resources/J3DI.js" type="application/javascript"> </script>
+<script src="resources/J3DIMath.js" type="application/javascript"> </script>
 <script id="vshader" type="x-shader/x-vertex">
     uniform mat4 u_modelViewProjMatrix;
     uniform mat4 u_normalMatrix;

--- a/sdk/demos/webkit/SpinningBox.html
+++ b/sdk/demos/webkit/SpinningBox.html
@@ -30,10 +30,10 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <title>Spinning WebGL Box</title>
 
-<script type="text/javascript" src="../common/webgl-utils.js"></script>
-<script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+<script type="application/javascript" src="../common/webgl-utils.js"></script>
+<script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
 <script src="resources/J3DI.js"> </script>
-<script src="resources/J3DIMath.js" type="text/javascript"> </script>
+<script src="resources/J3DIMath.js" type="application/javascript"> </script>
 <script id="vshader" type="x-shader/x-vertex">
     uniform mat4 u_modelViewProjMatrix;
     uniform mat4 u_normalMatrix;

--- a/sdk/demos/webkit/SpiritBox.html
+++ b/sdk/demos/webkit/SpiritBox.html
@@ -49,10 +49,10 @@ body, html {
   height: 100%;
 }
 </style>
-<script type="text/javascript" src="../common/webgl-utils.js"></script>
-<script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+<script type="application/javascript" src="../common/webgl-utils.js"></script>
+<script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
 <script src="resources/J3DI.js"> </script>
-<script src="resources/J3DIMath.js" type="text/javascript"> </script>
+<script src="resources/J3DIMath.js" type="application/javascript"> </script>
 <script id="vshader" type="x-shader/x-vertex">
     uniform mat4 u_modelViewProjMatrix;
     uniform mat4 u_normalMatrix;

--- a/sdk/demos/webkit/TeapotPerPixel.html
+++ b/sdk/demos/webkit/TeapotPerPixel.html
@@ -28,10 +28,10 @@
 <html>
   <head>
     <title>Teapot (per-pixel)</title>
-    <script type="text/javascript" src="../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
     <script src="resources/J3DI.js"> </script>
-    <script src="resources/J3DIMath.js" type="text/javascript"> </script>
+    <script src="resources/J3DIMath.js" type="application/javascript"> </script>
     <script id="vshader" type="x-shader/x-vertex">
         /*
           Copyright (c) 2008 Seneca College

--- a/sdk/demos/webkit/TeapotPerVertex.html
+++ b/sdk/demos/webkit/TeapotPerVertex.html
@@ -28,10 +28,10 @@
 <html>
   <head>
     <title>Teapot (per-vertex)</title>
-    <script type="text/javascript" src="../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
     <script src="resources/J3DI.js"> </script>
-    <script src="resources/J3DIMath.js" type="text/javascript"> </script>
+    <script src="resources/J3DIMath.js" type="application/javascript"> </script>
     <script id="vshader" type="x-shader/x-vertex">
         /*
           Copyright (c) 2008 Seneca College

--- a/sdk/demos/webkit/WebGL+CSS.html
+++ b/sdk/demos/webkit/WebGL+CSS.html
@@ -3,9 +3,9 @@
   <head>
     <title>WebGL + CSS Effects</title>
     <script src="resources/J3DI.js"> </script>
-    <script src="resources/J3DIMath.js" type="text/javascript"> </script>
-    <script type="text/javascript" src="../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+    <script src="resources/J3DIMath.js" type="application/javascript"> </script>
+    <script type="application/javascript" src="../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
     <script id="vshader" type="x-shader/x-vertex">
         /*
           Copyright (c) 2008 Seneca College

--- a/sdk/demos/webkit/WebGLLogo.html
+++ b/sdk/demos/webkit/WebGLLogo.html
@@ -28,10 +28,10 @@
 <html>
   <head>
     <title>WebGL Logo</title>
-    <script type="text/javascript" src="../common/webgl-utils.js"></script>
-    <script type="text/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
+    <script type="application/javascript" src="../common/webgl-utils.js"></script>
+    <script type="application/javascript" src="../../devtools/src/debug/webgl-debug.js"></script>
     <script src="resources/J3DI.js"> </script>
-    <script src="resources/J3DIMath.js" type="text/javascript"> </script>
+    <script src="resources/J3DIMath.js" type="application/javascript"> </script>
     <script id="vshader" type="x-shader/x-vertex">
         /*
           Copyright (c) 2008 Seneca College

--- a/sdk/tests/closure-library/closure/goog/base.js
+++ b/sdk/tests/closure-library/closure/goog/base.js
@@ -1164,18 +1164,18 @@ if (goog.DEPENDENCIES_ENABLED) {
       if (opt_sourceText === undefined) {
         if (!isOldIE) {
           doc.write(
-              '<script type="text/javascript" src="' +
+              '<script type="application/javascript" src="' +
                   src + '"></' + 'script>');
         } else {
           var state = " onreadystatechange='goog.onScriptLoad_(this, " +
               ++goog.lastNonModuleScriptIndex_ + ")' ";
           doc.write(
-              '<script type="text/javascript" src="' +
+              '<script type="application/javascript" src="' +
                   src + '"' + state + '></' + 'script>');
         }
       } else {
         doc.write(
-            '<script type="text/javascript">' +
+            '<script type="application/javascript">' +
             opt_sourceText +
             '</' + 'script>');
       }
@@ -1904,7 +1904,7 @@ goog.globalEval = function(script) {
     } else {
       var doc = goog.global.document;
       var scriptElt = doc.createElement('SCRIPT');
-      scriptElt.type = 'text/javascript';
+      scriptElt.type = 'application/javascript';
       scriptElt.defer = false;
       // Note(user): can't use .innerHTML since "t('<test>')" will fail and
       // .text doesn't work in Safari 2.  Therefore we append a text node.

--- a/sdk/tests/conformance/canvas/buffer-preserve-test.html
+++ b/sdk/tests/conformance/canvas/buffer-preserve-test.html
@@ -44,7 +44,7 @@ body {
 <canvas width="20" height="20" style="border: 1px solid blue;" id="c"></canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 
 description("This test ensures WebGL implementations correctly clear the drawing buffer " +

--- a/sdk/tests/conformance/canvas/to-data-url-test.html
+++ b/sdk/tests/conformance/canvas/to-data-url-test.html
@@ -38,7 +38,7 @@
 <canvas width="20" height="20" style="border: 1px solid black; width: 16px; height: 16px" id="c2d"></canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script type="text/javascript">
+<script type="application/javascript">
 var wtu = WebGLTestUtils;
 var numTests = 10;
 var gl;

--- a/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
+++ b/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
@@ -59,7 +59,7 @@ void main() {
     gl_FragColor = vec4(1.0 - a, a, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Comparing loop index to an uniform in a fragment shader should work.");
 debug("");

--- a/sdk/tests/conformance/glsl/bugs/compound-assignment-type-combination.html
+++ b/sdk/tests/conformance/glsl/bugs/compound-assignment-type-combination.html
@@ -63,7 +63,7 @@ void main() {
 <body onload="runTest()">
 <div id="description"></div>
 <div id="console"></div>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 

--- a/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
+++ b/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
@@ -92,7 +92,7 @@ void main() {
     gl_FragColor = vec4(0.0, 2.0 * a, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance/glsl/bugs/essl3-shaders-with-webgl1.html
+++ b/sdk/tests/conformance/glsl/bugs/essl3-shaders-with-webgl1.html
@@ -92,7 +92,7 @@ void main() {
     my_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("OpenGL ES 3 shading language shaders should not be accepted by WebGL 1.");
 GLSLConformanceTester.runTests([

--- a/sdk/tests/conformance/glsl/bugs/logic-inside-block-without-braces.html
+++ b/sdk/tests/conformance/glsl/bugs/logic-inside-block-without-braces.html
@@ -88,7 +88,7 @@ void main() {
     gl_FragColor = vec4(0.0, 1.0 - wrong, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Short-circuiting logic operator with side effects inside if/for statement without braces should work.");
 debug("");

--- a/sdk/tests/conformance/glsl/bugs/nested-loops-with-break-and-continue.html
+++ b/sdk/tests/conformance/glsl/bugs/nested-loops-with-break-and-continue.html
@@ -78,7 +78,7 @@ void main() {
     gl_FragColor = vec4(b, 1.0 - b, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Multiple loops using break and continue statements should work.");
 debug("");

--- a/sdk/tests/conformance/glsl/bugs/pow-of-small-constant-in-user-defined-function.html
+++ b/sdk/tests/conformance/glsl/bugs/pow-of-small-constant-in-user-defined-function.html
@@ -66,7 +66,7 @@ void main() {
     }
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 debug("");

--- a/sdk/tests/conformance/glsl/bugs/sequence-operator-evaluation-order.html
+++ b/sdk/tests/conformance/glsl/bugs/sequence-operator-evaluation-order.html
@@ -67,7 +67,7 @@ void main() {
     gl_FragColor = vec4(0.0, correct ? green : 0.0, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Ternary operator should be evaluated after previous operands in a sequence");
 debug("");

--- a/sdk/tests/conformance/glsl/matrices/matrix-compound-multiply.html
+++ b/sdk/tests/conformance/glsl/matrices/matrix-compound-multiply.html
@@ -60,7 +60,7 @@ void main() {
     gl_FragColor = vec4(0.0, diff < 0.01 ? 1.0 : 0.0, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Matrix compound multiplication test comparing against normal multiplication.");
 debug("");

--- a/sdk/tests/conformance/glsl/misc/const-variable-initialization.html
+++ b/sdk/tests/conformance/glsl/misc/const-variable-initialization.html
@@ -59,7 +59,7 @@ void main() {
 <body onload="runTest()">
 <div id="description"></div>
 <div id="console"></div>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 

--- a/sdk/tests/conformance/more/all_tests.html
+++ b/sdk/tests/conformance/more/all_tests.html
@@ -33,7 +33,7 @@
     h2 { display: inline; font-size: 1em; margin-bottom: 0.2em; }
     iframe { display: inline; border: 1px solid black; overflow: hidden;}
   </style>
-  <script type="text/javascript">
+  <script type="application/javascript">
     function loadTest(id, url) {
       document.getElementById(id).src = url;
     }

--- a/sdk/tests/conformance/more/all_tests_linkonly.html
+++ b/sdk/tests/conformance/more/all_tests_linkonly.html
@@ -33,7 +33,7 @@
     h2 { display: inline; font-size: 1em; margin-bottom: 0.2em; }
     iframe { display: inline; border: 1px solid black; overflow: hidden;}
   </style>
-  <script type="text/javascript">
+  <script type="application/javascript">
     function loadTest(id, url) {
       document.getElementById(id).src = url;
     }

--- a/sdk/tests/conformance/more/all_tests_sequential.html
+++ b/sdk/tests/conformance/more/all_tests_sequential.html
@@ -33,7 +33,7 @@
     h2 { display: inline; font-size: 1em; margin-bottom: 0.2em; }
     iframe { display: inline; border: 1px solid black; overflow: hidden;}
   </style>
-  <script type="text/javascript">
+  <script type="application/javascript">
     function loadTest(id, url) {
       document.getElementById(id).src = url;
     }

--- a/sdk/tests/conformance/more/conformance/badArgsArityLessThanArgc.html
+++ b/sdk/tests/conformance/more/conformance/badArgsArityLessThanArgc.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 /*
   The following tests are generated from

--- a/sdk/tests/conformance/more/conformance/constants.html
+++ b/sdk/tests/conformance/more/conformance/constants.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 /*
   The following tests are generated from

--- a/sdk/tests/conformance/more/conformance/fuzzTheAPI.html
+++ b/sdk/tests/conformance/more/conformance/fuzzTheAPI.html
@@ -29,10 +29,10 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 Tests.autorun = false;
 Tests.message = "This will fuzz the API with random inputs for a [long] while."

--- a/sdk/tests/conformance/more/conformance/getContext.html
+++ b/sdk/tests/conformance/more/conformance/getContext.html
@@ -29,10 +29,10 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 Tests.testGetWebGL = function() {
   var canvas = document.getElementById('webgl');

--- a/sdk/tests/conformance/more/conformance/methods.html
+++ b/sdk/tests/conformance/more/conformance/methods.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 /*
   The following tests are generated from

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-A.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-A.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-A.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-A.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B1.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B1.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-B1.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-B1.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B2.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B2.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-B2.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-B2.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B3.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B3.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-B3.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-B3.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-B4.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-B4.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-B4.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-B4.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-C.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-C.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-C.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-C.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-D_G.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-D_G.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-D_G.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-D_G.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-G_I.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-G_I.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-G_I.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-G_I.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-L_S.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-L_S.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-L_S.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-L_S.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPI-S_V.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI-S_V.html
@@ -29,12 +29,12 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
-<script type="application/x-javascript" src="argGenerators-S_V.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="argGenerators-S_V.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators work
 // when called with randomly generated valid arguments

--- a/sdk/tests/conformance/more/conformance/quickCheckAPIBadArgs.html
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPIBadArgs.html
@@ -29,11 +29,11 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="quickCheckAPI.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="quickCheckAPI.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 // Test that all GL functions specified in ArgGenerators fail
 // when called with randomly generated invalid arguments

--- a/sdk/tests/conformance/more/conformance/webGLArrays.html
+++ b/sdk/tests/conformance/more/conformance/webGLArrays.html
@@ -29,10 +29,10 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
 
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 function assertIdxs(name, arr, length) {
 //   assertOk(name+": Read with negative idx should work", function(){ return arr[-1] });

--- a/sdk/tests/conformance/more/demos/opengl_web.html
+++ b/sdk/tests/conformance/more/demos/opengl_web.html
@@ -31,9 +31,9 @@
 
 <title>OpenGL for the web</title>
 
-<script type="application/x-javascript" src="../util.js"></script>
+<script type="application/javascript" src="../util.js"></script>
 
-    <script type="application/x-javascript">
+    <script type="application/javascript">
 
 function log(msg) {
   document.getElementById('note').textContent += "\n"+msg;

--- a/sdk/tests/conformance/more/demos/video.html
+++ b/sdk/tests/conformance/more/demos/video.html
@@ -28,7 +28,7 @@
 */
 
 -->
-<script type="application/x-javascript" src="../util.js"></script>
+<script type="application/javascript" src="../util.js"></script>
 <script>
 "use strict";
 var processor = {

--- a/sdk/tests/conformance/more/functions/bindBuffer.html
+++ b/sdk/tests/conformance/more/functions/bindBuffer.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/bindBufferBadArgs.html
+++ b/sdk/tests/conformance/more/functions/bindBufferBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/bindFramebufferLeaveNonZero.html
+++ b/sdk/tests/conformance/more/functions/bindFramebufferLeaveNonZero.html
@@ -30,11 +30,11 @@
 -->
 <title>OpenGL for the web</title>
 
-<script type="application/x-javascript" src="../util.js"></script>
+<script type="application/javascript" src="../util.js"></script>
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../unit.js"></script>
 
-    <script type="application/x-javascript">
+    <script type="application/javascript">
 Tests.message = "This was segfaulting when the GL context got GC'd (in glXDestroyContext)";
 Tests.testSeg = function () {
     var canvas = document.getElementById('canvas');

--- a/sdk/tests/conformance/more/functions/bufferData.html
+++ b/sdk/tests/conformance/more/functions/bufferData.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/bufferDataBadArgs.html
+++ b/sdk/tests/conformance/more/functions/bufferDataBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/bufferSubData.html
+++ b/sdk/tests/conformance/more/functions/bufferSubData.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
     var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/bufferSubDataBadArgs.html
+++ b/sdk/tests/conformance/more/functions/bufferSubDataBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
     var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/copyTexImage2D.html
+++ b/sdk/tests/conformance/more/functions/copyTexImage2D.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/copyTexImage2DBadArgs.html
+++ b/sdk/tests/conformance/more/functions/copyTexImage2DBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
     var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/copyTexSubImage2D.html
+++ b/sdk/tests/conformance/more/functions/copyTexSubImage2D.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/copyTexSubImage2DBadArgs.html
+++ b/sdk/tests/conformance/more/functions/copyTexSubImage2DBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
     var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/deleteBufferBadArgs.html
+++ b/sdk/tests/conformance/more/functions/deleteBufferBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/drawArrays.html
+++ b/sdk/tests/conformance/more/functions/drawArrays.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
 var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];

--- a/sdk/tests/conformance/more/functions/drawArraysOutOfBounds.html
+++ b/sdk/tests/conformance/more/functions/drawArraysOutOfBounds.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
 var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];

--- a/sdk/tests/conformance/more/functions/drawElements.html
+++ b/sdk/tests/conformance/more/functions/drawElements.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
 var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];

--- a/sdk/tests/conformance/more/functions/drawElementsBadArgs.html
+++ b/sdk/tests/conformance/more/functions/drawElementsBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 // Tests.autorun = false;
 // Tests.message = "Caution: May crash your browser";

--- a/sdk/tests/conformance/more/functions/isTests.html
+++ b/sdk/tests/conformance/more/functions/isTests.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/isTestsBadArgs.html
+++ b/sdk/tests/conformance/more/functions/isTestsBadArgs.html
@@ -37,7 +37,7 @@
 <div id="description"></div>
 <div id="console"></div>
 <canvas id="canvas_element" width="1" height="1"></canvas>
-<script type="application/x-javascript">
+<script type="application/javascript">
 
 function runTest()
 {

--- a/sdk/tests/conformance/more/functions/readPixels.html
+++ b/sdk/tests/conformance/more/functions/readPixels.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
+++ b/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
@@ -29,10 +29,10 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="../../../js/webgl-test-utils.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="../../../js/webgl-test-utils.js"></script>
+<script type="application/javascript">
 var wtu = WebGLTestUtils;
 var defaultImgUrl = "http://www.opengl.org/img/opengl_logo.jpg";
 var localImgUrl = "../../../resources/opengl_logo.jpg";

--- a/sdk/tests/conformance/more/functions/texImage2D.html
+++ b/sdk/tests/conformance/more/functions/texImage2D.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/texImage2DBadArgs.html
+++ b/sdk/tests/conformance/more/functions/texImage2DBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
     var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/texImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texImage2DHTML.html
@@ -29,10 +29,10 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="../../../js/webgl-test-utils.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="../../../js/webgl-test-utils.js"></script>
+<script type="application/javascript">
 var wtu = WebGLTestUtils;
 var defaultImgUrl = "http://mashable.com/wp-content/uploads/2008/08/thunderbird-logo-64x64.png";
 var localImgUrl = "../../../resources/thunderbird-logo-64x64.png";

--- a/sdk/tests/conformance/more/functions/texImage2DHTMLBadArgs.html
+++ b/sdk/tests/conformance/more/functions/texImage2DHTMLBadArgs.html
@@ -29,9 +29,9 @@
 -->
 <meta charset="utf-8">
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/texSubImage2D.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2D.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/texSubImage2DBadArgs.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
     var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
@@ -29,10 +29,10 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript" src="../../../js/webgl-test-utils.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript" src="../../../js/webgl-test-utils.js"></script>
+<script type="application/javascript">
 var wtu = WebGLTestUtils;
 var defaultImgUrl = "http://mashable.com/wp-content/uploads/2008/08/thunderbird-logo-64x64.png";
 var localImgUrl = "../../../resources/thunderbird-logo-64x64.png";

--- a/sdk/tests/conformance/more/functions/texSubImage2DHTMLBadArgs.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DHTMLBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/uniformMatrix.html
+++ b/sdk/tests/conformance/more/functions/uniformMatrix.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/uniformMatrixBadArgs.html
+++ b/sdk/tests/conformance/more/functions/uniformMatrixBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/uniformf.html
+++ b/sdk/tests/conformance/more/functions/uniformf.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/uniformfArrayLen1.html
+++ b/sdk/tests/conformance/more/functions/uniformfArrayLen1.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/uniformfBadArgs.html
+++ b/sdk/tests/conformance/more/functions/uniformfBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/uniformi.html
+++ b/sdk/tests/conformance/more/functions/uniformi.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/uniformiBadArgs.html
+++ b/sdk/tests/conformance/more/functions/uniformiBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/functions/vertexAttrib.html
+++ b/sdk/tests/conformance/more/functions/vertexAttrib.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
 var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];

--- a/sdk/tests/conformance/more/functions/vertexAttribBadArgs.html
+++ b/sdk/tests/conformance/more/functions/vertexAttribBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
 var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];

--- a/sdk/tests/conformance/more/functions/vertexAttribPointer.html
+++ b/sdk/tests/conformance/more/functions/vertexAttribPointer.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
 var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];

--- a/sdk/tests/conformance/more/functions/vertexAttribPointerBadArgs.html
+++ b/sdk/tests/conformance/more/functions/vertexAttribPointerBadArgs.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
 var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];

--- a/sdk/tests/conformance/more/glsl/arrayOutOfBounds.html
+++ b/sdk/tests/conformance/more/glsl/arrayOutOfBounds.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/glsl/longLoops.html
+++ b/sdk/tests/conformance/more/glsl/longLoops.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/glsl/uniformOutOfBounds.html
+++ b/sdk/tests/conformance/more/glsl/uniformOutOfBounds.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.startUnit = function () {
   var canvas = document.getElementById('gl');

--- a/sdk/tests/conformance/more/glsl/unusedAttribsUniforms.html
+++ b/sdk/tests/conformance/more/glsl/unusedAttribsUniforms.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.autorun = false;
 Tests.message = "Caution: may crash the browser";

--- a/sdk/tests/conformance/more/performance/CPUvsGPU.html
+++ b/sdk/tests/conformance/more/performance/CPUvsGPU.html
@@ -30,9 +30,9 @@
 -->
 
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.autorun = false;
 Tests.message = "This might take a few seconds to run"

--- a/sdk/tests/conformance/more/performance/bandwidth.html
+++ b/sdk/tests/conformance/more/performance/bandwidth.html
@@ -30,9 +30,9 @@
 -->
 
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.autorun = false;
 Tests.message = "This might take a second or two. Take the upload numbers with a dose of salt, as there's no drawing code using the data.";

--- a/sdk/tests/conformance/more/performance/jsGCPause.html
+++ b/sdk/tests/conformance/more/performance/jsGCPause.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.autorun = false;
 

--- a/sdk/tests/conformance/more/performance/jsMatrixMult.html
+++ b/sdk/tests/conformance/more/performance/jsMatrixMult.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.autorun = false;
 Tests.message = "This might take a second or two (or ten)";

--- a/sdk/tests/conformance/more/performance/jsToGLOverhead.html
+++ b/sdk/tests/conformance/more/performance/jsToGLOverhead.html
@@ -29,9 +29,9 @@
 
 -->
 <link rel="stylesheet" type="text/css" href="../unit.css" />
-<script type="application/x-javascript" src="../unit.js"></script>
-<script type="application/x-javascript" src="../util.js"></script>
-<script type="application/x-javascript">
+<script type="application/javascript" src="../unit.js"></script>
+<script type="application/javascript" src="../util.js"></script>
+<script type="application/javascript">
 
 Tests.autorun = false;
 Tests.message = "This might take a second or two";

--- a/sdk/tests/conformance/programs/program-test.html
+++ b/sdk/tests/conformance/programs/program-test.html
@@ -65,7 +65,7 @@
 <div id="description"></div>
 <div id="console"></div>
 <canvas id="canvas" width="2" height="2"> </canvas>
-<script type="text/javascript">
+<script type="application/javascript">
 var wtu = WebGLTestUtils;
 function go() {
     description("Tests that program compiling/linking/using works correctly.");

--- a/sdk/tests/conformance/textures/tex-image-with-invalid-data.html
+++ b/sdk/tests/conformance/textures/tex-image-with-invalid-data.html
@@ -37,7 +37,7 @@
 <div id="description"></div>
 <div id="console"></div>
 <canvas id="canvas" width="2" height="2"> </canvas>
-<script type="text/javascript">
+<script type="application/javascript">
 description("texImage2D and texSubImage2D tests with invalid data");
 
 var wtu = WebGLTestUtils;

--- a/sdk/tests/conformance2/glsl3/array-as-return-value.html
+++ b/sdk/tests/conformance2/glsl3/array-as-return-value.html
@@ -133,7 +133,7 @@ void main() {
     my_FragColor = vec4(0.0, (success ? 1.0 : 0.0), 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Arrays as return values should work");
 debug("");

--- a/sdk/tests/conformance2/glsl3/array-assign-constructor.html
+++ b/sdk/tests/conformance2/glsl3/array-assign-constructor.html
@@ -91,7 +91,7 @@ void main() {
     my_FragColor = vec4(0.0, (fail ? 0.0 : 1.0), 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Assigning return values of array constructors should work.");
 debug("");

--- a/sdk/tests/conformance2/glsl3/array-assign.html
+++ b/sdk/tests/conformance2/glsl3/array-assign.html
@@ -90,7 +90,7 @@ void main() {
     my_FragColor = vec4(0.0, (fail ? 0.0 : 1.0), 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Assigning arrays should work.");
 

--- a/sdk/tests/conformance2/glsl3/array-complex-indexing.html
+++ b/sdk/tests/conformance2/glsl3/array-complex-indexing.html
@@ -99,7 +99,7 @@ void main() {
   color = (c == 2.0) ? vec4(0, 1.0, 0, 1.0) : vec4(1.0, 0, 0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Indexing complex array expressions");
 debug("");

--- a/sdk/tests/conformance2/glsl3/array-equality.html
+++ b/sdk/tests/conformance2/glsl3/array-equality.html
@@ -82,7 +82,7 @@ void main() {
     my_FragColor = vec4(0.0, (success ? 1.0 : 0.0), 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Comparing arrays should work.");
 

--- a/sdk/tests/conformance2/glsl3/array-in-complex-expression.html
+++ b/sdk/tests/conformance2/glsl3/array-in-complex-expression.html
@@ -127,7 +127,7 @@ void main() {
     my_FragColor = vec4(0.0, (result ? 1.0 : 0.0), 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Arrays in complex expressions should work");
 debug("");

--- a/sdk/tests/conformance2/glsl3/array-length-side-effects.html
+++ b/sdk/tests/conformance2/glsl3/array-length-side-effects.html
@@ -76,7 +76,7 @@ void main() {
     my_FragColor = vec4(float(a));
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 debug("These restrictions come from ESSL 3.00 section 5.9 definition of expression, which only allows length to be called on array names, not on arbitrary expressions returning an array.");

--- a/sdk/tests/conformance2/glsl3/compare-structs-containing-arrays.html
+++ b/sdk/tests/conformance2/glsl3/compare-structs-containing-arrays.html
@@ -81,7 +81,7 @@ void main() {
     color = b != c ? vec4(0, 1.0, 0, 1.0) : vec4(1.0, 0, 0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Comparing structs containing arrays should work.");
 debug("");

--- a/sdk/tests/conformance2/glsl3/invalid-default-precision.html
+++ b/sdk/tests/conformance2/glsl3/invalid-default-precision.html
@@ -64,7 +64,7 @@ void main() {
     my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 GLSLConformanceTester.runTests([

--- a/sdk/tests/conformance2/glsl3/misplaced-version-directive.html
+++ b/sdk/tests/conformance2/glsl3/misplaced-version-directive.html
@@ -89,7 +89,7 @@ void main() {
     my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 GLSLConformanceTester.runTests([

--- a/sdk/tests/conformance2/glsl3/sequence-operator-returns-non-constant.html
+++ b/sdk/tests/conformance2/glsl3/sequence-operator-returns-non-constant.html
@@ -55,7 +55,7 @@ void main() {
     float a[(2, 3)];
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description("Checks sequence operators returning non-constants and cannot be used as an array size.");
 debug("");

--- a/sdk/tests/conformance2/glsl3/shader-linking.html
+++ b/sdk/tests/conformance2/glsl3/shader-linking.html
@@ -69,7 +69,7 @@ void main() {
     gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
 }
 </script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 // See OpenGL ES Shading Language 3.00 spec section 1.5 or 3.3

--- a/sdk/tests/extra/constant-index-out-of-range.html
+++ b/sdk/tests/extra/constant-index-out-of-range.html
@@ -111,7 +111,7 @@ void main() {
 <body onload="runTest()">
 <div id="description"></div>
 <div id="console"></div>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 description();
 

--- a/sdk/tests/extra/offscreen-issue.html
+++ b/sdk/tests/extra/offscreen-issue.html
@@ -28,7 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<script type="text/javascript">
+<script type="application/javascript">
 
 window.onload = function() {
   setup("1");

--- a/sdk/tests/extra/program-test-1.html
+++ b/sdk/tests/extra/program-test-1.html
@@ -31,7 +31,7 @@
 <!-- This is a visual test that programs must have both a vertex and
      fragment shader attached; the fixed function pipeline on the
      desktop must remain disabled. -->
-<script type="text/javascript">
+<script type="application/javascript">
 function log() {
   var s = "";
   for (var i = 0; i < arguments.length; ++i) {

--- a/sdk/tests/extra/webgl-drawelements-validation.html
+++ b/sdk/tests/extra/webgl-drawelements-validation.html
@@ -35,7 +35,7 @@ canvas {
 }
 </style>
 <script src="../js/webgl-test-utils.js"></script>
-<script type="text/javascript">
+<script type="application/javascript">
 "use strict";
 
 var wtu = WebGLTestUtils;

--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -157,7 +157,7 @@
     padding-left: 1em;
   }
 </style>
-<script type="text/javascript" src="js/webgl-test-harness.js"></script>
+<script type="application/javascript" src="js/webgl-test-harness.js"></script>
 <script>
 "use strict";
 var DEFAULT_CONFORMANCE_TEST_VERSION = "1.0.4 (beta)";

--- a/specs/1.0.0/index.html
+++ b/specs/1.0.0/index.html
@@ -6,8 +6,8 @@
     <title>WebGL Specification</title>
     <meta name="generator" content="BBEdit 9.1">
     <link rel="stylesheet" type="text/css" href="../../resources/Khronos-Final.css" />
-    <script src="../../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
-    <script src="../../resources/generateTOC.js" type="text/javascript"></script>
+    <script src="../../resources/jquery-1.3.2.min.js" type="application/javascript"></script>
+    <script src="../../resources/generateTOC.js" type="application/javascript"></script>
 </head>
 <body onload="generateTOC(document.getElementById('toc'))">
     <!--begin-logo-->

--- a/specs/1.0.1/index.html
+++ b/specs/1.0.1/index.html
@@ -6,8 +6,8 @@
     <title>WebGL Specification</title>
     <meta name="generator" content="BBEdit 9.1">
     <link rel="stylesheet" type="text/css" href="../../resources/Khronos-Final.css" />
-    <script src="../../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
-    <script src="../../resources/generateTOC.js" type="text/javascript"></script>
+    <script src="../../resources/jquery-1.3.2.min.js" type="application/javascript"></script>
+    <script src="../../resources/generateTOC.js" type="application/javascript"></script>
 </head>
 <body onload="generateTOC(document.getElementById('toc'))">
     <!--begin-logo-->

--- a/specs/1.0.2/index.html
+++ b/specs/1.0.2/index.html
@@ -6,8 +6,8 @@
     <title>WebGL Specification</title>
     <meta name="generator" content="BBEdit 9.1">
     <link rel="stylesheet" type="text/css" href="../../resources/Khronos-Final.css" />
-    <script src="../../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
-    <script src="../../resources/generateTOC.js" type="text/javascript"></script>
+    <script src="../../resources/jquery-1.3.2.min.js" type="application/javascript"></script>
+    <script src="../../resources/generateTOC.js" type="application/javascript"></script>
 </head>
 <body onload="generateTOC(document.getElementById('toc'))">
     <!--begin-logo-->

--- a/specs/1.0.3/index.html
+++ b/specs/1.0.3/index.html
@@ -6,8 +6,8 @@
     <title>WebGL Specification</title>
     <meta name="generator" content="BBEdit 9.1">
     <link rel="stylesheet" type="text/css" href="../../resources/Khronos-Final.css" />
-    <script src="../../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
-    <script src="../../resources/generateTOC.js" type="text/javascript"></script>
+    <script src="../../resources/jquery-1.3.2.min.js" type="application/javascript"></script>
+    <script src="../../resources/generateTOC.js" type="application/javascript"></script>
 </head>
 <body onload="generateTOC(document.getElementById('toc'))">
     <!--begin-logo-->

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -6,8 +6,8 @@
     <title>WebGL Specification</title>
     <meta name="generator" content="BBEdit 9.1">
     <link rel="stylesheet" type="text/css" href="../../../resources/Khronos-WD.css" />
-    <script src="../../../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
-    <script src="../../../resources/generateTOC.js" type="text/javascript"></script>
+    <script src="../../../resources/jquery-1.3.2.min.js" type="application/javascript"></script>
+    <script src="../../../resources/generateTOC.js" type="application/javascript"></script>
 </head>
 <body onload="generateTOC(document.getElementById('toc'))">
     <!--begin-logo-->

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -5,8 +5,8 @@
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <title>WebGL 2 Specification</title>
     <link rel="stylesheet" type="text/css" href="../../../resources/Khronos-WD.css" />
-    <script src="../../../resources/jquery-1.3.2.min.js" type="text/javascript"></script>
-    <script src="../../../resources/generateTOC.js" type="text/javascript"></script>
+    <script src="../../../resources/jquery-1.3.2.min.js" type="application/javascript"></script>
+    <script src="../../../resources/generateTOC.js" type="application/javascript"></script>
 </head>
 <body onload="generateTOC(document.getElementById('toc'))">
     <!--begin-logo-->


### PR DESCRIPTION
application/x-javascript and text/javascript were both deprecated in
April 2006 by RFC 4329. WebGL does not require them, and the tests
should still pass even if a web browser drops support for the deprecated
names.