### PR TITLE
multiple uniform blocks in shader should be well-supported

### DIFF
--- a/sdk/tests/conformance2/buffers/uniform-buffers.html
+++ b/sdk/tests/conformance2/buffers/uniform-buffers.html
@@ -50,9 +50,15 @@ uniform UBOData {
     float UBOBlue;
 };
 
+uniform UBOD {
+    float UBOR;
+    float UBOG;
+    float UBOB;
+};
+
 void main()
 {
-    oColor = vec4(UBORed, UBOGreen, UBOBlue, 1.0);
+    oColor = vec4(UBORed * UBOR, UBOGreen * UBOG, UBOBlue * UBOB, 1.0);
 }
 </script>
 </head>


### PR DESCRIPTION
multiple uniform blocks in shader will expose an bug in Chromium. PTAL.