### PR TITLE
Restrict mag filter to NEAREST for float type texture

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
@@ -223,6 +223,9 @@ function runTexStorage2DTest()
             // defined texture images with null data, which should sample as RGBA 0,0,0,0.
             gl.texParameteri(target, gl.TEXTURE_MIN_FILTER,
                              testcase.mipmap ? gl.NEAREST_MIPMAP_NEAREST : gl.NEAREST);
+            if (testcase.type == gl.FLOAT) {
+                gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+            }
 
             // Now upload some red texture data
             var s = texsize;


### PR DESCRIPTION
Float type texture isn't texture filterable in ES 3.0.
A texture isn't complete if its internal color format is not
texture-filterable and either the magnification filter is not NEAREST or
the minification filter is neigher NEAREST nor NEAREST_MIPMAP_NEAREST.
Chrome will use a black texture for texture being accessed is not
complete which causes tex-storage-2d.html to fail.