### PR TITLE
Fixed bug in expando-loss.html test.

### DIFF
--- a/sdk/tests/conformance/misc/expando-loss.html
+++ b/sdk/tests/conformance/misc/expando-loss.html
@@ -208,6 +208,8 @@ function testFrameBufferAttachments() {
     // Attach a renderbuffer to all attachment points.
     attachments.forEach(function(attachment) {
         var renderbuffer = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
         setTestExpandos(renderbuffer);
         gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachment.enum, gl.RENDERBUFFER, renderbuffer);
         assertMsg(renderbuffer === gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, attachment.enum, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME),


### PR DESCRIPTION
It was attaching renderbuffers that hadn't yet been fully
initialized (never bound to the RENDERBUFFER binding point) to a
framebuffer object, causing an INVALID_OPERATION error.