### PR TITLE
Fix invalid operation on framebuffer in expando-loss.html

### DIFF
--- a/sdk/tests/conformance/misc/expando-loss.html
+++ b/sdk/tests/conformance/misc/expando-loss.html
@@ -201,8 +201,8 @@ function testFrameBufferAttachments() {
     var attachments = [
         { enum: gl.COLOR_ATTACHMENT0,       name: "COLOR_ATTACHMENT0" },
         { enum: gl.DEPTH_ATTACHMENT,        name: "DEPTH_ATTACHMENT" },
-        { enum: gl.DEPTH_STENCIL_ATTACHMENT,name: "DEPTH_STENCIL_ATTACHMENT" },
         { enum: gl.STENCIL_ATTACHMENT,      name: "STENCIL_ATTACHMENT" },
+        { enum: gl.DEPTH_STENCIL_ATTACHMENT,name: "DEPTH_STENCIL_ATTACHMENT" },
     ];
 
     // Attach a renderbuffer to all attachment points.


### PR DESCRIPTION
In WebGL 2.0, DEPTH_STENCIL_ATTACHMENT is considered an alias for
DEPTH_ATTACHMENT + STENCIL_ATTACHMENT. Attaching a different render
buffer to STENCIL_ATTACHMENT would make different images bound to depth
and stencil attachment points.
If attachment is DEPTH_STENCIL_ATTACHMENT and different images are bound
to the depth and stencil attachment points, getFramebufferAttachmentParameter
generates an INVALID_OPERATION error. Move DEPTH_STENCIL_ATTACHMENT to
the end of the attachments array to avoid such issue.