### PR TITLE
fix the bugs in buffercopy.js

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fBufferCopyTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fBufferCopyTests.js
@@ -244,16 +244,8 @@ goog.scope(function() {
                 // In WebGL 2, a copy between an ELEMENT_ARRAY_BUFFER and other data buffer
                 // (not COPY_WRITE_BUFFER nor COPY_READ_BUFFER nor ELEMENT_ARRAY_BUFFER)
                 // cannot be made, so let's skip those cases.
-                if (
-                    (bufferTargets[srcTargetNdx] == gl.ELEMENT_ARRAY_BUFFER &&
-                        bufferTargets[dstTargetNdx] != gl.COPY_READ_BUFFER &&
-                        bufferTargets[dstTargetNdx] != gl.COPY_WRITE_BUFFER &&
-                        bufferTargets[dstTargetNdx] != gl.ELEMENT_ARRAY_BUFFER) ||
-                    (bufferTargets[dstTargetNdx] == gl.ELEMENT_ARRAY_BUFFER &&
-                        bufferTargets[srcTargetNdx] != gl.COPY_READ_BUFFER &&
-                        bufferTargets[srcTargetNdx] != gl.COPY_WRITE_BUFFER &&
-                        bufferTargets[srcTargetNdx] != gl.ELEMENT_ARRAY_BUFFER)
-                )
+                if (bufferTargets[srcTargetNdx] == gl.ELEMENT_ARRAY_BUFFER ||
+                    bufferTargets[dstTargetNdx] == gl.ELEMENT_ARRAY_BUFFER)
                     continue;
 
                 var srcTarget = bufferTargets[srcTargetNdx];


### PR DESCRIPTION
For copyBufferSubData, ELEMENT_ARRAY_BUFFER are compatible with
COPY_READ_BUFFER and COPY_WRITE_BUFFER only if the COPY_READ/WRITE
buffer had been initially bound to an ELEMENT_ARRAY_BUFFER

This behavior is covered in buffer-copying-restrictions.html,
so skip these tests in buffercopy.js