### PR TITLE
Test availability of queries' results per WebGL 2.0 spec rules.

### DIFF
--- a/sdk/tests/conformance2/query/00_test_list.txt
+++ b/sdk/tests/conformance2/query/00_test_list.txt
@@ -1,1 +1,2 @@
+occlusion-query.html
 query.html

--- a/sdk/tests/conformance2/query/occlusion-query.html
+++ b/sdk/tests/conformance2/query/occlusion-query.html
@@ -1,0 +1,158 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Occlusion Query Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<canvas id="canvas" style="width: 50px; height: 50px;"> </canvas>
+<div id="console"></div>
+<script>
+"use strict";
+description("This test verifies the functionality of occlusion query objects.");
+
+debug("");
+
+var tests = [];
+var currentTest;
+var currentTestIndex = 0;
+var numberOfTestAttempts = 4; // Just to stress implementations a bit more.
+var query;
+var numberOfCompletionAttempts = 0;
+
+function setupTests(gl) {
+    tests = [
+        {
+            target: gl.ANY_SAMPLES_PASSED_CONSERVATIVE,
+            name:   "ANY_SAMPLES_PASSED_CONSERVATIVE",
+            result: 1,
+        },
+        {
+            target: gl.ANY_SAMPLES_PASSED,
+            name:   "ANY_SAMPLES_PASSED",
+            result: 1,
+        },
+    ];        
+}
+
+function runOcclusionQueryTest() {
+    currentTest = tests[currentTestIndex];
+
+    debug("");
+    debug("Testing completion and behavior of " + currentTest.name + " occlusion query");
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    var program = wtu.setupSimpleColorProgram(gl, 0);
+    gl.uniform4f(gl.getUniformLocation(program, "u_color"), 0, 1, 0, 1);
+    wtu.setupUnitQuad(gl, 0);
+    query = gl.createQuery();
+    var target = currentTest.target;
+    gl.beginQuery(target, query);
+    wtu.drawUnitQuad(gl);
+    gl.endQuery(target);
+
+    // Verify as best as possible that the implementation doesn't
+    // allow a query's result to become available the same frame, by
+    // spin-looping for some time and ensuring that none of the
+    // queries' results become available.
+    var numEarlyTests = 20000;
+    while (--numEarlyTests > 0) {
+        gl.finish();
+        if (gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE)) {
+            testFailed("Query's result became available too early");
+            finishTest();
+            return;
+        }
+    }
+
+    testPassed("Query's result didn't become available too early");
+    numberOfCompletionAttempts = 0;
+    requestAnimationFrame(completeOcclusionQueryTest);
+}
+
+function completeOcclusionQueryTest() {
+    ++numberOfCompletionAttempts;
+
+    if (numberOfCompletionAttempts > 500) {
+        testFailed("Query didn't become available in a reasonable time");
+        finishTest();
+        return;
+    }
+
+    if (!gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE)) {
+        requestAnimationFrame(completeOcclusionQueryTest);
+        return;
+    }
+
+    // No matter whether the test was run with ANY_SAMPLES_PASSED or
+    // ANY_SAMPLES_PASSED_CONSERVATIVE, the query object should always
+    // report a non-zero result.
+    var result = gl.getQueryParameter(query, gl.QUERY_RESULT);
+    if (result == currentTest.result) {
+        testPassed("Occlusion query " + currentTest.name + " returned a correct result (" + result + ")");
+    } else {
+        testFailed("Occlusion query " + currentTest.name + " returned an incorrect result " + result + " (expected " + currentTest.result + ")");
+    }
+
+    gl.deleteQuery(query);
+    query = null;
+
+    ++currentTestIndex;
+    if (currentTestIndex >= tests.length) {
+        --numberOfTestAttempts;
+        if (numberOfTestAttempts == 0) {
+            finishTest();
+        } else {
+            currentTestIndex = 0;
+            requestAnimationFrame(runOcclusionQueryTest);
+        }        
+    } else {
+        requestAnimationFrame(runOcclusionQueryTest);
+    }
+}
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas, null, 2);
+
+if (!gl) {
+    testFailed("WebGL context does not exist");
+} else {
+    testPassed("WebGL context exists");
+
+    setupTests(gl);
+    runOcclusionQueryTest();
+}
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/transform_feedback/transform_feedback.html
+++ b/sdk/tests/conformance2/transform_feedback/transform_feedback.html
@@ -68,6 +68,8 @@ var tf = null;
 var tf1 = null;
 var program = null;
 var activeInfo = null;
