### PR TITLE
Fixed failing program creation in gl-enum-tests

### DIFF
--- a/sdk/tests/js/tests/gl-enum-tests.js
+++ b/sdk/tests/js/tests/gl-enum-tests.js
@@ -44,7 +44,7 @@ if (!gl) {
   var buffer = new ArrayBuffer(2);
   var buf = new Uint16Array(buffer);
   var tex = gl.createTexture();
-  var program = wtu.loadUniformBlockProgram(gl);
+  var program = wtu.createProgram(gl, wtu.loadStandardVertexShader(gl), wtu.loadStandardFragmentShader(gl));
   gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
   wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 


### PR DESCRIPTION
The shader this was trying to load previously was `#version 300 es`, but this js file was used by both WebGL 1 and WebGL 2 tests. Switched it to use something that works for both.