### PR TITLE
Fixed bugs in extensions' unique object tests.

### DIFF
--- a/sdk/tests/conformance/extensions/angle-instanced-arrays.html
+++ b/sdk/tests/conformance/extensions/angle-instanced-arrays.html
@@ -186,6 +186,7 @@ function setupCanvas() {
     gl.clearColor(0, 0, 0, 0);
 
     program = wtu.setupProgram(gl, ["outputVertexShader", "outputFragmentShader"], ['aPosition', 'aOffset', 'aColor'], [positionLoc, offsetLoc, colorLoc]);
+    ext = gl.getExtension("ANGLE_instanced_arrays");
 }
 
 function runOutputTests() {
@@ -426,6 +427,7 @@ function runUniqueObjectTest()
 {
     debug("");
     debug("Testing that getExtension() returns the same object each time");
+    ext = null;
     gl.getExtension("ANGLE_instanced_arrays").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("ANGLE_instanced_arrays").myProperty', '2');

--- a/sdk/tests/conformance/extensions/ext-blend-minmax.html
+++ b/sdk/tests/conformance/extensions/ext-blend-minmax.html
@@ -231,6 +231,7 @@ function runUniqueObjectTest()
 {
     debug("");
     debug("Testing that getExtension() returns the same object each time");
+    ext = null;
     gl.getExtension("EXT_blend_minmax").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("EXT_blend_minmax").myProperty', '2');

--- a/sdk/tests/conformance/extensions/ext-frag-depth.html
+++ b/sdk/tests/conformance/extensions/ext-frag-depth.html
@@ -243,6 +243,7 @@ function runOutputTests() {
 function runUniqueObjectTest()
 {
     debug("Testing that getExtension() returns the same object each time");
+    ext = null;
     gl.getExtension("EXT_frag_depth").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("EXT_frag_depth").myProperty', '2');

--- a/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
+++ b/sdk/tests/conformance/extensions/ext-shader-texture-lod.html
@@ -280,6 +280,7 @@ function runUniqueObjectTest()
 {
     debug("");
     debug("Testing that getExtension() returns the same object each time");
+    ext = null;
     gl.getExtension("EXT_shader_texture_lod").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("EXT_shader_texture_lod").myProperty', '2');

--- a/sdk/tests/conformance/extensions/oes-standard-derivatives.html
+++ b/sdk/tests/conformance/extensions/oes-standard-derivatives.html
@@ -354,6 +354,7 @@ function runOutputTests() {
 function runUniqueObjectTest()
 {
     debug("Testing that getExtension() returns the same object each time");
+    ext = null;
     gl.getExtension("OES_standard_derivatives").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("OES_standard_derivatives").myProperty', '2');

--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -336,6 +336,7 @@ function runUniqueObjectTest()
 {
     debug("");
     debug("Testing that getExtension() returns the same object each time");
+    ext = null;
     gl.getExtension("OES_texture_half_float").myProperty = 2;
     webglHarnessCollectGarbage();
     shouldBe('gl.getExtension("OES_texture_half_float").myProperty', '2');


### PR DESCRIPTION
A few of these tests were leaving around a global reference to the
extension object, so the attempted garbage collection of the JavaScript
wrapper was having no effect. Nulling out the global reference exposes
more bugs in WebGL implementations.