### PR TITLE
Added state query tests and bugfixes.

### DIFF
--- a/sdk/tests/deqp/build.py
+++ b/sdk/tests/deqp/build.py
@@ -105,13 +105,17 @@ targets = {
     'fbostate' : 'functional.gles3.es3fFboStateQueryTests',
     'rbostate' : 'functional.gles3.es3fRboStateQueryTests',
     'bufferstate' : 'functional.gles3.es3fBufferObjectQueryTests',
+    'samplerstate' : 'functional.gles3.es3fSamplerStateQueryTests',
+    'texstate' : 'functional.gles3.es3fTextureStateQuery',
     'internalformatstate' : 'functional.gles3.es3fInternalFormatQueryTests',
     'texturespecification' : 'functional.gles3.es3fTextureSpecificationTests',
     'shadertexturefunction' : 'functional.gles3.es3fShaderTextureFunctionTests',
     'sync' : 'functional.gles3.es3fSyncTests',
     'readpixel' : 'functional.gles3.es3fReadPixelTests',
     'stringquery' : 'functional.gles3.es3fStringQueryTests',
-    'indexedstate' : 'functional.gles3.es3fIndexedStateQueryTests'
+    'indexedstate' : 'functional.gles3.es3fIndexedStateQueryTests',
+    'integerstate' : 'functional.gles3.es3fIntegerStateQueryTests',
+    'floatstate' : 'functional.gles3.es3fFloatStateQueryTests'
 }
 
 total_errors = 0

--- a/sdk/tests/deqp/framework/delibs/debase/deMath.js
+++ b/sdk/tests/deqp/framework/delibs/debase/deMath.js
@@ -658,12 +658,44 @@ deMath.binaryOr = function(a, b) {
 };
 
 /**
+ * @param {goog.NumberArray} a
+ * @param {number} b
+ * @return {Array<number>}
+ */
+deMath.binaryOrVecScalar = function(a, b) {
+    if (!Array.isArray(a))
+        throw new Error('First argument must be an array.');
+    if (typeof b !== 'number')
+        throw new Error('Second argument must be a number.');
+    var dst = [];
+    for (var i = 0; i < a.length; i++)
+        dst.push(deMath.binaryOp(a[i], b, deMath.BinaryOp.OR));
+    return dst;
+};
+
+/**
  * @param {number} a
  * @param {number} b
  * @return {number}
  */
 deMath.binaryXor = function(a, b) {
     return deMath.binaryOp(a, b, deMath.BinaryOp.XOR);
+};
+
+/**
+ * @param {goog.NumberArray} a
+ * @param {number} b
+ * @return {Array<number>}
+ */
+deMath.binaryXorVecScalar = function(a, b) {
+    if (!Array.isArray(a))
+        throw new Error('First argument must be an array.');
+    if (typeof b !== 'number')
+        throw new Error('Second argument must be a number.');
+    var dst = [];
+    for (var i = 0; i < a.length; i++)
+        dst.push(deMath.binaryOp(a[i], b, deMath.BinaryOp.XOR));
+    return dst;
 };
 
 /**
@@ -725,6 +757,17 @@ deMath.shiftLeft = function(value, steps) {
 };
 
 /**
+ * @param {Array<number>} a
+ * @param {number} b
+ */
+deMath.shiftLeftVecScalar = function(a, b) {
+    var dst = [];
+	for (var i = 0; i < a.length; i++)
+		dst.push(deMath.shiftLeft(a[i], b));
+	return dst;
+};
+
+/**
  * Shifts the given value 'steps' bits to the right. Replaces >> operator
  * This function should be used if the value is wider than 32-bits
  * @param {number} value
@@ -757,6 +800,17 @@ deMath.shiftRight = function(value, steps) {
         result[1] = value < 0 ? -1 : 0;
         return deMath.join32(result);
     }
+};
+
+/**
+ * @param {Array<number>} a
+ * @param {number} b
+ */
+deMath.shiftRightVecScalar = function(a, b) {
+    var dst = [];
+	for (var i = 0; i < a.length; i++)
+		dst.push(deMath.shiftRight(a[i], b));
+	return dst;
 };
 
 /** deMath.logicalAndBool over two arrays of booleans

--- a/sdk/tests/deqp/framework/opengl/simplereference/referencecontext.html
+++ b/sdk/tests/deqp/framework/opengl/simplereference/referencecontext.html
@@ -1,5 +1,3 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-"http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <html>
 <head>

--- a/sdk/tests/deqp/framework/referencerenderer/rrRenderer.js
+++ b/sdk/tests/deqp/framework/referencerenderer/rrRenderer.js
@@ -24,6 +24,7 @@ goog.require('framework.common.tcuTexture');
 goog.require('framework.common.tcuTextureUtil');
 goog.require('framework.delibs.debase.deMath');
 goog.require('framework.delibs.debase.deString');
+goog.require('framework.delibs.debase.deUtil');
 goog.require('framework.opengl.simplereference.sglrShaderProgram');
 goog.require('framework.referencerenderer.rrDefs');
 goog.require('framework.referencerenderer.rrFragmentOperations');
@@ -50,6 +51,7 @@ var rrGenericVector = framework.referencerenderer.rrGenericVector;
 var sglrShaderProgram = framework.opengl.simplereference.sglrShaderProgram;
 var rrVertexAttrib = framework.referencerenderer.rrVertexAttrib;
 var deString = framework.delibs.debase.deString;
+var deUtil = framework.delibs.debase.deUtil;
 
 /**
  * @enum

--- a/sdk/tests/deqp/functional/gles3/00_test_list.txt
+++ b/sdk/tests/deqp/functional/gles3/00_test_list.txt
@@ -69,11 +69,13 @@ fbomultisample.html
 fborender.html
 fbostatequery.html
 fbostencilbuffer.html
+floatstatequery.html
 fragdepth.html
 fragmentoutput.html
 framebufferblit.html
 indexedstatequery.html
 instancedrendering.html
+integerstatequery.html
 internalformatquery.html
 lifetime.html
 multisample.html
@@ -90,6 +92,7 @@ rasterizerdiscard.html
 rbostatequery.html
 readpixel.html
 samplerobject.html
+samplerstatequery.html
 shaderapi.html
 shaderbuiltinvar.html
 shadercommonfunction.html
@@ -160,6 +163,7 @@ texturespecification22.html
 texturespecification23.html
 texturespecification24.html
 texturespecification25.html
+texturestatequery.html
 texturewrap.html
 transformfeedback.html
 uniformapi.html

--- a/sdk/tests/deqp/functional/gles3/booleanstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/booleanstatequery.html
@@ -16,7 +16,7 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
+var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true, stencil: true}, 2);
 
 gl.getError();
     try {

--- a/sdk/tests/deqp/functional/gles3/es3fFboRenderTest.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboRenderTest.js
@@ -227,8 +227,9 @@ goog.scope(function() {
                 ' one of the following: ' +
                 requiredExts.join(', ')
             );
+            checkMessage(false, errMsg);
 
-            throw new Error(errMsg);
+            throw new TestFailedException(errMsg);
         }
     };
 

--- a/sdk/tests/deqp/functional/gles3/es3fFloatStateQueryTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFloatStateQueryTests.js
@@ -1,0 +1,431 @@
+/*-------------------------------------------------------------------------
+ * drawElements Quality Program OpenGL ES Utilities
+ * ------------------------------------------------
+ *
+ * Copyright 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+'use strict';
+goog.provide('functional.gles3.es3fFloatStateQueryTests');
+goog.require('framework.common.tcuTestCase');
+goog.require('framework.delibs.debase.deMath');
+goog.require('framework.delibs.debase.deRandom');
+goog.require('functional.gles3.es3fApiCase');
+goog.require('modules.shared.glsStateQuery');
+
+goog.scope(function() {
+	var es3fFloatStateQueryTests = functional.gles3.es3fFloatStateQueryTests;
+    var tcuTestCase = framework.common.tcuTestCase;
+	var deRandom = framework.delibs.debase.deRandom;
+	var deMath = framework.delibs.debase.deMath;
+	var es3fApiCase = functional.gles3.es3fApiCase;
+	var glsStateQuery = modules.shared.glsStateQuery;
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.DepthRangeCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.DepthRangeCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.DepthRangeCase.prototype.constructor = es3fFloatStateQueryTests.DepthRangeCase;
+
+	es3fFloatStateQueryTests.DepthRangeCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(gl.DEPTH_RANGE, new Float32Array([0.0, 1.0])));
+
+		/** @type {Array<Float32Array>} */ var fixedTests = [
+			new Float32Array([0.5, 1.0]),
+			new Float32Array([0.0, 0.5]),
+			new Float32Array([0.0, 0.0]),
+			new Float32Array([1.0, 1.0])
+		];
+
+		for (var ndx = 0; ndx < fixedTests.length; ++ndx) {
+			gl.depthRange(fixedTests[ndx][0], fixedTests[ndx][1]);
+			this.check(glsStateQuery.verify(gl.DEPTH_RANGE, fixedTests[ndx]));
+		}
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			// [dag] sorting to keep zNear < zFar
+			/** @type {Array<number>} */ var values = [rnd.getFloat(0, 1), rnd.getFloat(0, 1)].sort();
+			/** @type {Float32Array} */ var depth = new Float32Array(values);
+			gl.depthRange(depth[0], depth[1]);
+			this.check(glsStateQuery.verify(gl.DEPTH_RANGE, depth));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.LineWidthCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.LineWidthCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.LineWidthCase.prototype.constructor = es3fFloatStateQueryTests.LineWidthCase;
+
+	es3fFloatStateQueryTests.LineWidthCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(gl.LINE_WIDTH, 1.0));
+
+		/** @type {Float32Array} */ var range = /** @type {Float32Array} */ (gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE));
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var reference = rnd.getFloat(range[0], range[1]);
+
+			gl.lineWidth(reference);
+			this.check(glsStateQuery.verify(gl.LINE_WIDTH, reference));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.PolygonOffsetFactorCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.PolygonOffsetFactorCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.PolygonOffsetFactorCase.prototype.constructor = es3fFloatStateQueryTests.PolygonOffsetFactorCase;
+
+	es3fFloatStateQueryTests.PolygonOffsetFactorCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(gl.POLYGON_OFFSET_FACTOR, 0.0));
+
+		/** @type {Array<number>} */ var fixedTests = [0.0, 0.5, -0.5, 1.5];
+
+		for (var ndx = 0; ndx < fixedTests.length; ++ndx) {
+			gl.polygonOffset(fixedTests[ndx], 0);
+			this.check(glsStateQuery.verify(gl.POLYGON_OFFSET_FACTOR, fixedTests[ndx]));
+		}
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var reference = rnd.getFloat(-64000, 64000);
+
+			gl.polygonOffset(reference, 0);
+			this.check(glsStateQuery.verify(gl.POLYGON_OFFSET_FACTOR, reference));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.PolygonOffsetUnitsCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.PolygonOffsetUnitsCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.PolygonOffsetUnitsCase.prototype.constructor = es3fFloatStateQueryTests.PolygonOffsetUnitsCase;
+
+	es3fFloatStateQueryTests.PolygonOffsetUnitsCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(gl.POLYGON_OFFSET_UNITS, 0.0));
+
+		/** @type {Array<number>} */ var fixedTests = [0.0, 0.5, -0.5, 1.5];
+
+		for (var ndx = 0; ndx < fixedTests.length; ++ndx) {
+			gl.polygonOffset(0, fixedTests[ndx]);
+			this.check(glsStateQuery.verify(gl.POLYGON_OFFSET_UNITS, fixedTests[ndx]));
+		}
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var reference = rnd.getFloat(-64000, 64000);
+
+			gl.polygonOffset(0, reference);
+			this.check(glsStateQuery.verify(gl.POLYGON_OFFSET_UNITS, reference));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.SampleCoverageCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.SampleCoverageCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.SampleCoverageCase.prototype.constructor = es3fFloatStateQueryTests.SampleCoverageCase;
+
+	es3fFloatStateQueryTests.SampleCoverageCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(gl.SAMPLE_COVERAGE_VALUE, 1.0));
+
+		/** @type {Array<number>} */ var fixedTests = [0.0, 0.5, 0.45, 0.55];
+
+		for (var ndx = 0; ndx < fixedTests.length; ++ndx) {
+			gl.sampleCoverage(fixedTests[ndx], false);
+			this.check(glsStateQuery.verify(gl.SAMPLE_COVERAGE_VALUE, fixedTests[ndx]));
+		}
+
+		/** @type {Array<number>} */ var clampTests = [-1.0, -1.5, 1.45, 3.55];
+
+		for (var ndx = 0; ndx < clampTests.length; ++ndx) {
+			gl.sampleCoverage(clampTests[ndx], false);
+			this.check(glsStateQuery.verify(gl.SAMPLE_COVERAGE_VALUE, deMath.clamp(clampTests[ndx], 0.0, 1.0)));
+		}
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var reference	= rnd.getFloat(0, 1);
+			/** @type {boolean} */ var invert = rnd.getBool() ? true : false;
+
+			gl.sampleCoverage(reference, invert);
+			this.check(glsStateQuery.verify(gl.SAMPLE_COVERAGE_VALUE, reference));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.BlendColorCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.BlendColorCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.BlendColorCase.prototype.constructor = es3fFloatStateQueryTests.BlendColorCase;
+
+	es3fFloatStateQueryTests.BlendColorCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(gl.BLEND_COLOR, new Float32Array([0, 0, 0, 0])));
+
+		/** @type {Array<Float32Array>} */ var fixedTests = [
+			new Float32Array([0.5, 1.0, 0.5, 1.0]),
+			new Float32Array([0.0, 0.5, 0.0, 0.5]),
+			new Float32Array([0.0, 0.0, 0.0, 0.0]),
+			new Float32Array([1.0, 1.0, 1.0, 1.0])
+		];
+		for (var ndx = 0; ndx < fixedTests.length; ++ndx) {
+			gl.blendColor(fixedTests[ndx][0], fixedTests[ndx][1], fixedTests[ndx][2], fixedTests[ndx][3]);
+			this.check(glsStateQuery.verify(gl.BLEND_COLOR, fixedTests[ndx]));
+		}
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var r = rnd.getFloat(0, 1);
+			/** @type {number} */ var g = rnd.getFloat(0, 1);
+			/** @type {number} */ var b = rnd.getFloat(0, 1);
+			/** @type {number} */ var a = rnd.getFloat(0, 1);
+
+			gl.blendColor(r, g, b, a);
+			this.check(glsStateQuery.verify(gl.BLEND_COLOR, new Float32Array([r, g, b, a])));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.ColorClearCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.ColorClearCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.ColorClearCase.prototype.constructor = es3fFloatStateQueryTests.ColorClearCase;
+
+	es3fFloatStateQueryTests.ColorClearCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		// [dag] In the C++ dEQP code, initial color clear value check is temorarily removed. (until the framework does not alter it)
+		this.check(glsStateQuery.verify(gl.COLOR_CLEAR_VALUE, new Float32Array([0, 0, 0, 0])));
+
+		/** @type {Array<Float32Array>} */ var fixedTests = [
+			new Float32Array([0.5, 1.0, 0.5, 1.0]),
+			new Float32Array([0.0, 0.5, 0.0, 0.5]),
+			new Float32Array([0.0, 0.0, 0.0, 0.0]),
+			new Float32Array([1.0, 1.0, 1.0, 1.0])
+		];
+		for (var ndx = 0; ndx < fixedTests.length; ++ndx) {
+			gl.clearColor(fixedTests[ndx][0], fixedTests[ndx][1], fixedTests[ndx][2], fixedTests[ndx][3]);
+			this.check(glsStateQuery.verify(gl.COLOR_CLEAR_VALUE, fixedTests[ndx]));
+		}
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var r = rnd.getFloat(0, 1);
+			/** @type {number} */ var g = rnd.getFloat(0, 1);
+			/** @type {number} */ var b = rnd.getFloat(0, 1);
+			/** @type {number} */ var a = rnd.getFloat(0, 1);
+
+			gl.clearColor(r, g, b, a);
+			this.check(glsStateQuery.verify(gl.COLOR_CLEAR_VALUE, new Float32Array([r, g, b, a])));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.DepthClearCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.DepthClearCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.DepthClearCase.prototype.constructor = es3fFloatStateQueryTests.DepthClearCase;
+
+	es3fFloatStateQueryTests.DepthClearCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(gl.DEPTH_CLEAR_VALUE, 1));
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var ref = rnd.getFloat(0, 1);
+
+			gl.clearDepth(ref);
+			this.check(glsStateQuery.verify(gl.DEPTH_CLEAR_VALUE, ref));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.MaxTextureLODBiasCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.MaxTextureLODBiasCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.MaxTextureLODBiasCase.prototype.constructor = es3fFloatStateQueryTests.MaxTextureLODBiasCase;
+
+	es3fFloatStateQueryTests.MaxTextureLODBiasCase.prototype.test = function() {
+		this.check(glsStateQuery.verifyGreaterOrEqual(gl.MAX_TEXTURE_LOD_BIAS, 2.0));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.AliasedPointSizeRangeCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.AliasedPointSizeRangeCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.AliasedPointSizeRangeCase.prototype.constructor = es3fFloatStateQueryTests.AliasedPointSizeRangeCase;
+
+	es3fFloatStateQueryTests.AliasedPointSizeRangeCase.prototype.test = function() {
+		var pointSizeRange = /** @type {Float32Array} */ (gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE));
+		/** @type {Float32Array} */ var reference = new Float32Array([1, 1]);
+		this.check(pointSizeRange[0] <= reference[0] && pointSizeRange[1] >= reference[1]);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fFloatStateQueryTests.AliasedLineWidthRangeCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fFloatStateQueryTests.AliasedLineWidthRangeCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fFloatStateQueryTests.AliasedLineWidthRangeCase.prototype.constructor = es3fFloatStateQueryTests.AliasedLineWidthRangeCase;
+
+	es3fFloatStateQueryTests.AliasedLineWidthRangeCase.prototype.test = function() {
+		var lineWidthRange = /** @type {Float32Array} */ (gl.getParameter(gl.ALIASED_LINE_WIDTH_RANGE));
+		/** @type {Float32Array} */ var reference = new Float32Array([1, 1]);
+		this.check(lineWidthRange[0] <= reference[0] && lineWidthRange[1] >= reference[1]);
+	};
+
+    /**
+    * @constructor
+    * @extends {tcuTestCase.DeqpTest}
+    */
+    es3fFloatStateQueryTests.FloatStateQueryTests = function() {
+        tcuTestCase.DeqpTest.call(this, 'floats', 'Float Values');
+    };
+
+    es3fFloatStateQueryTests.FloatStateQueryTests.prototype = Object.create(tcuTestCase.DeqpTest.prototype);
+    es3fFloatStateQueryTests.FloatStateQueryTests.prototype.constructor = es3fFloatStateQueryTests.FloatStateQueryTests;
+
+    es3fFloatStateQueryTests.FloatStateQueryTests.prototype.init = function() {
+		this.addChild(new es3fFloatStateQueryTests.DepthRangeCase('depth_range', 'DEPTH_RANGE'));
+		this.addChild(new es3fFloatStateQueryTests.LineWidthCase('line_width', 'LINE_WIDTH'));
+		this.addChild(new es3fFloatStateQueryTests.PolygonOffsetFactorCase('polygon_offset_factor', 'POLYGON_OFFSET_FACTOR'));
+		this.addChild(new es3fFloatStateQueryTests.PolygonOffsetUnitsCase('polygon_offset_units', 'POLYGON_OFFSET_UNITS'));
+		this.addChild(new es3fFloatStateQueryTests.SampleCoverageCase('sample_coverage_value', 'SAMPLE_COVERAGE_VALUE'));
+		this.addChild(new es3fFloatStateQueryTests.BlendColorCase('blend_color', 'BLEND_COLOR'));
+		this.addChild(new es3fFloatStateQueryTests.ColorClearCase('color_clear_value', 'COLOR_CLEAR_VALUE'));
+		this.addChild(new es3fFloatStateQueryTests.DepthClearCase('depth_clear_value', 'DEPTH_CLEAR_VALUE'));
+		this.addChild(new es3fFloatStateQueryTests.MaxTextureLODBiasCase('max_texture_lod_bias', 'MAX_TEXTURE_LOD_BIAS'));
+		this.addChild(new es3fFloatStateQueryTests.AliasedPointSizeRangeCase('aliased_point_size_range', 'ALIASED_POINT_SIZE_RANGE'));
+		this.addChild(new es3fFloatStateQueryTests.AliasedLineWidthRangeCase('aliased_line_width_range', 'ALIASED_LINE_WIDTH_RANGE'));
+
+    };
+
+    /**
+    * Run test
+    * @param {WebGL2RenderingContext} context
+    */
+    es3fFloatStateQueryTests.run = function(context) {
+    	gl = context;
+    	//Set up Test Root parameters
+    	var state = tcuTestCase.runner;
+    	state.setRoot(new es3fFloatStateQueryTests.FloatStateQueryTests());
+
+    	//Set up name and description of this test series.
+    	setCurrentTestName(state.testCases.fullName());
+    	description(state.testCases.getDescription());
+
+    	try {
+    		//Run test cases
+    		tcuTestCase.runTestCases();
+    	}
+    	catch (err) {
+    		testFailedOptions('Failed to es3fFloatStateQueryTests.run tests', false);
+    		tcuTestCase.runner.terminate();
+    	}
+    };
+
+});

