### PR TITLE
Fix uniformBlockShader.vert

### DIFF
--- a/sdk/tests/resources/uniformBlockShader.vert
+++ b/sdk/tests/resources/uniformBlockShader.vert
@@ -23,14 +23,14 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-attribute vec4 a_vertex;
-attribute vec3 a_normal;
+in vec4 a_vertex;
+in vec3 a_normal;
 
 uniform Transform {
     mat4 u_modelViewMatrix;
     mat4 u_projectionMatrix;
     mat3 u_normalMatrix;
-}
+};
 
 out vec3 normal;
 out vec4 ecPosition;


### PR DESCRIPTION
The shader is supposed to be in ESSL 3.00, with "in" instead of
"attribute".

Also, it is somewhat unclear in the spec whether a semicolon is required
after a uniform block declaration (it's not present in all the examples),
but the grammar seems to suggest so.