### PR TITLE
Added more real query tests to ext-disjoint-timer-query.html.

### DIFF
--- a/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
+++ b/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
@@ -49,6 +49,7 @@ var query = null;
 var elapsed_query = null;
 var timestamp_query1 = null;
 var timestamp_query2 = null;
+var availability_retry = 16;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -68,6 +69,7 @@ if (!gl) {
         runElapsedTimeTest();
         runTimeStampTest();
 
+        gl.finish();
         setTimeout(checkQueryResults, 0);
     }
 }
@@ -160,11 +162,16 @@ function runTimeStampTest() {
 }
 
 function checkQueryResults() {
+    if (availability_retry <= 0 || !ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)) {
+        availability_retry--;
+        setTimeout(checkQueryResults, 1);
+        return;
+    }
+
     debug("");
     debug("Testing query results");
 
     // Make sure queries are available.
-    gl.finish();
     shouldBe("ext.getQueryObjectEXT(elapsed_query, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
     shouldBe("ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
     shouldBe("ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");

--- a/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
+++ b/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
@@ -46,6 +46,9 @@ var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
 var ext = null;
 var query = null;
+var elapsed_query = null;
+var timestamp_query1 = null;
+var timestamp_query2 = null;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -58,6 +61,14 @@ if (!gl) {
         testPassed("No EXT_disjoint_timer_query support -- this is legal");
     } else {
         runSanityTests();
+
+        // Clear disjoint value.
+        gl.getParameter(ext.GPU_DISJOINT_EXT);
+
+        runElapsedTimeTest();
+        runTimeStampTest();
+
+        setTimeout(checkQueryResults, 0);
     }
 }
 
@@ -84,12 +95,12 @@ function runSanityTests() {
     query = ext.createQueryEXT();
     shouldBe("ext.isQueryEXT(query)", "false");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Query creation must succeed.");
-    ext.beginQueryEXT(ext.TIMESTAMP_EXT, query)
+    ext.beginQueryEXT(ext.TIMESTAMP_EXT, query);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Beginning a timestamp query should fail.");
-    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query)
+    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
     shouldBe("ext.isQueryEXT(query)", "true");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Beginning an inactive time elapsed query should succeed.");
-    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query)
+    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Attempting to begin an active query should fail.");
     shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "query");
     ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
@@ -123,10 +134,65 @@ function runSanityTests() {
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "getParameter disjoint calls should work.");
 }
 
+function runElapsedTimeTest() {
+    debug("");
+    debug("Testing elapsed time query");
+
+    elapsed_query = ext.createQueryEXT();
+    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, elapsed_query);
+    gl.clearColor(0, 0, 1, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Time elapsed query should have no errors");
+}
+
+function runTimeStampTest() {
+    debug("");
+    debug("Testing timestamp query");
+
+    timestamp_query1 = ext.createQueryEXT();
+    timestamp_query2 = ext.createQueryEXT();
+    ext.queryCounterEXT(timestamp_query1, ext.TIMESTAMP_EXT);
+    gl.clearColor(1, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    ext.queryCounterEXT(timestamp_query2, ext.TIMESTAMP_EXT);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Timestamp queries should have no errors");
+}
+
+function checkQueryResults() {
+    debug("");
+    debug("Testing query results");
+
+    // Make sure queries are available.
+    gl.finish();
+    shouldBe("ext.getQueryObjectEXT(elapsed_query, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
+    shouldBe("ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
+    shouldBe("ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
+
+    var disjoint_value = gl.getParameter(ext.GPU_DISJOINT_EXT);
+    if (disjoint_value) {
+        // Cannot validate results make sense, but this is okay.
+        testPassed("Disjoint triggered.");
+    } else {
+        var elapsed_result = ext.getQueryObjectEXT(elapsed_query, ext.QUERY_RESULT_EXT);
+        var timestamp_result1 = ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_EXT);
+        var timestamp_result2 = ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_EXT);
+        if (elapsed_result <= 0) {
+            testFailed("Time elapsed query returned invalid data.");
+        } else if (timestamp_result1 <= 0 ||
+                   timestamp_result2 <= 0 ||
+                   timestamp_result2 <= timestamp_result1) {
+            testFailed("Timestamp queries returned invalid data.");
+        }
+        testPassed("Query results were valid.");
+    }
+
+    debug("");
+    finishTest();
+}
+
 var successfullyParsed = true;
-  debug("");
 </script>
-<script src="../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
+++ b/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
@@ -46,10 +46,11 @@ var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
 var ext = null;
 var query = null;
+var query2 = null;
 var elapsed_query = null;
 var timestamp_query1 = null;
 var timestamp_query2 = null;
-var availability_retry = 16;
+var availability_retry = 500;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -70,7 +71,7 @@ if (!gl) {
         runTimeStampTest();
 
         gl.finish();
-        setTimeout(checkQueryResults, 0);
+        window.requestAnimationFrame(checkQueryResults);
     }
 }
 
@@ -134,6 +135,44 @@ function runSanityTests() {
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "getParameter timestamp calls should work.");
     gl.getParameter(ext.GPU_DISJOINT_EXT);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "getParameter disjoint calls should work.");
+
+    debug("");
+    debug("Testing current query conditions");
+    query = ext.createQueryEXT();
+    query2 = ext.createQueryEXT();
+    shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "null");
+    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
+    shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "query");
+
+    debug("");
+    debug("Testing failed begin query should not change the current query.");
+    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query2);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Beginning an elapsed query without ending should fail.");
+    shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "query");
+
+    debug("");
+    debug("Testing beginning a timestamp query should not change the elapsed query.");
+    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query2)
+    shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "query");;
+
+    debug("");
+    debug("Testing timestamp queries end immediately so are never current.");
+    ext.queryCounterEXT(query2, ext.TIMESTAMP_EXT);
+    shouldBe("ext.getQueryEXT(ext.TIMESTAMP_EXT, ext.CURRENT_QUERY_EXT)", "null");
+
+    debug("");
+    debug("Testing ending the query should clear the current query.");
+    ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
+    shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "null");
+
+    debug("");
+    debug("Testing beginning a elapsed query using a timestamp query should fail and not affect current query.")
+    ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query2);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Switching query targets should fail.");
+    shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "null");
+
+    ext.deleteQueryEXT(query);
+    ext.deleteQueryEXT(query2);
 }
 
 function runElapsedTimeTest() {
@@ -162,9 +201,16 @@ function runTimeStampTest() {
 }
 
 function checkQueryResults() {
-    if (availability_retry <= 0 || !ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)) {
+    if (availability_retry > 0 && !ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)) {
+        var error = gl.getError();
+        if (error != gl.NO_ERROR) {
+            testFailed("getQueryObjectEXT should have no errors: " + wtu.glEnumToString(gl, error));
+            debug("");
+            finishTest();
+            return;
+        }
         availability_retry--;
-        setTimeout(checkQueryResults, 1);
+        window.requestAnimationFrame(checkQueryResults);
         return;
     }
 


### PR DESCRIPTION
Previously the conformance test for EXT_disjoint_timer_query
only looked for error results. I've added a simple test which
tests that the query makes sure the results become available
and give reasonable results.