### PR TITLE
Fixed bugs affecting transform feedback test.

### DIFF
--- a/sdk/tests/deqp/framework/opengl/gluShaderProgram.js
+++ b/sdk/tests/deqp/framework/opengl/gluShaderProgram.js
@@ -215,6 +215,13 @@ gluShaderProgram.Program.prototype.link = function() {
 };
 
 /**
+ * return {boolean}
+ */
+gluShaderProgram.Program.prototype.getLinkStatus = function() {
+    return this.info.linkOk;
+};
+
+/**
  * @param {Array<string>} varyings
  * @param {number} bufferMode
  */
@@ -285,7 +292,7 @@ gluShaderProgram.ShaderProgram.prototype.getProgramInfo = function() {
 };
 
 gluShaderProgram.ShaderProgram.prototype.isOk = function() {
-    return this.shadersOK;
+    return this.shadersOK && this.program.getLinkStatus();
 };
 
 gluShaderProgram.containerTypes = {


### PR DESCRIPTION
 - Don't resume transform feedback after every draw call.
 - Fixed vector type iteration in es3fTransformFeedbackTests.isProgramSupported.
 - Fixed bug in es3fTransformFeedbackTests.hasArraysInTFVaryings.
 - Fixed ShaderProgram.isOk() to properly report link errors.
 - Dump program info log if link fails.