### PR TITLE
Fix dEQP texture sampling when generating reference images

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuTexture.js
+++ b/sdk/tests/deqp/framework/common/tcuTexture.js
@@ -1012,9 +1012,8 @@ tcuTexture.sampleNearest2D = function(access, sampler, u, v, depthOrOffset) {
     var width = access.getWidth();
     var height = access.getHeight();
 
-    /* TODO: Shouldn't it be just Math.round? */
-    var x = Math.round(Math.floor(u)) + xOffset;
-    var y = Math.round(Math.floor(v)) + yOffset;
+    var x = Math.floor(u) + xOffset;
+    var y = Math.floor(v) + yOffset;
 
     // Check for CLAMP_TO_BORDER.
     if ((sampler.wrapS == tcuTexture.WrapMode.CLAMP_TO_BORDER && !deMath.deInBounds32(x, 0, width)) ||
@@ -1050,9 +1049,9 @@ tcuTexture.sampleNearest3D = function(access, sampler, u, v, w, offset) {
         zOffset = offset[2];
     }
 
-    var x = Math.round(Math.floor(u)) + xOffset;
-    var y = Math.round(Math.floor(v)) + yOffset;
-    var z = Math.round(Math.floor(w)) + zOffset;
+    var x = Math.floor(u) + xOffset;
+    var y = Math.floor(v) + yOffset;
+    var z = Math.floor(w) + zOffset;
 
     // Check for CLAMP_TO_BORDER.
     if ((sampler.wrapS == tcuTexture.WrapMode.CLAMP_TO_BORDER && !deMath.deInBounds32(x, 0, width)) ||
@@ -1605,7 +1604,7 @@ tcuTexture.ConstPixelBufferAccess.prototype.sample2DCompare = function(sampler, 
     }
 
     switch (filter) {
-        case tcuTexture.FilterMode.NEAREST: return tcuTexture.execCompare(tcuTexture.sampleNearest2D(this, sampler, u, v, offset[0]), sampler.compare, sampler.compareChannel, ref, isFixedPointDepth);
+        case tcuTexture.FilterMode.NEAREST: return tcuTexture.execCompare(tcuTexture.sampleNearest2D(this, sampler, u, v, offset), sampler.compare, sampler.compareChannel, ref, isFixedPointDepth);
         case tcuTexture.FilterMode.LINEAR: return tcuTexture.sampleLinear2DCompare(this, sampler, ref, u, v, offset, isFixedPointDepth);
         default:
             DE_ASSERT(false);


### PR DESCRIPTION
These bring the port in line with native dEQP, fixing the reference
rendering in most of the texture2darrayshadow tests.

1. Pass entire offset instead of just the first value when calling
sampleNearest2D() in sample2DCompare().

2. Remove extraneous Math.round from sampleNearest*().