### PR TITLE
Update dEQP shader preprocessor tests from deqp-dev

### DIFF
--- a/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
+++ b/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
@@ -2737,7 +2737,7 @@ group pragmas "Pragma Tests"
 	case pragma_unrecognized_token
 		expect build_successful
 		both ""
-			#pragma ¤¤½
+			#pragma **%
 
 			// trailing bytes form a valid but unrecognized preprocessor token
 
@@ -2872,7 +2872,7 @@ group extensions "Extension Tests"
 	case invalid_char_in_name
 		expect compile_fail
 		both ""
-	#extension all¤ : warn
+	#extension all* : warn
 			precision mediump float;
 			void main()
 			{
@@ -2884,7 +2884,7 @@ group extensions "Extension Tests"
 	case invalid_char_in_behavior
 		expect compile_fail
 		both ""
-	#extension all : war¤n
+	#extension all : war*n
 			precision mediump float;
 			void main()
 			{

--- a/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
+++ b/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
@@ -112,6 +112,21 @@ group basic "Basic Tests"
 		""
 	end
 
+	case identifier_with_double_underscore
+		values { output float out0 = 1.0; }
+		both ""
+			precision mediump float;
+			${DECLARATIONS}
+			# define __VALUE__	1
+
+			void main()
+			{
+				// __VALUE__ not used since it might be set by an "underlying software layer"
+				out0 = float(1.0);
+				${OUTPUT}
+			}
+		""
+	end
 end # basic
 
 group definitions "Symbol Definition Tests"
@@ -558,19 +573,6 @@ group object_redefinitions "Object Redefinition Tests"
 end # object_redefinitions
 
 group invalid_redefinitions "Invalid Redefinitions Tests"
-
-	case invalid_identifier_1
-		expect compile_fail
-		both ""
-			precision mediump float;
-			# define __VALUE__	1
-
-			void main()
-			{
-				${POSITION_FRAG_COLOR} = vec4(__VALUE__);
-			}
-		""
-	end
 
 	case invalid_identifier_2
 		expect compile_fail
@@ -2640,20 +2642,62 @@ end # builtin
 
 group pragmas "Pragma Tests"
 
-	case pragma
+	case pragma_vertex
 		values { output float out0 = 1.0; }
-		both ""
-	#pragma
-	#pragma STDGL invariant(all)
-	#pragma debug(off)
-	#pragma optimize(off)
+
+		vertex ""
+			#pragma
+			#pragma STDGL invariant(all)
+			#pragma debug(off)
+			#pragma optimize(off)
 
 			precision mediump float;
-			${DECLARATIONS}
+			${VERTEX_DECLARATIONS}
+			varying float v_val;
 			void main()
 			{
-				out0 = 1.0;
-				${OUTPUT}
+				v_val = 1.0;
+				${VERTEX_OUTPUT}
+			}
+		""
+		fragment ""
+			precision mediump float;
+			${FRAGMENT_DECLARATIONS}
+			invariant varying float v_val;
+			void main()
+			{
+				out0 = v_val;
+				${FRAGMENT_OUTPUT}
+			}
+		""
+	end
+
+	case pragma_fragment
+		values { output float out0 = 1.0; }
+
+		vertex ""
+			precision mediump float;
+			${VERTEX_DECLARATIONS}
+			varying float v_val;
+			void main()
+			{
+				v_val = 1.0;
+				${VERTEX_OUTPUT}
+			}
+		""
+		fragment ""
+			#pragma
+			#pragma STDGL invariant(all)
+			#pragma debug(off)
+			#pragma optimize(off)
+
+			precision mediump float;
+			${FRAGMENT_DECLARATIONS}
+			varying float v_val;
+			void main()
+			{
+				out0 = v_val;
+				${FRAGMENT_OUTPUT}
 			}
 		""
 	end
@@ -2675,10 +2719,12 @@ group pragmas "Pragma Tests"
 		""
 	end
 
-	case invalid_pragma_invalid_debug
-		expect compile_fail
+	case pragma_unrecognized_debug
+		expect build_successful
 		both ""
 			#pragma debug(1.23)
+
+			// unrecognized preprocessor token
 
 			precision mediump float;
 			void main()
@@ -2688,10 +2734,12 @@ group pragmas "Pragma Tests"
 		""
 	end
 
-	case invalid_pragma_invalid_token
-		expect compile_fail
+	case pragma_unrecognized_token
+		expect build_successful
 		both ""
 			#pragma ¤¤½
+
+			// trailing bytes form a valid but unrecognized preprocessor token
 
 			precision mediump float;
 			void main()

--- a/sdk/tests/deqp/data/gles3/shaders/preprocessor.test
+++ b/sdk/tests/deqp/data/gles3/shaders/preprocessor.test
@@ -134,6 +134,23 @@ group basic "Basic Tests"
 		""
 	end
 
+	case identifier_with_double_underscore
+		values { output float out0 = 1.0; }
+		version 300 es
+		both ""
+			#version 300 es
+			precision mediump float;
+			${DECLARATIONS}
+			# define __VALUE__	1
+
+			void main()
+			{
+				// __VALUE__ not used since it might be set by an "underlying software layer"
+				out0 = float(1.0);
+				${OUTPUT}
+			}
+		""
+	end
 end # basic
 
 group definitions "Symbol Definition Tests"
@@ -646,22 +663,6 @@ end # object_redefinitions
 
 group invalid_redefinitions "Invalid Redefinitions Tests"
 
-	case invalid_identifier_1
-		version 300 es
-		expect compile_fail
-		both ""
-			#version 300 es
-			precision mediump float;
-			${DECLARATIONS}
-			# define __VALUE__	1
-
-			void main()
-			{
-				${POSITION_FRAG_COLOR} = vec4(__VALUE__);
-			}
-		""
-	end
-
 	case invalid_identifier_2
 		version 300 es
 		expect compile_fail
@@ -799,6 +800,39 @@ group comments "Comment Tests"
 		""
 	end
 
+	case backslash_in_a_comment_1
+		version 300 es
+		expect build_successful
+		both ""
+			#version 300 es
+			// \\note these are some declarations
+			precision mediump float;
+			${DECLARATIONS}
+			// \\note this is the main function
+			void main()
+			{
+				// \\note this is a function body
+				${OUTPUT}
+			}
+		""
+	end
+
+	case backslash_in_a_comment_2
+		version 300 es
+		expect build_successful
+		both ""
+			#version 300 es
+			/* \\note these are some declarations */
+			precision mediump float;
+			${DECLARATIONS}
+			/* \\note this is the main function */
+			void main()
+			{
+				/* \\note this is a function body */
+				${OUTPUT}
+			}
+		""
+	end
 end # comments
 
 group line_continuation "Line Continuation Tests"
@@ -1623,6 +1657,115 @@ group conditional_inclusion "Conditional Inclusion Tests"
 	#define AAA defined(BBB)
 
 	#if !AAA
+				out0 = 1.0;
+	#else
+				out0 = 0.0;
+	#endif
+				${OUTPUT}
+			}
+		""
+	end
+
+	case defined_macro_defined_test
+		version 300 es
+		values { output float out0 = 1.0; }
+		both ""
+			#version 300 es
+			precision mediump float;
+			${DECLARATIONS}
+			void main()
+			{
+	#define AAA defined
+
+	#if AAA AAA
+				out0 = 1.0;
+	#else
+				out0 = 0.0;
+	#endif
+				${OUTPUT}
+			}
+		""
+	end
+
+	case defined_macro_undef
+		version 300 es
+		values { output float out0 = 1.0; }
+		both ""
+			#version 300 es
+			precision mediump float;
+			${DECLARATIONS}
+			void main()
+			{
+	#define BBB 1
+	#define AAA defined(BBB)
+	#undef BBB
+
+	#if !AAA
+				out0 = 1.0;
+	#else
+				out0 = 0.0;
+	#endif
+				${OUTPUT}
+			}
+		""
+	end
+
+	case define_defined
+		version 300 es
+		values { output float out0 = 1.0; }
+		both ""
+			#version 300 es
+			precision mediump float;
+			${DECLARATIONS}
+			void main()
+			{
+	#define CCC 1
+	#define defined BBB
+	#define AAA defined
+
+	#if AAA CCC
+				out0 = 1.0;
+	#else
+				out0 = 0.0;
+	#endif
+				${OUTPUT}
+			}
+		""
+	end
+
+	case define_defined_outside_if
+		version 300 es
+		values { output float out0 = 1.0; }
+		both ""
+			#version 300 es
+			precision mediump float;
+			${DECLARATIONS}
+			void main()
+			{
+	#define CCC - 0.5
+	#define defined 0.5
+	#define AAA defined
+				out0 = 1.0 - (AAA CCC);
+				${OUTPUT}
+			}
+		""
+	end
+
+	case defined_invalid_before_all_macros_replaced
+		version 300 es
+		expect compile_fail
+		values { output float out0 = 1.0; }
+		both ""
+			#version 300 es
+			precision mediump float;
+			${DECLARATIONS}
+			void main()
+			{
+	#define FOO 1
+	#define OPEN defined(
+	#define CLOSE FOO)
+
+	#if OPEN CLOSE
 				out0 = 1.0;
 	#else
 				out0 = 0.0;
@@ -3253,12 +3396,14 @@ group pragmas "Pragma Tests"
 		""
 	end
 
-	case invalid_pragma_invalid_debug
+	case pragma_unrecognized_debug
 		version 300 es
-		expect compile_fail
+		expect build_successful
 		both ""
 			#version 300 es
 			#pragma debug(1.23)
+
+			// unrecognized preprocessor token
 
 			precision mediump float;
 			${DECLARATIONS}
@@ -3269,12 +3414,14 @@ group pragmas "Pragma Tests"
 		""
 	end
 
-	case invalid_pragma_invalid_token
+	case pragma_unrecognized_token
 		version 300 es
-		expect compile_fail
+		expect build_successful
 		both ""
 			#version 300 es
 			#pragma ¤¤½
+
+			// trailing bytes form a valid but unrecognized preprocessor token
 
 			precision mediump float;
 			${DECLARATIONS}

--- a/sdk/tests/deqp/data/gles3/shaders/preprocessor.test
+++ b/sdk/tests/deqp/data/gles3/shaders/preprocessor.test
@@ -3419,7 +3419,7 @@ group pragmas "Pragma Tests"
 		expect build_successful
 		both ""
 			#version 300 es
-			#pragma ¤¤½
+			#pragma **%
 
 			// trailing bytes form a valid but unrecognized preprocessor token
 
@@ -3582,7 +3582,7 @@ group extensions "Extension Tests"
 		expect compile_fail
 		both ""
 			#version 300 es
-			#extension all¤ : warn
+			#extension all* : warn
 			precision mediump float;
 			${DECLARATIONS}
 			void main()
@@ -3597,7 +3597,7 @@ group extensions "Extension Tests"
 		expect compile_fail
 		both ""
 			#version 300 es
-			#extension all : war¤n
+			#extension all : war*n
 			precision mediump float;
 			${DECLARATIONS}
 			void main()

--- a/sdk/tests/deqp/modules/shared/glsShaderLibrary.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderLibrary.js
@@ -42,6 +42,7 @@ var gluShaderUtil = framework.opengl.gluShaderUtil;
         }
         catch (err) {
             bufferedLogToConsole(err);
+            testFailed('Failed to parse shader test case file');
             return false;
         }
         return true;
@@ -886,6 +887,7 @@ var gluShaderUtil = framework.opengl.gluShaderUtil;
                             case 'compile_fail': return glsShaderLibraryCase.expectResult.EXPECT_COMPILE_FAIL;
                             case 'link_fail': return glsShaderLibraryCase.expectResult.EXPECT_LINK_FAIL;
                             case 'compile_or_link_fail': return glsShaderLibraryCase.expectResult.EXPECT_COMPILE_LINK_FAIL;
+                            case 'build_successful': return glsShaderLibraryCase.expectResult.EXPECT_BUILD_SUCCESSFUL;
                             default:
                                 throw Error('invalid expected result value: ' + m_curTokenStr);
                         }

