### PR TITLE
Add disallowed variants of ESSL3 operators to spec

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -8,6 +8,7 @@ array-length-side-effects.html
 attrib-location-length-limits.html
 compare-structs-containing-arrays.html
 const-array-init.html
+forbidden-operators.html
 frag-depth.html
 invalid-default-precision.html
 misplaced-version-directive.html
@@ -18,6 +19,5 @@ shader-with-1024-character-identifier.frag.html
 shader-with-1025-character-define.html
 shader-with-1025-character-identifier.frag.html
 short-circuiting-in-loop-condition.html
-ternary-operator-on-arrays-glsl3.html
 uniform-location-length-limits.html
 vector-dynamic-indexing.html

--- a/sdk/tests/conformance2/glsl3/forbidden-operators.html
+++ b/sdk/tests/conformance2/glsl3/forbidden-operators.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL GLSL Conformance Tests - Ternary operator on arrays</title>
+<title>WebGL GLSL Conformance Tests - Unsupported variants of operators</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
 <script src="../../js/js-test-pre.js"></script>
@@ -61,21 +61,81 @@ void main()
   MyStruct d = true ? b : c;
 }
 </script>
+<script id="fshader-void-ternary-operator" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+void foo() {}
+
+void main()
+{
+  true ? foo() : foo();
+}
+</script>
+<script id="fshader-array-sequence-operator" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+void main()
+{
+  float a[3];
+  float b[3] = (true, a);
+}
+</script>
+<script id="fshader-struct-array-sequence-operator" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+struct MyStruct {
+    bool a[3];
+};
+
+void main()
+{
+  MyStruct b;
+  MyStruct c = (true, b);
+}
+</script>
+<script id="fshader-void-sequence-operator" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+void foo() {}
+
+void main()
+{
+  (foo(), foo());
+}
+</script>
 <script>
 "use strict";
-description("Checks ternary operators for structs and arrays.");
+description("Check unsupported variants of operators.");
+
+// WebGL 2.0 spec section "Unsupported variants of GLSL ES 3.00 operators"
 
 GLSLConformanceTester.runTests([
 { fShaderId: 'fshader-array-ternary-operator',
-  fShaderSuccess: true,
-  linkSuccess: true,
-  passMsg: "Using ternary operators with arrays is allowed in glsl3",
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Using ternary operators with arrays is not allowed",
 },
 { fShaderId: 'fshader-struct-array-ternary-operator',
-  fShaderSuccess: true,
-  linkSuccess: true,
-  passMsg: "By implication, using ternary operators with structs containing arrays is allowed in glsl3",
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Using ternary operators with structs containing arrays is not allowed",
 },
+{ fShaderId: 'fshader-void-ternary-operator',
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Using ternary operators with void is not allowed",
+},
+{ fShaderId: 'fshader-array-sequence-operator',
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Using sequence operators with arrays is not allowed",
+},
+{ fShaderId: 'fshader-struct-array-sequence-operator',
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Using sequence operators with structs containing arrays is not allowed",
+},
+{ fShaderId: 'fshader-void-sequence-operator',
+  fShaderSuccess: false,
+  linkSuccess: false,
+  passMsg: "Using sequence operators with void is not allowed",
+}
 ], 2);
 
 debug("");

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 24 October 2015</h2>
+    <h2 class="no-toc">Editor's Draft 18 November 2015</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -3036,6 +3036,22 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
     <div class="note rationale">
         This restriction is enforced to improve portability by avoiding exposing uniform block
         layouts that are specific to one vendor's GPUs.
+    </div>
+
+    <h3>Disallowed variants of GLSL ES 3.00 operators</h3>
+
+    <p>
+        In the WebGL 2.0 API, the following shading language constructs are not allowed and
+        attempting to use them must result in a compile error:
+    </p>
+
+    <ul>
+        <li>Ternary operator applied to void, arrays, or structs containing arrays</li>
+        <li>Sequence operator applied to void, arrays, or structs containing arrays</li>
+    </ul>
+
+    <div class="note rationale">
+        This restriction ensures easy portability across OpenGL ES 3.0 supporting devices.
     </div>
 
 <!-- ======================================================================================================= -->


### PR DESCRIPTION
Supporting ternary and sequence operators on void and arrays is likely to
be made optional in GLSL ES 3.00 according to current draft for a future
version of the spec. For WebGL, it's the best to disallow any features
that may not be implemented on all reasonable target platforms. These
restrictions on target platforms could be worked around, but that adds an
extra burden on implementations for very little gain in corner case
features in this case.