### PR TITLE
Fix minor issues in short-circuiting in loop condition test

### DIFF
--- a/sdk/tests/conformance2/glsl3/short-circuiting-in-loop-condition.html
+++ b/sdk/tests/conformance2/glsl3/short-circuiting-in-loop-condition.html
@@ -32,7 +32,7 @@
 <title>Short circuit in loop condition test</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
-<script src="../../resources/webgl-test-utils.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -81,7 +81,7 @@ void main() {
   if (!gl) {
     testFailed("context does not exist");
   } else {
-    var program = wtu.setupProgram(gl, ["vertex-shader", "fshader"]);
+    var program = wtu.setupProgram(gl, ["vertex-shader", "fshader"], ['aPosition'], undefined, true);
     wtu.setupUnitQuad(gl);
 
     debug("Test short-circuiting operator in a loop with a true condition.");
@@ -95,6 +95,8 @@ void main() {
     wtu.clearAndDrawUnitQuad(gl);
     wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
   }
+var successfullyParsed = true;
+finishTest();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Fix path to webgl-test-utils.js, add call to finish test and add shader
logging for easier debugging.