### PR TITLE
Use RGBA for renderable textures, as RGB isn't renderable.

### DIFF
--- a/sdk/tests/conformance/rendering/framebuffer-switch.html
+++ b/sdk/tests/conformance/rendering/framebuffer-switch.html
@@ -48,7 +48,7 @@ var program = wtu.setupTexturedQuad(gl);
 
 var tex1 = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex1);
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, canvas.width, canvas.height, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
 var fb1 = gl.createFramebuffer();
@@ -57,7 +57,7 @@ gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex
 
 var tex2 = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex2);
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, canvas.width, canvas.height, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
 var fb2 = gl.createFramebuffer();

--- a/sdk/tests/conformance/rendering/framebuffer-texture-switch.html
+++ b/sdk/tests/conformance/rendering/framebuffer-texture-switch.html
@@ -51,13 +51,13 @@ gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
 
 var tex2 = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex2);
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, canvas.width, canvas.height, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
 
 var tex1 = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex1);
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, canvas.width, canvas.height, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, canvas.width, canvas.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
 

--- a/sdk/tests/conformance/textures/misc/texture-fakeblack.html
+++ b/sdk/tests/conformance/textures/misc/texture-fakeblack.html
@@ -40,36 +40,36 @@
 <div id="console"></div>
 <script>
 "use strict";
-    
+
 function createTexture(gl,r,g,b,a) {
     // setup render target texture //
-    
+
     var texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB, 3, 3, 0, gl.RGB, gl.UNSIGNED_BYTE, null);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 3, 3, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
     gl.bindTexture(gl.TEXTURE_2D, null);
-    
+
     // setup framebuffer //
     var fbo = gl.createFramebuffer();
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    
+
     // fill the framebuffer //
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
     gl.clearColor(r, g, b, a);
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    
+
     gl.deleteFramebuffer(fbo);
-    
+
     return texture;
 }
-    
+
 function init() {
     /*
      * This test has been written due to a bug found in firefox's code
@@ -81,25 +81,25 @@ function init() {
 
     var gl = wtu.create3DContext("example");
     var program = wtu.setupTexturedQuad(gl);
-    
+
     var texture0 = createTexture(gl,1,0,0,1);
     var texture1 = createTexture(gl,0,1,0,1);
-    
+
     gl.bindTexture(gl.TEXTURE_2D, texture0);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     wtu.checkCanvas(gl, [255, 0, 0, 255]);
-    
+
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     wtu.checkCanvas(gl, [0, 0, 0, 255]);
-    
+
     gl.bindTexture(gl.TEXTURE_2D, texture1);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     wtu.checkCanvas(gl, [0, 255, 0, 255]);
-    
+
     gl.bindTexture(gl.TEXTURE_2D, texture0);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     wtu.checkCanvas(gl, [0, 0, 0, 255]);


### PR DESCRIPTION
The WebGL 1 spec guarantees that RGBA/UNSIGNED_BYTE textures are renderable (valid framebuffer formats), but it does not guaratee that RGB/UNSIGNED_BYTE textures are. 

(See GLES 2.0.25, p117, Table 4.5 for the list of renderable formats in GLES2)