### PR TITLE
Fix some tests to allow ambiguous error cases.

### DIFF
--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -157,7 +157,7 @@ function testLosingAndRestoringContext()
       // restore the context after this event has exited.
       setTimeout(function() {
         shouldGenerateGLError(gl, gl.NO_ERROR, "WEBGL_lose_context.restoreContext()");
-        // The context should still be lost. It will not get restored until the 
+        // The context should still be lost. It will not get restored until the
         // webglrestorecontext event is fired.
         shouldBeTrue("gl.isContextLost()");
         shouldBe("gl.getError()", "gl.NO_ERROR");
@@ -248,7 +248,8 @@ function testOESTextureFloat() {
     // Extension must still be lost.
     var tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex);
-    shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.FLOAT, null)");
+    wtu.shouldGenerateGLErrorIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
+                                "gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.FLOAT, null)");
     // Try re-enabling extension
     OES_texture_float = reGetExtensionAndTestForProperty(gl, "OES_texture_float", false);
     shouldGenerateGLError(gl, gl.NO_ERROR, "gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.FLOAT, null)");

--- a/sdk/tests/conformance/extensions/ext-sRGB.html
+++ b/sdk/tests/conformance/extensions/ext-sRGB.html
@@ -125,9 +125,7 @@ function testInvalidFormat(fn, internalFormat, formatName, enabled) {
   var err = gl.getError();
   if (err == gl.NO_ERROR) {
     testFailed("should NOT be able to create type " + formatName);
-  } else if (err == gl.INVALID_OPERATION) {
-    testFailed("should return gl.INVALID_ENUM for type " + formatName);
-  } else if (err == gl.INVALID_ENUM) {
+  } else if (err == gl.INVALID_ENUM || err == gl.INVALID_OPERATION) {
     testPassed("not able to create invalid format: " + formatName);
   }
 }
@@ -328,7 +326,7 @@ function runFramebufferTextureConversionTest(format) {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
   shouldBe('gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, ext.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT)', 'ext.SRGB_EXT');
-  
+
   if (validFormat) {
     shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
 

--- a/sdk/tests/conformance/extensions/oes-texture-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float.html
@@ -157,7 +157,8 @@ function runTextureCreationTest(testProgram, extensionEnabled, opt_format, opt_n
     }
     gl.texImage2D(gl.TEXTURE_2D, 0, format, width, height, 0, format, gl.FLOAT, data);
     if (expectFailure) {
-        wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "floating-point texture allocation must be disallowed if OES_texture_float isn't enabled");
+        wtu.glErrorShouldBe(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
+                            "floating-point texture allocation must be disallowed if OES_texture_float isn't enabled");
         return;
     } else {
         wtu.glErrorShouldBe(gl, gl.NO_ERROR, "floating-point texture allocation should succeed if OES_texture_float is enabled");
@@ -181,10 +182,10 @@ function arrayToString(arr, size) {
         mySize = size;
     var out = "[";
     for (var ii = 0; ii < mySize; ++ii) {
-	if (ii > 0) {
-	    out += ", ";
-	}
-	out += arr[ii];
+    if (ii > 0) {
+        out += ", ";
+    }
+    out += arr[ii];
     }
     return out + "]";
 }
@@ -250,25 +251,25 @@ function runRenderTargetAndReadbackTest(testProgram, format, numberOfChannels, s
     var implType = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "getParameter of IMPLEMENTATION_COLOR_READ_{FORMAT|TYPE} should succeed");
     if ((implFormat == gl.RGBA || implFormat == gl.RGB) && implType == gl.FLOAT) {
-	debug("Checking readback of floating-point values");
-	var arraySize = (implFormat == gl.RGBA) ? 4 : 3
-	var buf = new Float32Array(arraySize);
-	gl.readPixels(0, 0, 1, 1, implFormat, implType , buf);
-	wtu.glErrorShouldBe(gl, gl.NO_ERROR, "readPixels from floating-point renderbuffer should succeed");
-	var ok = true;
-	var tolerance = 8.0; // TODO: factor this out from both this test and the subtractor shader above.
-	for (var ii = 0; ii < buf.length; ++ii) {
-	    if (Math.abs(buf[ii] - subtractor[ii]) > tolerance) {
-		ok = false;
-		break;
-	    }
-	}
-	if (ok) {
-	    testPassed("readPixels of float-type data from floating-point renderbuffer succeeded");
-	} else {
-	    testFailed("readPixels of float-type data from floating-point renderbuffer failed: expected "
-		       + arrayToString(subtractor, arraySize) + ", got " + arrayToString(buf));
-	}
+    debug("Checking readback of floating-point values");
+    var arraySize = (implFormat == gl.RGBA) ? 4 : 3
+    var buf = new Float32Array(arraySize);
+    gl.readPixels(0, 0, 1, 1, implFormat, implType , buf);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "readPixels from floating-point renderbuffer should succeed");
+    var ok = true;
+    var tolerance = 8.0; // TODO: factor this out from both this test and the subtractor shader above.
+    for (var ii = 0; ii < buf.length; ++ii) {
+        if (Math.abs(buf[ii] - subtractor[ii]) > tolerance) {
+        ok = false;
+        break;
+        }
+    }
+    if (ok) {
+        testPassed("readPixels of float-type data from floating-point renderbuffer succeeded");
+    } else {
+        testFailed("readPixels of float-type data from floating-point renderbuffer failed: expected "
+               + arrayToString(subtractor, arraySize) + ", got " + arrayToString(buf));
+    }
     }
 }
 

