### PR TITLE
Update dEQP shader keywords tests from deqp-dev

### DIFF
--- a/sdk/tests/deqp/data/gles2/shaders/keywords.test
+++ b/sdk/tests/deqp/data/gles2/shaders/keywords.test
@@ -1558,57 +1558,6 @@ group reserved_keywords "Usage of reserved keywords as identifiers."
 end # reserved_keywords
 group invalid_identifiers "Usage of invalid identifiers."
 
-	case two_underscores_begin
-		expect compile_fail
-		values {}
-
-		both ""
-			precision mediump float;
-
-			${DECLARATIONS}
-
-			void main()
-			{
-				${SETUP}
-				float __invalid = 1.0;
-				${OUTPUT}
-			}
-		""
-	end
-	case two_underscores_middle
-		expect compile_fail
-		values {}
-
-		both ""
-			precision mediump float;
-
-			${DECLARATIONS}
-
-			void main()
-			{
-				${SETUP}
-				float in__valid = 1.0;
-				${OUTPUT}
-			}
-		""
-	end
-	case two_underscores_end
-		expect compile_fail
-		values {}
-
-		both ""
-			precision mediump float;
-
-			${DECLARATIONS}
-
-			void main()
-			{
-				${SETUP}
-				float invalid__ = 1.0;
-				${OUTPUT}
-			}
-		""
-	end
 	case gl_begin
 		expect compile_fail
 		values {}

--- a/sdk/tests/deqp/data/gles3/shaders/keywords.test
+++ b/sdk/tests/deqp/data/gles3/shaders/keywords.test
@@ -3143,60 +3143,6 @@ group reserved_keywords "Usage of reserved keywords as identifiers."
 end # reserved_keywords
 group invalid_identifiers "Usage of invalid identifiers."
 
-	case two_underscores_begin
-		expect compile_fail
-		values {}
-		version 300 es
-
-		both ""
-			#version 300 es
-			precision mediump float;
-			${DECLARATIONS}
-
-			void main()
-			{
-				${SETUP}
-				float __invalid = 1.0;
-				${OUTPUT}
-			}
-		""
-	end
-	case two_underscores_middle
-		expect compile_fail
-		values {}
-		version 300 es
-
-		both ""
-			#version 300 es
-			precision mediump float;
-			${DECLARATIONS}
-
-			void main()
-			{
-				${SETUP}
-				float in__valid = 1.0;
-				${OUTPUT}
-			}
-		""
-	end
-	case two_underscores_end
-		expect compile_fail
-		values {}
-		version 300 es
-
-		both ""
-			#version 300 es
-			precision mediump float;
-			${DECLARATIONS}
-
-			void main()
-			{
-				${SETUP}
-				float invalid__ = 1.0;
-				${OUTPUT}
-			}
-		""
-	end
 	case gl_begin
 		expect compile_fail
 		values {}


### PR DESCRIPTION
This removes double underscore test cases from dEQP. After this commit,
the dEQP tests don't address double underscores in identifiers in any
way. Using double underscores in identifiers is covered elsewhere in the
WebGL conformance suite, so the intent of this patch is simply to bring
the copy of the tests closer to latest native dEQP, not to change the
expected behavior.

The other test that makes sure double underscores are not allowed in
identifiers is:

/conformance/glsl/misc/shader-with-reserved-words.html