### PR TITLE
Verify that fetching result or availability from active query fails.

### DIFF
--- a/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
+++ b/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
@@ -107,6 +107,10 @@ function runSanityTests() {
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Beginning an inactive time elapsed query should succeed.");
     ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Attempting to begin an active query should fail.");
+    ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Fetching query result availability of an active query should fail.");
+    ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Fetching query result of an active query should fail.");
     shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "query");
     ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Ending an active time elapsed query should succeed.");


### PR DESCRIPTION
This is per David Yen's review of https://codereview.chromium.org/1385793002 .