--- a/sdk/tests/deqp/functional/gles3/es3fIntegerStateQueryTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fIntegerStateQueryTests.js
@@ -1,0 +1,2047 @@
+/*-------------------------------------------------------------------------
+ * drawElements Quality Program OpenGL ES Utilities
+ * ------------------------------------------------
+ *
+ * Copyright 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+'use strict';
+goog.provide('functional.gles3.es3fIntegerStateQueryTests');
+goog.require('framework.common.tcuTestCase');
+goog.require('framework.delibs.debase.deRandom');
+goog.require('functional.gles3.es3fApiCase');
+goog.require('modules.shared.glsStateQuery');
+
+goog.scope(function() {
+	var es3fIntegerStateQueryTests = functional.gles3.es3fIntegerStateQueryTests;
+    var tcuTestCase = framework.common.tcuTestCase;
+	var deRandom = framework.delibs.debase.deRandom;
+	var es3fApiCase = functional.gles3.es3fApiCase;
+	var glsStateQuery = modules.shared.glsStateQuery;
+
+	/** @type {string} */ var transformFeedbackTestVertSource = '' +
+		'#version 300 es\n' +
+		'void main (void)\n' +
+		'{\n' +
+		'	gl_Position = vec4(0.0);\n' +
+		'}\n';
+
+	/** @type {string} */ var transformFeedbackTestFragSource = '' +
+		'#version 300 es\n' +
+		'layout(location = 0) out mediump vec4 fragColor;' +
+		'void main (void)\n' +
+		'{\n' +
+		'	fragColor = vec4(0.0);\n' +
+		'}\n';
+
+	/** @type {string} */ var testVertSource = '' +
+		'#version 300 es\n' +
+		'void main (void)\n' +
+		'{\n' +
+		'	gl_Position = vec4(0.0);\n' +
+		'}\n';
+
+	/** @type {string} */ var testFragSource = '' +
+		'#version 300 es\n' +
+		'layout(location = 0) out mediump vec4 fragColor;' +
+		'void main (void)\n' +
+		'{\n' +
+		'	fragColor = vec4(0.0);\n' +
+		'}\n';
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.TransformFeedbackTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {WebGLTransformFeedback} */ this.m_transformfeedback;
+	};
+
+	es3fIntegerStateQueryTests.TransformFeedbackTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.TransformFeedbackTestCase.prototype.constructor = es3fIntegerStateQueryTests.TransformFeedbackTestCase;
+
+	es3fIntegerStateQueryTests.TransformFeedbackTestCase.prototype.testTransformFeedback = function() {
+		throw new Error('This method should be implemented by child classes.');
+	};
+
+	es3fIntegerStateQueryTests.TransformFeedbackTestCase.prototype.test = function() {
+		this.beforeTransformFeedbackTest(); // [dag] added this as there is no other way this method would be called.
+
+		this.m_transformfeedback = gl.createTransformFeedback();
+
+		/** @type {WebGLShader} */ var shaderVert = gl.createShader(gl.VERTEX_SHADER);
+		gl.shaderSource(shaderVert, transformFeedbackTestVertSource);
+		gl.compileShader(shaderVert);
+
+		/** @type {boolean} */ var compileStatus = /** @type {boolean} */ (gl.getShaderParameter(shaderVert, gl.COMPILE_STATUS));
+		glsStateQuery.compare(compileStatus, true);
+
+		/** @type {WebGLShader} */ var shaderFrag = gl.createShader(gl.FRAGMENT_SHADER);
+		gl.shaderSource(shaderFrag, transformFeedbackTestFragSource);
+		gl.compileShader(shaderFrag);
+
+		compileStatus = /** @type {boolean} */ (gl.getShaderParameter(shaderFrag, gl.COMPILE_STATUS));
+		glsStateQuery.compare(compileStatus, true);
+
+		/** @type {WebGLProgram} */ var shaderProg = gl.createProgram();
+		gl.attachShader(shaderProg, shaderVert);
+		gl.attachShader(shaderProg, shaderFrag);
+		/** @type {Array<string>} */ var transform_feedback_outputs = ['gl_Position'];
+		gl.transformFeedbackVaryings(shaderProg, transform_feedback_outputs, gl.INTERLEAVED_ATTRIBS);
+		gl.linkProgram(shaderProg);
+
+		/** @type {boolean} */ var linkStatus = /** @type {boolean} */ (gl.getProgramParameter(shaderProg, gl.LINK_STATUS));
+		glsStateQuery.compare(linkStatus, true);
+
+		gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, this.m_transformfeedback);
+
+
+		/** @type {WebGLBuffer} */ var feedbackBufferId = gl.createBuffer();
+		gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, feedbackBufferId);
+		gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, new Float32Array(16), gl.DYNAMIC_READ);
+		gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, feedbackBufferId);
+
+		gl.useProgram(shaderProg);
+
+		this.testTransformFeedback();
+
+		gl.useProgram(null);
+		gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+		gl.deleteTransformFeedback(this.m_transformfeedback);
+		gl.deleteBuffer(feedbackBufferId);
+		gl.deleteShader(shaderVert);
+		gl.deleteShader(shaderFrag);
+		gl.deleteProgram(shaderProg);
+
+		this.afterTransformFeedbackTest(); // [dag] added this as there is no other way this method would be called.
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fIntegerStateQueryTests.TransformFeedbackTestCase}
+	 * @param {string} name
+	 */
+	es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase = function(name) {
+		es3fIntegerStateQueryTests.TransformFeedbackTestCase.call(this, name, 'GL_TRANSFORM_FEEDBACK_BINDING');
+	};
+
+	es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase.prototype = Object.create(es3fIntegerStateQueryTests.TransformFeedbackTestCase.prototype);
+	es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase;
+
+
+	es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase.prototype.beforeTransformFeedbackTest = function() {
+		this.check(glsStateQuery.verify(gl.TRANSFORM_FEEDBACK_BINDING, null), 'beforeTransformFeedbackTest');
+	};
+
+	es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase.prototype.testTransformFeedback = function() {
+		this.check(glsStateQuery.verify(gl.TRANSFORM_FEEDBACK_BINDING, this.m_transformfeedback), 'testTransformFeedback');
+	};
+
+	es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase.prototype.afterTransformFeedbackTest = function() {
+		this.check(glsStateQuery.verify(gl.TRANSFORM_FEEDBACK_BINDING, null), 'afterTransformFeedbackTest');
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} targetName
+	 * @param {number} minValue
+	 */
+	es3fIntegerStateQueryTests.ConstantMinimumValueTestCase = function(name, description, targetName, minValue) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_targetName = targetName;
+		/** @type {number} */ this.m_minValue = minValue;
+	};
+
+	es3fIntegerStateQueryTests.ConstantMinimumValueTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ConstantMinimumValueTestCase.prototype.constructor = es3fIntegerStateQueryTests.ConstantMinimumValueTestCase;
+
+	es3fIntegerStateQueryTests.ConstantMinimumValueTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verifyGreaterOrEqual(this.m_targetName, this.m_minValue), 'Fail');
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} targetName
+	 * @param {number} minValue
+	 */
+	es3fIntegerStateQueryTests.ConstantMaximumValueTestCase = function(name, description, targetName, minValue) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_targetName = targetName;
+		/** @type {number} */ this.m_minValue = minValue;
+	};
+
+	es3fIntegerStateQueryTests.ConstantMaximumValueTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ConstantMaximumValueTestCase.prototype.constructor = es3fIntegerStateQueryTests.ConstantMaximumValueTestCase;
+
+	es3fIntegerStateQueryTests.ConstantMaximumValueTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verifyLessOrEqual(this.m_targetName, this.m_minValue), 'Fail');
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.SampleBuffersTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.SampleBuffersTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.SampleBuffersTestCase.prototype.constructor = es3fIntegerStateQueryTests.SampleBuffersTestCase;
+
+	es3fIntegerStateQueryTests.SampleBuffersTestCase.prototype.test = function() {
+		/** @type {number} */ var expectedSampleBuffers = (/** @type {number} */ (gl.getParameter(gl.SAMPLES)) > 1) ? 1 : 0;
+
+		bufferedLogToConsole('Sample count is ' + expectedSampleBuffers + ', expecting GL_SAMPLE_BUFFERS to be ' + expectedSampleBuffers);
+
+		this.check(glsStateQuery.verify(gl.SAMPLE_BUFFERS, expectedSampleBuffers));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.SamplesTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.SamplesTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.SamplesTestCase.prototype.constructor = es3fIntegerStateQueryTests.SamplesTestCase;
+
+	es3fIntegerStateQueryTests.SamplesTestCase.prototype.test = function() {
+		/** @type {number} */ var numSamples = /** @type {number} */ (gl.getParameter(gl.SAMPLES));
+		// MSAA?
+		if (numSamples > 1) {
+			bufferedLogToConsole('Sample count is ' + numSamples);
+
+			this.check(glsStateQuery.verify(gl.SAMPLES, numSamples));
+		} else {
+			/** @type {Array<number>} */ var validSamples = [0, 1];
+
+			bufferedLogToConsole('Expecting GL_SAMPLES to be 0 or 1');
+
+			this.check(glsStateQuery.verifyAnyOf(gl.SAMPLES, validSamples));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} targetName
+	 */
+	es3fIntegerStateQueryTests.HintTestCase = function(name, description, targetName) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_targetName = targetName;
+	};
+
+	es3fIntegerStateQueryTests.HintTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.HintTestCase.prototype.constructor = es3fIntegerStateQueryTests.HintTestCase;
+
+	es3fIntegerStateQueryTests.HintTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_targetName, gl.DONT_CARE));
+
+		gl.hint(this.m_targetName, gl.NICEST);
+		this.check(glsStateQuery.verify(this.m_targetName, gl.NICEST));
+
+		gl.hint(this.m_targetName, gl.FASTEST);
+		this.check(glsStateQuery.verify(this.m_targetName, gl.FASTEST));
+
+		gl.hint(this.m_targetName, gl.DONT_CARE);
+		this.check(glsStateQuery.verify(this.m_targetName, gl.DONT_CARE));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.DepthFuncTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.DepthFuncTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.DepthFuncTestCase.prototype.constructor = es3fIntegerStateQueryTests.DepthFuncTestCase;
+
+	es3fIntegerStateQueryTests.DepthFuncTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.DEPTH_FUNC, gl.LESS));
+
+		/** @type {Array<number>} */ var depthFunctions = [gl.NEVER, gl.ALWAYS, gl.LESS, gl.LEQUAL, gl.EQUAL, gl.GREATER, gl.GEQUAL, gl.NOTEQUAL];
+		for (var ndx = 0; ndx < depthFunctions.length; ndx++) {
+			gl.depthFunc(depthFunctions[ndx]);
+
+			this.check(glsStateQuery.verify(gl.DEPTH_FUNC, depthFunctions[ndx]));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.CullFaceTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.CullFaceTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.CullFaceTestCase.prototype.constructor = es3fIntegerStateQueryTests.CullFaceTestCase;
+
+	es3fIntegerStateQueryTests.CullFaceTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.CULL_FACE_MODE, gl.BACK));
+
+		/** @type {Array<number>} */ var cullFaces = [gl.FRONT, gl.BACK, gl.FRONT_AND_BACK];
+		for (var ndx = 0; ndx < cullFaces.length; ndx++) {
+			gl.cullFace(cullFaces[ndx]);
+
+			this.check(glsStateQuery.verify(gl.CULL_FACE_MODE, cullFaces[ndx]));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.FrontFaceTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.FrontFaceTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.FrontFaceTestCase.prototype.constructor = es3fIntegerStateQueryTests.FrontFaceTestCase;
+
+	es3fIntegerStateQueryTests.FrontFaceTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.FRONT_FACE, gl.CCW));
+
+		/** @type {Array<number>} */ var frontFaces = [gl.CW, gl.CCW];
+		for (var ndx = 0; ndx < frontFaces.length; ndx++) {
+			gl.frontFace(frontFaces[ndx]);
+
+			this.check(glsStateQuery.verify(gl.FRONT_FACE, frontFaces[ndx]));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.ViewPortTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.ViewPortTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ViewPortTestCase.prototype.constructor = es3fIntegerStateQueryTests.ViewPortTestCase;
+
+	es3fIntegerStateQueryTests.ViewPortTestCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		/** @type {Array<number>} */ var maxViewportDimensions = /** @type {Array<number>} */ (gl.getParameter(gl.MAX_VIEWPORT_DIMS));
+
+		// verify initial value of first two values
+		this.check(glsStateQuery.verify(gl.VIEWPORT, new Int32Array([0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight])));
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var x = rnd.getInt(-64000, 64000);
+			/** @type {number} */ var y = rnd.getInt(-64000, 64000);
+			/** @type {number} */ var width = rnd.getInt(0, maxViewportDimensions[0]);
+			/** @type {number} */ var height = rnd.getInt(0, maxViewportDimensions[1]);
+
+			gl.viewport(x, y, width, height);
+			this.check(glsStateQuery.verify(gl.VIEWPORT, new Int32Array([x, y, width, height])));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.ScissorBoxTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.ScissorBoxTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ScissorBoxTestCase.prototype.constructor = es3fIntegerStateQueryTests.ScissorBoxTestCase;
+
+	es3fIntegerStateQueryTests.ScissorBoxTestCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		// verify initial value of first two values
+		this.check(glsStateQuery.verifyMask(gl.SCISSOR_BOX, [0, 0, 0, 0], [true, true, false, false]));
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var left = rnd.getInt(-64000, 64000);
+			/** @type {number} */ var bottom = rnd.getInt(-64000, 64000);
+			/** @type {number} */ var width = rnd.getInt(0, 64000);
+			/** @type {number} */ var height = rnd.getInt(0, 64000);
+
+			gl.scissor(left, bottom, width, height);
+			this.check(glsStateQuery.verify(gl.SCISSOR_BOX, new Int32Array([left, bottom, width, height])));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.MaxViewportDimsTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.MaxViewportDimsTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.MaxViewportDimsTestCase.prototype.constructor = es3fIntegerStateQueryTests.MaxViewportDimsTestCase;
+
+	es3fIntegerStateQueryTests.MaxViewportDimsTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verifyGreaterOrEqual(gl.MAX_VIEWPORT_DIMS, [gl.drawingBufferWidth, gl.drawingBufferHeight]));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 */
+	es3fIntegerStateQueryTests.StencilRefTestCase = function(name, description, testTargetName) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+	};
+
+	es3fIntegerStateQueryTests.StencilRefTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilRefTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilRefTestCase;
+
+	es3fIntegerStateQueryTests.StencilRefTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_testTargetName, 0));
+
+		/** @type {number} */ var stencilBits = /** @type {number} */ (gl.getParameter(gl.STENCIL_BITS));
+
+		for (var stencilBit = 0; stencilBit < stencilBits; ++stencilBit) {
+			/** @type {number} */ var ref = 1 << stencilBit;
+
+			gl.stencilFunc(gl.ALWAYS, ref, 0); // mask should not affect the REF
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, ref));
+
+			gl.stencilFunc(gl.ALWAYS, ref, ref);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, ref));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} stencilFuncTargetFace
+	 */
+	es3fIntegerStateQueryTests.StencilRefSeparateTestCase = function(name, description, testTargetName, stencilFuncTargetFace) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+		/** @type {number} */ this.m_stencilFuncTargetFace = stencilFuncTargetFace;
+	};
+
+	es3fIntegerStateQueryTests.StencilRefSeparateTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilRefSeparateTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilRefSeparateTestCase;
+
+	es3fIntegerStateQueryTests.StencilRefSeparateTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_testTargetName, 0));
+
+		/** @type {number} */ var stencilBits = /** @type {number} */ (gl.getParameter(gl.STENCIL_BITS));
+
+		for (var stencilBit = 0; stencilBit < stencilBits; ++stencilBit) {
+			/** @type {number} */ var ref = 1 << stencilBit;
+
+			gl.stencilFuncSeparate(this.m_stencilFuncTargetFace, gl.ALWAYS, ref, 0);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, ref));
+
+			gl.stencilFuncSeparate(this.m_stencilFuncTargetFace, gl.ALWAYS, ref, ref);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, ref));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} stencilOpName
+	 */
+	es3fIntegerStateQueryTests.StencilOpTestCase = function(name, description, stencilOpName) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_stencilOpName = stencilOpName;
+	};
+
+	es3fIntegerStateQueryTests.StencilOpTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilOpTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilOpTestCase;
+
+	es3fIntegerStateQueryTests.StencilOpTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_stencilOpName, gl.KEEP));
+
+		/** @type {Array<number>} */ var stencilOpValues = [gl.KEEP, gl.ZERO, gl.REPLACE, gl.INCR, gl.DECR, gl.INVERT, gl.INCR_WRAP, gl.DECR_WRAP];
+		for (var ndx = 0; ndx < stencilOpValues.length; ++ndx) {
+			this.setStencilOp(stencilOpValues[ndx]);
+
+			this.check(glsStateQuery.verify(this.m_stencilOpName, stencilOpValues[ndx]));
+		}
+	};
+
+	es3fIntegerStateQueryTests.StencilOpTestCase.prototype.deinit = function() {
+		// [dag] need to reset everything once the test is done, otherwise related tests fail
+		gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+	};
+
+	/**
+	 * @param  {number} stencilOpValue
+	 */
+	es3fIntegerStateQueryTests.StencilOpTestCase.prototype.setStencilOp = function(stencilOpValue) {
+		switch (this.m_stencilOpName) {
+			case gl.STENCIL_FAIL:
+			case gl.STENCIL_BACK_FAIL:
+				gl.stencilOp(stencilOpValue, gl.KEEP, gl.KEEP);
+				break;
+
+			case gl.STENCIL_PASS_DEPTH_FAIL:
+			case gl.STENCIL_BACK_PASS_DEPTH_FAIL:
+				gl.stencilOp(gl.KEEP, stencilOpValue, gl.KEEP);
+				break;
+
+			case gl.STENCIL_PASS_DEPTH_PASS:
+			case gl.STENCIL_BACK_PASS_DEPTH_PASS:
+				gl.stencilOp(gl.KEEP, gl.KEEP, stencilOpValue);
+				break;
+
+			default:
+				throw new Error('should not happen');
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fIntegerStateQueryTests.StencilOpTestCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} stencilOpName
+	 * @param {number} stencilOpFace
+	 */
+	es3fIntegerStateQueryTests.StencilOpSeparateTestCase = function(name, description, stencilOpName, stencilOpFace) {
+		es3fIntegerStateQueryTests.StencilOpTestCase.call(this, name, description, stencilOpName);
+		/** @type {number} */ this.m_stencilOpName = stencilOpName;
+		/** @type {number} */ this.m_stencilOpFace = stencilOpFace;
+	};
+
+	es3fIntegerStateQueryTests.StencilOpSeparateTestCase.prototype = Object.create(es3fIntegerStateQueryTests.StencilOpTestCase.prototype);
+	es3fIntegerStateQueryTests.StencilOpSeparateTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilOpSeparateTestCase;
+
+	es3fIntegerStateQueryTests.StencilOpSeparateTestCase.prototype.test = function() {};
+
+	/**
+	 * @param  {number} stencilOpValue
+	 */
+	es3fIntegerStateQueryTests.StencilOpSeparateTestCase.prototype.setStencilOp = function(stencilOpValue) {
+		switch (this.m_stencilOpName) {
+			case gl.STENCIL_FAIL:
+			case gl.STENCIL_BACK_FAIL:
+				gl.stencilOpSeparate(this.m_stencilOpFace, stencilOpValue, gl.KEEP, gl.KEEP);
+				break;
+
+			case gl.STENCIL_PASS_DEPTH_FAIL:
+			case gl.STENCIL_BACK_PASS_DEPTH_FAIL:
+				gl.stencilOpSeparate(this.m_stencilOpFace, gl.KEEP, stencilOpValue, gl.KEEP);
+				break;
+
+			case gl.STENCIL_PASS_DEPTH_PASS:
+			case gl.STENCIL_BACK_PASS_DEPTH_PASS:
+				gl.stencilOpSeparate(this.m_stencilOpFace, gl.KEEP, gl.KEEP, stencilOpValue);
+				break;
+
+			default:
+				throw new Error('should not happen');
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.StencilFuncTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.StencilFuncTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilFuncTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilFuncTestCase;
+
+	es3fIntegerStateQueryTests.StencilFuncTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.STENCIL_FUNC, gl.ALWAYS));
+
+		/** @type {Array<number>} */ var stencilfuncValues = [gl.NEVER, gl.ALWAYS, gl.LESS, gl.LEQUAL, gl.EQUAL, gl.GEQUAL, gl.GREATER, gl.NOTEQUAL];
+
+		for (var ndx = 0; ndx < stencilfuncValues.length; ++ndx) {
+			gl.stencilFunc(stencilfuncValues[ndx], 0, 0);
+
+			this.check(glsStateQuery.verify(gl.STENCIL_FUNC, stencilfuncValues[ndx]));
+
+			this.check(glsStateQuery.verify(gl.STENCIL_BACK_FUNC, stencilfuncValues[ndx]));
+		}
+	};
+
+	es3fIntegerStateQueryTests.StencilFuncTestCase.prototype.deinit = function() {
+		// [dag] reset stencilFunc to ALWAYS
+		gl.stencilFunc(gl.ALWAYS, 0, 0);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} stencilFuncName
+	 * @param {number} stencilFuncFace
+	 */
+	es3fIntegerStateQueryTests.StencilFuncSeparateTestCase = function(name, description, stencilFuncName, stencilFuncFace) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_stencilFuncName = stencilFuncName;
+		/** @type {number} */ this.m_stencilFuncFace = stencilFuncFace;
+	};
+
+	es3fIntegerStateQueryTests.StencilFuncSeparateTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilFuncSeparateTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilFuncSeparateTestCase;
+
+	es3fIntegerStateQueryTests.StencilFuncSeparateTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_stencilFuncName, gl.ALWAYS));
+
+		/** @type {Array<number>} */ var stencilfuncValues = [gl.NEVER, gl.ALWAYS, gl.LESS, gl.LEQUAL, gl.EQUAL, gl.GEQUAL, gl.GREATER, gl.NOTEQUAL];
+
+		for (var ndx = 0; ndx < stencilfuncValues.length; ++ndx) {
+			gl.stencilFuncSeparate(this.m_stencilFuncFace, stencilfuncValues[ndx], 0, 0);
+
+			this.check(glsStateQuery.verify(this.m_stencilFuncName, stencilfuncValues[ndx]));
+		}
+	};
+
+	es3fIntegerStateQueryTests.StencilFuncSeparateTestCase.prototype.deinit = function() {
+		// [dag] reset the stencil func
+		gl.stencilFuncSeparate(this.m_stencilFuncFace, gl.ALWAYS, 0, 0);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 */
+	es3fIntegerStateQueryTests.StencilMaskTestCase = function(name, description, testTargetName) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+	};
+
+	es3fIntegerStateQueryTests.StencilMaskTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilMaskTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilMaskTestCase;
+
+	es3fIntegerStateQueryTests.StencilMaskTestCase.prototype.test = function() {
+		/** @type {number} */ var stencilBits = /** @type {number} */ (gl.getParameter(gl.STENCIL_BITS));
+
+		this.check(glsStateQuery.verify(this.m_testTargetName, stencilBits));
+
+		for (var stencilBit = 0; stencilBit < stencilBits; ++stencilBit) {
+			/** @type {number} */ var mask = 1 << stencilBit;
+
+			gl.stencilFunc(gl.ALWAYS, 0, mask);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, mask));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} stencilFuncTargetFace
+	 */
+	es3fIntegerStateQueryTests.StencilMaskSeparateTestCase = function(name, description, testTargetName, stencilFuncTargetFace) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+		/** @type {number} */ this.m_stencilFuncTargetFace = stencilFuncTargetFace;
+	};
+
+	es3fIntegerStateQueryTests.StencilMaskSeparateTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilMaskSeparateTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilMaskSeparateTestCase;
+
+	es3fIntegerStateQueryTests.StencilMaskSeparateTestCase.prototype.test = function() {
+		/** @type {number} */ var stencilBits = /** @type {number} */ (gl.getParameter(gl.STENCIL_BITS));
+
+		this.check(glsStateQuery.verify(this.m_testTargetName, stencilBits));
+
+		for (var stencilBit = 0; stencilBit < stencilBits; ++stencilBit) {
+			/** @type {number} */ var mask = 1 << stencilBit;
+
+			gl.stencilFuncSeparate(this.m_stencilFuncTargetFace, gl.ALWAYS, 0, mask);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, mask));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 */
+	es3fIntegerStateQueryTests.StencilWriteMaskTestCase = function(name, description, testTargetName) {
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.StencilWriteMaskTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilWriteMaskTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilWriteMaskTestCase;
+
+	es3fIntegerStateQueryTests.StencilWriteMaskTestCase.prototype.test = function() {
+		/** @type {number} */ var stencilBits = /** @type {number} */ (gl.getParameter(gl.STENCIL_BITS));
+
+		for (var stencilBit = 0; stencilBit < stencilBits; ++stencilBit) {
+			/** @type {number} */ var mask = 1 << stencilBit;
+
+			gl.stencilMask(mask);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, mask));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} stencilTargetFace
+	 */
+	es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase = function(name, description, testTargetName, stencilTargetFace) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+		/** @type {number} */ this.m_stencilTargetFace = stencilTargetFace;
+	};
+
+	es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase;
+
+	es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase.prototype.test = function() {
+		/** @type {number} */ var stencilBits = /** @type {number} */ (gl.getParameter(gl.STENCIL_BITS));
+
+		for (var stencilBit = 0; stencilBit < stencilBits; ++stencilBit) {
+			/** @type {number} */ var mask = 1 << stencilBit;
+
+			gl.stencilMaskSeparate(this.m_stencilTargetFace, mask);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, mask));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} initialValue
+	 */
+	es3fIntegerStateQueryTests.PixelStoreTestCase = function(name, description, testTargetName, initialValue) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+		/** @type {number} */ this.m_initialValue = initialValue;
+	};
+
+	es3fIntegerStateQueryTests.PixelStoreTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.PixelStoreTestCase.prototype.constructor = es3fIntegerStateQueryTests.PixelStoreTestCase;
+
+	es3fIntegerStateQueryTests.PixelStoreTestCase.prototype.test = function() {
+		/** @type {deRandom.Random} */ var rnd = new deRandom.Random(0xabcdef);
+
+		this.check(glsStateQuery.verify(this.m_testTargetName, this.m_initialValue));
+
+		/** @type {number} */ var numIterations = 120;
+		for (var i = 0; i < numIterations; ++i) {
+			/** @type {number} */ var referenceValue = rnd.getInt(0, 64000);
+
+			gl.pixelStorei(this.m_testTargetName, referenceValue);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, referenceValue));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 */
+	es3fIntegerStateQueryTests.PixelStoreAlignTestCase = function(name, description, testTargetName) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+	};
+
+	es3fIntegerStateQueryTests.PixelStoreAlignTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.PixelStoreAlignTestCase.prototype.constructor = es3fIntegerStateQueryTests.PixelStoreAlignTestCase;
+
+	es3fIntegerStateQueryTests.PixelStoreAlignTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_testTargetName, 4));
+
+		/** @type {Array<number>} */ var alignments = [1, 2, 4, 8];
+
+		for (var ndx = 0; ndx < alignments.length; ++ndx) {
+			/** @type {number} */ var referenceValue = alignments[ndx];
+
+			gl.pixelStorei(this.m_testTargetName, referenceValue);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, referenceValue));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} initialValue
+	 */
+	es3fIntegerStateQueryTests.BlendFuncTestCase = function(name, description, testTargetName, initialValue) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_testTargetName = testTargetName;
+		/** @type {number} */ this.m_initialValue = initialValue;
+	};
+
+	es3fIntegerStateQueryTests.BlendFuncTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.BlendFuncTestCase.prototype.constructor = es3fIntegerStateQueryTests.BlendFuncTestCase;
+
+	es3fIntegerStateQueryTests.BlendFuncTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_testTargetName, this.m_initialValue));
+
+		/** @type {Array<number>} */ var blendFuncValues = [
+			gl.ZERO, gl.ONE, gl.SRC_COLOR, gl.ONE_MINUS_SRC_COLOR, gl.DST_COLOR, gl.ONE_MINUS_DST_COLOR,
+			gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.DST_ALPHA, gl.ONE_MINUS_DST_ALPHA, gl.CONSTANT_COLOR,
+			gl.ONE_MINUS_CONSTANT_COLOR, gl.CONSTANT_ALPHA, gl.ONE_MINUS_CONSTANT_ALPHA,
+			gl.SRC_ALPHA_SATURATE
+		];
+
+		for (var ndx = 0; ndx < blendFuncValues.length; ++ndx) {
+			/** @type {number} */ var referenceValue = blendFuncValues[ndx];
+
+			this.setBlendFunc(referenceValue);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, referenceValue));
+		}};
+
+	/**
+	 * @param  {number} func
+	 */
+	es3fIntegerStateQueryTests.BlendFuncTestCase.prototype.setBlendFunc = function(func) {
+		switch (this.m_testTargetName) {
+			case gl.BLEND_SRC_RGB:
+			case gl.BLEND_SRC_ALPHA:
+				gl.blendFunc(func, gl.ZERO);
+				break;
+
+			case gl.BLEND_DST_RGB:
+			case gl.BLEND_DST_ALPHA:
+				gl.blendFunc(gl.ZERO, func);
+				break;
+
+			default:
+				throw new Error('should not happen');
+		}
+	};
+
+	es3fIntegerStateQueryTests.BlendFuncTestCase.prototype.deinit = function() {
+		gl.blendFunc(this.m_initialValue, this.m_initialValue);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fIntegerStateQueryTests.BlendFuncTestCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} initialValue
+	 */
+	es3fIntegerStateQueryTests.BlendFuncSeparateTestCase = function(name, description, testTargetName, initialValue) {
+		es3fIntegerStateQueryTests.BlendFuncTestCase.call(this, name, description, testTargetName, initialValue);
+	 /** @type {number} */ this.m_testTargetName = testTargetName;
+	 /** @type {number} */ this.m_initialValue = initialValue;
+	};
+
+	es3fIntegerStateQueryTests.BlendFuncSeparateTestCase.prototype = Object.create(es3fIntegerStateQueryTests.BlendFuncTestCase.prototype);
+	es3fIntegerStateQueryTests.BlendFuncSeparateTestCase.prototype.constructor = es3fIntegerStateQueryTests.BlendFuncSeparateTestCase;
+
+	/**
+	 * @param  {number} func
+	 */
+	es3fIntegerStateQueryTests.BlendFuncSeparateTestCase.prototype.setBlendFunc = function(func) {
+		switch (this.m_testTargetName) {
+			case gl.BLEND_SRC_RGB:
+				gl.blendFuncSeparate(func, gl.ZERO, gl.ZERO, gl.ZERO);
+				break;
+
+			case gl.BLEND_DST_RGB:
+				gl.blendFuncSeparate(gl.ZERO, func, gl.ZERO, gl.ZERO);
+				break;
+
+			case gl.BLEND_SRC_ALPHA:
+				gl.blendFuncSeparate(gl.ZERO, gl.ZERO, func, gl.ZERO);
+				break;
+
+			case gl.BLEND_DST_ALPHA:
+				gl.blendFuncSeparate(gl.ZERO, gl.ZERO, gl.ZERO, func);
+				break;
+
+			default:
+				throw new Error('should not happen');
+		}
+	};
+
+	es3fIntegerStateQueryTests.BlendFuncSeparateTestCase.prototype.deinit = function() {
+		gl.blendFuncSeparate(this.m_initialValue, this.m_initialValue, this.m_initialValue, this.m_initialValue);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} initialValue
+	 */
+	es3fIntegerStateQueryTests.BlendEquationTestCase = function(name, description, testTargetName, initialValue) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	 /** @type {number} */ this.m_testTargetName = testTargetName;
+	 /** @type {number} */ this.m_initialValue = initialValue;
+	};
+
+	es3fIntegerStateQueryTests.BlendEquationTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.BlendEquationTestCase.prototype.constructor = es3fIntegerStateQueryTests.BlendEquationTestCase;
+
+	es3fIntegerStateQueryTests.BlendEquationTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_testTargetName, this.m_initialValue));
+
+		/** @type {Array<number>} */ var blendFuncValues = [gl.FUNC_ADD, gl.FUNC_SUBTRACT, gl.FUNC_REVERSE_SUBTRACT, gl.MIN, gl.MAX];
+
+		for (var ndx = 0; ndx < blendFuncValues.length; ++ndx) {
+			/** @type {number} */ var referenceValue = blendFuncValues[ndx];
+
+			this.setBlendEquation(referenceValue);
+
+			this.check(glsStateQuery.verify(this.m_testTargetName, referenceValue));
+		}
+	};
+
+	/**
+	 * @param  {number} equation
+	 */
+	es3fIntegerStateQueryTests.BlendEquationTestCase.prototype.setBlendEquation = function(equation) {
+		gl.blendEquation(equation);
+	};
+
+	es3fIntegerStateQueryTests.BlendEquationTestCase.prototype.deinit = function() {
+		gl.blendEquation(this.m_initialValue);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fIntegerStateQueryTests.BlendEquationTestCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} initialValue
+	 */
+	es3fIntegerStateQueryTests.BlendEquationSeparateTestCase = function(name, description, testTargetName, initialValue) {
+		es3fIntegerStateQueryTests.BlendEquationTestCase.call(this, name, description, testTargetName, initialValue);
+	 /** @type {number} */ this.m_testTargetName = testTargetName;
+	 /** @type {number} */ this.m_initialValue = initialValue;
+	};
+
+	es3fIntegerStateQueryTests.BlendEquationSeparateTestCase.prototype = Object.create(es3fIntegerStateQueryTests.BlendEquationTestCase.prototype);
+	es3fIntegerStateQueryTests.BlendEquationSeparateTestCase.prototype.constructor = es3fIntegerStateQueryTests.BlendEquationSeparateTestCase;
+
+	/**
+	 * @param  {number} equation
+	 */
+	es3fIntegerStateQueryTests.BlendEquationSeparateTestCase.prototype.setBlendEquation = function(equation) {
+		switch (this.m_testTargetName) {
+			case gl.BLEND_EQUATION_RGB:
+				gl.blendEquationSeparate(equation, gl.FUNC_ADD);
+				break;
+
+			case gl.BLEND_EQUATION_ALPHA:
+				gl.blendEquationSeparate(gl.FUNC_ADD, equation);
+				break;
+
+			default:
+				throw new Error('should not happen');
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testTargetName
+	 * @param {number} minValue
+	 */
+	es3fIntegerStateQueryTests.ImplementationArrayTestCase = function(name, description, testTargetName, minValue) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	 	/** @type {number} */ this.m_testTargetName = testTargetName;
+	 	/** @type {number} */ this.m_minValue = minValue;
+	};
+
+	es3fIntegerStateQueryTests.ImplementationArrayTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ImplementationArrayTestCase.prototype.constructor = es3fIntegerStateQueryTests.ImplementationArrayTestCase;
+
+	es3fIntegerStateQueryTests.ImplementationArrayTestCase.prototype.test = function() {
+		/** @type {Array<number>} */ var queryResult = /** @type {Array<number>} */ (gl.getParameter(this.m_testTargetName));
+		this.check(glsStateQuery.compare(queryResult.length, this.m_minValue));
+
+		/** @type {Array<number>} */ var textureFormats = [
+			gl.COMPRESSED_R11_EAC, gl.COMPRESSED_SIGNED_R11_EAC, gl.COMPRESSED_RG11_EAC, gl.COMPRESSED_SIGNED_RG11_EAC, gl.COMPRESSED_RGB8_ETC2, gl.COMPRESSED_SRGB8_ETC2,
+			gl.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2, gl.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2, gl.COMPRESSED_RGBA8_ETC2_EAC, gl.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC
+		];
+
+		for (var ndx = 0; ndx < textureFormats.length; ndx++) {
+			/** @type {number} */ var format = textureFormats[ndx];
+			/** @type {boolean} */ var isInArray = queryResult.indexOf(format) !== -1;
+			this.check(glsStateQuery.compare(isInArray, true));
+		}
+
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.CurrentProgramBindingTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.CurrentProgramBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.CurrentProgramBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.CurrentProgramBindingTestCase;
+
+	es3fIntegerStateQueryTests.CurrentProgramBindingTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.CURRENT_PROGRAM, null));
+
+		/** @type {WebGLShader} */ var shaderVert = gl.createShader(gl.VERTEX_SHADER);
+		gl.shaderSource(shaderVert, testVertSource);
+		gl.compileShader(shaderVert);
+		/** @type {boolean} */ var compileStatus = /** @type {boolean} */ (gl.getShaderParameter(shaderVert, gl.COMPILE_STATUS));
+		this.check(glsStateQuery.compare(compileStatus, true));
+
+		/** @type {WebGLShader} */ var shaderFrag = gl.createShader(gl.FRAGMENT_SHADER);
+		gl.shaderSource(shaderFrag, testFragSource);
+		gl.compileShader(shaderFrag);
+		compileStatus = /** @type {boolean} */ (gl.getShaderParameter(shaderFrag, gl.COMPILE_STATUS));
+		this.check(glsStateQuery.compare(compileStatus, true));
+
+		/** @type {WebGLProgram} */ var shaderProg = gl.createProgram();
+		gl.attachShader(shaderProg, shaderVert);
+		gl.attachShader(shaderProg, shaderFrag);
+		gl.linkProgram(shaderProg);
+		/** @type {boolean} */ var linkStatus = /** @type {boolean} */ (gl.getProgramParameter(shaderProg, gl.LINK_STATUS));
+		this.check(glsStateQuery.compare(linkStatus, true));
+
+		gl.useProgram(shaderProg);
+
+		this.check(glsStateQuery.verify(gl.CURRENT_PROGRAM, shaderProg));
+
+		gl.deleteShader(shaderVert);
+		gl.deleteShader(shaderFrag);
+		gl.deleteProgram(shaderProg);
+
+		this.check(glsStateQuery.verify(gl.CURRENT_PROGRAM, shaderProg));
+
+		gl.useProgram(null);
+		this.check(glsStateQuery.verify(gl.CURRENT_PROGRAM, null));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.VertexArrayBindingTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.VertexArrayBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.VertexArrayBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.VertexArrayBindingTestCase;
+
+	es3fIntegerStateQueryTests.VertexArrayBindingTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.VERTEX_ARRAY_BINDING, null));
+
+		/** @type {WebGLVertexArrayObject} */ var vertexArrayObject = gl.createVertexArray();
+
+		gl.bindVertexArray(vertexArrayObject);
+		this.check(glsStateQuery.verify(gl.VERTEX_ARRAY_BINDING, vertexArrayObject));
+
+		gl.deleteVertexArray(vertexArrayObject);
+		this.check(glsStateQuery.verify(gl.VERTEX_ARRAY_BINDING, null));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} bufferBindingName
+	 * @param {number} bufferType
+	 */
+	es3fIntegerStateQueryTests.BufferBindingTestCase = function(name, description, bufferBindingName, bufferType) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	 /** @type {number} */ this.m_bufferBindingName = bufferBindingName;
+	 /** @type {number} */ this.m_bufferType = bufferType;
+	};
+
+	es3fIntegerStateQueryTests.BufferBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.BufferBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.BufferBindingTestCase;
+
+	es3fIntegerStateQueryTests.BufferBindingTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_bufferBindingName, null));
+
+		/** @type {WebGLBuffer} */ var bufferObject = gl.createBuffer();
+
+		gl.bindBuffer(this.m_bufferType, bufferObject);
+		this.check(glsStateQuery.verify(this.m_bufferBindingName, bufferObject));
+
+		gl.deleteBuffer(bufferObject);
+		this.check(glsStateQuery.verify(this.m_bufferBindingName, null));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 */
+	es3fIntegerStateQueryTests.ElementArrayBufferBindingTestCase = function(name) {
+		es3fApiCase.ApiCase.call(this, name, 'GL_ELEMENT_ARRAY_BUFFER_BINDING', gl);
+	};
+
+	es3fIntegerStateQueryTests.ElementArrayBufferBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ElementArrayBufferBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.ElementArrayBufferBindingTestCase;
+
+	es3fIntegerStateQueryTests.ElementArrayBufferBindingTestCase.prototype.test = function() {
+		// Test with default VAO
+		bufferedLogToConsole('DefaultVAO: Test with default VAO');
+
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, null));
+
+		/** @type {WebGLBuffer} */ var bufferObject = gl.createBuffer();
+
+		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferObject);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, bufferObject));
+
+		gl.deleteBuffer(bufferObject);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, null));
+
+		// Test with multiple VAOs
+		bufferedLogToConsole('WithVAO: Test with VAO');
+
+		/** @type {Array<WebGLVertexArrayObject>} */ var vaos = [];
+		/** @type {Array<WebGLBuffer>} */ var buffers = [];
+
+		for (var ndx = 0; ndx < 2; ndx++) {
+			vaos[ndx] = gl.createVertexArray();
+			buffers[ndx] = gl.createBuffer();
+		}
+
+		// initial
+		gl.bindVertexArray(vaos[0]);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, null));
+
+		// after setting
+		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffers[0]);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, buffers[0]));
+
+		// initial of vao 2
+		gl.bindVertexArray(vaos[1]);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, null));
+
+		// after setting to 2
+		gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffers[1]);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, buffers[1]));
+
+		// vao 1 still has buffer 1 bound?
+		gl.bindVertexArray(vaos[0]);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, buffers[0]));
+
+		// deleting clears from bound vaos ...
+		for (var ndx = 0; ndx < 2; ndx++)
+			gl.deleteBuffer(buffers[ndx]);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, null));
+
+		// ... but does not from non-bound vaos?
+		gl.bindVertexArray(vaos[1]);
+		this.check(glsStateQuery.verify(gl.ELEMENT_ARRAY_BUFFER_BINDING, buffers[1]));
+
+		for (var ndx = 0; ndx < 2; ndx++)
+			gl.deleteVertexArray(vaos[ndx]);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.StencilClearValueTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.StencilClearValueTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.StencilClearValueTestCase.prototype.constructor = es3fIntegerStateQueryTests.StencilClearValueTestCase;
+
+	es3fIntegerStateQueryTests.StencilClearValueTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.STENCIL_CLEAR_VALUE, 0));
+
+		/** @type {number} */ var stencilBits = /** @type {number} */ (gl.getParameter(gl.STENCIL_BITS));
+
+		for (var stencilBit = 0; stencilBit < stencilBits; ++stencilBit) {
+			/** @type {number} */ var ref = 1 << stencilBit;
+
+			gl.clearStencil(ref); // mask should not affect the REF
+
+			this.check(glsStateQuery.verify(gl.STENCIL_CLEAR_VALUE, ref));
+		}
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.ActiveTextureTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.ActiveTextureTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ActiveTextureTestCase.prototype.constructor = es3fIntegerStateQueryTests.ActiveTextureTestCase;
+
+	es3fIntegerStateQueryTests.ActiveTextureTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.ACTIVE_TEXTURE, gl.TEXTURE0));
+
+		/** @type {number} */ var textureUnits = /** @type {number} */ (gl.getParameter(gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS));
+
+		for (var ndx = 0; ndx < textureUnits; ++ndx) {
+			gl.activeTexture(gl.TEXTURE0 + ndx);
+
+			this.check(glsStateQuery.verify(gl.ACTIVE_TEXTURE, gl.TEXTURE0 + ndx));
+		}
+	};
+
+	es3fIntegerStateQueryTests.ActiveTextureTestCase.prototype.deinit = function() {
+		// [dag] reset the state of the context
+ 		gl.activeTexture(gl.TEXTURE0);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.RenderbufferBindingTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.RenderbufferBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.RenderbufferBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.RenderbufferBindingTestCase;
+
+	es3fIntegerStateQueryTests.RenderbufferBindingTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.RENDERBUFFER_BINDING, null));
+
+		/** @type {WebGLRenderbuffer} */ var renderBuffer = gl.createRenderbuffer();
+
+		gl.bindRenderbuffer(gl.RENDERBUFFER, renderBuffer);
+
+		this.check(glsStateQuery.verify(gl.RENDERBUFFER_BINDING, renderBuffer));
+
+		gl.deleteRenderbuffer(renderBuffer);
+		this.check(glsStateQuery.verify(gl.RENDERBUFFER_BINDING, null));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.SamplerObjectBindingTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.SamplerObjectBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.SamplerObjectBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.SamplerObjectBindingTestCase;
+
+	es3fIntegerStateQueryTests.SamplerObjectBindingTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.SAMPLER_BINDING, null));
+
+		bufferedLogToConsole('SingleUnit: Single unit');
+		/** @type {WebGLSampler} */ var sampler = gl.createSampler();
+
+		gl.bindSampler(0, sampler);
+
+		this.check(glsStateQuery.verify(gl.SAMPLER_BINDING, sampler));
+
+		gl.deleteSampler(sampler);
+		this.check(glsStateQuery.verify(gl.SAMPLER_BINDING, null));
+
+		bufferedLogToConsole('MultipleUnits: Multiple units');
+
+		/** @type {WebGLSampler} */ var samplerA = gl.createSampler();
+		/** @type {WebGLSampler} */ var samplerB = gl.createSampler();
+
+		gl.bindSampler(1, samplerA);
+		gl.bindSampler(2, samplerB);
+
+		this.check(glsStateQuery.verify(gl.SAMPLER_BINDING, null));
+
+		gl.activeTexture(gl.TEXTURE1);
+		this.check(glsStateQuery.verify(gl.SAMPLER_BINDING, samplerA));
+
+		gl.activeTexture(gl.TEXTURE2);
+		this.check(glsStateQuery.verify(gl.SAMPLER_BINDING, samplerB));
+
+		gl.deleteSampler(samplerB);
+		gl.deleteSampler(samplerA);
+	};
+
+	es3fIntegerStateQueryTests.SamplerObjectBindingTestCase.prototype.deinit = function() {
+		gl.activeTexture(gl.TEXTURE0);
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} testBindingName
+	 * @param {number} textureType
+	 */
+	es3fIntegerStateQueryTests.TextureBindingTestCase = function(name, description, testBindingName, textureType) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	 /** @type {number} */ this.m_testBindingName = testBindingName;
+	 /** @type {number} */ this.m_textureType = textureType;
+	};
+
+	es3fIntegerStateQueryTests.TextureBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.TextureBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.TextureBindingTestCase;
+
+	es3fIntegerStateQueryTests.TextureBindingTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(this.m_testBindingName, null));
+
+		/** @type {WebGLTexture} */ var texture = gl.createTexture();
+
+		gl.bindTexture(this.m_textureType, texture);
+		this.check(glsStateQuery.verify(this.m_testBindingName, texture));
+
+		gl.deleteTexture(texture);
+
+		this.check(glsStateQuery.verify(this.m_testBindingName, null));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.FrameBufferBindingTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.FrameBufferBindingTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.FrameBufferBindingTestCase.prototype.constructor = es3fIntegerStateQueryTests.FrameBufferBindingTestCase;
+
+	es3fIntegerStateQueryTests.FrameBufferBindingTestCase.prototype.test = function() {
+		this.check(glsStateQuery.verify(gl.DRAW_FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.READ_FRAMEBUFFER_BINDING, null));
+
+		/** @type {WebGLFramebuffer} */ var framebufferId = gl.createFramebuffer();
+
+		gl.bindFramebuffer(gl.FRAMEBUFFER, framebufferId);
+
+		this.check(glsStateQuery.verify(gl.DRAW_FRAMEBUFFER_BINDING,	framebufferId));
+		this.check(glsStateQuery.verify(gl.FRAMEBUFFER_BINDING,	framebufferId));
+		this.check(glsStateQuery.verify(gl.READ_FRAMEBUFFER_BINDING,	framebufferId));
+
+		gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+
+		this.check(glsStateQuery.verify(gl.DRAW_FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.READ_FRAMEBUFFER_BINDING, null));
+
+		gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebufferId);
+
+		this.check(glsStateQuery.verify(gl.DRAW_FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.READ_FRAMEBUFFER_BINDING,	framebufferId));
+
+		gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebufferId);
+
+		this.check(glsStateQuery.verify(gl.DRAW_FRAMEBUFFER_BINDING,	framebufferId));
+		this.check(glsStateQuery.verify(gl.FRAMEBUFFER_BINDING,	framebufferId));
+		this.check(glsStateQuery.verify(gl.READ_FRAMEBUFFER_BINDING,	framebufferId));
+
+		gl.deleteFramebuffer(framebufferId);
+
+		this.check(glsStateQuery.verify(gl.DRAW_FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.FRAMEBUFFER_BINDING, null));
+		this.check(glsStateQuery.verify(gl.READ_FRAMEBUFFER_BINDING, null));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.ImplementationColorReadTestCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.ImplementationColorReadTestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ImplementationColorReadTestCase.prototype.constructor = es3fIntegerStateQueryTests.ImplementationColorReadTestCase;
+
+	es3fIntegerStateQueryTests.ImplementationColorReadTestCase.prototype.test = function() {
+		/** @type {Array<number>} */ var defaultColorTypes = [
+			gl.UNSIGNED_BYTE, gl.BYTE, gl.UNSIGNED_SHORT, gl.SHORT,
+			gl.UNSIGNED_INT, gl.INT, gl.HALF_FLOAT, gl.FLOAT, gl.UNSIGNED_SHORT_5_6_5,
+			gl.UNSIGNED_SHORT_4_4_4_4, gl.UNSIGNED_SHORT_5_5_5_1,
+			gl.UNSIGNED_INT_2_10_10_10_REV, gl.UNSIGNED_INT_10F_11F_11F_REV
+		];
+
+		/** @type {Array<number>} */ var defaultColorFormats = [
+			gl.RGBA, gl.RGBA_INTEGER, gl.RGB, gl.RGB_INTEGER,
+			gl.RG, gl.RG_INTEGER, gl.RED, gl.RED_INTEGER
+		];
+
+		/** @type {Array<number>} */ var validColorTypes = [];
+		/** @type {Array<number>} */ var validColorFormats = [];
+
+		// Defined by the spec
+
+		for (var ndx = 0; ndx < defaultColorTypes.length; ++ndx)
+			validColorTypes.push(defaultColorTypes[ndx]);
+		for (var ndx = 0; ndx < defaultColorFormats.length; ++ndx)
+			validColorFormats.push(defaultColorFormats[ndx]);
+
+		// Extensions
+
+		// if (this.m_context.getContextInfo().isExtensionSupported("gl.EXT_texture_format_BGRA8888") ||
+		// 	this.m_context.getContextInfo().isExtensionSupported("gl.APPLE_texture_format_BGRA8888"))
+		// 	validColorFormats.push(gl.BGRA);
+		//
+		// if (this.m_context.getContextInfo().isExtensionSupported("gl.EXT_read_format_bgra")) {
+		// 	validColorFormats.push(gl.BGRA);
+		// 	validColorTypes.push(gl.UNSIGNED_SHORT_4_4_4_4_REV);
+		// 	validColorTypes.push(gl.UNSIGNED_SHORT_1_5_5_5_REV);
+		// }
+		//
+		// if (this.m_context.getContextInfo().isExtensionSupported("gl.IMG_read_format")) {
+		// 	validColorFormats.push(gl.BGRA);
+		// 	validColorTypes.push(gl.UNSIGNED_SHORT_4_4_4_4_REV);
+		// }
+		//
+		// if (this.m_context.getContextInfo().isExtensionSupported("gl.NV_sRGB_formats")) {
+		// 	validColorFormats.push(gl.SLUMINANCE_NV);
+		// 	validColorFormats.push(gl.SLUMINANCE_ALPHA_NV);
+		// }
+		//
+		// if (this.m_context.getContextInfo().isExtensionSupported("gl.NV_bgr")) {
+		// 	validColorFormats.push(gl.BGR_NV);
+		// }
+
+		this.check(glsStateQuery.verifyAnyOf(gl.IMPLEMENTATION_COLOR_READ_TYPE, validColorTypes));
+		this.check(glsStateQuery.verifyAnyOf(gl.IMPLEMENTATION_COLOR_READ_FORMAT, validColorFormats));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.ReadBufferCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.ReadBufferCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ReadBufferCase.prototype.constructor = es3fIntegerStateQueryTests.ReadBufferCase;
+
+	es3fIntegerStateQueryTests.ReadBufferCase.prototype.test = function() {
+		/** @type {Array<number>} */ var validInitialValues = [gl.BACK, gl.NONE];
+		this.check(glsStateQuery.verifyAnyOf(gl.READ_BUFFER, validInitialValues));
+
+		gl.readBuffer(gl.NONE);
+		this.check(glsStateQuery.verify(gl.READ_BUFFER, gl.NONE));
+
+		gl.readBuffer(gl.BACK);
+		this.check(glsStateQuery.verify(gl.READ_BUFFER, gl.BACK));
+
+		// test gl.READ_BUFFER with framebuffers
+
+		/** @type {WebGLFramebuffer} */ var framebufferId = gl.createFramebuffer();
+
+		/** @type {WebGLRenderbuffer} */ var renderbuffer_id = gl.createRenderbuffer();
+
+		gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer_id);
+
+		gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, 128, 128);
+
+		gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebufferId);
+
+		gl.framebufferRenderbuffer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, renderbuffer_id);
+
+		this.check(glsStateQuery.verify(gl.READ_BUFFER, gl.COLOR_ATTACHMENT0));
+
+		gl.deleteFramebuffer(framebufferId);
+		gl.deleteRenderbuffer(renderbuffer_id);
+
+		this.check(glsStateQuery.verify(gl.READ_BUFFER, gl.BACK));
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 */
+	es3fIntegerStateQueryTests.DrawBufferCase = function(name, description) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+	};
+
+	es3fIntegerStateQueryTests.DrawBufferCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.DrawBufferCase.prototype.constructor = es3fIntegerStateQueryTests.DrawBufferCase;
+
+	es3fIntegerStateQueryTests.DrawBufferCase.prototype.test = function() {
+		/** @type {Array<number>} */ var validInitialValues = [gl.BACK, gl.NONE];
+		this.check(glsStateQuery.verifyAnyOf(gl.DRAW_BUFFER0, validInitialValues));
+
+		/** @type {number} */ var bufs = gl.NONE;
+		gl.drawBuffers([bufs]);
+		this.check(glsStateQuery.verify(gl.DRAW_BUFFER0, gl.NONE));
+
+		bufs = gl.BACK;
+		gl.drawBuffers([bufs]);
+		this.check(glsStateQuery.verify(gl.DRAW_BUFFER0, gl.BACK));
+
+		// test gl.DRAW_BUFFER with framebuffers
+
+		/** @type {WebGLFramebuffer} */ var framebufferId = gl.createFramebuffer();
+
+		/** @type {Array<WebGLRenderbuffer>} */ var renderbuffer_ids = [];
+
+		for (var ndx = 0; ndx < 2; ndx++)
+			renderbuffer_ids[ndx] = gl.createRenderbuffer();
+
+		gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer_ids[0]);
+		gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, 128, 128);
+
+		gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer_ids[1]);
+		gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, 128, 128);
+
+		gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebufferId);
+
+		gl.framebufferRenderbuffer(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, renderbuffer_ids[0]);
+		gl.framebufferRenderbuffer(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.RENDERBUFFER, renderbuffer_ids[1]);
+
+		// only the initial state the draw buffer for fragment color zero is defined
+		this.check(glsStateQuery.verify(gl.DRAW_BUFFER0, gl.COLOR_ATTACHMENT0));
+
+		/** @type {Array<number>} */ var bufTargets = [gl.NONE, gl.COLOR_ATTACHMENT1];
+		gl.drawBuffers(bufTargets);
+		this.check(glsStateQuery.verify(gl.DRAW_BUFFER0, gl.NONE));
+		this.check(glsStateQuery.verify(gl.DRAW_BUFFER1, gl.COLOR_ATTACHMENT1));
+
+		gl.deleteFramebuffer(framebufferId);
+		gl.deleteRenderbuffer(renderbuffer_ids[0]);
+		gl.deleteRenderbuffer(renderbuffer_ids[1]);
+
+		this.check(glsStateQuery.verify(gl.DRAW_BUFFER0, gl.BACK));
+	};
+
+	// Integer64
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} targetName
+	 * @param {number} minValue
+	 */
+	es3fIntegerStateQueryTests.ConstantMinimumValue64TestCase = function(name, description, targetName, minValue) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_targetName = targetName;
+		/** @type {number} */ this.m_minValue = minValue;
+	};
+
+	es3fIntegerStateQueryTests.ConstantMinimumValue64TestCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.ConstantMinimumValue64TestCase.prototype.constructor = es3fIntegerStateQueryTests.ConstantMinimumValue64TestCase;
+
+	es3fIntegerStateQueryTests.ConstantMinimumValue64TestCase.prototype.test = function() {
+		this.check(glsStateQuery.verifyGreaterOrEqual(this.m_targetName, this.m_minValue), 'Fail');
+	};
+
+	/**
+	 * @constructor
+	 * @extends {es3fApiCase.ApiCase}
+	 * @param {string} name
+	 * @param {string} description
+	 * @param {number} targetName
+	 * @param {number} targetMaxUniformBlocksName
+	 * @param {number} targetMaxUniformComponentsName
+	 */
+	es3fIntegerStateQueryTests.MaxCombinedStageUniformComponentsCase = function(name, description, targetName, targetMaxUniformBlocksName, targetMaxUniformComponentsName) {
+		es3fApiCase.ApiCase.call(this, name, description, gl);
+		/** @type {number} */ this.m_targetName = targetName;
+		/** @type {number} */ this.m_targetMaxUniformBlocksName = targetMaxUniformBlocksName;
+		/** @type {number} */ this.m_targetMaxUniformComponentsName = targetMaxUniformComponentsName;
+	};
+
+	es3fIntegerStateQueryTests.MaxCombinedStageUniformComponentsCase.prototype = Object.create(es3fApiCase.ApiCase.prototype);
+	es3fIntegerStateQueryTests.MaxCombinedStageUniformComponentsCase.prototype.constructor = es3fIntegerStateQueryTests.MaxCombinedStageUniformComponentsCase;
+
+	es3fIntegerStateQueryTests.MaxCombinedStageUniformComponentsCase.prototype.test = function() {
+		/** @type {number} */ var uniformBlockSize = /** @type {number} */ (gl.getParameter(gl.MAX_UNIFORM_BLOCK_SIZE));
+		/** @type {number} */ var maxUniformBlocks = /** @type {number} */ (gl.getParameter(this.m_targetMaxUniformBlocksName));
+		/** @type {number} */ var maxUniformComponents = /** @type {number} */ (gl.getParameter(this.m_targetMaxUniformComponentsName));
+
+		// MAX_stage_UNIFORM_BLOCKS * MAX_UNIFORM_BLOCK_SIZE / 4 + MAX_stage_UNIFORM_COMPONENTS
+		/** @type {number} */ var minCombinedUniformComponents = maxUniformBlocks * uniformBlockSize / 4 + maxUniformComponents;
+
+		this.check(glsStateQuery.verifyGreaterOrEqual(this.m_targetName, minCombinedUniformComponents));
+	};
+
+    /**
+    * @constructor
+    * @extends {tcuTestCase.DeqpTest}
+    */
+    es3fIntegerStateQueryTests.IntegerStateQueryTests = function() {
+        tcuTestCase.DeqpTest.call(this, 'integers', 'Integer Values');
+    };
+
+    es3fIntegerStateQueryTests.IntegerStateQueryTests.prototype = Object.create(tcuTestCase.DeqpTest.prototype);
+    es3fIntegerStateQueryTests.IntegerStateQueryTests.prototype.constructor = es3fIntegerStateQueryTests.IntegerStateQueryTests;
+
+    es3fIntegerStateQueryTests.IntegerStateQueryTests.prototype.init = function() {
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} targetName
+		 * @param {number} value
+		 */
+		var LimitedStateInteger = function(name, description, targetName, value) {
+			/** @type {string} */ this.name = name;
+			/** @type {string} */ this.description = description;
+			/** @type {number} */ this.targetName = targetName;
+			/** @type {number} */ this.value = value;
+		};
+
+		/** @type {Array<LimitedStateInteger>} */ var implementationMinLimits = [
+			new LimitedStateInteger('subpixel_bits', 'SUBPIXEL_BITS has minimum value of 4', gl.SUBPIXEL_BITS, 4),
+			new LimitedStateInteger('max_3d_texture_size', 'MAX_3D_TEXTURE_SIZE has minimum value of 256', gl.MAX_3D_TEXTURE_SIZE, 256),
+			new LimitedStateInteger('max_texture_size', 'MAX_TEXTURE_SIZE has minimum value of 2048', gl.MAX_TEXTURE_SIZE, 2048),
+			new LimitedStateInteger('max_array_texture_layers', 'MAX_ARRAY_TEXTURE_LAYERS has minimum value of 256', gl.MAX_ARRAY_TEXTURE_LAYERS, 256),
+			new LimitedStateInteger('max_cube_map_texture_size', 'MAX_CUBE_MAP_TEXTURE_SIZE has minimum value of 2048', gl.MAX_CUBE_MAP_TEXTURE_SIZE, 2048),
+			new LimitedStateInteger('max_renderbuffer_size', 'MAX_RENDERBUFFER_SIZE has minimum value of 2048', gl.MAX_RENDERBUFFER_SIZE, 2048),
+			new LimitedStateInteger('max_draw_buffers', 'MAX_DRAW_BUFFERS has minimum value of 4', gl.MAX_DRAW_BUFFERS, 4),
+			new LimitedStateInteger('max_color_attachments', 'MAX_COLOR_ATTACHMENTS has minimum value of 4', gl.MAX_COLOR_ATTACHMENTS, 4),
+			new LimitedStateInteger('max_elements_indices', 'MAX_ELEMENTS_INDICES has minimum value of 0', gl.MAX_ELEMENTS_INDICES, 0),
+			new LimitedStateInteger('max_elements_vertices', 'MAX_ELEMENTS_VERTICES has minimum value of 0', gl.MAX_ELEMENTS_VERTICES, 0),
+			new LimitedStateInteger('max_vertex_attribs', 'MAX_VERTEX_ATTRIBS has minimum value of 16', gl.MAX_VERTEX_ATTRIBS, 16),
+			new LimitedStateInteger('max_vertex_uniform_components', 'MAX_VERTEX_UNIFORM_COMPONENTS has minimum value of 1024', gl.MAX_VERTEX_UNIFORM_COMPONENTS, 1024),
+			new LimitedStateInteger('max_vertex_uniform_vectors', 'MAX_VERTEX_UNIFORM_VECTORS has minimum value of 256', gl.MAX_VERTEX_UNIFORM_VECTORS, 256),
+			new LimitedStateInteger('max_vertex_uniform_blocks', 'MAX_VERTEX_UNIFORM_BLOCKS has minimum value of 12', gl.MAX_VERTEX_UNIFORM_BLOCKS, 12),
+			new LimitedStateInteger('max_vertex_output_components', 'MAX_VERTEX_OUTPUT_COMPONENTS has minimum value of 64', gl.MAX_VERTEX_OUTPUT_COMPONENTS, 64),
+			new LimitedStateInteger('max_vertex_texture_image_units', 'MAX_VERTEX_TEXTURE_IMAGE_UNITS has minimum value of 16', gl.MAX_VERTEX_TEXTURE_IMAGE_UNITS, 16),
+			new LimitedStateInteger('max_fragment_uniform_components', 'MAX_FRAGMENT_UNIFORM_COMPONENTS has minimum value of 896', gl.MAX_FRAGMENT_UNIFORM_COMPONENTS, 896),
+			new LimitedStateInteger('max_fragment_uniform_vectors', 'MAX_FRAGMENT_UNIFORM_VECTORS has minimum value of 224', gl.MAX_FRAGMENT_UNIFORM_VECTORS, 224),
+			new LimitedStateInteger('max_fragment_uniform_blocks', 'MAX_FRAGMENT_UNIFORM_BLOCKS has minimum value of 12', gl.MAX_FRAGMENT_UNIFORM_BLOCKS, 12),
+			new LimitedStateInteger('max_fragment_input_components', 'MAX_FRAGMENT_INPUT_COMPONENTS has minimum value of 60', gl.MAX_FRAGMENT_INPUT_COMPONENTS, 60),
+			new LimitedStateInteger('max_texture_image_units', 'MAX_TEXTURE_IMAGE_UNITS has minimum value of 16', gl.MAX_TEXTURE_IMAGE_UNITS, 16),
+			new LimitedStateInteger('max_program_texel_offset', 'MAX_PROGRAM_TEXEL_OFFSET has minimum value of 7', gl.MAX_PROGRAM_TEXEL_OFFSET, 7),
+			new LimitedStateInteger('max_uniform_buffer_bindings', 'MAX_UNIFORM_BUFFER_BINDINGS has minimum value of 24', gl.MAX_UNIFORM_BUFFER_BINDINGS, 24),
+			new LimitedStateInteger('max_combined_uniform_blocks', 'MAX_COMBINED_UNIFORM_BLOCKS has minimum value of 24', gl.MAX_COMBINED_UNIFORM_BLOCKS, 24),
+			new LimitedStateInteger('max_varying_components', 'MAX_VARYING_COMPONENTS has minimum value of 60', gl.MAX_VARYING_COMPONENTS, 60),
+			new LimitedStateInteger('max_varying_vectors', 'MAX_VARYING_VECTORS has minimum value of 15', gl.MAX_VARYING_VECTORS, 15),
+			new LimitedStateInteger('max_combined_texture_image_units', 'MAX_COMBINED_TEXTURE_IMAGE_UNITS has minimum value of 32', gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS, 32),
+			new LimitedStateInteger('max_transform_feedback_interleaved_components', 'MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS has minimum value of 64', gl.MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS, 64),
+			new LimitedStateInteger('max_transform_feedback_separate_attribs', 'MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS has minimum value of 4', gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS, 4),
+			new LimitedStateInteger('max_transform_feedback_separate_components', 'MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS has minimum value of 4', gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS, 4),
+			new LimitedStateInteger('max_samples', 'MAX_SAMPLES has minimum value of 4', gl.MAX_SAMPLES, 4),
+			new LimitedStateInteger('red_bits', 'RED_BITS has minimum value of 0', gl.RED_BITS, 0),
+			new LimitedStateInteger('green_bits', 'GREEN_BITS has minimum value of 0', gl.GREEN_BITS, 0),
+			new LimitedStateInteger('blue_bits', 'BLUE_BITS has minimum value of 0', gl.BLUE_BITS, 0),
+			new LimitedStateInteger('alpha_bits', 'ALPHA_BITS has minimum value of 0', gl.ALPHA_BITS, 0),
+			new LimitedStateInteger('depth_bits', 'DEPTH_BITS has minimum value of 0', gl.DEPTH_BITS, 0),
+			new LimitedStateInteger('stencil_bits', 'STENCIL_BITS has minimum value of 0', gl.STENCIL_BITS, 0)
+		];
+
+		/** @type {Array<LimitedStateInteger>} */ var implementationMaxLimits = [
+			new LimitedStateInteger('min_program_texel_offset', 'MIN_PROGRAM_TEXEL_OFFSET has maximum value of -8', gl.MIN_PROGRAM_TEXEL_OFFSET, -8),
+			new LimitedStateInteger('uniform_buffer_offset_alignment', 'UNIFORM_BUFFER_OFFSET_ALIGNMENT has minimum value of 1', gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT, 256)
+		];
+
+		var testCtx = this;
+
+		for (var testNdx = 0; testNdx < implementationMinLimits.length; testNdx++)
+			testCtx.addChild(new es3fIntegerStateQueryTests.ConstantMinimumValueTestCase(implementationMinLimits[testNdx].name, implementationMinLimits[testNdx].description, implementationMinLimits[testNdx].targetName, implementationMinLimits[testNdx].value));
+
+		for (var testNdx = 0; testNdx < implementationMaxLimits.length; testNdx++)
+			testCtx.addChild(new es3fIntegerStateQueryTests.ConstantMaximumValueTestCase(implementationMaxLimits[testNdx].name, implementationMaxLimits[testNdx].description, implementationMaxLimits[testNdx].targetName, implementationMaxLimits[testNdx].value));
+
+		testCtx.addChild(new es3fIntegerStateQueryTests.SampleBuffersTestCase('sample_buffers', 'SAMPLE_BUFFERS'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.SamplesTestCase('samples' , 'SAMPLES'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.HintTestCase('generate_mipmap_hint', 'GENERATE_MIPMAP_HINT', gl.GENERATE_MIPMAP_HINT));
+		testCtx.addChild(new es3fIntegerStateQueryTests.HintTestCase('fragment_shader_derivative_hint', 'FRAGMENT_SHADER_DERIVATIVE_HINT', gl.FRAGMENT_SHADER_DERIVATIVE_HINT));
+		testCtx.addChild(new es3fIntegerStateQueryTests.DepthFuncTestCase('depth_func', 'DEPTH_FUNC'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.CullFaceTestCase('cull_face_mode', 'CULL_FACE_MODE'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.FrontFaceTestCase('front_face_mode', 'FRONT_FACE'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.ViewPortTestCase('viewport', 'VIEWPORT'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.ScissorBoxTestCase('scissor_box', 'SCISSOR_BOX'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.MaxViewportDimsTestCase('max_viewport_dims', 'MAX_VIEWPORT_DIMS'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilRefTestCase('stencil_ref', 'STENCIL_REF', gl.STENCIL_REF));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilRefTestCase('stencil_back_ref', 'STENCIL_BACK_REF', gl.STENCIL_BACK_REF));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilRefSeparateTestCase('stencil_ref_separate', 'STENCIL_REF (separate)', gl.STENCIL_REF, gl.FRONT));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilRefSeparateTestCase('stencil_ref_separate_both', 'STENCIL_REF (separate)', gl.STENCIL_REF, gl.FRONT_AND_BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilRefSeparateTestCase('stencil_back_ref_separate', 'STENCIL_BACK_REF (separate)', gl.STENCIL_BACK_REF, gl.BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilRefSeparateTestCase('stencil_back_ref_separate_both', 'STENCIL_BACK_REF (separate)', gl.STENCIL_BACK_REF, gl.FRONT_AND_BACK));
+
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} frontDescription
+		 * @param {number} frontTarget
+		 * @param {string} backDescription
+		 * @param {number} backTarget
+		 */
+		 var NamedStencilOp = function(name, frontDescription, frontTarget, backDescription, backTarget) {
+			/** @type {string} */ this.name = name;
+    		/** @type {string} */ this.frontDescription = frontDescription;
+    		/** @type {number} */ this.frontTarget = frontTarget;
+    		/** @type {string} */ this.backDescription = backDescription;
+    		/** @type {number} */ this.backTarget = backTarget;
+		};
+
+		/** @type {Array<NamedStencilOp>} */ var stencilOps = [
+			new NamedStencilOp('fail', 'STENCIL_FAIL', gl.STENCIL_FAIL, 'STENCIL_BACK_FAIL', gl.STENCIL_BACK_FAIL),
+			new NamedStencilOp('depth_fail', 'STENCIL_PASS_DEPTH_FAIL', gl.STENCIL_PASS_DEPTH_FAIL, 'STENCIL_BACK_PASS_DEPTH_FAIL', gl.STENCIL_BACK_PASS_DEPTH_FAIL),
+			new NamedStencilOp('depth_pass', 'STENCIL_PASS_DEPTH_PASS', gl.STENCIL_PASS_DEPTH_PASS, 'STENCIL_BACK_PASS_DEPTH_PASS', gl.STENCIL_BACK_PASS_DEPTH_PASS)
+		];
+
+		for (var testNdx = 0; testNdx < stencilOps.length; testNdx++) {
+			testCtx.addChild(new es3fIntegerStateQueryTests.StencilOpTestCase('stencil_' + stencilOps[testNdx].name, stencilOps[testNdx].frontDescription, stencilOps[testNdx].frontTarget));
+			testCtx.addChild(new es3fIntegerStateQueryTests.StencilOpTestCase('stencil_back_' + stencilOps[testNdx].name, stencilOps[testNdx].backDescription, stencilOps[testNdx].backTarget));
+
+			testCtx.addChild(new es3fIntegerStateQueryTests.StencilOpSeparateTestCase('stencil_' + stencilOps[testNdx].name + '_separate_both', stencilOps[testNdx].frontDescription, stencilOps[testNdx].frontTarget, gl.FRONT_AND_BACK));
+			testCtx.addChild(new es3fIntegerStateQueryTests.StencilOpSeparateTestCase('stencil_back_' + stencilOps[testNdx].name + '_separate_both', stencilOps[testNdx].backDescription, stencilOps[testNdx].backTarget, gl.FRONT_AND_BACK));
+
+			testCtx.addChild(new es3fIntegerStateQueryTests.StencilOpSeparateTestCase('stencil_' + stencilOps[testNdx].name + '_separate', stencilOps[testNdx].frontDescription, stencilOps[testNdx].frontTarget, gl.FRONT));
+			testCtx.addChild(new es3fIntegerStateQueryTests.StencilOpSeparateTestCase('stencil_back_' + stencilOps[testNdx].name + '_separate', stencilOps[testNdx].backDescription, stencilOps[testNdx].backTarget, gl.BACK));
+		}
+
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilFuncTestCase('stencil_func', 'STENCIL_FUNC'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilFuncSeparateTestCase('stencil_func_separate', 'STENCIL_FUNC (separate)', gl.STENCIL_FUNC, gl.FRONT));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilFuncSeparateTestCase('stencil_func_separate_both', 'STENCIL_FUNC (separate)', gl.STENCIL_FUNC, gl.FRONT_AND_BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilFuncSeparateTestCase('stencil_back_func_separate', 'STENCIL_FUNC (separate)', gl.STENCIL_BACK_FUNC, gl.BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilFuncSeparateTestCase('stencil_back_func_separate_both', 'STENCIL_FUNC (separate)', gl.STENCIL_BACK_FUNC, gl.FRONT_AND_BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilMaskTestCase('stencil_value_mask', 'STENCIL_VALUE_MASK', gl.STENCIL_VALUE_MASK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilMaskTestCase('stencil_back_value_mask', 'STENCIL_BACK_VALUE_MASK', gl.STENCIL_BACK_VALUE_MASK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilMaskSeparateTestCase('stencil_value_mask_separate', 'STENCIL_VALUE_MASK (separate)', gl.STENCIL_VALUE_MASK, gl.FRONT));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilMaskSeparateTestCase('stencil_value_mask_separate_both', 'STENCIL_VALUE_MASK (separate)', gl.STENCIL_VALUE_MASK, gl.FRONT_AND_BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilMaskSeparateTestCase('stencil_back_value_mask_separate', 'STENCIL_BACK_VALUE_MASK (separate)', gl.STENCIL_BACK_VALUE_MASK, gl.BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilMaskSeparateTestCase('stencil_back_value_mask_separate_both', 'STENCIL_BACK_VALUE_MASK (separate)', gl.STENCIL_BACK_VALUE_MASK, gl.FRONT_AND_BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilWriteMaskTestCase('stencil_writemask', 'STENCIL_WRITEMASK', gl.STENCIL_WRITEMASK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilWriteMaskTestCase('stencil_back_writemask', 'STENCIL_BACK_WRITEMASK', gl.STENCIL_BACK_WRITEMASK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase('stencil_writemask_separate', 'STENCIL_WRITEMASK (separate)', gl.STENCIL_WRITEMASK, gl.FRONT));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase('stencil_writemask_separate_both', 'STENCIL_WRITEMASK (separate)', gl.STENCIL_WRITEMASK, gl.FRONT_AND_BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase('stencil_back_writemask_separate', 'STENCIL_BACK_WRITEMASK (separate)', gl.STENCIL_BACK_WRITEMASK, gl.BACK));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilWriteMaskSeparateTestCase('stencil_back_writemask_separate_both', 'STENCIL_BACK_WRITEMASK (separate)', gl.STENCIL_BACK_WRITEMASK, gl.FRONT_AND_BACK));
+
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} target
+		 * @param {number} initialValue
+		 */
+		var PixelStoreState = function(name, description, target, initialValue) {
+		    /** @type {string} */ this.name = name;
+		    /** @type {string} */ this.description = description;
+		    /** @type {number} */ this.target = target;
+		    /** @type {number} */ this.initialValue = initialValue;
+		};
+
+		/** @type {Array<PixelStoreState>} */ var pixelStoreStates = [
+			new PixelStoreState('unpack_image_height', 'UNPACK_IMAGE_HEIGHT', gl.UNPACK_IMAGE_HEIGHT, 0),
+			new PixelStoreState('unpack_skip_images', 'UNPACK_SKIP_IMAGES', gl.UNPACK_SKIP_IMAGES, 0),
+			new PixelStoreState('unpack_row_length', 'UNPACK_ROW_LENGTH', gl.UNPACK_ROW_LENGTH, 0),
+			new PixelStoreState('unpack_skip_rows', 'UNPACK_SKIP_ROWS', gl.UNPACK_SKIP_ROWS, 0),
+			new PixelStoreState('unpack_skip_pixels', 'UNPACK_SKIP_PIXELS', gl.UNPACK_SKIP_PIXELS, 0),
+			new PixelStoreState('pack_row_length', 'PACK_ROW_LENGTH', gl.PACK_ROW_LENGTH, 0),
+			new PixelStoreState('pack_skip_rows', 'PACK_SKIP_ROWS', gl.PACK_SKIP_ROWS, 0),
+			new PixelStoreState('pack_skip_pixels', 'PACK_SKIP_PIXELS', gl.PACK_SKIP_PIXELS, 0)
+		];
+
+		for (var testNdx = 0; testNdx < pixelStoreStates.length; testNdx++)
+			testCtx.addChild(new es3fIntegerStateQueryTests.PixelStoreTestCase(pixelStoreStates[testNdx].name, pixelStoreStates[testNdx].description, pixelStoreStates[testNdx].target, pixelStoreStates[testNdx].initialValue));
+
+		testCtx.addChild(new es3fIntegerStateQueryTests.PixelStoreAlignTestCase('unpack_alignment', 'UNPACK_ALIGNMENT', gl.UNPACK_ALIGNMENT));
+		testCtx.addChild(new es3fIntegerStateQueryTests.PixelStoreAlignTestCase('pack_alignment', 'PACK_ALIGNMENT', gl.PACK_ALIGNMENT));
+
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} target
+		 * @param {number} initialValue
+		 */
+		var BlendColorState = function(name, description, target, initialValue) {
+		    /** @type {string} */ this.name = name;
+		    /** @type {string} */ this.description = description;
+		    /** @type {number} */ this.target = target;
+		    /** @type {number} */ this.initialValue = initialValue;
+		};
+
+		/** @type {Array<PixelStoreState>} */ var blendColorStates = [
+			new BlendColorState('blend_src_rgb', 'BLEND_SRC_RGB', gl.BLEND_SRC_RGB, gl.ONE),
+			new BlendColorState('blend_src_alpha', 'BLEND_SRC_ALPHA', gl.BLEND_SRC_ALPHA, gl.ONE),
+			new BlendColorState('blend_dst_rgb', 'BLEND_DST_RGB', gl.BLEND_DST_RGB, gl.ZERO),
+			new BlendColorState('blend_dst_alpha', 'BLEND_DST_ALPHA', gl.BLEND_DST_ALPHA, gl.ZERO)
+		];
+
+		for (var testNdx = 0; testNdx < blendColorStates.length; testNdx++) {
+			testCtx.addChild(new es3fIntegerStateQueryTests.BlendFuncTestCase(blendColorStates[testNdx].name, blendColorStates[testNdx].description, blendColorStates[testNdx].target, blendColorStates[testNdx].initialValue));
+			testCtx.addChild(new es3fIntegerStateQueryTests.BlendFuncSeparateTestCase(blendColorStates[testNdx].name + '_separate', blendColorStates[testNdx].description, blendColorStates[testNdx].target, blendColorStates[testNdx].initialValue));
+		}
+
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} target
+		 * @param {number} initialValue
+		 */
+		var BlendEquationState = function(name, description, target, initialValue) {
+		    /** @type {string} */ this.name = name;
+		    /** @type {string} */ this.description = description;
+		    /** @type {number} */ this.target = target;
+		    /** @type {number} */ this.initialValue = initialValue;
+		};
+
+		/** @type {Array<PixelStoreState>} */ var blendEquationStates = [
+			new BlendEquationState('blend_equation_rgb', 'BLEND_EQUATION_RGB', gl.BLEND_EQUATION_RGB, gl.FUNC_ADD),
+			new BlendEquationState('blend_equation_alpha', 'BLEND_EQUATION_ALPHA', gl.BLEND_EQUATION_ALPHA, gl.FUNC_ADD)
+		];
+
+		for (var testNdx = 0; testNdx < blendEquationStates.length; testNdx++) {
+			testCtx.addChild(new es3fIntegerStateQueryTests.BlendEquationTestCase(blendEquationStates[testNdx].name, blendEquationStates[testNdx].description, blendEquationStates[testNdx].target, blendEquationStates[testNdx].initialValue));
+			testCtx.addChild(new es3fIntegerStateQueryTests.BlendEquationSeparateTestCase(blendEquationStates[testNdx].name + '_separate', blendEquationStates[testNdx].description, blendEquationStates[testNdx].target, blendEquationStates[testNdx].initialValue));
+		}
+
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} target
+		 * @param {number} minValue
+		 */
+		var ImplementationArrayReturningState = function(name, description, target, minValue) {
+		    /** @type {string} */ this.name = name;
+		    /** @type {string} */ this.description = description;
+		    /** @type {number} */ this.target = target;
+		    /** @type {number} */ this.minValue = minValue;
+		};
+
+		/** @type {ImplementationArrayReturningState} */ var implementationArrayReturningStates = new ImplementationArrayReturningState('compressed_texture_formats', 'COMPRESSED_TEXTURE_FORMATS', gl.COMPRESSED_TEXTURE_FORMATS, 10);
+
+		testCtx.addChild(new es3fIntegerStateQueryTests.ImplementationArrayTestCase(implementationArrayReturningStates.name, implementationArrayReturningStates.description, implementationArrayReturningStates.target, implementationArrayReturningStates.minValue));
+
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} target
+		 * @param {number} type
+		 */
+		var BufferBindingState = function(name, description, target, type) {
+			/** @type {string} */ this.name = name;
+			/** @type {string} */ this.description = description;
+			/** @type {number} */ this.target = target;
+			/** @type {number} */ this.type = type;
+		};
+
+		/** @type {Array<BufferBindingState>} */ var bufferBindingStates = [
+			new BufferBindingState('array_buffer_binding', 'ARRAY_BUFFER_BINDING', gl.ARRAY_BUFFER_BINDING, gl.ARRAY_BUFFER),
+			new BufferBindingState('uniform_buffer_binding', 'UNIFORM_BUFFER_BINDING', gl.UNIFORM_BUFFER_BINDING, gl.UNIFORM_BUFFER),
+			new BufferBindingState('pixel_pack_buffer_binding', 'PIXEL_PACK_BUFFER_BINDING', gl.PIXEL_PACK_BUFFER_BINDING, gl.PIXEL_PACK_BUFFER),
+			new BufferBindingState('pixel_unpack_buffer_binding', 'PIXEL_UNPACK_BUFFER_BINDING', gl.PIXEL_UNPACK_BUFFER_BINDING, gl.PIXEL_UNPACK_BUFFER),
+			new BufferBindingState('transform_feedback_buffer_binding', 'TRANSFORM_FEEDBACK_BUFFER_BINDING', gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, gl.TRANSFORM_FEEDBACK_BUFFER),
+			new BufferBindingState('copy_read_buffer_binding', 'COPY_READ_BUFFER_BINDING', gl.COPY_READ_BUFFER_BINDING, gl.COPY_READ_BUFFER),
+			new BufferBindingState('copy_write_buffer_binding', 'COPY_WRITE_BUFFER_BINDING', gl.COPY_WRITE_BUFFER_BINDING, gl.COPY_WRITE_BUFFER)
+		];
+
+		for (var testNdx = 0; testNdx < bufferBindingStates.length; testNdx++)
+			testCtx.addChild(new es3fIntegerStateQueryTests.BufferBindingTestCase(bufferBindingStates[testNdx].name, bufferBindingStates[testNdx].description, bufferBindingStates[testNdx].target, bufferBindingStates[testNdx].type));
+
+		testCtx.addChild(new es3fIntegerStateQueryTests.ElementArrayBufferBindingTestCase('element_array_buffer_binding'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase('transform_feedback_binding'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.TransformFeedbackBindingTestCase('transform_feedback_binding'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.CurrentProgramBindingTestCase('current_program_binding', 'CURRENT_PROGRAM'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.VertexArrayBindingTestCase('vertex_array_binding', 'VERTEX_ARRAY_BINDING'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.StencilClearValueTestCase('stencil_clear_value', 'STENCIL_CLEAR_VALUE'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.ActiveTextureTestCase('active_texture', 'ACTIVE_TEXTURE'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.RenderbufferBindingTestCase('renderbuffer_binding', 'RENDERBUFFER_BINDING'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.SamplerObjectBindingTestCase('sampler_binding', 'SAMPLER_BINDING'));
+
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} target
+		 * @param {number} type
+		 */
+		var TextureBinding = function(name, description, target, type) {
+			/** @type {string} */ this.name = name;
+			/** @type {string} */ this.description = description;
+			/** @type {number} */ this.target = target;
+			/** @type {number} */ this.type = type;
+		};
+
+		/** @type {Array<TextureBinding>} */ var textureBindings = [
+			new TextureBinding('texture_binding_2d', 'TEXTURE_BINDING_2D', gl.TEXTURE_BINDING_2D, gl.TEXTURE_2D),
+			new TextureBinding('texture_binding_3d', 'TEXTURE_BINDING_3D', gl.TEXTURE_BINDING_3D, gl.TEXTURE_3D),
+			new TextureBinding('texture_binding_2d_array', 'TEXTURE_BINDING_2D_ARRAY', gl.TEXTURE_BINDING_2D_ARRAY, gl.TEXTURE_2D_ARRAY),
+			new TextureBinding('texture_binding_cube_map', 'TEXTURE_BINDING_CUBE_MAP', gl.TEXTURE_BINDING_CUBE_MAP, gl.TEXTURE_CUBE_MAP)
+		];
+
+		for (var testNdx = 0; testNdx < textureBindings.length; testNdx++)
+			testCtx.addChild(new es3fIntegerStateQueryTests.TextureBindingTestCase(textureBindings[testNdx].name, textureBindings[testNdx].description, textureBindings[testNdx].target, textureBindings[testNdx].type));
+
+		testCtx.addChild(new es3fIntegerStateQueryTests.FrameBufferBindingTestCase('framebuffer_binding', 'DRAW_FRAMEBUFFER_BINDING and READ_FRAMEBUFFER_BINDING'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.ImplementationColorReadTestCase('implementation_color_read', 'IMPLEMENTATION_COLOR_READ_TYPE and IMPLEMENTATION_COLOR_READ_FORMAT'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.ReadBufferCase('read_buffer', 'READ_BUFFER'));
+		testCtx.addChild(new es3fIntegerStateQueryTests.DrawBufferCase('draw_buffer', 'DRAW_BUFFER'));
+
+
+		// Integer64
+		/**
+		 * @struct
+		 * @constructor
+		 * @param {string} name
+		 * @param {string} description
+		 * @param {number} targetName
+		 * @param {number} minValue
+		 */
+		var LimitedStateInteger64 = function(name, description, targetName, minValue) {
+			/** @type {string} */ this.name = name;
+			/** @type {string} */ this.description = description;
+			/** @type {number} */ this.targetName = targetName;
+			/** @type {number} */ this.minValue = minValue;
+
+		};
+
+		/** @type {Array<LimitedStateInteger64>} */ var implementationLimits = [
+			new LimitedStateInteger64('max_element_index', 'MAX_ELEMENT_INDEX', gl.MAX_ELEMENT_INDEX, 0x00FFFFFF),
+			new LimitedStateInteger64('max_server_wait_timeout', 'MAX_SERVER_WAIT_TIMEOUT', gl.MAX_SERVER_WAIT_TIMEOUT, 0),
+			new LimitedStateInteger64('max_uniform_block_size', 'MAX_UNIFORM_BLOCK_SIZE', gl.MAX_UNIFORM_BLOCK_SIZE, 16384)
+		];
+
+		for (var testNdx = 0; testNdx < implementationLimits.length; testNdx++)
+			this.addChild(new es3fIntegerStateQueryTests.ConstantMinimumValue64TestCase(implementationLimits[testNdx].name, implementationLimits[testNdx].description, implementationLimits[testNdx].targetName, implementationLimits[testNdx].minValue));
+
+		this.addChild(new es3fIntegerStateQueryTests.MaxCombinedStageUniformComponentsCase('max_combined_vertex_uniform_components', 'MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS', gl.MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS, gl.MAX_VERTEX_UNIFORM_BLOCKS, gl.MAX_VERTEX_UNIFORM_COMPONENTS));
+		this.addChild(new es3fIntegerStateQueryTests.MaxCombinedStageUniformComponentsCase('max_combined_fragment_uniform_components', 'MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS', gl.MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS, gl.MAX_FRAGMENT_UNIFORM_BLOCKS, gl.MAX_FRAGMENT_UNIFORM_COMPONENTS));
+
+	};
+
+    /**
+    * Run test
+    * @param {WebGL2RenderingContext} context
+    */
+    es3fIntegerStateQueryTests.run = function(context) {
+    	gl = context;
+    	//Set up Test Root parameters
+    	var state = tcuTestCase.runner;
+    	state.setRoot(new es3fIntegerStateQueryTests.IntegerStateQueryTests());
+
+    	//Set up name and description of this test series.
+    	setCurrentTestName(state.testCases.fullName());
+    	description(state.testCases.getDescription());
+
+    	try {
+    		//Run test cases
+    		tcuTestCase.runTestCases();
+    	}
+    	catch (err) {
+    		testFailedOptions('Failed to es3fIntegerStateQueryTests.run tests', false);
+    		tcuTestCase.runner.terminate();
+    	}
+    };
+
+});

--- a/sdk/tests/deqp/functional/gles3/es3fSamplerStateQueryTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fSamplerStateQueryTests.js
@@ -1,0 +1,205 @@
+/*-------------------------------------------------------------------------
+ * drawElements Quality Program OpenGL ES Utilities
+ * ------------------------------------------------
+ *
+ * Copyright 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+'use strict';
+goog.provide('functional.gles3.es3fSamplerStateQueryTests');
+goog.require('framework.common.tcuTestCase');
+goog.require('framework.delibs.debase.deRandom');
+goog.require('functional.gles3.es3fApiCase');
+goog.require('modules.shared.glsStateQuery');
+
+goog.scope(function() {
+var es3fSamplerStateQueryTests = functional.gles3.es3fSamplerStateQueryTests;
+var tcuTestCase = framework.common.tcuTestCase;
+var glsStateQuery = modules.shared.glsStateQuery;
+var es3fApiCase = functional.gles3.es3fApiCase;
+var deRandom = framework.delibs.debase.deRandom;
+
+var setParentClass = function(child, parent) {
+    child.prototype = Object.create(parent.prototype);
+    child.prototype.constructor = child;
+};
+
+/**
+ * @constructor
+ * @extends {es3fApiCase.ApiCase}
+ * @param {string} name
+ * @param {string} description
+ */
+es3fSamplerStateQueryTests.SamplerCase = function(name, description) {
+    es3fApiCase.ApiCase.call(this, name, description, gl);
+    /** @type {WebGLSampler} */ this.m_sampler;
+};
+
+setParentClass(es3fSamplerStateQueryTests.SamplerCase, es3fApiCase.ApiCase);
+
+es3fSamplerStateQueryTests.SamplerCase.prototype.testSampler = function() {
+    throw new Error('Virtual function. Please override.');
+};
+
+es3fSamplerStateQueryTests.SamplerCase.prototype.test = function() {
+    this.m_sampler = gl.createSampler();
+
+    this.testSampler();
+
+    gl.deleteSampler(this.m_sampler);
+};
+
+/**
+ * @constructor
+ * @extends {es3fSamplerStateQueryTests.SamplerCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} valueName
+ * @param {number} initialValue
+ * @param {Array<number>} valueRange
+ */
+es3fSamplerStateQueryTests.SamplerModeCase = function(name, description, valueName, initialValue, valueRange) {
+    es3fSamplerStateQueryTests.SamplerCase.call(this, name, description);
+    this.m_valueName = valueName;
+    this.m_initialValue = initialValue;
+    this.m_valueRange = valueRange;
+};
+
+setParentClass(es3fSamplerStateQueryTests.SamplerModeCase, es3fSamplerStateQueryTests.SamplerCase);
+
+es3fSamplerStateQueryTests.SamplerModeCase.prototype.testSampler = function() {
+    this.check(glsStateQuery.verifySampler(this.m_sampler, this.m_valueName, this.m_initialValue));
+
+    for (var ndx = 0; ndx < this.m_valueRange.length; ++ndx) {
+        gl.samplerParameteri(this.m_sampler, this.m_valueName, this.m_valueRange[ndx]);
+
+        this.check(glsStateQuery.verifySampler(this.m_sampler, this.m_valueName, this.m_valueRange[ndx]));
+    }
+
+    //check unit conversions with float
+
+    for (var ndx = 0; ndx < this.m_valueRange.length; ++ndx) {
+        gl.samplerParameterf(this.m_sampler, this.m_valueName, this.m_valueRange[ndx]);
+
+        this.check(glsStateQuery.verifySampler(this.m_sampler, this.m_valueName, this.m_valueRange[ndx]));
+    }
+};
+
+/**
+ * @constructor
+ * @extends {es3fSamplerStateQueryTests.SamplerCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} lodTarget
+ * @param {number} initialValue
+ */
+es3fSamplerStateQueryTests.SamplerLODCase = function(name, description, lodTarget, initialValue) {
+    es3fSamplerStateQueryTests.SamplerCase.call(this, name, description);
+    this.m_lodTarget = lodTarget;
+    this.m_initialValue = initialValue;
+};
+
+setParentClass(es3fSamplerStateQueryTests.SamplerLODCase, es3fSamplerStateQueryTests.SamplerCase);
+
+es3fSamplerStateQueryTests.SamplerLODCase.prototype.testSampler = function() {
+    var rnd = new deRandom.Random(0xabcdef);
+
+    this.check(glsStateQuery.verifySampler(this.m_sampler, this.m_lodTarget, this.m_initialValue));
+    var numIterations = 60;
+    for (var ndx = 0; ndx < numIterations; ++ndx) {
+        var ref = rnd.getFloat(-64000, 64000);
+
+        gl.samplerParameterf(this.m_sampler, this.m_lodTarget, ref);
+
+        this.check(glsStateQuery.verifySampler(this.m_sampler, this.m_lodTarget, ref));
+    }
+
+    // check unit conversions with int
+
+    for (var ndx = 0; ndx < numIterations; ++ndx) {
+        var ref = rnd.getInt(-64000, 64000);
+
+        gl.samplerParameteri(this.m_sampler, this.m_lodTarget, ref);
+
+        this.check(glsStateQuery.verifySampler(this.m_sampler, this.m_lodTarget, ref));
+    }
+};
+
+/**
+* @constructor
+* @extends {tcuTestCase.DeqpTest}
+*/
+es3fSamplerStateQueryTests.SamplerStateQueryTests = function() {
+    tcuTestCase.DeqpTest.call(this, 'sampler', 'Sampler State Query tests');
+};
+
+es3fSamplerStateQueryTests.SamplerStateQueryTests.prototype = Object.create(tcuTestCase.DeqpTest.prototype);
+es3fSamplerStateQueryTests.SamplerStateQueryTests.prototype.constructor = es3fSamplerStateQueryTests.SamplerStateQueryTests;
+
+es3fSamplerStateQueryTests.SamplerStateQueryTests.prototype.init = function() {
+    var wrapValues = [gl.CLAMP_TO_EDGE, gl.REPEAT, gl.MIRRORED_REPEAT];
+    this.addChild(new es3fSamplerStateQueryTests.SamplerModeCase('sampler_texture_wrap_s' , 'TEXTURE_WRAP_S',
+        gl.TEXTURE_WRAP_S, gl.REPEAT, wrapValues));
+    this.addChild(new es3fSamplerStateQueryTests.SamplerModeCase('sampler_texture_wrap_t' , 'TEXTURE_WRAP_T',
+        gl.TEXTURE_WRAP_T, gl.REPEAT, wrapValues));
+    this.addChild(new es3fSamplerStateQueryTests.SamplerModeCase('sampler_texture_wrap_r' , 'TEXTURE_WRAP_R',
+        gl.TEXTURE_WRAP_R, gl.REPEAT, wrapValues));
+
+    var magValues = [gl.NEAREST, gl.LINEAR];
+    this.addChild(new es3fSamplerStateQueryTests.SamplerModeCase('sampler_texture_mag_filter' , 'TEXTURE_MAG_FILTER',
+        gl.TEXTURE_MAG_FILTER, gl.LINEAR, magValues));
+
+    var minValues = [gl.NEAREST, gl.LINEAR, gl.NEAREST_MIPMAP_NEAREST, gl.NEAREST_MIPMAP_LINEAR, gl.LINEAR_MIPMAP_NEAREST, gl.LINEAR_MIPMAP_LINEAR];
+    this.addChild(new es3fSamplerStateQueryTests.SamplerModeCase('sampler_texture_min_filter' , 'TEXTURE_MIN_FILTER',
+        gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_LINEAR, minValues));
+
+    this.addChild(new es3fSamplerStateQueryTests.SamplerLODCase('sampler_texture_min_lod' , 'TEXTURE_MIN_LOD', gl.TEXTURE_MIN_LOD, -1000));
+    this.addChild(new es3fSamplerStateQueryTests.SamplerLODCase('sampler_texture_max_lod' , 'TEXTURE_MAX_LOD', gl.TEXTURE_MAX_LOD, 1000));
+
+    var modes = [gl.COMPARE_REF_TO_TEXTURE, gl.NONE];
+    this.addChild(new es3fSamplerStateQueryTests.SamplerModeCase('sampler_texture_compare_mode' , 'TEXTURE_COMPARE_MODE',
+        gl.TEXTURE_COMPARE_MODE, gl.NONE, modes));
+
+    var compareFuncs = [gl.LEQUAL, gl.GEQUAL, gl.LESS, gl.GREATER, gl.EQUAL, gl.NOTEQUAL, gl.ALWAYS, gl.NEVER];
+    this.addChild(new es3fSamplerStateQueryTests.SamplerModeCase('sampler_texture_compare_func' , 'TEXTURE_COMPARE_FUNC',
+        gl.TEXTURE_COMPARE_FUNC, gl.LEQUAL, compareFuncs));
+};
+
+/**
+* Run test
+* @param {WebGL2RenderingContext} context
+*/
+es3fSamplerStateQueryTests.run = function(context) {
+    gl = context;
+    //Set up Test Root parameters
+    var state = tcuTestCase.runner;
+    state.setRoot(new es3fSamplerStateQueryTests.SamplerStateQueryTests());
+
+    //Set up name and description of this test series.
+    setCurrentTestName(state.testCases.fullName());
+    description(state.testCases.getDescription());
+
+    try {
+        //Run test cases
+        tcuTestCase.runTestCases();
+    }
+    catch (err) {
+        testFailedOptions('Failed to es3fSamplerStateQueryTests.run tests', false);
+        tcuTestCase.runner.terminate();
+    }
+};
+
+});

--- a/sdk/tests/deqp/functional/gles3/es3fShaderStateQueryTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderStateQueryTests.js
@@ -744,87 +744,41 @@ es3fShaderStateQueryTests.ProgramActiveUniformBlocksCase.prototype.test = functi
 
     var uniformIndices = gl.getUniformIndices(program, uniformNames);
 
-    /* TODO: wait for spec clarification */
+    var uniformsBlockIndices = gl.getActiveUniforms(program, uniformIndices, gl.UNIFORM_BLOCK_INDEX);
+    this.check(uniformsBlockIndices[0] == longlongUniformBlockIndex &&
+        uniformsBlockIndices[1] == shortUniformBlockIndex &&
+        uniformsBlockIndices[2] == shortUniformBlockIndex,
+        'Expected [' + longlongUniformBlockIndex + ", " + shortUniformBlockIndex + ", " + shortUniformBlockIndex + ']; got ' +
+        uniformsBlockIndices[0] + ", " + uniformsBlockIndices[1] + ", " + uniformsBlockIndices[2] + "]");
 
-    // glGetActiveUniformsiv(program, DE_LENGTH_OF_ARRAY(uniformNames), uniformIndices, gl.UNIFORM_BLOCK_INDEX, uniformsBlockIndices);
-    // uniformsBlockIndices.verifyValidity(m_testCtx);
-    // expectError(gl.NO_ERROR);
+    // test UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER & UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER
 
-    // if (uniformsBlockIndices[0] != longlongUniformBlockIndex ||
-    //     uniformsBlockIndices[1] != shortUniformBlockIndex ||
-    //     uniformsBlockIndices[2] != shortUniformBlockIndex)
-    // {
-    //     m_testCtx.getLog() << TestLog::Message
-    //         << "// ERROR: Expected [" << longlongUniformBlockIndex << ", " << shortUniformBlockIndex << ", " << shortUniformBlockIndex << "];"
-    //         << "got [" << uniformsBlockIndices[0] << ", " << uniformsBlockIndices[1] << ", " << uniformsBlockIndices[2] << "]" << TestLog::EndMessage;
-    //     if (m_testCtx.getTestResult() == QP_TEST_RESULT_PASS)
-    //         m_testCtx.setTestResult(QP_TEST_RESULT_FAIL, "got wrong uniform block index");
-    // }
+    this.check(glsStateQuery.verifyActiveUniformBlock(program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER, true));
+    this.check(glsStateQuery.verifyActiveUniformBlock(program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER, true));
+    this.check(glsStateQuery.verifyActiveUniformBlock(program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER, true));
+    this.check(glsStateQuery.verifyActiveUniformBlock(program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER, false));
 
-    // // test UNIFORM_BLOCK_NAME_LENGTH
+    // test UNIFORM_BLOCK_ACTIVE_UNIFORMS
 
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_NAME_LENGTH, (GLint)std::string("longlongUniformBlockName").length() + 1); // including null-terminator
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_NAME_LENGTH, (GLint)std::string("shortUniformBlockName").length() + 1); // including null-terminator
-    // expectError(gl.NO_ERROR);
+    this.check(glsStateQuery.verifyActiveUniformBlock(program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS, 1));
+    this.check(glsStateQuery.verifyActiveUniformBlock(program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS, 2));
 
-    // // test UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER & UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER
+    // test UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES
 
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER, true);
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER, true);
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER, true);
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER, false);
-    // expectError(gl.NO_ERROR);
+    var shortUniformBlockIndices = gl.getActiveUniformBlockParameter(program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES);
+    this.check(shortUniformBlockIndices.length == 2, 'Expected 2 indices; got ' + shortUniformBlockIndices.length);
 
-    // // test UNIFORM_BLOCK_ACTIVE_UNIFORMS
+    this.check(glsStateQuery.compare(shortUniformBlockIndices, new Uint32Array([uniformIndices[1], uniformIndices[2]])) ||
+               glsStateQuery.compare(shortUniformBlockIndices, new Uint32Array([uniformIndices[2], uniformIndices[1]])),
+                'Expected { ' + uniformIndices[1] +', ' + uniformIndices[2] +
+                '}; got {' + shortUniformBlockIndices[0] + ', ' + shortUniformBlockIndices[1] + '}');
 
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS, 1);
-    // verifyActiveUniformBlockParam(m_testCtx, *this, program, shortUniformBlockIndex, gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS, 2);
-    // expectError(gl.NO_ERROR);
+    // check block names
 
-    // // test UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES
-
-    // {
-    //     StateQueryMemoryWriteGuard<GLint> longlongUniformBlockUniforms;
-    //     glGetActiveUniformBlockiv(program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS, &longlongUniformBlockUniforms);
-    //     longlongUniformBlockUniforms.verifyValidity(m_testCtx);
-
-    //     if (longlongUniformBlockUniforms == 2)
-    //     {
-    //         StateQueryMemoryWriteGuard<GLint[2]> longlongUniformBlockUniformIndices;
-    //         glGetActiveUniformBlockiv(program, longlongUniformBlockIndex, gl.UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES, longlongUniformBlockUniformIndices);
-    //         longlongUniformBlockUniformIndices.verifyValidity(m_testCtx);
-
-    //         if ((GLuint(longlongUniformBlockUniformIndices[0]) != uniformIndices[0] || GLuint(longlongUniformBlockUniformIndices[1]) != uniformIndices[1]) &&
-    //             (GLuint(longlongUniformBlockUniformIndices[1]) != uniformIndices[0] || GLuint(longlongUniformBlockUniformIndices[0]) != uniformIndices[1]))
-    //         {
-    //             m_testCtx.getLog() << TestLog::Message
-    //                 << "// ERROR: Expected {" << uniformIndices[0] << ", " << uniformIndices[1] << "};"
-    //                 << "got {" << longlongUniformBlockUniformIndices[0] << ", " << longlongUniformBlockUniformIndices[1] << "}" << TestLog::EndMessage;
-
-    //             if (m_testCtx.getTestResult() == QP_TEST_RESULT_PASS)
-    //                 m_testCtx.setTestResult(QP_TEST_RESULT_FAIL, "got wrong uniform indices");
-    //         }
-
-    //     }
-    // }
-
-    // // check block names
-
-    // {
-    //     char buffer[2048] = {'x'};
-    //     GLint written = 0;
-    //     glGetActiveUniformBlockName(program, longlongUniformBlockIndex, DE_LENGTH_OF_ARRAY(buffer), &written, buffer);
-    //     checkIntEquals(m_testCtx, written, (GLint)std::string("longlongUniformBlockName").length());
-
-    //     written = 0;
-    //     glGetActiveUniformBlockName(program, shortUniformBlockIndex, DE_LENGTH_OF_ARRAY(buffer), &written, buffer);
-    //     checkIntEquals(m_testCtx, written, (GLint)std::string("shortUniformBlockName").length());
-
-    //     // and one with too small buffer
-    //     written = 0;
-    //     glGetActiveUniformBlockName(program, longlongUniformBlockIndex, 1, &written, buffer);
-    //     checkIntEquals(m_testCtx, written, 0);
-    // }
+    var name = gl.getActiveUniformBlockName(program, longlongUniformBlockIndex);
+    this.check(name == "longlongUniformBlockName", 'Wrong uniform block name, expected longlongUniformBlockName; got ' + name);
+    name = gl.getActiveUniformBlockName(program, shortUniformBlockIndex)
+    this.check(name == "shortUniformBlockName", 'Wrong uniform block name, expected shortUniformBlockName; got ' + name);
 
     gl.deleteShader(shaderVert);
     gl.deleteShader(shaderFrag);
@@ -2172,8 +2126,7 @@ es3fShaderStateQueryTests.ShaderStateQueryTests.prototype.init = function() {
 
     this.addChild(new es3fShaderStateQueryTests.ProgramActiveUniformNameCase('program_active_uniform_name', 'ACTIVE_UNIFORMS'));
     this.addChild(new es3fShaderStateQueryTests.ProgramUniformCase('program_active_uniform_types', 'UNIFORM_TYPE, UNIFORM_SIZE, and UNIFORM_IS_ROW_MAJOR'));
-    // this.addChild(new es3fShaderStateQueryTests.ProgramActiveUniformBlocksCase ("program_active_uniform_blocks", "ACTIVE_UNIFORM_BLOCK_x"));
-    // this.addChild(new es3fShaderStateQueryTests.ProgramBinaryCase ("program_binary", "PROGRAM_BINARY_LENGTH and PROGRAM_BINARY_RETRIEVABLE_HINT"));
+    this.addChild(new es3fShaderStateQueryTests.ProgramActiveUniformBlocksCase ("program_active_uniform_blocks", "ACTIVE_UNIFORM_BLOCK_x"));
 
     // transform feedback
     this.addChild(new es3fShaderStateQueryTests.TransformFeedbackCase('transform_feedback', 'TRANSFORM_FEEDBACK_BUFFER_MODE, TRANSFORM_FEEDBACK_VARYINGS, TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH'));

--- a/sdk/tests/deqp/functional/gles3/es3fTextureStateQuery.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureStateQuery.js
@@ -1,0 +1,376 @@
+/*-------------------------------------------------------------------------
+ * drawElements Quality Program OpenGL ES Utilities
+ * ------------------------------------------------
+ *
+ * Copyright 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+'use strict';
+goog.provide('functional.gles3.es3fTextureStateQuery');
+goog.require('framework.common.tcuTestCase');
+goog.require('framework.delibs.debase.deRandom');
+goog.require('functional.gles3.es3fApiCase');
+goog.require('modules.shared.glsStateQuery');
+
+goog.scope(function() {
+var es3fTextureStateQuery = functional.gles3.es3fTextureStateQuery;
+var tcuTestCase = framework.common.tcuTestCase;
+var glsStateQuery = modules.shared.glsStateQuery;
+var es3fApiCase = functional.gles3.es3fApiCase;
+var deRandom = framework.delibs.debase.deRandom;
+
+var setParentClass = function(child, parent) {
+    child.prototype = Object.create(parent.prototype);
+    child.prototype.constructor = child;
+};
+
+/**
+ * @constructor
+ * @extends {es3fApiCase.ApiCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} textureTarget
+ */
+es3fTextureStateQuery.TextureCase = function(name, description, textureTarget) {
+    es3fApiCase.ApiCase.call(this, name, description, gl);
+    /** @type {WebGLTexture} */ this.m_texture;
+    this.m_textureTarget = textureTarget;
+};
+
+setParentClass(es3fTextureStateQuery.TextureCase, es3fApiCase.ApiCase);
+
+es3fTextureStateQuery.TextureCase.prototype.testTexture = function() {
+    throw new Error('Virtual function. Please override.');
+};
+
+es3fTextureStateQuery.TextureCase.prototype.test = function() {
+    this.m_texture = gl.createTexture();
+    gl.bindTexture(this.m_textureTarget, this.m_texture);
+
+    this.testTexture();
+
+    gl.bindTexture(this.m_textureTarget, null);
+    gl.deleteTexture(this.m_texture);
+};
+
+/**
+ * @constructor
+ * @extends {es3fTextureStateQuery.TextureCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} textureTarget
+ */
+es3fTextureStateQuery.IsTextureCase = function(name, description, textureTarget) {
+    es3fTextureStateQuery.TextureCase.call(this, name, description, textureTarget);
+};
+
+setParentClass(es3fTextureStateQuery.IsTextureCase, es3fTextureStateQuery.TextureCase);
+
+es3fTextureStateQuery.IsTextureCase.prototype.testTexture = function() {
+    this.check(glsStateQuery.compare(gl.isTexture(this.m_texture), true), 'gl.isTexture() should have returned true');
+};
+
+/**
+ * @constructor
+ * @extends {es3fTextureStateQuery.TextureCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} textureTarget
+ * @param {number} valueName
+ * @param {number} initialValue
+ * @param {Array<number>} valueRange
+ */
+es3fTextureStateQuery.TextureParamCase = function(name, description, textureTarget, valueName, initialValue, valueRange) {
+    es3fTextureStateQuery.TextureCase.call(this, name, description, textureTarget);
+    this.m_valueName = valueName;
+    this.m_initialValue = initialValue;
+    this.m_valueRange = valueRange;
+};
+
+setParentClass(es3fTextureStateQuery.TextureParamCase, es3fTextureStateQuery.TextureCase);
+
+es3fTextureStateQuery.TextureParamCase.prototype.testTexture = function() {
+    this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_valueName, this.m_initialValue));
+
+    for (var ndx = 0; ndx < this.m_valueRange.length; ++ndx) {
+        gl.texParameteri(this.m_textureTarget, this.m_valueName, this.m_valueRange[ndx]);
+
+        this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_valueName, this.m_valueRange[ndx]));
+    }
+
+    //check unit conversions with float
+
+    for (var ndx = 0; ndx < this.m_valueRange.length; ++ndx) {
+        gl.texParameterf(this.m_textureTarget, this.m_valueName, this.m_valueRange[ndx]);
+
+        this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_valueName, this.m_valueRange[ndx]));
+    }
+};
+
+/**
+ * @constructor
+ * @extends {es3fTextureStateQuery.TextureCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} textureTarget
+ * @param {number} lodTarget
+ * @param {number} initialValue
+ */
+es3fTextureStateQuery.TextureLODCase = function(name, description, textureTarget, lodTarget, initialValue) {
+    es3fTextureStateQuery.TextureCase.call(this, name, description, textureTarget);
+    this.m_lodTarget = lodTarget;
+    this.m_initialValue = initialValue;
+};
+
+setParentClass(es3fTextureStateQuery.TextureLODCase, es3fTextureStateQuery.TextureCase);
+
+es3fTextureStateQuery.TextureLODCase.prototype.testTexture = function() {
+    var rnd = new deRandom.Random(0xabcdef);
+
+    this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_lodTarget, this.m_initialValue));
+
+    var numIterations = 60;
+    for (var ndx = 0; ndx < numIterations; ++ndx) {
+        var ref = rnd.getFloat(-64000, 64000);
+
+        gl.texParameterf(this.m_textureTarget, this.m_lodTarget, ref);
+
+        this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_lodTarget, ref));
+    }
+
+    // check unit conversions with int
+
+    for (var ndx = 0; ndx < numIterations; ++ndx) {
+        var ref = rnd.getInt(-64000, 64000);
+
+        gl.texParameteri(this.m_textureTarget, this.m_lodTarget, ref);
+
+        this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_lodTarget, ref));
+    }
+};
+
+/**
+ * @constructor
+ * @extends {es3fTextureStateQuery.TextureCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} textureTarget
+ * @param {number} levelTarget
+ * @param {number} initialValue
+ */
+es3fTextureStateQuery.TextureLevelCase = function(name, description, textureTarget, levelTarget, initialValue) {
+    es3fTextureStateQuery.TextureCase.call(this, name, description, textureTarget);
+    this.m_levelTarget = levelTarget;
+    this.m_initialValue = initialValue;
+};
+
+setParentClass(es3fTextureStateQuery.TextureLevelCase, es3fTextureStateQuery.TextureCase);
+
+es3fTextureStateQuery.TextureLevelCase.prototype.testTexture = function() {
+    var rnd = new deRandom.Random(0xabcdef);
+
+    this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_levelTarget, this.m_initialValue));
+
+    var numIterations = 60;
+    for (var ndx = 0; ndx < numIterations; ++ndx) {
+        var ref = rnd.getInt(0, 64000);
+
+        gl.texParameteri(this.m_textureTarget, this.m_levelTarget, ref);
+
+        this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_levelTarget, ref));
+    }
+
+    // check unit conversions with float
+    var nonSignificantOffsets = [-0.45, -0.25, 0, 0.45]; // offsets O so that for any integers z in Z, o in O roundToClosestInt(z+o)==z
+
+    for (var ndx = 0; ndx < numIterations; ++ndx) {
+        var ref = rnd.getInt(0, 64000);
+
+        for (var i = 0; i < nonSignificantOffsets.length; i++) {
+            gl.texParameterf(this.m_textureTarget, this.m_levelTarget, ref + nonSignificantOffsets[i]);
+            this.check(glsStateQuery.verifyTexture(this.m_textureTarget, this.m_levelTarget, ref));
+        }
+    }
+};
+
+/**
+ * @constructor
+ * @extends {es3fTextureStateQuery.TextureCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} textureTarget
+ */
+es3fTextureStateQuery.TextureImmutableLevelsCase = function(name, description, textureTarget) {
+    es3fTextureStateQuery.TextureCase.call(this, name, description, textureTarget);
+};
+
+setParentClass(es3fTextureStateQuery.TextureImmutableLevelsCase, es3fTextureStateQuery.TextureCase);
+
+es3fTextureStateQuery.TextureImmutableLevelsCase.prototype.testTexture = function() {
+    this.check(glsStateQuery.verifyTexture(this.m_textureTarget, gl.TEXTURE_IMMUTABLE_LEVELS, 0));
+    for (var level = 1; level <= 8; ++level) {
+        var textureID = gl.createTexture();
+        gl.bindTexture(this.m_textureTarget, textureID);
+
+        if (this.m_textureTarget == gl.TEXTURE_2D_ARRAY || this.m_textureTarget == gl.TEXTURE_3D)
+            gl.texStorage3D(this.m_textureTarget, level, gl.RGB8, 256, 256, 256);
+        else
+            gl.texStorage2D(this.m_textureTarget, level, gl.RGB8, 256, 256);
+
+        this.check(glsStateQuery.verifyTexture(this.m_textureTarget, gl.TEXTURE_IMMUTABLE_LEVELS, level));
+        gl.deleteTexture(textureID);
+    }
+};
+
+/**
+ * @constructor
+ * @extends {es3fTextureStateQuery.TextureCase}
+ * @param {string} name
+ * @param {string} description
+ * @param {number} textureTarget
+ */
+es3fTextureStateQuery.TextureImmutableFormatCase = function(name, description, textureTarget) {
+    es3fTextureStateQuery.TextureCase.call(this, name, description, textureTarget);
+};
+
+setParentClass(es3fTextureStateQuery.TextureImmutableFormatCase, es3fTextureStateQuery.TextureCase);
+
+es3fTextureStateQuery.TextureImmutableFormatCase.prototype.testTexture = function() {
+    this.check(glsStateQuery.verifyTexture(this.m_textureTarget, gl.TEXTURE_IMMUTABLE_LEVELS, 0));
+    var testSingleFormat = function(format) {
+        var textureID = gl.createTexture();
+        gl.bindTexture(this.m_textureTarget, textureID);
+
+        if (this.m_textureTarget == gl.TEXTURE_2D_ARRAY || this.m_textureTarget == gl.TEXTURE_3D)
+            gl.texStorage3D(this.m_textureTarget, 1, format, 32, 32, 32);
+        else
+            gl.texStorage2D(this.m_textureTarget, 1, format, 32, 32);
+
+        this.check(glsStateQuery.verifyTexture(this.m_textureTarget, gl.TEXTURE_IMMUTABLE_FORMAT, 1));
+        gl.deleteTexture(textureID);
+    };
+
+    var formats = [
+        gl.RGBA32I, gl.RGBA32UI, gl.RGBA16I, gl.RGBA16UI, gl.RGBA8, gl.RGBA8I,
+        gl.RGBA8UI, gl.SRGB8_ALPHA8, gl.RGB10_A2, gl.RGB10_A2UI, gl.RGBA4,
+        gl.RGB5_A1, gl.RGB8, gl.RGB565, gl.RG32I, gl.RG32UI, gl.RG16I, gl.RG16UI,
+        gl.RG8, gl.RG8I, gl.RG8UI, gl.R32I, gl.R32UI, gl.R16I, gl.R16UI, gl.R8,
+        gl.R8I, gl.R8UI,
+
+        gl.RGBA32F, gl.RGBA16F, gl.RGBA8_SNORM, gl.RGB32F,
+        gl.RGB32I, gl.RGB32UI, gl.RGB16F, gl.RGB16I, gl.RGB16UI, gl.RGB8_SNORM,
+        gl.RGB8I, gl.RGB8UI, gl.SRGB8, gl.R11F_G11F_B10F, gl.RGB9_E5, gl.RG32F,
+        gl.RG16F, gl.RG8_SNORM, gl.R32F, gl.R16F, gl.R8_SNORM
+    ];
+
+    var non3dFormats = [
+        gl.DEPTH_COMPONENT32F, gl.DEPTH_COMPONENT24, gl.DEPTH_COMPONENT16,
+        gl.DEPTH32F_STENCIL8, gl.DEPTH24_STENCIL8
+    ];
+
+    for (var formatNdx = 0; formatNdx < formats.length; ++formatNdx)
+        testSingleFormat.bind(this, formats[formatNdx]);
+
+    if (this.m_textureTarget != gl.TEXTURE_3D)
+        for (var formatNdx = 0; formatNdx < non3dFormats.length; ++formatNdx)
+            testSingleFormat.bind(this, non3dFormats[formatNdx]);
+};
+
+/**
+* @constructor
+* @extends {tcuTestCase.DeqpTest}
+*/
+es3fTextureStateQuery.TextureStateQuery = function() {
+    tcuTestCase.DeqpTest.call(this, 'texture', 'Texture State Query tests');
+};
+
+es3fTextureStateQuery.TextureStateQuery.prototype = Object.create(tcuTestCase.DeqpTest.prototype);
+es3fTextureStateQuery.TextureStateQuery.prototype.constructor = es3fTextureStateQuery.TextureStateQuery;
+
+es3fTextureStateQuery.TextureStateQuery.prototype.init = function() {
+    var textureTargets = [
+        ['texture_2d', gl.TEXTURE_2D],
+        ['texture_3d', gl.TEXTURE_3D],
+        ['texture_2d_array', gl.TEXTURE_2D_ARRAY],
+        ['texture_cube_map', gl.TEXTURE_CUBE_MAP]
+    ];
+
+    var state = this;
+    var wrapValues = [gl.CLAMP_TO_EDGE, gl.REPEAT, gl.MIRRORED_REPEAT];
+    var magValues = [gl.NEAREST, gl.LINEAR];
+    var minValues = [gl.NEAREST, gl.LINEAR, gl.NEAREST_MIPMAP_NEAREST, gl.NEAREST_MIPMAP_LINEAR, gl.LINEAR_MIPMAP_NEAREST, gl.LINEAR_MIPMAP_LINEAR];
+    var modes = [gl.COMPARE_REF_TO_TEXTURE, gl.NONE];
+    var compareFuncs = [gl.LEQUAL, gl.GEQUAL, gl.LESS, gl.GREATER, gl.EQUAL, gl.NOTEQUAL, gl.ALWAYS, gl.NEVER];
+    textureTargets.forEach(function(elem) {
+        var name = elem[0];
+        var target = elem[1];
+        state.addChild(new es3fTextureStateQuery.IsTextureCase(name + '_is_texture', 'IsTexture', target));
+        state.addChild(new es3fTextureStateQuery.TextureParamCase(name + '_texture_wrap_s' , 'TEXTURE_WRAP_S',
+            target, gl.TEXTURE_WRAP_S, gl.REPEAT, wrapValues));
+        if (target == gl.TEXTURE_2D ||
+            target == gl.TEXTURE_3D ||
+            target == gl.TEXTURE_CUBE_MAP)
+            state.addChild(new es3fTextureStateQuery.TextureParamCase(name + '_texture_wrap_t' , 'TEXTURE_WRAP_T',
+                target, gl.TEXTURE_WRAP_T, gl.REPEAT, wrapValues));
+
+        if (target == gl.TEXTURE_3D)
+            state.addChild(new es3fTextureStateQuery.TextureParamCase(name + '_texture_wrap_r' , 'TEXTURE_WRAP_R',
+                target, gl.TEXTURE_WRAP_R, gl.REPEAT, wrapValues));
+
+        state.addChild(new es3fTextureStateQuery.TextureParamCase(name + '_texture_mag_filter' , 'TEXTURE_MAG_FILTER',
+            target, gl.TEXTURE_MAG_FILTER, gl.LINEAR, magValues));
+        state.addChild(new es3fTextureStateQuery.TextureParamCase(name + '_texture_min_filter' , 'TEXTURE_MIN_FILTER',
+            target, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_LINEAR, minValues));
+        state.addChild(new es3fTextureStateQuery.TextureLODCase(name + '_texture_min_lod' , 'TEXTURE_MIN_LOD', target, gl.TEXTURE_MIN_LOD, -1000));
+        state.addChild(new es3fTextureStateQuery.TextureLODCase(name + '_texture_max_lod' , 'TEXTURE_MAX_LOD', target, gl.TEXTURE_MAX_LOD, 1000));
+        state.addChild(new es3fTextureStateQuery.TextureLevelCase(name + '_texture_base_level' , 'TEXTURE_BASE_LEVEL', target, gl.TEXTURE_BASE_LEVEL, 0));
+        state.addChild(new es3fTextureStateQuery.TextureLevelCase(name + '_texture_max_level' , 'TEXTURE_MAX_LEVEL', target, gl.TEXTURE_MAX_LEVEL, 1000));
+
+        state.addChild(new es3fTextureStateQuery.TextureParamCase(name + '_texture_compare_mode' , 'TEXTURE_COMPARE_MODE',
+            target, gl.TEXTURE_COMPARE_MODE, gl.NONE, modes));
+        state.addChild(new es3fTextureStateQuery.TextureParamCase(name + '_texture_compare_func' , 'TEXTURE_COMPARE_FUNC',
+            target, gl.TEXTURE_COMPARE_FUNC, gl.LEQUAL, compareFuncs));
+
+        state.addChild(new es3fTextureStateQuery.TextureImmutableLevelsCase(name + '_texture_immutable_levels', 'TEXTURE_IMMUTABLE_LEVELS', target));
+        state.addChild(new es3fTextureStateQuery.TextureImmutableFormatCase(name + '_texture_immutable_format', 'TEXTURE_IMMUTABLE_FORMAT', target));
+    });
+};
+
+/**
+* Run test
+* @param {WebGL2RenderingContext} context
+*/
+es3fTextureStateQuery.run = function(context) {
+    gl = context;
+    //Set up Test Root parameters
+    var state = tcuTestCase.runner;
+    state.setRoot(new es3fTextureStateQuery.TextureStateQuery());
+
+    //Set up name and description of this test series.
+    setCurrentTestName(state.testCases.fullName());
+    description(state.testCases.getDescription());
+
+    try {
+        //Run test cases
+        tcuTestCase.runTestCases();
+    }
+    catch (err) {
+        testFailedOptions('Failed to es3fTextureStateQuery.run tests', false);
+        tcuTestCase.runner.terminate();
+    }
+};
+
+});

