### PR TITLE
Fix bug in invalidate-framebuffer.html.

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/invalidate-framebuffer.html
+++ b/sdk/tests/conformance2/renderbuffers/invalidate-framebuffer.html
@@ -78,7 +78,8 @@ if (!gl) {
   gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, rb);
   // invalidate the framebuffer when the attachment is incomplete: no storage allocated to the attached renderbuffer
   invalidateIncompleteAttachment(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT);
-  gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, canvas.width, canvas.height);
+  gl.renderbufferStorageMultisample(gl.RENDERBUFFER, samples[0], gl.DEPTH_COMPONENT16, canvas.width, canvas.height);
+  gl.clear(gl.DEPTH_BUFFER_BIT);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,
       "should be no errors after attaching a renderbuffer to fbo.");
 


### PR DESCRIPTION
Samplers for all attachments of the fbo should be the same.
Otherwise, it will lead to FRAMEBUFFER_INCOMPLETE