### PR TITLE
Add test for texSubImage2D

### DIFF
--- a/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
+++ b/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
@@ -47,6 +47,8 @@ var c = document.getElementById("c");
 var gl = wtu.create3DContext("testbed");
 var tex = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 1, gl.RGBA, gl.UNSIGNED_BYTE, c);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "no previously defined texture image");
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setup should succeed"); 
 


### PR DESCRIPTION
GL_INVALID_OPERATION is generated if the texture array has not been
defined by a previous glTexImage2D or glCopyTexImage2D operation when
calling glTexSubImage2D.