### PR TITLE
Make extension status in WebGL 2.0 clearer on extension pages

### DIFF
--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -207,7 +207,7 @@
 </xsl:template>
 
 <xsl:template match="core" mode="depends">
-  <p> Promoted to core in <xsl:apply-templates select="."/> specification. <xsl:apply-templates select="glsl" mode="requires" /></p>
+  <p> Promoted to core and no longer available as an extension in <xsl:apply-templates select="."/> specification. <xsl:apply-templates select="glsl" mode="requires" /></p>
 
   <xsl:choose>
     <xsl:when test="count(addendum)!=0">


### PR DESCRIPTION
The extension registry front page already mentions that extensions
promoted to core are no longer available in the version where they were
promoted, but it's nicer if that is also clearly stated on each
individual extension's page.