--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -115,13 +115,13 @@ if (!gl) {
         formats.forEach(function(f) {
             runTextureCreationTest(true, f.format, null, f.expected);
         });
-        
+
         // Texture creation should fail when passed with non-null, non-Uint16 ArrayBufferView
         formats.forEach(function(f) {
             var width = 2;
             var height = 2;
             var format = f.format;
-            
+
             // Float32Array
             var float32Data = new Float32Array(width * height * getNumberOfChannels(format));
             for (var ii = 0; ii < float32Data.length; ii++) {
@@ -138,7 +138,7 @@ if (!gl) {
         });
 
         // Test that Uint16 encoded half float values can be used as texture data.
-        
+
         // First test that values in the 0-1 range can be written and read.
         var halfFloatOneThird = 0x3555; // Half float 1/3
         var uint16Formats = [
@@ -232,19 +232,20 @@ function runTextureCreationTest(extensionEnabled, opt_format, opt_data, opt_expe
     var format = opt_format || gl.RGBA;
     var data = opt_data || null;
     var expectSuccess = true;
-    
+
     if (!extensionEnabled || !opt_expected)
         expectSuccess = false;
     debug("Testing texture creation with extension " + (extensionEnabled ? "enabled" : "disabled") +
           ", format " + getFormatName(format) + ", and data " + (data ? "non-null" : "null") +
-          ". Expect " + (expectSuccess ? "Success" : "Failure"));   
+          ". Expect " + (expectSuccess ? "Success" : "Failure"));
 
     var texture = allocateTexture();
     var width = 2;
     var height = 2;
     gl.texImage2D(gl.TEXTURE_2D, 0, format, width, height, 0, format, halfFloatOESEnum, data);
     if(!extensionEnabled) {
-        wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Half floating point texture must be disallowed if OES_texture_half_float isn't enabled");
+        wtu.glErrorShouldBeIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
+                              "Half floating point texture must be disallowed if OES_texture_half_float isn't enabled");
         return;
     } else if (!opt_expected) {
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Half floating point texture allocation must be disallowed when ArrayBufferView is not-null and not-Uint16");

--- a/sdk/tests/conformance/extensions/webgl-depth-texture.html
+++ b/sdk/tests/conformance/extensions/webgl-depth-texture.html
@@ -116,8 +116,10 @@ function runTestDisabled() {
 
     var tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex);
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1, 1, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_SHORT, null)');
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1, 1, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, null)');
+    wtu.shouldGenerateGLErrorIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
+                                'gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1, 1, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_SHORT, null)');
+    wtu.shouldGenerateGLErrorIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
+                                'gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1, 1, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, null)');
 }
 
 

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -228,8 +228,8 @@ function runEnumTestEnabled() {
 
   debug("Testing drawBuffersWEBGL with default drawing buffer");
   shouldBe("gl.getParameter(ext.DRAW_BUFFER0_WEBGL)", "gl.BACK");
-  wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "ext.drawBuffersWEBGL([])");
-  wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "ext.drawBuffersWEBGL([gl.NONE, gl.NONE])");
+  wtu.shouldGenerateGLErrorIn(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "ext.drawBuffersWEBGL([])");
+  wtu.shouldGenerateGLErrorIn(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "ext.drawBuffersWEBGL([gl.NONE, gl.NONE])");
   wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "ext.drawBuffersWEBGL([ext.COLOR_ATTACHMENT0_WEBGL])");
   shouldBe("gl.getParameter(ext.DRAW_BUFFER0_WEBGL)", "gl.BACK");
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "ext.drawBuffersWEBGL([gl.NONE])");