+var query = null;
+var numberOfQueryCompletionAttempts = 0;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -77,8 +79,6 @@ if (!gl) {
     runBindingTest();
     runObjectTest();
     runFeedbackTest();
-    runVaryingsTest();
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
 
 function runBindingTest() {
@@ -163,6 +163,9 @@ function runFeedbackTest() {
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking transform feedback shader should not set an error");
     shouldBeNonNull("program");
 
+    // Create a query object to check the number of primitives written
+    query = gl.createQuery();
+
     // Draw the the transform feedback buffers
     tf = gl.createTransformFeedback();
 
@@ -176,9 +179,11 @@ function runFeedbackTest() {
 
     gl.enable(gl.RASTERIZER_DISCARD);
     gl.beginTransformFeedback(gl.POINTS);
+    gl.beginQuery(gl.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, query);
 
     gl.drawArrays(gl.POINTS, 0, 3);
 
+    gl.endQuery(gl.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN);
     gl.endTransformFeedback();
     gl.disable(gl.RASTERIZER_DISCARD);
 
@@ -204,6 +209,50 @@ function runFeedbackTest() {
 
     tf = null;
     program = null;
+
+    // Check the result of the query. It should not be available yet.
+    // This constant was chosen arbitrarily to take around 1 second on
+    // one WebGL implementation on one desktop operating system. (Busy-
+    // loops based on calling Date.now() have been found unreliable.)
+    var numEarlyTests = 50000;
+    while (--numEarlyTests > 0) {
+        gl.finish();
+        if (gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE)) {
+            testFailed("Query's result became available too early");
+            finishTest();
+            return;
+        }
+    }
+    testPassed("TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN query's result didn't become available too early");
+
+    // Complete the rest of the test asynchronously.
+    requestAnimationFrame(completeTransformFeedbackQueryTest);
+}
+
+function completeTransformFeedbackQueryTest() {
+    debug("");
+    debug("Testing TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN query");
+
+    ++numberOfQueryCompletionAttempts;
+    if (numberOfQueryCompletionAttempts > 500) {
+        testFailed("Query didn't become available in a reasonable time");
+        finishTest();
+        return;
+    }
+
+    if (!gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE)) {
+        requestAnimationFrame(completeTransformFeedbackQueryTest);
+        return;
+    }
+
+    var result = gl.getQueryParameter(query, gl.QUERY_RESULT);
+    if (result == 3) {
+        testPassed("TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN query returned a correct result (3)");
+    } else {
+        testFailed("TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN query returned an incorrect result " + result + " (expected 3)");
+    }
+
+    runVaryingsTest();
 }
 
 function runVaryingsTest() {
@@ -236,12 +285,13 @@ function runVaryingsTest() {
     activeInfo = gl.getTransformFeedbackVarying(program, 2);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Should be GL_INVALID_VALUE when calling getTransformFeedbackVarying with an invalid index.");
     shouldBeNull("activeInfo");
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+    finishTest();
 }
 
 debug("");
-var successfullyParsed = true;
 </script>
-<script src="../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/es3fTransformFeedbackTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTransformFeedbackTests.js
@@ -648,10 +648,10 @@ goog.scope(function() {
     es3fTransformFeedbackTests.getTransformFeedbackPrimitiveCount = function(primitiveType, numElements) {
 
     switch (primitiveType) {
-        case gluDrawUtil.primitiveType.TRIANGLES: return numElements - numElements / 3;
+        case gluDrawUtil.primitiveType.TRIANGLES: return Math.floor(numElements / 3);
         case gluDrawUtil.primitiveType.TRIANGLE_STRIP: return Math.max(0, numElements - 2);
         case gluDrawUtil.primitiveType.TRIANGLE_FAN: return Math.max(0, numElements - 2);
-        case gluDrawUtil.primitiveType.LINES: return numElements - numElements / 2;
+        case gluDrawUtil.primitiveType.LINES: return Math.floor(numElements / 2);
         case gluDrawUtil.primitiveType.LINE_STRIP: return Math.max(0, numElements - 1);
         case gluDrawUtil.primitiveType.LINE_LOOP: return numElements > 1 ? numElements : 0;
         case gluDrawUtil.primitiveType.POINTS: return numElements;
@@ -1257,8 +1257,10 @@ goog.scope(function() {
 
         bufferedLogToConsole('gl.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN = ' + numPrimitives);
 
-        if (numPrimitives != expectedCount)
+        if (numPrimitives != expectedCount) {
+            queryOk = false;
             bufferedLogToConsole('ERROR: Expected ' + expectedCount + ' primitives!');
+        }
 
         // Clear transform feedback state.
         gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);

--- a/sdk/tests/deqp/functional/gles3/transformfeedback.html
+++ b/sdk/tests/deqp/functional/gles3/transformfeedback.html
@@ -16,7 +16,11 @@
 <canvas id="canvas" width="320" height="240"></canvas>
 <script>
     var wtu = WebGLTestUtils;
-    var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
+    // Useful for debugging early errors, but not so much once the
+    // test is running a lot of code, because raising an exception
+    // breaks the subsequent tests.
+    // var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
+    var gl = wtu.create3DContext('canvas', {preserveDrawingBuffer: true}, 2);
 
     try {
         functional.gles3.es3fTransformFeedbackTests.run(gl);


### PR DESCRIPTION
Queries' results must not become available until control returns to the browser's event loop. Verify this for ANY_SAMPLES_PASSED and ANY_SAMPLES_PASSED_CONSERVATIVE occlusion queries in a new targeted test, and modify the transform_feedback test to verify this for TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN queries (which require more setup code).

Change the ported dEQP transform feedback test to enforce that the query's result is as expected, since the logic was recently changed to obey the new specification rules. Fix a bug in the computation of the expected number of primitives.