### PR TITLE
WebGL2 - Improve tex image and sub image tests

### DIFF
--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_short_5_6_5.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r32f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8-red-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8ui-red_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg32f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8-rg-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb32f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba32f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r32f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8-red-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8ui-red_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg32f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8-rg-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8ui-rg_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb32f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba32f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-half_float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r32f-red-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8-red-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8ui-red_integer-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-half_float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg32f-rg-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8-rg-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-half_float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb32f-rgb-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8-rgb-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-half_float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-half_float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba32f-rgba-float.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8-rgba-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8-rgb-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -38,11 +38,12 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
 </head>
 <body>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 <script>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r32f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8-red-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8ui-red_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg32f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8-rg-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8ui-rg_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb32f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba32f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r32f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8-red-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8ui-red_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg32f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8-rg-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8ui-rg_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb32f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba32f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r32f-red-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8-red-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8ui-red_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg32f-rg-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8-rg-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb32f-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-half_float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba32f-rgba-float.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8-rgb-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -38,6 +38,7 @@ DO NOT EDIT!
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-utils.js
@@ -1,0 +1,249 @@
+/*
+** Copyright (c) 2012 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+var TexImageUtils = (function() {
+
+  "use strict";
+
+  var wtu = WebGLTestUtils;
+
+  /**
+   * A vertex shader for a single texture.
+   * @type {string}
+   */
+  var simpleTextureVertexShaderES3 = [
+    '#version 300 es',
+    'in vec4 vPosition;',
+    'in vec2 texCoord0;',
+    'out vec2 texCoord;',
+    'void main() {',
+    '    gl_Position = vPosition;',
+    '    texCoord = texCoord0;',
+    '}'].join('\n');
+
+  /**
+   * A fragment shader for a single integer texture.
+   * @type {string}
+   */
+  var simpleUintTextureFragmentShaderES3 = [
+    '#version 300 es',
+    'precision mediump float;',
+    'uniform usampler2D tex;',
+    'in vec2 texCoord;',
+    'out vec4 fragData;',
+    'void main() {',
+    '    fragData.rgb = texture(tex, texCoord).rgb / 255.0;',
+    '    fragData.a = 1;',
+    '}'].join('\n');
+
+  /**
+   * A fragment shader for a single cube map integer texture.
+   * @type {string}
+   */
+    // A fragment shader for a single integer cube map texture.
+  var simpleCubeMapUintTextureFragmentShaderES3 = [
+    '#version 300 es',
+    'precision mediump float;',
+    'uniform usamplerCube tex;',
+    'uniform int face;',
+    'in vec2 texCoord;',
+    'out vec4 fragData;',
+    'void main() {',
+    // Transform [0, 1] -> [-1, 1]
+    '    vec2 texC2 = (texCoord * 2.) - 1.;',
+    // Transform 2d tex coord. to each face of TEXTURE_CUBE_MAP coord.
+    '    vec3 texCube = vec3(0., 0., 0.);',
+    '    if (face == 34069) {',         // TEXTURE_CUBE_MAP_POSITIVE_X
+    '        texCube = vec3(1., -texC2.y, -texC2.x);',
+    '    } else if (face == 34070) {',  // TEXTURE_CUBE_MAP_NEGATIVE_X
+    '        texCube = vec3(-1., -texC2.y, texC2.x);',
+    '    } else if (face == 34071) {',  // TEXTURE_CUBE_MAP_POSITIVE_Y
+    '        texCube = vec3(texC2.x, 1., texC2.y);',
+    '    } else if (face == 34072) {',  // TEXTURE_CUBE_MAP_NEGATIVE_Y
+    '        texCube = vec3(texC2.x, -1., -texC2.y);',
+    '    } else if (face == 34073) {',  // TEXTURE_CUBE_MAP_POSITIVE_Z
+    '        texCube = vec3(texC2.x, -texC2.y, 1.);',
+    '    } else if (face == 34074) {',  // TEXTURE_CUBE_MAP_NEGATIVE_Z
+    '        texCube = vec3(-texC2.x, -texC2.y, -1.);',
+    '    }',
+    '    fragData.rgb = texture(tex, texCube).rgb / 255.0;',
+    '    fragData.a = 1;',
+    '}'].join('\n');
+
+  /**
+   * Creates a simple texture vertex shader.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @return {!WebGLShader}
+   */
+  var setupSimpleTextureVertexShader = function(gl) {
+    return WebGLTestUtils.loadShader(gl, simpleTextureVertexShaderES3, gl.VERTEX_SHADER);
+  };
+
+  /**
+   * Creates a simple unsigned integer texture fragment shader.
+   * Output is scaled by 1/255 to bring the result into normalized float range.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @return {!WebGLShader}
+   */
+  var setupSimpleUintTextureFragmentShader = function(gl) {
+    return WebGLTestUtils.loadShader(gl, simpleUintTextureFragmentShaderES3, gl.FRAGMENT_SHADER);
+  };
+
+  /**
+   * Creates a simple cube map unsigned integer texture fragment shader.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @return {!WebGLShader}
+   */
+  var setupSimpleCubeMapUintTextureFragmentShader = function(gl) {
+    return WebGLTestUtils.loadShader(gl, simpleCubeMapUintTextureFragmentShaderES3, gl.FRAGMENT_SHADER);
+  };
+
+  /**
+   * Creates a simple unsigned integer texture program.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @param {number} opt_positionLocation The attrib location for position.
+   * @param {number} opt_texcoordLocation The attrib location for texture coords.
+   * @return {WebGLProgram}
+   */
+  var setupSimpleUintTextureProgram = function(gl, opt_positionLocation, opt_texcoordLocation)
+  {
+    opt_positionLocation = opt_positionLocation || 0;
+    opt_texcoordLocation = opt_texcoordLocation || 1;
+    var vs = setupSimpleTextureVertexShader(gl),
+        fs = setupSimpleUintTextureFragmentShader(gl);
+    if (!vs || !fs) {
+      return null;
+    }
+    var program = WebGLTestUtils.setupProgram(
+      gl,
+      [vs, fs],
+      ['vPosition', 'texCoord0'],
+      [opt_positionLocation, opt_texcoordLocation]);
+    if (!program) {
+      gl.deleteShader(fs);
+      gl.deleteShader(vs);
+    }
+    gl.useProgram(program);
+    return program;
+  };
+
+  /**
+   * Creates a simple cube map unsigned integer texture program.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @param {number} opt_positionLocation The attrib location for position.
+   * @param {number} opt_texcoordLocation The attrib location for texture coords.
+   * @return {WebGLProgram}
+   */
+  var setupSimpleCubeMapUintTextureProgram = function(gl, opt_positionLocation, opt_texcoordLocation) {
+    opt_positionLocation = opt_positionLocation || 0;
+    opt_texcoordLocation = opt_texcoordLocation || 1;
+    var vs = setupSimpleTextureVertexShader(gl);
+    var fs = setupSimpleCubeMapUintTextureFragmentShader(gl);
+    if (!vs || !fs) {
+      return null;
+    }
+    var program = WebGLTestUtils.setupProgram(
+      gl,
+      [vs, fs],
+      ['vPosition', 'texCoord0'],
+      [opt_positionLocation, opt_texcoordLocation]);
+    if (!program) {
+      gl.deleteShader(fs);
+      gl.deleteShader(vs);
+    }
+    gl.useProgram(program);
+    return program;
+  };
+
+  /**
+   * Creates a program and buffers for rendering a unsigned integer textured quad.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @return {!WebGLProgram}
+   */
+  var setupUintTexturedQuad = function(gl) {
+    var program = setupSimpleUintTextureProgram(gl);
+    wtu.setupUnitQuad(gl);
+    return program;
+  };
+
+  /**
+   * Creates a program and buffers for rendering a textured quad with
+   * a cube map unsigned integer texture.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @return {!WebGLProgram}
+   */
+  var setupUintTexturedQuadWithCubeMap = function(gl)
+  {
+    var program = setupSimpleCubeMapUintTextureProgram(gl);
+    wtu.setupUnitQuad(gl);
+    return program;
+  };
+
+  /**
+   * Does the GL internal format represent an unsigned integer format
+   * texture?
+   * @return {boolean}
+   */
+  var isUintFormat = function(internalFormat)
+  {
+    return (internalFormat == "R8UI" ||
+            internalFormat == "RG8UI" ||
+            internalFormat == "RGB8UI" ||
+            internalFormat == "RGBA8UI");
+  };
+
+  /**
+   * Createa a program and buffers for rendering a textured quad for
+   * tex-image-and-sub-image tests. Handle selection of correct
+   * program to handle texture format.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @param {string} internalFormat The internal format for texture to be tested.
+   */
+  var setupTexturedQuad = function(gl, internalFormat)
+  {
+    if (isUintFormat(internalFormat))
+      return setupUintTexturedQuad(gl);
+
+    return wtu.setupTexturedQuad(gl);
+  };
+
+  /**
+   * Createa a program and buffers for rendering a textured quad with
+   * a cube map for tex-image-and-sub-image tests. Handle selection of
+   * correct program to handle texture format.
+   * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+   * @param {string} internalFormat The internal format for texture to be tested.
+   */
+  function setupTexturedQuadWithCubeMap(gl, internalFormat)
+  {
+    if (isUintFormat(internalFormat))
+      return setupUintTexturedQuadWithCubeMap(gl);
+
+    return wtu.setupTexturedQuadWithCubeMap(gl);
+  }
+
+  return {
+    setupTexturedQuad: setupTexturedQuad,
+    setupTexturedQuadWithCubeMap: setupTexturedQuadWithCubeMap
+  };
+
+}());

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-utils.js
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2012 The Khronos Group Inc.
+** Copyright (c) 2015 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
@@ -23,13 +23,14 @@
 
 function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
     var wtu = WebGLTestUtils;
