### PR TITLE
Require that framebuffer attachments are cube complete

### DIFF
--- a/sdk/tests/conformance/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance/textures/misc/00_test_list.txt
@@ -1,6 +1,7 @@
 compressed-tex-image.html
 copy-tex-image-and-sub-image-2d.html
 --min-version 1.0.2 copy-tex-image-2d-formats.html
+--min-version 1.0.4 cube-incomplete-fbo.html
 --min-version 1.0.3 default-texture.html
 --min-version 1.0.2 --max-version 1.9.9 gl-get-tex-parameter.html
 gl-pixelstorei.html

--- a/sdk/tests/conformance/textures/misc/cube-incomplete-fbo.html
+++ b/sdk/tests/conformance/textures/misc/cube-incomplete-fbo.html
@@ -1,0 +1,93 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test that cube incomplete textures can not be used as FBO attachments</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="24" height="24"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+var wtu = WebGLTestUtils;
+description();
+
+var gl = wtu.create3DContext("example");
+
+var testIncompleteCubemapFaceInFBO = function() {
+    // Create a cube map texture that's not cube complete.
+    var tex2 = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_CUBE_MAP, tex2);
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+
+    var cube_map_faces = [
+        gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+        gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+        gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+        gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+        gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+        gl.TEXTURE_CUBE_MAP_NEGATIVE_Z
+    ];
+    // Fill in all but 1 cube map face
+    for (var i = 0; i < cube_map_faces.length - 1; ++i) {
+        gl.texImage2D(cube_map_faces[i], 0, gl.RGBA, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    }
+
+    var fb2 = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_CUBE_MAP_POSITIVE_X, tex2, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors after attaching cube map face.");
+    debug("Cubemap has 1 missing face, so framebuffer should not be complete.");
+    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
+
+    debug("");
+
+    // Fill in missing cube map face
+    gl.texImage2D(cube_map_faces[5], 0, gl.RGBA, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    debug("Missing face is added, so framebuffer should become complete.");
+    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+}
+
+testIncompleteCubemapFaceInFBO();
+
+var successfullyParsed = true;
+finishTest();
+
+</script>
+
+</body>
+</html>
+

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 05 October 2015</h2>
+    <h2 class="no-toc">Editor's Draft 12 October 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -3880,6 +3880,20 @@ extensions.
     not enforced the rule that's written in the GLSL ES spec, and neither have WebGL
     implementations, so relaxing the rule is the only way to make the spec well-defined while being
     compatible with existing content.
+</div>
+
+<h3>Completeness of Cube Map Framebuffer Attachments</h3>
+
+<p>
+    In the WebGL API, a face of a cube map that is not cube complete is not framebuffer attachment
+    complete. Querying framebuffer status when a face of an incomplete cube map is attached must
+    return <code>FRAMEBUFFER_INCOMPLETE_ATTACHMENT</code>.
+</p>
+
+<div class="note rationale">
+    APIs that WebGL is implemented on, including recent OpenGL core versions and OpenGL ES 3.0 and
+    newer have a requirement that cube map faces used as a framebuffer attachment must be part of
+    a cube complete cube map.
 </div>
 
 <!-- ======================================================================================================= -->


### PR DESCRIPTION
This rule is added to improve the portability of WebGL implementations -
some underlying GL implementations enforce this restriction found in
newer OpenGL specs and working around it is complex. The backwards
compatibility impact of enforcing this rule in WebGL is expected to be
minimal.

This rule is not extended to require mipmap completeness as well, as
using non-mipmap complete attachments is already covered by WebGL tests
and working, and there might be content relying on that.