### PR TITLE
Add bufferData and bufferSubData test cases

### DIFF
--- a/sdk/tests/conformance/buffers/buffer-data-and-buffer-sub-data.html
+++ b/sdk/tests/conformance/buffers/buffer-data-and-buffer-sub-data.html
@@ -45,16 +45,13 @@ debug('Regression test for <a href="https://bugs.webkit.org/show_bug.cgi?id=4188
 
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
-var buf = null;
-var array = null;
-var arrayZero = null;
 if (!gl) {
     testFailed("WebGL context does not exist");
 } else {
     testPassed("WebGL context exists");
 
     bufferDataTest();
-    bufferDataTestWithArrayBuffer();
+    bufferDataSizesTest();    
 
     bufferSubDataTest();
 }
@@ -63,8 +60,8 @@ function bufferDataTest() {
     debug("");
     debug("Test bufferData without ArrayBuffer input");
 
-    buf = gl.createBuffer();
-    shouldBeNonNull("buf");
+    var buf = gl.createBuffer();
+    shouldBeNonNull(buf);
 
     gl.bufferData(gl.ARRAY_BUFFER, 4, gl.STATIC_DRAW);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "no buffer bound");
@@ -76,45 +73,62 @@ function bufferDataTest() {
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE,
         "calling bufferData when buffer size is negative should generate INVALID_VALUE");
 
-    gl.bufferData(gl.ARRAY_BUFFER, 0, gl.STATIC_DRAW);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-        "calling bufferData when buffer size is zero should succeed");
-
-    gl.bufferData(gl.ARRAY_BUFFER, 4, gl.STATIC_DRAW);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "calling bufferData should succeed");
-
-    gl.bindBuffer(gl.ARRAY_BUFFER, null);
-}
-
-function bufferDataTestWithArrayBuffer() {
-    debug("");
-    debug("Test bufferData with ArrayBuffer input");
-
-    array = new ArrayBuffer(128);
-    shouldBeNonNull("array");
-
-    buf = gl.createBuffer();
-    shouldBeNonNull("buf");
-
-    gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "no buffer bound");
-
-    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-
     gl.bufferData(gl.ARRAY_BUFFER, null, gl.STATIC_DRAW);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE,
         "calling bufferData when BufferDataSource is null should generate INVALID_VALUE");
 
-    gl.bufferData(gl.ARRAY_BUFFER, array, gl.STATIC_DRAW);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-        "calling bufferData with ArrayBuffer should succeed");
+    gl.bufferData(gl.ARRAY_BUFFER, undefined, gl.STATIC_DRAW);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE,
+        "calling bufferData when BufferDataSource is undefined should generate INVALID_VALUE");
 