--- a/sdk/tests/deqp/modules/shared/glsShaderLibraryCase.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderLibraryCase.js
@@ -45,7 +45,8 @@ glsShaderLibraryCase.expectResult = {
     EXPECT_COMPILE_FAIL: 1,
     EXPECT_LINK_FAIL: 2,
     EXPECT_COMPILE_LINK_FAIL: 3,
-    EXPECT_VALIDATION_FAIL: 4
+    EXPECT_VALIDATION_FAIL: 4,
+    EXPECT_BUILD_SUCCESSFUL: 5
 };
 
 /**
@@ -887,6 +888,7 @@ glsShaderLibraryCase.execute = function() {
     switch (spec.expectResult) {
         case glsShaderLibraryCase.expectResult.EXPECT_PASS:
         case glsShaderLibraryCase.expectResult.EXPECT_VALIDATION_FAIL:
+        case glsShaderLibraryCase.expectResult.EXPECT_BUILD_SUCCESSFUL:
             if (!allCompilesOk)
                 failReason = 'expected shaders to compile and link properly, but failed to compile.';
             else if (!allLinksOk)
@@ -933,8 +935,13 @@ glsShaderLibraryCase.execute = function() {
     // Return if compile/link expected to fail.
     if (spec.expectResult === glsShaderLibraryCase.expectResult.EXPECT_COMPILE_FAIL ||
         spec.expectResult === glsShaderLibraryCase.expectResult.EXPECT_COMPILE_LINK_FAIL ||
-        spec.expectResult === glsShaderLibraryCase.expectResult.EXPECT_LINK_FAIL) {
-        testPassedOptions('Compile/link is expected to fail', true);
+        spec.expectResult === glsShaderLibraryCase.expectResult.EXPECT_LINK_FAIL ||
+        spec.expectResult === glsShaderLibraryCase.expectResult.EXPECT_BUILD_SUCCESSFUL) {
+        if (spec.expectResult === glsShaderLibraryCase.expectResult.EXPECT_BUILD_SUCCESSFUL) {
+            testPassedOptions('Compile/link is expected to succeed', true);
+        } else {
+            testPassedOptions('Compile/link is expected to fail', true);
+        }
         setCurrentTestName('');
         return (failReason === null);
     }


### PR DESCRIPTION
Pull in latest changes to the tests from deqp-dev branch.

This contains the following changes:

-Double underscores in macro names are now expected to be accepted by the
 compiler. See previous discussion in pull request #1230.
-Unrecognized pragmas are now expected to be accepted by the compiler.
 ESSL 1.00 and 3.00 specs say "If an implementation does not recognize
 the tokens following #pragma, then it will ignore that pragma".
-Non-matching varying invariance is fixed in some #pragma tests.
-Added tests for "defined" operator corner cases for ESSL 3.00 (now
 covered by WebGL 1.0 spec section 6.31)
-Added tests for backslash in a comment for ESSL 3.00

gles2/shaders/preprocessor.test is not a direct copy from dEQP, since
WebGL-specific changes apply to the behavior of extension directives.

dEQP scripts are updated with support for "build_successful" expectation.
Also, testFailed() is now called if the shader file can't be parsed to
get debugging information automatically.