--- a/sdk/tests/deqp/functional/gles3/es3fTransformFeedbackTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTransformFeedbackTests.js
@@ -895,9 +895,13 @@ goog.scope(function() {
 
             if (linkFail) {
                 if (!es3fTransformFeedbackTests.isProgramSupported(this.m_progSpec, this.m_bufferMode)) {
-                    throw new Error('Not Supported. Implementation limits exceeded.');
+                    var msg = 'Not Supported. Implementation limits exceeded.';
+                    checkMessage(false, msg);
+                    throw new TestFailedException(msg);
                 } else if (es3fTransformFeedbackTests.hasArraysInTFVaryings(this.m_progSpec)) {
-                    throw new Error('Capturing arrays is not supported (undefined in specification)');
+                    msg = 'Capturing arrays is not supported (undefined in specification)';
+                    checkMessage(false, msg);
+                    throw new TestFailedException(msg);
                 } else {
                     throw new Error('Link failed: ' + this.m_program.getProgramInfo().infoLog);
                 }

--- a/sdk/tests/deqp/functional/gles3/floatstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/floatstatequery.html
@@ -1,14 +1,14 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<title>WebGL Occlusion Query Conformance Tests</title>
+<title>WebGL Float State Query Tests Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 
 <script src="../../../closure-library/closure/goog/base.js"></script>
 <script src="../../deqp-deps.js"></script>
-<script>goog.require('functional.gles3.es3fOcclusionQueryTests');</script>
+<script>goog.require('functional.gles3.es3fFloatStateQueryTests');</script>
 </head>
 <body>
 <div id="description"></div>
@@ -16,11 +16,11 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true, stencil: true}, 2);
+var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
 
 gl.getError();
     try {
-        functional.gles3.es3fOcclusionQueryTests.run(gl);
+        functional.gles3.es3fFloatStateQueryTests.run(gl);
     }
     catch(err)
     {

--- a/sdk/tests/deqp/functional/gles3/integerstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/integerstatequery.html
@@ -1,14 +1,14 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<title>WebGL Occlusion Query Conformance Tests</title>
+<title>WebGL Integer Values Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 
 <script src="../../../closure-library/closure/goog/base.js"></script>
 <script src="../../deqp-deps.js"></script>
-<script>goog.require('functional.gles3.es3fOcclusionQueryTests');</script>
+<script>goog.require('functional.gles3.es3fIntegerStateQueryTests');</script>
 </head>
 <body>
 <div id="description"></div>
@@ -16,11 +16,11 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true, stencil: true}, 2);
+var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
 
 gl.getError();
     try {
-        functional.gles3.es3fOcclusionQueryTests.run(gl);
+        functional.gles3.es3fIntegerStateQueryTests.run(gl);
     }
     catch(err)
     {

--- a/sdk/tests/deqp/functional/gles3/rasterizerdiscard.html
+++ b/sdk/tests/deqp/functional/gles3/rasterizerdiscard.html
@@ -16,7 +16,7 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
+var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true, stencil: true}, 2);
 
     try {
         functional.gles3.es3fRasterizerDiscardTests.run(gl);

--- a/sdk/tests/deqp/functional/gles3/samplerstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/samplerstatequery.html
@@ -1,14 +1,14 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<title>WebGL Occlusion Query Conformance Tests</title>
+<title>WebGL Sampler State Query Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 
 <script src="../../../closure-library/closure/goog/base.js"></script>
 <script src="../../deqp-deps.js"></script>
-<script>goog.require('functional.gles3.es3fOcclusionQueryTests');</script>
+<script>goog.require('functional.gles3.es3fSamplerStateQueryTests');</script>
 </head>
 <body>
 <div id="description"></div>
@@ -16,11 +16,11 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true, stencil: true}, 2);
+var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
 
 gl.getError();
     try {
-        functional.gles3.es3fOcclusionQueryTests.run(gl);
+        functional.gles3.es3fSamplerStateQueryTests.run(gl);
     }
     catch(err)
     {

--- a/sdk/tests/deqp/functional/gles3/texturestatequery.html
+++ b/sdk/tests/deqp/functional/gles3/texturestatequery.html
@@ -1,14 +1,14 @@
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<title>WebGL Occlusion Query Conformance Tests</title>
+<title>WebGL Texture State Query Conformance Tests</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 
 <script src="../../../closure-library/closure/goog/base.js"></script>
 <script src="../../deqp-deps.js"></script>
-<script>goog.require('functional.gles3.es3fOcclusionQueryTests');</script>
+<script>goog.require('functional.gles3.es3fTextureStateQuery');</script>
 </head>
 <body>
 <div id="description"></div>
@@ -16,11 +16,11 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true, stencil: true}, 2);
+var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
 
 gl.getError();
     try {
-        functional.gles3.es3fOcclusionQueryTests.run(gl);
+        functional.gles3.es3fTextureStateQuery.run(gl);
     }
     catch(err)
     {

--- a/sdk/tests/deqp/modules/shared/glsShaderExecUtil.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderExecUtil.js
@@ -472,21 +472,25 @@ goog.scope(function() {
         // Read back data.
         var result = new ArrayBuffer(outputBufferStride * numValues);
         gl.getBufferSubData(gl.TRANSFORM_FEEDBACK_BUFFER, 0, result);
-          /** @type {number} */ var curOffset = 0; // Offset in buffer in bytes.
+        /** @type {number} */ var curOffset = 0; // Offset in buffer in bytes.
 
-          for (var outputNdx = 0; outputNdx < this.m_outputs.length; outputNdx++) {
-              symbol = this.m_outputs[outputNdx];
-              /** @type {number} */ var scalarSize = symbol.varType.getScalarSize();
-              /*void* */var dstPtr = new Uint8Array(scalarSize * numValues * 4);
+        for (var outputNdx = 0; outputNdx < this.m_outputs.length; outputNdx++) {
+            symbol = this.m_outputs[outputNdx];
+            /** @type {number} */ var scalarSize = symbol.varType.getScalarSize();
+            var readPtr = new Uint8Array(result, curOffset);
 
-            for (var ndx = 0; ndx < numValues; ndx++) {
-            for (var j = 0; j < scalarSize * 4; j++) {
-                dstPtr[scalarSize * ndx + j] = result[curOffset + ndx * outputBufferStride + j];
+            if (scalarSize * 4 === outputBufferStride)
+                outputs[outputNdx] = readPtr;
+            else {
+                var dstPtr = new Uint8Array(scalarSize * numValues * 4);
+
+                for (var ndx = 0; ndx < numValues; ndx++)
+                    for (var j = 0; j < scalarSize * 4; j++) {
+                        dstPtr[scalarSize * 4 * ndx + j] = readPtr[ndx * outputBufferStride + j];
+                    }
+                outputs[outputNdx] = dstPtr;
             }
-        }
-        outputs[outputNdx] = dstPtr;
-
-              curOffset += scalarSize * 4;
+            curOffset += scalarSize * 4;
           }
 
         if (useTFObject)

--- a/sdk/tests/deqp/modules/shared/glsStateQuery.js
+++ b/sdk/tests/deqp/modules/shared/glsStateQuery.js
@@ -156,6 +156,38 @@ glsStateQuery.verifyProgram = function(program, param, reference) {
 };
 
 /**
+ * Verify that WebGL sampler state 'param' has the expected value
+ * @param {WebGLSampler} sampler
+ * @param {number} param
+ * @param {*} reference
+ * @return {boolean}
+ */
+glsStateQuery.verifySampler = function(sampler, param, reference) {
+    var value = gl.getSamplerParameter(sampler, param);
+    var result = glsStateQuery.compare(value, reference);
+    if (!result) {
+        bufferedLogToConsole('Result: ' + value + ' Expected: ' + reference);
+    }
+    return result;
+};
+
+/**
+ * Verify that WebGL texture state 'param' has the expected value
+ * @param {number} target
+ * @param {number} param
+ * @param {*} reference
+ * @return {boolean}
+ */
+glsStateQuery.verifyTexture = function(target, param, reference) {
+    var value = gl.getTexParameter(target, param);
+    var result = glsStateQuery.compare(value, reference);
+    if (!result) {
+        bufferedLogToConsole('Result: ' + value + ' Expected: ' + reference);
+    }
+    return result;
+};
+
+/**
  * Verify that WebGL state 'param' has one of the expected values
  * @param {number} param
  * @param {Array<*>} reference
@@ -285,6 +317,49 @@ glsStateQuery.verifyRenderbuffer = function(param, reference) {
         bufferedLogToConsole('Result: ' + value + ' Expected: ' + reference);
     }
     return result;
+};
+
+/**
+ * Verify that WebGL active uniform block's attribute 'param' has the expected value
+ * @param {WebGLProgram} program
+ * @param {number} index
+ * @param {number} param
+ * @param {*} reference
+ * @return {boolean}
+ */
+glsStateQuery.verifyActiveUniformBlock = function(program, index, param, reference) {
+    var value = gl.getActiveUniformBlockParameter(program, index, param);
+    var result = glsStateQuery.compare(value, reference);
+    if (!result) {
+        bufferedLogToConsole('Result: ' + value + ' Expected: ' + reference);
+    }
+    return result;
+};
+
+/**
+	 * @param  {number} param
+	 * @param  {Array<number>} reference
+	 * @param  {Array<boolean>} enableRef
+	 * @return  {boolean}
+	 */
+
+glsStateQuery.verifyMask = function(param, reference, enableRef) {
+	/** @type {Array<number>} */ var intVector4 = /** @type {Array<number>} */ (gl.getParameter(param));
+
+	if ((enableRef[0] && (intVector4[0] != reference[0])) ||
+		(enableRef[1] && (intVector4[1] != reference[1])) ||
+		(enableRef[2] && (intVector4[2] != reference[2])) ||
+		(enableRef[3] && (intVector4[3] != reference[3])))
+	{
+		bufferedLogToConsole("// ERROR: expected " +
+			(enableRef[0] ? "" : "(") + reference[0] + (enableRef[0] ? "" : ")") + ", " +
+			(enableRef[1] ? "" : "(") + reference[1] + (enableRef[1] ? "" : ")") + ", " +
+			(enableRef[2] ? "" : "(") + reference[2] + (enableRef[2] ? "" : ")") + ", " +
+			(enableRef[3] ? "" : "(") + reference[3] + (enableRef[3] ? "" : ")"));
+
+		return false;
+	}
+    return true;
 };
 
 });


### PR DESCRIPTION
New tests for: sampler state, texture state, integer and floating point state parameters.

Fixed querying result in occlusion query test.
Added stencil context creation parameter where tests are using stencil buffer.
Fixed Fbo render test to skip over unsupported formats instead of reporting errors.
Fixed TF test to skip unsupported cases.
Fixed framework code for getting test results in transform feedback buffers.

Signed-off-by: Janusz Sobczak <janusz.sobczak@mobica.com>