### PR TITLE
Updated EXT_sRGB conformance test to use checkCanvasRect correctly

### DIFF
--- a/sdk/tests/conformance/extensions/ext-sRGB.html
+++ b/sdk/tests/conformance/extensions/ext-sRGB.html
@@ -67,7 +67,7 @@ function expectResult(target) {
                       Math.floor(gl.drawingBufferHeight / 2),
                       1,
                       1,
-                      target,
+                      [target, target, target, 255],
                       undefined,
                       e);
 }


### PR DESCRIPTION
This uncovers bugs related to the sRGB color space conversion.