### PR TITLE
Add a test for ANGLE constructor bugs

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 1.0.4 angle-constructor-invalid-parameters.html
 --min-version 1.0.3 angle-d3d11-compiler-error.html
 --min-version 1.0.3 angle-dx-variable-bug.html
 --min-version 1.0.3 array-of-struct-with-int-first-position.html

--- a/sdk/tests/conformance/glsl/bugs/angle-constructor-invalid-parameters.html
+++ b/sdk/tests/conformance/glsl/bugs/angle-constructor-invalid-parameters.html
@@ -1,0 +1,77 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>ANGLE constructor bugs test</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderSamplerInConstructorArguments" type="x-shader/x-fragment">
+precision mediump float;
+uniform sampler2D s;
+void main()
+{
+    gl_FragColor = vec4(0.0, s, 0.0, 0.0);
+}
+</script>
+<script id="fshaderVoidInConstructorArguments" type="x-shader/x-fragment">
+precision mediump float;
+void foo() {}
+void main()
+{
+    gl_FragColor = vec4(0.0, foo(), 0.0, 0.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Test constructors that have had issues in ANGLE");
+
+GLSLConformanceTester.runTests([
+{
+  fShaderId: 'fshaderSamplerInConstructorArguments',
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Sampler in constructor arguments should not compile"
+},
+{
+  fShaderId: 'fshaderVoidInConstructorArguments',
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Void in constructor arguments should not compile"
+},
+]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Passing invalid parameters to constructors can pass shader validation
with the current version of ANGLE. Most driver compilers should fail
compilation and the test will still pass, but running the test does cause
issues at least on OSS NVIDIA Linux driver stack.