+    var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
     var whiteColor = [255, 255, 255, 255];
     var redColor = [255, 0, 0];
     var greenColor = [0, 255, 0];
 
-    var init = function()
+    function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking canvas elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
@@ -239,9 +240,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         function runTexImageTest(bindingTarget) {
             var program;
             if (bindingTarget == gl.TEXTURE_2D) {
-                program = wtu.setupTexturedQuad(gl);
+                program = tiu.setupTexturedQuad(gl, internalFormat);
             } else {
-                program = wtu.setupTexturedQuadWithCubeMap(gl);
+                program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
             }
 
             return new Promise(function(resolve, reject) {
@@ -278,7 +279,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
                 finishTest();
             });
-        })
+        });
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
@@ -23,11 +23,12 @@
 
 function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
     var wtu = WebGLTestUtils;
+    var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
     var imageData = null;
 
-    var init = function()
+    function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking ImageData (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
@@ -127,9 +128,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function runTest()
     {
-        var program = wtu.setupTexturedQuad(gl);
+        var program = tiu.setupTexturedQuad(gl, internalFormat);
         runTestOnBindingTarget(gl.TEXTURE_2D, program);
-        program = wtu.setupTexturedQuadWithCubeMap(gl);
+        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
         runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
 
         wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
@@ -23,13 +23,14 @@
 
 function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
     var wtu = WebGLTestUtils;
+    var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
     var imgCanvas;
     var red = [255, 0, 0];
     var green = [0, 255, 0];
 
-    var init = function()
+    function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking image elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
@@ -117,7 +118,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             { sub: true, flipY: false, topColor: green, bottomColor: red },
         ];
 
-        var program = wtu.setupTexturedQuad(gl);
+        var program = tiu.setupTexturedQuad(gl, internalFormat);
         for (var i in cases) {
             runOneIteration(image, cases[i].sub, cases[i].flipY,
                             cases[i].topColor, cases[i].bottomColor,
@@ -126,7 +127,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         // cube map texture must be square.
         if (image.width != image.height)
             return;
-        program = wtu.setupTexturedQuadWithCubeMap(gl);
+        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
         for (var i in cases) {
             runOneIteration(image, cases[i].sub, cases[i].flipY,
                             cases[i].topColor, cases[i].bottomColor,

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
@@ -27,8 +27,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var gl = null;
     var successfullyParsed = false;
     var imgCanvas;
-    var red = [255, 0, 0];
-    var green = [0, 255, 0];
+    var redColor = [255, 0, 0];
+    var greenColor = [0, 255, 0];
 
     function init()
     {
@@ -39,6 +39,16 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         if (!prologue(gl)) {
             finishTest();
             return;
+        }
+
+        switch (gl[pixelFormat]) {
+        case gl.RED:
+        case gl.RED_INTEGER:
+          greenColor = [0, 0, 0];
+          break;
+
+        default:
+          break;
         }
 
         gl.clearColor(0,0,0,1);
@@ -112,10 +122,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function runTestOnImage(image) {
         var cases = [
-            { sub: false, flipY: true, topColor: red, bottomColor: green },
-            { sub: false, flipY: false, topColor: green, bottomColor: red },
-            { sub: true, flipY: true, topColor: red, bottomColor: green },
-            { sub: true, flipY: false, topColor: green, bottomColor: red },
+            { sub: false, flipY: true, topColor: redColor, bottomColor: greenColor },
+            { sub: false, flipY: false, topColor: greenColor, bottomColor: redColor },
+            { sub: true, flipY: true, topColor: redColor, bottomColor: greenColor },
+            { sub: true, flipY: false, topColor: greenColor, bottomColor: redColor },
         ];
 
         var program = tiu.setupTexturedQuad(gl, internalFormat);
@@ -146,13 +156,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var imgData = imgCtx.createImageData(1, 2);
         for (var i = 0; i < 2; i++) {
             var stride = i * 8;
-            imgData.data[stride + 0] = red[0];
-            imgData.data[stride + 1] = red[1];
-            imgData.data[stride + 2] = red[2];
+            imgData.data[stride + 0] = redColor[0];
+            imgData.data[stride + 1] = redColor[1];
+            imgData.data[stride + 2] = redColor[2];
             imgData.data[stride + 3] = 255;
-            imgData.data[stride + 4] = green[0];
-            imgData.data[stride + 5] = green[1];
-            imgData.data[stride + 6] = green[2];
+            imgData.data[stride + 4] = greenColor[0];
+            imgData.data[stride + 5] = greenColor[1];
+            imgData.data[stride + 6] = greenColor[2];
             imgData.data[stride + 7] = 255;
         }
         imgCtx.putImageData(imgData, 0, 0);

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
@@ -23,13 +23,14 @@
 
 function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
     var wtu = WebGLTestUtils;
+    var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
     var imgCanvas;
     var red = [255, 0, 0];
     var green = [0, 255, 0];
 
-    var init = function()
+    function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking SVG image elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
@@ -109,9 +110,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function runTest(image)
     {
-        var program = wtu.setupTexturedQuad(gl);
+        var program = tiu.setupTexturedQuad(gl, internalFormat);
         runTestOnBindingTarget(image, gl.TEXTURE_2D, program);
-        program = wtu.setupTexturedQuadWithCubeMap(gl);
+        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
         runTestOnBindingTarget(image, gl.TEXTURE_CUBE_MAP, program);
 
         wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
@@ -27,8 +27,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var gl = null;
     var successfullyParsed = false;
     var imgCanvas;
-    var red = [255, 0, 0];
-    var green = [0, 255, 0];
+    var redColor = [255, 0, 0];
+    var greenColor = [0, 255, 0];
 
     function init()
     {
@@ -39,6 +39,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         if (!prologue(gl)) {
             finishTest();
             return;
+        }
+
+        switch (gl[pixelFormat]) {
+          case gl.RED:
+          case gl.RED_INTEGER:
+            greenColor = [0, 0, 0];
+            break;
+          default:
+            break;
         }
 
         gl.clearColor(0,0,0,1);
@@ -121,10 +130,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function runTestOnBindingTarget(image, bindingTarget, program) {
         var cases = [
-            { sub: false, flipY: true, topColor: red, bottomColor: green },
-            { sub: false, flipY: false, topColor: green, bottomColor: red },
-            { sub: true, flipY: true, topColor: red, bottomColor: green },
-            { sub: true, flipY: false, topColor: green, bottomColor: red },
+            { sub: false, flipY: true, topColor: redColor, bottomColor: greenColor },
+            { sub: false, flipY: false, topColor: greenColor, bottomColor: redColor },
+            { sub: true, flipY: true, topColor: redColor, bottomColor: greenColor },
+            { sub: true, flipY: false, topColor: greenColor, bottomColor: redColor },
         ];
         for (var i in cases) {
             runOneIteration(image, cases[i].sub, cases[i].flipY,

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
@@ -37,6 +37,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
+    var redColor = [255, 0, 0];
+    var greenColor = [0, 255, 0];
 
     // Test each format separately because many browsers implement each
     // differently. Some might be GPU accelerated, some might not. Etc...
@@ -55,6 +57,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         if (!prologue(gl)) {
             finishTest();
             return;
+        }
+
+        switch (gl[pixelFormat]) {
+          case gl.RED:
+          case gl.RED_INTEGER:
+            greenColor = [0, 0, 0];
+            break;
+          default:
+            break;
         }
 
         gl.clearColor(0,0,0,1);
@@ -144,13 +155,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function runTest(videoElement)
     {
-        var red = [255, 0, 0];
-        var green = [0, 255, 0];
         var cases = [
-            { sub: false, flipY: true, topColor: red, bottomColor: green },
-            { sub: false, flipY: false, topColor: green, bottomColor: red },
-            { sub: true, flipY: true, topColor: red, bottomColor: green },
-            { sub: true, flipY: false, topColor: green, bottomColor: red },
+            { sub: false, flipY: true, topColor: redColor, bottomColor: greenColor },
+            { sub: false, flipY: false, topColor: greenColor, bottomColor: redColor },
+            { sub: true, flipY: true, topColor: redColor, bottomColor: greenColor },
+            { sub: true, flipY: false, topColor: greenColor, bottomColor: redColor },
         ];
 
         function runTexImageTest(bindingTarget) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
@@ -34,6 +34,7 @@ var debug = function(msg) {
 
 function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
     var wtu = WebGLTestUtils;
+    var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
 
@@ -45,7 +46,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       { src: resourcePath + "red-green.theora.ogv",   type: 'video/ogg; codecs="theora, vorbis"',         },
     ];
 
-    var init = function()
+    function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking video elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
@@ -155,9 +156,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         function runTexImageTest(bindingTarget) {
             var program;
             if (bindingTarget == gl.TEXTURE_2D) {
-                program = wtu.setupTexturedQuad(gl);
+                program = tiu.setupTexturedQuad(gl, internalFormat);
             } else {
-                program = wtu.setupTexturedQuadWithCubeMap(gl);
+                program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
             }
 
             return new Promise(function(resolve, reject) {
@@ -215,7 +216,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
                 finishTest();
             });
-        })
+        });
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -23,10 +23,11 @@
 
 function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
     var wtu = WebGLTestUtils;
+    var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
 
-    var init = function()
+    function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking webgl canvas elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
@@ -180,9 +181,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         function runTexImageTest(bindingTarget) {
             var program;
             if (bindingTarget == gl.TEXTURE_2D) {
-                program = wtu.setupTexturedQuad(gl);
+                program = tiu.setupTexturedQuad(gl, internalFormat);
             } else {
-                program = wtu.setupTexturedQuadWithCubeMap(gl);
+                program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
             }
 
             return new Promise(function(resolve, reject) {
@@ -219,7 +220,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
                 finishTest();
             });
-        })
+        });
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -26,6 +26,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
+    var redColor = [255, 0, 0];
+    var greenColor = [0, 255, 0];
 
     function init()
     {
@@ -36,6 +38,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         if (!prologue(gl)) {
             finishTest();
             return;
+        }
+
+        switch (gl[pixelFormat]) {
+          case gl.RED:
+          case gl.RED_INTEGER:
+            greenColor = [0, 0, 0];
+            break;
+          default:
+            break;
         }
 
         gl.clearColor(0,0,0,1);
@@ -77,7 +88,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       ctx.canvas.height = 2;
       setCanvasToRedGreen(ctx);
     }
-
+  
     function runOneIteration(canvas, useTexSubImage2D, flipY, program, bindingTarget, opt_texture)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') + ' with flipY=' +
@@ -127,8 +138,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var top = flipY ? (height - halfHeight) : 0;
         var bottom = flipY ? 0 : (height - halfHeight);
 
-        var red = [255, 0, 0];
-        var green = [0, 255, 0];
         var loc;
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             loc = gl.getUniformLocation(program, "face");
@@ -143,11 +152,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
             // Check the top and bottom halves and make sure they have the right color.
             debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, red,
-                    "shouldBe " + red);
+            wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, redColor,
+                    "shouldBe " + redColor);
             debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, 0, top, width, halfHeight, green,
-                    "shouldBe " + green);
+            wtu.checkCanvasRect(gl, 0, top, width, halfHeight, greenColor,
+                    "shouldBe " + greenColor);
         }
 
         if (false) {

--- a/sdk/tests/py/tex_image_test_generator.py
+++ b/sdk/tests/py/tex_image_test_generator.py
@@ -138,15 +138,14 @@ def WriteTest(filename, element_type, internal_format, format, type):
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-%(element_type)s.js"></script>
 </head>
 <body>"""
   if element_type == 'image-data':
     code += """
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>"""
-  else:
-    code += """
+<canvas id="texcanvas" width="2" height="2"></canvas>"""
+  code += """
 <canvas id="example" width="32" height="32"></canvas>"""
   code += """
 <div id="description"></div>


### PR DESCRIPTION
I fixed up the texImage2D and texSubImage2D tests that work with various DOM elements to work with GL_RED as well as unsigned integer textures.

I made some improvements to the tests taking `image data` to exercise that pre-multiplied alpha was applied.

PTAL