--- a/sdk/tests/conformance/more/functions/texImage2DBadArgs.html
+++ b/sdk/tests/conformance/more/functions/texImage2DBadArgs.html
@@ -61,7 +61,8 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_ENUM, "bad target", function(){
         gl.texImage2D(gl.FLOAT, 0, gl.RGBA, 1,1,0,gl.RGBA,gl.UNSIGNED_BYTE, null);
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad internal format/format", function(){
+    assertGLErrorIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
+                    "bad internal format/format", function(){
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.FLOAT, 1,1,0,gl.FLOAT,gl.UNSIGNED_BYTE, null);
     });
     assertGLError(gl, gl.INVALID_VALUE, "border > 0", function(){
@@ -78,10 +79,10 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_VALUE, "negative height", function(){
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1,-1,0,gl.RGBA,gl.UNSIGNED_BYTE, null);
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad format", function(){
+    assertGLErrorIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], "bad format", function(){
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1,1,0,gl.FLOAT,gl.UNSIGNED_BYTE, null);
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad type", function(){
+    assertGLErrorIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], "bad type", function(){
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1,1,0,gl.RGBA,gl.TEXTURE_2D, null);
     });
     assertGLError(gl, gl.INVALID_OPERATION, "not enough data", function(){

--- a/sdk/tests/conformance/more/functions/texSubImage2DBadArgs.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DBadArgs.html
@@ -91,7 +91,7 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_ENUM, "bad format", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.FLOAT,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad type", function(){
+    assertGLErrorIn(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], "bad type", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.TEXTURE_2D, new Uint8Array([0,0,0,0]));
     });
     assertGLError(gl, gl.INVALID_OPERATION, "not enough data", function(){

--- a/sdk/tests/conformance/more/util.js
+++ b/sdk/tests/conformance/more/util.js
@@ -1020,6 +1020,40 @@ function assertGLError(gl, err, name, f) {
   return true;
 }
 
+// Assert that f generates a GL error from a list.
+function assertGLErrorIn(gl, expectedErrorList, name, f) {
+  if (f == null) { f = name; name = null; }
+
+  var actualError = 0;
+  try {
+    f();
+  } catch(e) {
+    if ('glError' in e) {
+      actualError = e.glError;
+    } else {
+      testFailed("assertGLError: UNEXPCETED EXCEPTION", name, f);
+      return false;
+    }
+  }
+
+  var expectedErrorStrList = [];
+  var expectedErrorSet = {};
+  for (var i in expectedErrorList) {
+    var cur = expectedErrorList[i];
+    expectedErrorSet[cur] = true;
+    expectedErrorStrList.push(getGLErrorAsString(gl, cur));
+  }
+  var expectedErrorListStr = "[" + expectedErrorStrList.join(", ") + "]";
+
+  if (actualError in expectedErrorSet) {
+    return true;
+  }
+
+  testFailed("assertGLError: expected: " + expectedErrorListStr +
+             " actual: " + getGLErrorAsString(gl, actualError), name, f);
+  return false;
+}
+
 // Assert that f generates some GL error. Used in situations where it's
 // ambigious which of multiple possible errors will be generated.
 function assertSomeGLError(gl, name, f) {

--- a/sdk/tests/conformance/renderbuffers/framebuffer-test.html
+++ b/sdk/tests/conformance/renderbuffers/framebuffer-test.html
@@ -156,15 +156,17 @@ if (!gl) {
   wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
             "calling framebufferRenderbuffer with attachment = COLOR_ATTACHMENT1 should generate INVALID_ENUM.");
 
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbtex, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "attaching a texture to a framebuffer should succeed.");
+
+  // This must come after the successful attachment, otherwise it could also
+  // generate INVALID_OPERATION.
   gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER,
                                        gl.COLOR_ATTACHMENT0,
                                        desktopGL.FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING);
   wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
             "calling getFramebufferAttachmentParameter with pname = GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING should generate INVALID_ENUM.");
