### PR TITLE
Add test from Austin Appleby from Google Maps team.

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -5,6 +5,7 @@
 --min-version 1.0.3 complex-glsl-does-not-crash.html
 --min-version 1.0.3 conditional-discard-optimization.html
 --min-version 1.0.3 constant-precision-qualifier.html
+--min-version 1.0.4 floor-div-cos-should-not-truncate.html
 --min-version 1.0.3 floored-division-accuracy.html
 --min-version 1.0.3 fragcoord-linking-bug.html
 --min-version 1.0.3 long-expressions-should-not-crash.html


### PR DESCRIPTION
Confirmed that this fails in Chrome Canary on an Intel GPU with the command line argument --disable-d3d11.