### PR TITLE
Fixed #1061: WebGL 2 Conformance - state/gl-object-get-calls

### DIFF
--- a/sdk/tests/js/tests/gl-object-get-calls.js
+++ b/sdk/tests/js/tests/gl-object-get-calls.js
@@ -131,7 +131,10 @@ var renderbuffer = gl.createRenderbuffer();
 wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, 2, 2);
+if (contextVersion == 1)
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, 2, 2);
+else
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH24_STENCIL8, 2, 2);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, renderbuffer);
 if (contextVersion > 1)


### PR DESCRIPTION
The intent of the WebGL 2.0 version of this test was clearly that a
DEPTH24_STENCIL8 renderbuffer be used. Allocation of this renderbuffer
isn't working correctly in either Chromium or Firefox yet, but the
WebGL 1.0 version of this test still passes with this change.