-
-  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbtex, 0);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-            "attaching a texture to a framebuffer should succeed.");
 
   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, null, 0);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,

--- a/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
+++ b/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
@@ -54,7 +54,7 @@ gl.bindTexture(gl.TEXTURE_2D, tex);
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 1, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "no previously defined texture image");
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, c);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setup should succeed"); 
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setup should succeed");
 
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 1, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "y + height > texture height");
@@ -66,8 +66,12 @@ gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, -1, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "negative y");
 gl.texSubImage2D(gl.TEXTURE_2D, -1, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "negative level");
+
+// GL_INVALID_VALUE may be generated if level is greater than log 2 max, where max is the returned value of GL_MAX_TEXTURE_SIZE.
+// GL_INVALID_OPERATION is generated if the texture array has not been defined by a previous  glTexImage2D or glCopyTexImage2D operation whose internalformat matches the format of glTexSubImage2D.
 gl.texSubImage2D(gl.TEXTURE_2D, maxTextureLevel + 1, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
-wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "too high level");
+wtu.glErrorShouldBeIn(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "too high level");
+
 gl.texSubImage2D(gl.FLOAT, 0, 0,0, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "bad target");
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
@@ -106,7 +110,7 @@ for (var f = 0; f < 6; f++) {
     gl.bindTexture(gl.TEXTURE_CUBE_MAP, tex);
     gl.texImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + f, 0, gl.RGB, gl.RGB, gl.UNSIGNED_BYTE, c);
     gl.texSubImage2D(gl.TEXTURE_CUBE_MAP_POSITIVE_X + f, maxCubeMapTextureLevel + 1, 0, 0, gl.RGB, gl.UNSIGNED_BYTE, c);
-    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "too high level");
+    wtu.glErrorShouldBeIn(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "too high level");
     gl.deleteTexture(tex);
 }
 

--- a/sdk/tests/conformance/textures/misc/texture-formats-test.html
+++ b/sdk/tests/conformance/textures/misc/texture-formats-test.html
@@ -83,9 +83,7 @@ if (!gl) {
       var err = gl.getError();
       if (err == gl.NO_ERROR) {
           testFailed("should NOT be able to create texture of type " + formatName);
-      } else if (err == gl.INVALID_OPERATION) {
-          testFailed("should return gl.INVALID_ENUM for type " + formatName);
-      } else if (err == gl.INVALID_ENUM) {
+      } else if (err == gl.INVALID_ENUM || err == gl.INVALID_OPERATION) {
           testPassed("not able to create invalid format: " + formatName);
       }
   }

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -1479,9 +1479,9 @@ var hasAttributeCaseInsensitive = function(obj, attr) {
   }
 };
 
