### PR TITLE
Fixed Khronos bug 14551: WebGL 1.0.3: ternary-operators-in-global-ini…

### DIFF
--- a/conformance-suites/1.0.3/conformance/glsl/misc/ternary-operators-in-global-initializers.html
+++ b/conformance-suites/1.0.3/conformance/glsl/misc/ternary-operators-in-global-initializers.html
@@ -38,8 +38,8 @@
 <div id="console"></div>
 <script id="fragmentShader" type="text/something-not-javascript">
 precision mediump float;
-$(type) green = $(green);
-$(type) black = $(black);
+const $(type) green = $(green);
+const $(type) black = $(black);
 $(type) var = (true) ? green : black;
 void main() {
     gl_FragColor = $(asVec4);

--- a/sdk/tests/conformance/glsl/misc/ternary-operators-in-global-initializers.html
+++ b/sdk/tests/conformance/glsl/misc/ternary-operators-in-global-initializers.html
@@ -38,8 +38,8 @@
 <div id="console"></div>
 <script id="fragmentShader" type="text/something-not-javascript">
 precision mediump float;
-$(type) green = $(green);
-$(type) black = $(black);
+const $(type) green = $(green);
+const $(type) black = $(black);
 $(type) var = (true) ? green : black;
 void main() {
     gl_FragColor = $(asVec4);


### PR DESCRIPTION
…tializers

Added "const" to the declarations of the variables on the two sides of the ternary operator.