### PR TITLE
Add a simple ESSL3 test for constant array initialization

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -7,6 +7,7 @@ array-in-complex-expression.html
 array-length-side-effects.html
 attrib-location-length-limits.html
 compare-structs-containing-arrays.html
+const-array-init.html
 frag-depth.html
 invalid-default-precision.html
 misplaced-version-directive.html

--- a/sdk/tests/conformance2/glsl3/const-array-init.html
+++ b/sdk/tests/conformance2/glsl3/const-array-init.html
@@ -1,0 +1,119 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Constant array initialization test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderGlobalConstArray" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+
+const vec4 constants[2] = vec4[] (
+    vec4(0.6, 0.3, 0.0, 3.0),
+    vec4(-0.6, 0.7, 0.0, -2.0)
+);
+
+void main()
+{
+    my_FragColor = constants[0] + constants[1];
+    return;
+}
+</script>
+<script id="fshaderGlobalConstArrayWithReferenceToConstArray" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+
+const vec4 constants[2] = vec4[] (
+    vec4(0.6, 0.3, 0.0, 3.0),
+    vec4(-0.6, 0.7, 0.0, -2.0)
+);
+
+const vec4 constants2[2] = vec4[] (
+    constants[1],
+    constants[0]
+);
+
+void main()
+{
+    my_FragColor = constants2[0] + constants2[1];
+    return;
+}
+</script>
+<script id="fshaderGlobalConstArrayInitializedToConstArray" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+
+const vec4 constants[2] = vec4[] (
+    vec4(0.6, 0.3, 0.0, 3.0),
+    vec4(-0.6, 0.7, 0.0, -2.0)
+);
+
+const vec4 constants2[2] = constants;
+
+void main()
+{
+    my_FragColor = constants2[0] + constants2[1];
+    return;
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Test initializing a constant global array");
+
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderGlobalConstArray',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Global constant array with vec4 constructors and literals in the initializer"
+},
+{
+  fShaderId: 'fshaderGlobalConstArrayWithReferenceToConstArray',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Global constant array which indexes another global constant array in the initializer"
+},
+{
+  fShaderId: 'fshaderGlobalConstArrayInitializedToConstArray',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Global constant array initialized to another global constant array"
+}
+], 2);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Constant array initialization in the global scope can be problematic,
for the combination of these reasons:

1. It's often undesirable to constant fold array constructors.

2. Constant array constructors that are not folded may need to be
   implemented using function calls on HLSL.

3. Function calls are not allowed in the global scope.

So a WebGL test for this is necessary.