-/**   
- * Returns a map of URL querystring options    
- * @return {Object?} Object containing all the values in the URL querystring   
+/**
+ * Returns a map of URL querystring options
+ * @return {Object?} Object containing all the values in the URL querystring
  */
 var getUrlOptions = (function() {
   var _urlOptionsParsed = false;
@@ -1640,26 +1640,6 @@ function create3DContextWithWrapperThatThrowsOnGLError(canvas, opt_attributes, o
 };
 
 /**
- * Tests that an evaluated expression generates a specific GL error.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
- * @param {string} evalStr The string to evaluate.
- */
-var shouldGenerateGLError = function(gl, glErrors, evalStr) {
-  var exception;
-  try {
-    eval(evalStr);
-  } catch (e) {
-    exception = e;
-  }
-  if (exception) {
-    testFailed(evalStr + " threw exception " + exception);
-  } else {
-    glErrorShouldBe(gl, glErrors, "after evaluating: " + evalStr);
-  }
-};
-
-/**
  * Tests that an evaluated expression does not generate a GL error.
  * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
  * @param {string} evalStr The string to evaluate.
@@ -1688,7 +1668,35 @@ var glErrorShouldBe = function(gl, glErrors, opt_msg) {
   glErrorShouldBeImpl(gl, glErrors, true, opt_msg);
 };
 
+/**
+ * Tests that the first error GL returns is in the specified error list.
+ * @param {!WebGLContext} gl The WebGLContext to use.
+ * @param {!Array.<number>} expectedErrorList The list of expected gl errors.
+ * @param {string} opt_msg
+ */
+var glErrorShouldBeIn = function(gl, expectedErrorList, opt_msg) {
+  opt_msg = opt_msg || "";
 
+  var expectedErrorStrList = [];
+  var expectedErrorSet = {};
+
+  for (var i in expectedErrorList) {
+    var cur = expectedErrorList[i];
+
+    expectedErrorStrList.push(glEnumToString(gl, cur));
+    expectedErrorSet[cur] = true;
+  }
+
+  var expectedErrorStr = "[" + expectedErrorStrList.join(", ") + "]";
+
+  var actualError = gl.getError();
+  if (actualError in expectedErrorSet) {
+    testPassed("getError was in expected values: " + expectedErrorStr + " : " + opt_msg);
+  } else {
+    testFailed("getError expected: " + expectedErrorStr +
+               ". Was " + glEnumToString(gl, actualError) + " : " + opt_msg);
+  }
+};
 
 /**
  * Tests that the first error GL returns is the specified error. Allows suppression of successes.
@@ -1715,6 +1723,46 @@ var glErrorShouldBeImpl = function(gl, glErrors, reportSuccesses, opt_msg) {
   } else if (reportSuccesses) {
     var msg = "getError was " + ((glErrors.length > 1) ? "one of: " : "expected value: ");
     testPassed(msg + expected + " : " + opt_msg);
+  }
+};
+
+/**
+ * Tests that an evaluated expression generates a specific GL error.
+ * @param {!WebGLContext} gl The WebGLContext to use.
+ * @param {number} glError The expected gl error.
+ * @param {string} evalSTr The string to evaluate.
+ */
+var shouldGenerateGLError = function(gl, glError, evalStr) {
+  var exception;
+  try {
+    eval(evalStr);
+  } catch (e) {
+    exception = e;
+  }
+  if (exception) {
+    testFailed(evalStr + " threw exception " + exception);
+  } else {
+    glErrorShouldBe(gl, glError, evalStr);
+  }
+};
+
+/**
+ * Tests that an evaluated expression generates a GL error from a list.
+ * @param {!WebGLContext} gl The WebGLContext to use.
+ * @param {!Array.<number>} expectedErrorList The list of expected gl errors.
+ * @param {string} evalSTr The string to evaluate.
+ */
+var shouldGenerateGLErrorIn = function(gl, expectedErrorList, evalStr) {
+  var exception;
+  try {
+    eval(evalStr);
+  } catch (e) {
+    exception = e;
+  }
+  if (exception) {
+    testFailed(evalStr + " threw exception " + exception);
+  } else {
+    glErrorShouldBeIn(gl, expectedErrorList, evalStr);
   }
 };
 
@@ -3053,6 +3101,7 @@ return {
   getUniformMap: getUniformMap,
   glEnumToString: glEnumToString,
   glErrorShouldBe: glErrorShouldBe,
+  glErrorShouldBeIn: glErrorShouldBeIn,
   glTypeToTypedArrayType: glTypeToTypedArrayType,
   hasAttributeCaseInsensitive: hasAttributeCaseInsensitive,
   insertImage: insertImage,
@@ -3111,6 +3160,7 @@ return {
   startPlayingAndWaitForVideo: startPlayingAndWaitForVideo,
   startsWith: startsWith,
   shouldGenerateGLError: shouldGenerateGLError,
+  shouldGenerateGLErrorIn: shouldGenerateGLErrorIn,
   readFile: readFile,
   readFileList: readFileList,
   replaceParams: replaceParams,


### PR DESCRIPTION
There are a number of tests that assume the most obvious GL errors will be generated. However, a single function call can match multiple error generation criteria.

I add functions that take a list of possible errors, and make sure that the generated error in the given list.