### PR TITLE
Fix draw referencing a texture that was never bound

### DIFF
--- a/sdk/tests/conformance/extensions/oes-element-index-uint.html
+++ b/sdk/tests/conformance/extensions/oes-element-index-uint.html
@@ -133,7 +133,7 @@ function runDrawTests(drawType) {
     canvas.width = 50; canvas.height = 50;
     gl.viewport(0, 0, canvas.width, canvas.height);
     
-    var program = wtu.setupNoTexCoordTextureProgram(gl);
+    var program = wtu.setupSimpleColorProgram(gl);
 
     function setupDraw(s) {
         // Create a vertex buffer that cannot be fully indexed via shorts
@@ -197,6 +197,7 @@ function runDrawTests(drawType) {
     function verifyDraw(s) {
         gl.clearColor(1.0, 1.0, 1.0, 1.0);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        wtu.setFloatDrawColor(gl, [0.0, 0.0, 0.0, 1.0]);
         gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_INT, 0);
 
         var blackList = [];


### PR DESCRIPTION
This test was accidentally rendering with the 0 texture, which worked
because it was expecting black to be drawn. This exposed a bug in
Chrome, and a separate test has been created to provoke it and ensure
drawing with texture 0 results in black, but for this test it's better
for the draw call to explicitly draw a black quad without unnecessary
texture sampling.