### PR TITLE
Add a wtu function to query the default context version.

### DIFF
--- a/sdk/tests/conformance/rendering/gl-drawelements.html
+++ b/sdk/tests/conformance/rendering/gl-drawelements.html
@@ -103,10 +103,10 @@ function init()
     var vertexObject = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vertexObject);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint32Array([ 0, 1, 2]), gl.STATIC_DRAW);
-
     checkDrawElements(
         gl.TRIANGLES, 3, gl.UNSIGNED_INT,
-        gl.INVALID_ENUM, "gl.DrawElements should return INVALID_ENUM with UNSIGNED_INT");
+        wtu.getDefault3DContextVersion() > 1 ? gl.NO_ERROR : gl.INVALID_ENUM,
+        "gl.DrawElements should return INVALID_ENUM with UNSIGNED_INT");
     checkDrawElements(
         gl.TRIANGLES, 3, gl.FLOAT,
         gl.INVALID_ENUM, "gl.DrawElements should return INVALID_ENUM with FLOAT");

--- a/sdk/tests/conformance/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance/textures/misc/00_test_list.txt
@@ -24,9 +24,9 @@ texture-complete.html
 --min-version 1.0.3 texture-copying-feedback-loops.html
 --min-version 1.0.4 texture-cube-as-fbo-attachment.html
 --min-version 1.0.2 texture-hd-dpi.html
---min-version 1.0.2 texture-formats-test.html
+--min-version 1.0.2 --max-version 1.9.9 texture-formats-test.html
 texture-mips.html
-texture-npot-video.html
+--max-version 1.9.9 texture-npot-video.html
 --max-version 1.9.9 texture-npot.html
 texture-size.html
 texture-size-cube-maps.html
@@ -36,5 +36,5 @@ texture-transparent-pixels-initialized.html
 --min-version 1.0.2 texture-upload-cube-maps.html
 --min-version 1.0.3 texture-upload-size.html
 --min-version 1.0.2 mipmap-fbo.html
---min-version 1.0.3 texture-fakeblack.html
+--min-version 1.0.3 --max-version 1.9.9 texture-fakeblack.html
 --min-version 1.0.3 texture-draw-with-2d-and-cube.html

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -1410,6 +1410,15 @@ var setDefault3DContextVersion = function(version) {
 };
 
 /**
+ * Get the default contex version for create3DContext.
+ * First it looks at the URI option |webglVersion|. If it does not exist,
+ * then look at the global default3DContextVersion variable.
+ */
+var getDefault3DContextVersion = function() {
+    return parseInt(getUrlOptions().webglVersion, 10) || default3DContextVersion;
+};
+
+/**
  * Creates a webgl context.
  * @param {!Canvas|string} opt_canvas The canvas tag to get
  *     context from. If one is not passed in one will be
@@ -2917,6 +2926,7 @@ return {
   failIfGLError: failIfGLError,
   fillTexture: fillTexture,
   getBytesPerComponent: getBytesPerComponent,
+  getDefault3DContextVersion: getDefault3DContextVersion,
   getExtensionPrefixedNames: getExtensionPrefixedNames,
   getExtensionWithKnownPrefixes: getExtensionWithKnownPrefixes,
   getFileListAsync: getFileListAsync,


### PR DESCRIPTION
Hook it up with gl-drawelements.html so it runs correctly in both WebGL 1/2.

Also, mark a few tests as WebGL 1 only.