### PR TITLE
Add new tests for ternary operators in global initializers

### DIFF
--- a/sdk/tests/conformance/glsl/misc/global-variable-init.html
+++ b/sdk/tests/conformance/glsl/misc/global-variable-init.html
@@ -166,6 +166,26 @@ void main() {
     gl_Position = aPosition;
 }
 </script>
+<script id="globalNonConstTernary" type="x-shader/x-fragment">
+precision mediump float;
+float green = 1.0;
+float black = 0.0;
+float f = true ? green : black;
+
+void main() {
+    gl_FragColor = vec4(0.0, f, 0.0, 1.0);
+}
+</script>
+<script id="globalUniformTernary" type="x-shader/x-fragment">
+precision mediump float;
+uniform float u_zero;
+float green = 1.0 + u_zero;
+float f = true ? green : u_zero;
+
+void main() {
+    gl_FragColor = vec4(0.0, f, 0.0, 1.0);
+}
+</script>
 <script type="application/javascript">
 "use strict";
 description();
@@ -231,6 +251,20 @@ GLSLConformanceTester.runTests([
     vShaderSuccess: false,
     linkSuccess: false,
     passMsg: "Another global as an l-value (parameter of ++) in a global variable initializer should not be accepted by WebGL."
+  },
+  {
+    fShaderId: "globalNonConstTernary",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Non-const global variables as operands for a ternary operator in a global variable initializer should be accepted by WebGL."
+  },
+  {
+    fShaderId: "globalUniformTernary",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "An uniform as an operand for a ternary operator in a global variable initializer should be accepted by WebGL."
   }
 ]);
 var successfullyParsed = true;


### PR DESCRIPTION
This is to restore coverage that was lost when
glsl/misc/ternary-operators-in-global-initializers.html was recently
changed.

See #1168.