### PR TITLE
Clean up ternary-operator-on-arrays tests

### DIFF
--- a/sdk/tests/conformance/glsl/misc/ternary-operator-on-arrays.html
+++ b/sdk/tests/conformance/glsl/misc/ternary-operator-on-arrays.html
@@ -65,9 +65,6 @@ void main()
 "use strict";
 description("Checks ternary operators for structs and arrays.");
 
-var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext();
-
 GLSLConformanceTester.runTests([
 { fShaderId: 'fshader-array-ternary-operator',
   fShaderSuccess: false,

--- a/sdk/tests/conformance2/glsl3/ternary-operator-on-arrays-glsl3.html
+++ b/sdk/tests/conformance2/glsl3/ternary-operator-on-arrays-glsl3.html
@@ -65,9 +65,6 @@ void main()
 "use strict";
 description("Checks ternary operators for structs and arrays.");
 
-var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext();
-
 GLSLConformanceTester.runTests([
 { fShaderId: 'fshader-array-ternary-operator',
   fShaderSuccess: true,
@@ -79,7 +76,7 @@ GLSLConformanceTester.runTests([
   linkSuccess: true,
   passMsg: "By implication, using ternary operators with structs containing arrays is allowed in glsl3",
 },
-]);
+], 2);
 
 debug("");
 var successfullyParsed = true;


### PR DESCRIPTION
Require a WebGL 2 context on the ESSL 3 version of the test when it is
run without parameters, and remove extra context init.