### PR TITLE
Remove dEQP #extension directive test to keep backwards compatibility

### DIFF
--- a/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
+++ b/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
@@ -2856,21 +2856,6 @@ group extensions "Extension Tests"
 			}
 		""
 	end
-
-	case after_non_preprocessing_tokens
-		expect compile_fail
-		both ""
-	#extension all : warn
-
-			precision mediump float;
-			${DECLARATIONS}
-			void main()
-			{
-	#extension all : disable
-				${POSITION_FRAG_COLOR} = vec4(1.0);
-			}
-		""
-	end
 end # extensions
 
 group expressions "Expression Tests"

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 29 September 2015</h2>
+    <h2 class="no-toc">Editor's Draft 05 October 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -3860,6 +3860,26 @@ extensions.
     This behavior is enforced across GLES implementations by dEQP tests, so shaders created on other
     platforms may rely on it. In addition, the ported dEQP tests in the WebGL conformance suite are
     only valid if this behavior is specified.
+</div>
+
+<h3><a name="EXTENSION_DIRECTIVE_LOCATION">GLSL ES #extension directive location</a></h3>
+
+<p>
+    The GLSL ES 1.00 <a href="#refsGLES20GLSL">[GLES20GLSL]</a> specification mandates that
+    <code>#extension</code> directives must occur before any non-preprocessor tokens unless the
+    extension specification says otherwise. In the WebGL API, <code>#extension</code> directives
+    may always occur after non-preprocessor tokens in GLSL ES 1.00 shaders. The scope of
+    <code>#extension</code> directives in GLSL ES 1.00 shaders is always the whole shader, and
+    <code>#extension</code> directives that occur later override those seen earlier for the whole
+    shader.
+</p>
+
+<div class="note rationale">
+    Letting extensions determine where the <code>#extension</code> directives should be placed has
+    resulted in a lot of room for interpretation in the spec. In practice GLES implementations have
+    not enforced the rule that's written in the GLSL ES spec, and neither have WebGL
+    implementations, so relaxing the rule is the only way to make the spec well-defined while being
+    compatible with existing content.
 </div>
 
 <!-- ======================================================================================================= -->

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 02 October 2015</h2>
+    <h2 class="no-toc">Editor's Draft 05 October 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -2994,6 +2994,23 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         specification of <a href="#GET_QUERY_PARAMETER">getQueryParameter</a> for discussion and
         rationale.
     </p>
+
+    <h3>GLSL ES 3.00 #extension directive location</h3>
+
+    <p>
+        The WebGL 1.0 specification section <a href="../1.0/index.html#EXTENSION_DIRECTIVE_LOCATION">
+        GLSL ES #extension directive location</a> only applies to OpenGL ES Shading Language 1.00
+        shaders. It does not apply to shaders that are written in OpenGL ES Shading Language 3.00.
+        In shaders written in OpenGL ES Shading Language 3.00, <code>#extension</code> directives
+        must occur before non-preprocessor tokens regardless of what is written in the extension
+        specification.
+    </p>
+
+    <div class="note rationale">
+        This is done to make WebGL 2.0 to follow the written GLSL ES 3.00 specification more
+        closely. Enforcing the restriction more strictly than native GLES drivers makes the behavior
+        well-defined.
+    </div>
 
 <!-- ======================================================================================================= -->
 


### PR DESCRIPTION
When ANGLE implemented a fix to this test in May 2015, significant issues
with backwards compatibility were detected. It was decided that the ESSL1
compiler should issue a warning rather than an error in this case, though
the WebGL spec was not updated.

The spec is still strictly enforced in the case of ESSL3 shaders and
WebGL 2 with a similar gles3 dEQP test.