-    arrayZero = new ArrayBuffer(0);
-    shouldBeNonNull("arrayZero");
-    gl.bufferData(gl.ARRAY_BUFFER, arrayZero, gl.STATIC_DRAW);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-        "calling bufferData with zero-sized ArrayBuffer should succeed");
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+}
+
+function bufferDataSizesTest() {
+    debug("");
+    debug("Test bufferData overloads");
+
+    // bufferData has an integer overload and an ArrayBuffer overload.
+    // Per the WebIDL spec, the overload resolution algorithm should resolve types as follows:
+    // - If the argument is null or undefined, pick the nullable type, which is ArrayBuffer.
+    //   Per the WebGL spec, null should flag INVALID_VALUE.
+    // - If the argument is an ArrayBuffer, then pick the ArrayBuffer overload
+    // - Everything else should pick the numeric overload. This means things like objects, strings,
+    //   floating point numbers, arrays of numbers and strings, etc should convert themselves to a number.
+    var bufferDataParams = [
+        { parameter: 0, expectedBufferSize: 0 },
+        { parameter: 4, expectedBufferSize: 4 },
+        { parameter: 5.1, expectedBufferSize: 5 },
+        { parameter: 5.8, expectedBufferSize: 5 },
+        { parameter: 5.5, expectedBufferSize: 5 },
+
+        { parameter: "4", expectedBufferSize: 4 },
+        { parameter: "5.1", expectedBufferSize: 5 },
+        { parameter: "5.8", expectedBufferSize: 5 },
+        { parameter: "5.5", expectedBufferSize: 5 },
+        { parameter: "0", expectedBufferSize: 0 },
+
+        { parameter: [42, 64], expectedBufferSize: 0 },
+        { parameter: [42], expectedBufferSize: 42 },
+        { parameter: ["42"], expectedBufferSize: 42 },
+        { parameter: ["42", "64"], expectedBufferSize: 0 },
+
+        { parameter: new ArrayBuffer(0), expectedBufferSize: 0 },
+        { parameter: new ArrayBuffer(4), expectedBufferSize: 4 },
+
+        { parameter: "WebGL Rocks!", expectedBufferSize: 0 },
+        { parameter: { mystring: "WebGL Rocks!" }, expectedBufferSize: 0 },
+    ];
+
+    bufferDataParams.forEach(function (bufferDataParam) {
+        var buffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+
+        gl.bufferData(gl.ARRAY_BUFFER, bufferDataParam.parameter, gl.STATIC_DRAW);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Passing " + bufferDataParam.parameter + " to bufferData");
+
+        shouldEvaluateTo("gl.getBufferParameter(gl.ARRAY_BUFFER, gl.BUFFER_SIZE)", bufferDataParam.expectedBufferSize);
+    });
 
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
 }
@@ -123,12 +137,16 @@ function bufferSubDataTest() {
     debug("");
     debug("Test bufferSubData");
 
-    buf = gl.createBuffer();
+    var buf = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+
+    gl.bufferSubData(gl.ARRAY_BUFFER, 0, new ArrayBuffer(1));
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Calling bufferSubData before bufferData should fail");
+
     gl.bufferData(gl.ARRAY_BUFFER, 128, gl.STATIC_DRAW);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
-    array = new ArrayBuffer(64);
+    var array = new ArrayBuffer(64);
 
     gl.bufferSubData(gl.ARRAY_BUFFER, -10, array);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE,
@@ -149,9 +167,18 @@ function bufferSubDataTest() {
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE,
         "calling bufferSubData when BufferDataSource is null should generate INVALID_VALUE");
 
+    wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "gl.bufferSubData(gl.ARRAY_BUFFER, 10, undefined)");
+
     gl.bufferSubData(gl.ARRAY_BUFFER, 10, new Float32Array(0));
     wtu.glErrorShouldBe(gl, gl.NO_ERROR,
         "calling bufferSubData with zero-sized ArrayBufferView should succeed");
+
+    // Arguments that are not ArrayBuffers, null or undefined should throw a TypeError exception
+    shouldThrow("gl.bufferSubData(gl.ARRAY_BUFFER, 0, 42);");
+    shouldThrow("gl.bufferSubData(gl.ARRAY_BUFFER, 0, 5.5);");
+    shouldThrow("gl.bufferSubData(gl.ARRAY_BUFFER, 0, \"5.5\");");
+    shouldThrow("gl.bufferSubData(gl.ARRAY_BUFFER, 0, [4]);");
+    shouldThrow("gl.bufferSubData(gl.ARRAY_BUFFER, 0, { mynumber: 42});");
 
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
 }


### PR DESCRIPTION
bufferData has an integer overload and an ArrayBuffer overload.
Per the WebIDL spec, the overload resolution algorithm should resolve types as follows:
- If the argument is null or undefined, pick the nullable type, which is ArrayBuffer.
Per the WebGL spec, null should flag INVALID_VALUE.
- If the argument is an ArrayBuffer, then pick the ArrayBuffer overload
- Everything else should pick the numeric overload. This means things like objects, strings, floating point numbers, arrays of numbers and strings, etc should convert themselves to an integer.
    
Unlike bufferData, bufferSubData is typed to accept an ArrayBuffer. No overloads.
Per the WebIDL spec, passing undefined should convert to null.  Per the WebGL spec, null should
flag an INVALID_VALUE error.