### PR TITLE
Add union type typedefs for vertexAttrib*fv, and make argument names …

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 07 September 2015</h2>
+    <h2 class="no-toc">Editor's Draft 14 September 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -1792,17 +1792,14 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void validateProgram(WebGLProgram? program);
 
     void vertexAttrib1f(GLuint indx, GLfloat x);
-    void vertexAttrib1fv(GLuint indx, Float32Array values);
-    void vertexAttrib1fv(GLuint indx, sequence&lt;GLfloat&gt; values);
+    typedef (Float32Array or sequence&lt;GLfloat&gt;) VertexAttribFVSource;
+    void vertexAttrib1fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
-    void vertexAttrib2fv(GLuint indx, Float32Array values);
-    void vertexAttrib2fv(GLuint indx, sequence&lt;GLfloat&gt; values);
+    void vertexAttrib2fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
-    void vertexAttrib3fv(GLuint indx, Float32Array values);
-    void vertexAttrib3fv(GLuint indx, sequence&lt;GLfloat&gt; values);
+    void vertexAttrib3fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
-    void vertexAttrib4fv(GLuint indx, Float32Array values);
-    void vertexAttrib4fv(GLuint indx, sequence&lt;GLfloat&gt; values);
+    void vertexAttrib4fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttribPointer(GLuint indx, GLint size, GLenum type,
                              GLboolean normalized, GLsizei stride, GLintptr offset);
 

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -705,17 +705,14 @@ interface WebGLRenderingContextBase
     void validateProgram(WebGLProgram? program);
 
     void vertexAttrib1f(GLuint indx, GLfloat x);
-    void vertexAttrib1fv(GLuint indx, Float32Array values);
-    void vertexAttrib1fv(GLuint indx, sequence<GLfloat> values);
+    typedef (Float32Array or sequence<GLfloat>) VertexAttribFVSource;
+    void vertexAttrib1fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
-    void vertexAttrib2fv(GLuint indx, Float32Array values);
-    void vertexAttrib2fv(GLuint indx, sequence<GLfloat> values);
+    void vertexAttrib2fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
-    void vertexAttrib3fv(GLuint indx, Float32Array values);
-    void vertexAttrib3fv(GLuint indx, sequence<GLfloat> values);
+    void vertexAttrib3fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
-    void vertexAttrib4fv(GLuint indx, Float32Array values);
-    void vertexAttrib4fv(GLuint indx, sequence<GLfloat> values);
+    void vertexAttrib4fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttribPointer(GLuint indx, GLint size, GLenum type,
                              GLboolean normalized, GLsizei stride, GLintptr offset);
 

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -756,10 +756,10 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   void uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
   typedef (Int32Array or sequence&lt;GLint&gt;) VertexAttribIVSource;
-  void vertexAttribI4iv(GLuint index, VertexAttribIVSource value);
+  void vertexAttribI4iv(GLuint index, VertexAttribIVSource values);
   void vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
   typedef (Uint32Array or sequence&lt;GLuint&gt;) VertexAttribUIVSource;
-  void vertexAttribI4uiv(GLuint index, VertexAttribUIVSource v);
+  void vertexAttribI4uiv(GLuint index, VertexAttribUIVSource values);
   void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
 
   /* Writing to the drawing buffer */

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -372,10 +372,10 @@ interface WebGL2RenderingContextBase
   void uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
   typedef (Int32Array or sequence<GLint>) VertexAttribIVSource;
-  void vertexAttribI4iv(GLuint index, VertexAttribIVSource value);
+  void vertexAttribI4iv(GLuint index, VertexAttribIVSource values);
   void vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
   typedef (Uint32Array or sequence<GLuint>) VertexAttribUIVSource;
-  void vertexAttribI4uiv(GLuint index, VertexAttribUIVSource v);
+  void vertexAttribI4uiv(GLuint index, VertexAttribUIVSource values);
   void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
 
   /* Writing to the drawing buffer */


### PR DESCRIPTION
…consistent.

Follow-up to #1189.