### PR TITLE
Fix OES 2D texture with image data tests.

### DIFF
--- a/sdk/tests/conformance/extensions/oes-texture-float-with-image-data.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float-with-image-data.html
@@ -48,8 +48,8 @@ function testPrologue(gl) {
 </script>
 </head>
 <body onload='generateTest("RGBA", "RGBA", "FLOAT", testPrologue, "../../resources/")()'>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="2" height="2"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 </body>

--- a/sdk/tests/conformance/extensions/oes-texture-half-float-with-image-data.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float-with-image-data.html
@@ -53,8 +53,8 @@ function testPrologue(gl) {
 </script>
 </head>
 <body onload='generateTest("RGBA", "RGBA", "HALF_FLOAT_OES", testPrologue, "../../resources/")()'>
-<canvas id="texcanvas" width="1" height="2"></canvas>
-<canvas id="example" width="1" height="2"></canvas>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="2" height="2"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 </body>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
@@ -146,10 +146,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             // the right color.
             debug("Checking " + (flipY ? "top" : "bottom"));
             wtu.checkCanvasRect(gl, 0, bottom, halfWidth, halfHeight, tl, "shouldBe " + tl);
-            wtu.checkCanvasRect(gl, halfWidth, bottom, width, halfHeight, tr, "shouldBe " + tr);
+            wtu.checkCanvasRect(gl, halfWidth, bottom, halfWidth, halfHeight, tr, "shouldBe " + tr);
             debug("Checking " + (flipY ? "bottom" : "top"));
             wtu.checkCanvasRect(gl, 0, top, halfWidth, halfHeight, bl, "shouldBe " + bl);
-            wtu.checkCanvasRect(gl, halfWidth, top, width, halfHeight, br, "shouldBe " + br);
+            wtu.checkCanvasRect(gl, halfWidth, top, halfWidth, halfHeight, br, "shouldBe " + br);
         }
     }
 


### PR DESCRIPTION
The test script [sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js](../blob/master/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js) populates a 2x2 test image, but `conformance/extensions/oes-texture*-with-image-data.html` tests use 1x2 canvas, which results in no-op checks. This is fixed in the pull request.

Additionally, the test script checks all four image pixels, and it should not check out-of-canvas-bounds areas.
