### PR TITLE
Added query arg to change the test root folder.

### DIFF
--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -165,7 +165,8 @@ var DEFAULT_CONFORMANCE_TEST_VERSION = "1.0.4 (beta)";
 var OPTIONS = {
   version: DEFAULT_CONFORMANCE_TEST_VERSION,
   frames: 1,
-  allowSkip: 0
+  allowSkip: 0,
+  root: null
 };
 
 var testVersions = [
@@ -890,10 +891,15 @@ function start() {
   };
   var iframes = makeIFrames();
 
+  var testPath = "00_test_list.txt";
+  if (OPTIONS.root) {
+    testPath = OPTIONS.root + "/" + testPath;
+  }
+
   var reporter = new Reporter(iframes);
   var testHarness = new WebGLTestHarnessModule.TestHarness(
       iframes,
-      '00_test_list.txt',
+      testPath,
       function(type, url, msg, success, skipped) {
         return reporter.reportFunc(type, url, msg, success, skipped);
       },


### PR DESCRIPTION
Useful for debugging a subset of the tests. So, for example: If you only wanted to see the WebGL2 portion of the conformance test you could use

`?version=2.0.0&root=conformance2`

Or maybe you're only testing WebGL1 extensions?

`?root=conformance/extensions`