### PR TITLE
Improve mipmap-fbo test

### DIFF
--- a/conformance-suites/1.0.2/conformance/textures/mipmap-fbo.html
+++ b/conformance-suites/1.0.2/conformance/textures/mipmap-fbo.html
@@ -53,7 +53,7 @@ function init(){
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, 2, 2, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
     gl.bindTexture(gl.TEXTURE_2D, null);
                 
     // setup framebuffer //

--- a/conformance-suites/1.0.3/conformance/textures/mipmap-fbo.html
+++ b/conformance-suites/1.0.3/conformance/textures/mipmap-fbo.html
@@ -52,7 +52,7 @@ function init(){
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, 2, 2, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
     gl.bindTexture(gl.TEXTURE_2D, null);
                 
     // setup framebuffer //

--- a/sdk/tests/conformance/textures/misc/mipmap-fbo.html
+++ b/sdk/tests/conformance/textures/misc/mipmap-fbo.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>Tests if mipmap generation on a texture filled by an FBO works correctly</title>
+<title>Test if mipmap incomplete textures can be used as FBO attachments, and mipmap generation on a texture filled by an FBO works correctly</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
@@ -40,19 +40,19 @@
 <div id="console"></div>
 <script>
 "use strict";
-function init(){
-    var wtu = WebGLTestUtils;
-    description();
 
-    var gl = wtu.create3DContext("example");
-    var program = wtu.setupTexturedQuad(gl);
+var wtu = WebGLTestUtils;
+description();
 
+var gl = wtu.create3DContext("example");
+
+function testMipmapGeneration() {
     // setup render target texture //
     var texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, 2, 2, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
     gl.bindTexture(gl.TEXTURE_2D, null);
                 
     // setup framebuffer //
@@ -63,6 +63,7 @@ function init(){
                 
     // fill the framebuffer //
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.viewport(0, 0, 32, 32);
     gl.clearColor(1, 0, 1, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
@@ -71,13 +72,55 @@ function init(){
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.generateMipmap(gl.TEXTURE_2D);
 
+    var program = wtu.setupTexturedQuad(gl);
+    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
                 
     // readback //
     wtu.checkCanvas(gl, [255, 0, 255, 255]);
 }
 
-init();
+var testCubemapFaceWithIncompleteMipmapInFBO = function() {
+    // Create a cube map texture that's not mipmap complete.
+    var tex2 = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_CUBE_MAP, tex2);
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+
+    var cube_map_faces = [
+        gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+        gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+        gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+        gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+        gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+        gl.TEXTURE_CUBE_MAP_NEGATIVE_Z
+    ];
+    for (var i = 0; i < cube_map_faces.length; ++i) {
+        gl.texImage2D(cube_map_faces[i], 0, gl.RGBA, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    }
+
+    var fb2 = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_CUBE_MAP_POSITIVE_X, tex2, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors after attaching cube map face.");
+    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+    gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
+
+    var colorProgram = wtu.setupColorQuad(gl);
+    var colorLocation = gl.getUniformLocation(colorProgram, 'u_color');
+    gl.uniform4f(colorLocation, 0.0, 1.0, 0.0, 1.0);
+    gl.viewport(0, 0, 32, 32);
+    wtu.drawUnitQuad(gl);
+    // Read what's in the framebuffer - note that we need to use checkCanvasRect since the
+    // FB dimensions are different from canvas dimensions.
+    wtu.checkCanvasRect(gl, 0, 0, 32, 32, [0, 255, 0, 255],
+                        "Framebuffer with a non-mipmap complete cube map attachment should be green");
+}
+
+testMipmapGeneration();
+debug("");
+testCubemapFaceWithIncompleteMipmapInFBO();
+
 var successfullyParsed = true;
 </script>
 <script src="../../../js/js-test-post.js"></script>


### PR DESCRIPTION
Improve the existing test case in the following ways:
-Change the size of the mipmapped texture so that it is minified when
 drawing and two levels actually need to be sampled.
-Specify viewport when the framebuffer dimensions change.
-Use RGBA format. Support for RGB framebuffer attachments is not
 guaranteed by the spec. This bugfix is ported also to versions 1.0.3
 and 1.0.2 of the conformance suite.

Also add a separate subtest for using a cube map face with incomplete
mipmaps as a framebuffer attachment.

These tests already pass at least on Chrome and Firefox on Windows and
Linux with NVIDIA HW.