### PR TITLE
Add tolerance to pow-with-constant-exponent test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/pow-with-constant-exponent-should-not-crash.html
+++ b/sdk/tests/conformance/glsl/bugs/pow-with-constant-exponent-should-not-crash.html
@@ -62,17 +62,21 @@ void main()
 <script>
 "use strict";
 
+// This test has quite a lot of tolerance since pow() doesn't have explicit precision requirements
+// in ESSL1, and in ESSL3 the limits are very loose.
 GLSLConformanceTester.runRenderTests([
   {
     fShaderId: "fshaderTest",
     fShaderSuccess: true,
     linkSuccess: true,
+    renderTolerance: 20,
     passMsg: "shader with pow() with a constant vector exponent should not crash",
   },
   {
     fShaderId: "fshaderNestedTest",
     fShaderSuccess: true,
     linkSuccess: true,
+    renderTolerance: 20,
     passMsg: "shader with nested pow() calls with constant vector exponents should not crash",
   }
 ]);

--- a/sdk/tests/js/glsl-conformance-test.js
+++ b/sdk/tests/js/glsl-conformance-test.js
@@ -264,7 +264,12 @@ function runOneTest(gl, info) {
   wtu.insertImage(div, "result", wtu.makeImageFromCanvas(gl.canvas));
   div.appendChild(document.createElement('br'));
   consoleDiv.appendChild(div);
-  wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
+
+  var tolerance = 0;
+  if (info.renderTolerance !== undefined) {
+    tolerance = info.renderTolerance;
+  }
+  wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", tolerance);
 }
 
 function runTests(shaderInfos, opt_contextVersion) {


### PR DESCRIPTION
Result of (x^2)^0.5 may differ from x enough to affect the result of the
test if the mediump pow function is run at the precision suggested in the
GLSL ES 3.00 spec, where it inherits its precision from exp2(y*log2(x)).

The lack of tolerance caused the test to fail at least on Nexus 5.