### PR TITLE
Added stress test of resource deallocation upon page reloading / navi…

### DIFF
--- a/sdk/tests/extra/texture-allocation-stress-test.html
+++ b/sdk/tests/extra/texture-allocation-stress-test.html
@@ -1,0 +1,68 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tests that resources allocated by a WebGL context are freed in a reasonable timeframe.</title>
+<link rel="stylesheet" href="../resources/js-test-style.css"/>
+<script src="../js/js-test-pre.js"></script>
+<script src="../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="32" height="32">
+</canvas>
+<script>
+"use strict";
+description();
+
+debug("Creates a WebGL context and textures consuming ~80 MB of video memory, then reloads the page and does it over again.")
+debug("GPU memory usage should be capped. It should not grow unboundedly.")
+
+var wtu = WebGLTestUtils;
+
+var gl = wtu.create3DContext(document.getElementById("canvas"));
+var textures = [];
+
+for (var ii = 0; ii < 20; ++ii) {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1024, 1024, 0, gl.RGBA, gl.UNSIGNED_BYTE,
+                  null);
+    textures.push(tex);
+}
+
+setTimeout(function() { debug("Reloading..."); window.location.reload(); }, 500);
+
+var successfullyParsed = true;
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
…gation.

Intended to ensure that Chrome's mechanism for freeing resources doesn't regress when changing how WebGL objects are tracked.