### PR TITLE
Improve short circuiting in loop condition test

### DIFF
--- a/sdk/tests/conformance2/glsl3/short-circuiting-in-loop-condition.html
+++ b/sdk/tests/conformance2/glsl3/short-circuiting-in-loop-condition.html
@@ -45,7 +45,7 @@
     gl_Position = aPosition;
   }
 </script>
-<script id="fshader" type="x-shader/x-fragment">#version 300 es
+<script id="fshaderWhile" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 uniform bool u;
 out vec4 result;
@@ -61,40 +61,128 @@ void main() {
   int iterations = 0;
 
   while(u && foo()) {
+    ++iterations;
+    if (iterations >= 10) {
+      break;
+    }
+  }
+
+  bool success = (u && sideEffectCounter == 10) || (!u && sideEffectCounter == 0);
+  result = success ? vec4(0, 1.0, 0, 1.0) : vec4(0, 1.0, 0, 0);
+}
+</script>
+<script id="fshaderFor" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform bool u;
+out vec4 result;
+int sideEffectCounter;
+
+bool foo() {
+  ++sideEffectCounter;
+  return true;
+}
+
+void main() {
+  sideEffectCounter = 0;
+  for(int iterations = 0; true; u && foo()) {
+    ++iterations;
     if (iterations > 10) {
       break;
     }
-    ++iterations;
   }
 
-  bool success = (u && sideEffectCounter == 12) || (!u && sideEffectCounter == 0);
+  bool success = (u && sideEffectCounter == 10) || (!u && sideEffectCounter == 0);
+  result = success ? vec4(0, 1.0, 0, 1.0) : vec4(0, 1.0, 0, 0);
+}
+</script>
+<script id="fshaderDoWhile" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform bool u;
+out vec4 result;
+int sideEffectCounter;
+
+bool foo() {
+  ++sideEffectCounter;
+  return true;
+}
+
+void main() {
+  sideEffectCounter = 0;
+  int iterations = 0;
+
+  do {
+    ++iterations;
+    if (iterations > 10) {
+      break;
+    }
+  } while (u && foo());
+
+  bool success = (u && sideEffectCounter == 10) || (!u && sideEffectCounter == 0);
+  result = success ? vec4(0, 1.0, 0, 1.0) : vec4(0, 1.0, 0, 0);
+}
+</script>
+<script id="fshaderSequence" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform bool u;
+out vec4 result;
+int sideEffectCounter;
+
+bool foo() {
+  ++sideEffectCounter;
+  return true;
+}
+
+void main() {
+  sideEffectCounter = 0;
+  int iterations = 0;
+
+  while(u, u && foo()) {
+    ++iterations;
+    if (iterations >= 10) {
+      break;
+    }
+  }
+
+  bool success = (u && sideEffectCounter == 10) || (!u && sideEffectCounter == 0);
   result = success ? vec4(0, 1.0, 0, 1.0) : vec4(0, 1.0, 0, 0);
 }
 </script>
 <script type="text/javascript">
 "use strict";
-  description("Test behavior of a short-circuiting operator in a loop condition using a function call with side effects");
-  debug("");
+description("Test behavior of a short-circuiting operator in a loop using a function call with side effects");
 
-  var wtu = WebGLTestUtils;
-  var gl = wtu.create3DContext(undefined, undefined, 2);
-  if (!gl) {
-    testFailed("context does not exist");
-  } else {
-    var program = wtu.setupProgram(gl, ["vertex-shader", "fshader"], ['aPosition'], undefined, true);
-    wtu.setupUnitQuad(gl);
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext(undefined, undefined, 2);
+wtu.setupUnitQuad(gl);
 
-    debug("Test short-circuiting operator in a loop with a true condition.");
+var testShader = function(fshaderId, subTestDescription) {
+    debug("");
+    debug(subTestDescription);
+    var program = wtu.setupProgram(gl, ["vertex-shader", fshaderId], ['aPosition'], undefined, true);
+    if (!program) {
+        testFailed('Program compilation failed');
+        return;
+    }
+
+    debug("Test short-circuiting operator with a true condition.");
     gl.uniform1i(gl.getUniformLocation(program, "u"), 1);
     wtu.clearAndDrawUnitQuad(gl);
     wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
-    debug("");
 
-    debug("Test short-circuiting operator in a loop with a false condition.");
+    debug("Test short-circuiting operator with a false condition.");
     gl.uniform1i(gl.getUniformLocation(program, "u"), 0);
     wtu.clearAndDrawUnitQuad(gl);
     wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
-  }
+};
+
+if (!gl) {
+    testFailed("context does not exist");
+} else {
+    testShader("fshaderWhile", "in while loop condition");
+    testShader("fshaderFor", "in for loop expression");
+    testShader("fshaderDoWhile", "in do-while loop condition");
+    testShader("fshaderSequence", "inside a sequence in while loop condition");
+}
 var successfullyParsed = true;
 finishTest();
 </script>


### PR DESCRIPTION
Test having a short circuiting operator in the for loop expression, in
do-while loop condition, and inside a sequence operator in a loop
condition.

Also make the while loop test a bit more intuitive. Shuffling around
a few operations makes the sideEffectCounter value at the end match
the number "iterations" is compared against.