### PR TITLE
Added conformance test for EXT_color_buffer_float

### DIFF
--- a/sdk/tests/conformance2/00_test_list.txt
+++ b/sdk/tests/conformance2/00_test_list.txt
@@ -1,6 +1,7 @@
 attribs/00_test_list.txt
 buffers/00_test_list.txt
 context/00_test_list.txt
+extensions/00_test_list.txt
 glsl3/00_test_list.txt
 misc/00_test_list.txt
 query/00_test_list.txt

--- a/sdk/tests/conformance2/extensions/00_test_list.txt
+++ b/sdk/tests/conformance2/extensions/00_test_list.txt
@@ -1,0 +1,1 @@
+ext-color-buffer-float.html

--- a/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
+++ b/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
@@ -1,0 +1,318 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL EXT_color_buffer_float Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<canvas id="canvas" style="width: 50px; height: 50px;"> </canvas>
+<div id="console"></div>
+<!-- Shaders for testing floating-point textures -->
+<script id="testFragmentShader" type="x-shader/x-fragment">
+precision mediump float;
+uniform sampler2D tex;
+uniform vec4 subtractor;
+varying vec2 texCoord;
+void main()
+{
+    vec4 color = texture2D(tex, texCoord);
+    if (abs(color.r - subtractor.r) +
+        abs(color.g - subtractor.g) +
+        abs(color.b - subtractor.b) +
+        abs(color.a - subtractor.a) < 16.0) {
+        gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+    } else {
+        gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+    }
+}
+</script>
+<!-- Shaders for testing floating-point render targets -->
+<script id="positionVertexShader" type="x-shader/x-vertex">
+attribute vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+<script id="floatingPointFragmentShader" type="x-shader/x-fragment">
+void main()
+{
+    gl_FragColor = vec4(1000.0, 1000.0, 1000.0, 1000.0);
+}
+</script>
+<script>
+"use strict";
+
+function allocateTexture()
+{
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture parameter setup should succeed");
+    return texture;
+}
+
+function checkRenderingResults()
+{
+    wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green");
+}
+
+function arrayToString(arr, size) {
+    var mySize;
+    if (!size)
+        mySize = arr.length;
+    else
+        mySize = size;
+    var out = "[";
+    for (var ii = 0; ii < mySize; ++ii) {
+    if (ii > 0) {
+        out += ", ";
+    }
+    out += arr[ii];
+    }
+    return out + "]";
+}
+
+function runReadbackTest(testProgram, subtractor)
+{
+    // Verify floating point readback
+    debug("Checking readback of floating-point values");
+    var buf = new Float32Array(4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT , buf);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "readPixels from floating-point framebuffer should succeed");
+    var ok = true;
+    var tolerance = 8.0; // TODO: factor this out from both this test and the subtractor shader above.
+    for (var ii = 0; ii < buf.length; ++ii) {
+        if (Math.abs(buf[ii] - subtractor[ii]) > tolerance) {
+        ok = false;
+        break;
+        }
+    }
+    if (ok) {
+        testPassed("readPixels of float-type data from floating-point framebuffer succeeded");
+    } else {
+        testFailed("readPixels of float-type data from floating-point framebuffer failed: expected "
+                   + arrayToString(subtractor, 4) + ", got " + arrayToString(buf));
+    }
+}
+
+function runFloatTextureRenderTargetTest(enabled, internalFormat, format, testProgram, numberOfChannels, subtractor, texSubImageCover)
+{
+    var formatString = wtu.glEnumToString(gl, internalFormat);
+    debug("");
+    debug("testing floating-point " + formatString + " texture render target" + (texSubImageCover > 0 ? " after calling texSubImage" : ""));
+
+    var texture = allocateTexture();
+    var width = 2;
+    var height = 2;
+    gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, width, height, 0, format, gl.FLOAT, null);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "floating-point texture allocation should succeed if EXT_color_buffer_float is enabled");
+
+    // Try to use this texture as a render target.
+    var fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+
+    var completeStatus = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (!enabled) {
+        if (completeStatus == gl.FRAMEBUFFER_COMPLETE && !enabled)
+            testFailed("floating-point " + formatString + " render target should not be supported without enabling EXT_color_buffer_float");
+        else
+            testPassed("floating-point " + formatString + " render target should not be supported without enabling EXT_color_buffer_float");
+        return;
+    }
+
+    if (completeStatus != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("floating-point " + formatString + " render target not supported");
+        return;
+    }
+
+    if (texSubImageCover > 0) {
+        // Ensure that replacing the whole texture or a part of it with texSubImage2D doesn't affect renderability
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        var data = new Float32Array(width * height * numberOfChannels * texSubImageCover);
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height * texSubImageCover, format, gl.FLOAT, data);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texSubImage2D should succeed if EXT_color_buffer_float is enabled");
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+            testFailed("render target support changed after calling texSubImage2D");
+            return;
+        }
+    }
+
+    var renderProgram =
+        wtu.setupProgram(gl,
+                         ["positionVertexShader", "floatingPointFragmentShader"],
+                         ['vPosition'],
+                         [0]);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "rendering to floating-point texture should succeed");
+
+    // Now sample from the floating-point texture and verify we got the correct values.
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.useProgram(testProgram);
+    gl.uniform1i(gl.getUniformLocation(testProgram, "tex"), 0);
+    gl.uniform4fv(gl.getUniformLocation(testProgram, "subtractor"), subtractor);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "rendering from floating-point texture should succeed");
+    checkRenderingResults();
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    runReadbackTest(testProgram, subtractor);
+}
+
+function runFloatRenderbufferRenderTargetTest(enabled, internalFormat, testProgram, numberOfChannels, subtractor)
+{
+    var formatString = wtu.glEnumToString(gl, internalFormat);
+    debug("");
+    debug("testing floating-point " + formatString + " renderbuffer render target");
+
+    var colorbuffer = gl.createRenderbuffer();
+    var width = 2;
+    var height = 2;
+    gl.bindRenderbuffer(gl.RENDERBUFFER, colorbuffer);
+    gl.renderbufferStorage(gl.RENDERBUFFER, internalFormat, width, height);
+    if (!enabled) {
+        wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "floating-point renderbuffer allocation should fail if EXT_color_buffer_float is not enabled");
+        return;
+    } else {
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "floating-point renderbuffer allocation should succeed if EXT_color_buffer_float is enabled");
+    }
+
+    // Try to use this texture as a render target.
+    var fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, colorbuffer, 0);
+    gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+
+    var completeStatus = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (completeStatus != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("floating-point " + formatString + " render target not supported");
+        return;
+    }
+
+    gl.clearColor(1000.0, 1000.0, 1000.0, 1000.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    runReadbackTest(testProgram, subtractor);
+}
+
+function runUniqueObjectTest()
+{
+    debug("");
+    debug("Testing that getExtension() returns the same object each time");
+    gl.getExtension("EXT_color_buffer_float").myProperty = 2;
+    webglHarnessCollectGarbage();
+    shouldBe('gl.getExtension("EXT_color_buffer_float").myProperty', '2');
+}
+
+description("This test verifies the functionality of the EXT_color_buffer_float extension, if it is available.");
+
+debug("");
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas, null, 2);
+
+if (!gl) {
+  testFailed("WebGL context does not exist");
+} else {
+  testPassed("WebGL context exists");
+
+  var texturedShaders = [
+      wtu.setupSimpleTextureVertexShader(gl),
+      "testFragmentShader"
+  ];
+  var testProgram =
+      wtu.setupProgram(gl,
+                       texturedShaders,
+                       ['vPosition', 'texCoord0'],
+                       [0, 1]);
+  var quadParameters = wtu.setupUnitQuad(gl, 0, 1);
+
+  // Ensure these formats can't be used for rendering if the extension is disabled
+  runFloatTextureRenderTargetTest(false, gl.R16F, gl.RED);
+  runFloatTextureRenderTargetTest(false, gl.RG16F, gl.RG);
+  runFloatTextureRenderTargetTest(false, gl.RGBA16F, gl.RGBA);
+  runFloatTextureRenderTargetTest(false, gl.R32F, gl.RED);
+  runFloatTextureRenderTargetTest(false, gl.RG32F, gl.RG);
+  runFloatTextureRenderTargetTest(false, gl.RGBA32F, gl.RGBA);
+  runFloatTextureRenderTargetTest(false, gl.R11F_G11F_B10F, gl.RGB);
+
+  runFloatRenderbufferRenderTargetTest(false, gl.R16F);
+  runFloatRenderbufferRenderTargetTest(false, gl.RG16F);
+  runFloatRenderbufferRenderTargetTest(false, gl.RGBA16F);
+  runFloatRenderbufferRenderTargetTest(false, gl.R32F);
+  runFloatRenderbufferRenderTargetTest(false, gl.RG32F);
+  runFloatRenderbufferRenderTargetTest(false, gl.RGBA32F);
+  runFloatRenderbufferRenderTargetTest(false, gl.R11F_G11F_B10F);
+
+  if (!gl.getExtension("EXT_color_buffer_float")) {
+      testPassed("No EXT_color_buffer_float support -- this is legal");
+  } else {
+      testPassed("Successfully enabled EXT_color_buffer_float extension");
+      runFloatTextureRenderTargetTest(true, gl.R16F, gl.RED, testProgram, 1, [1000, 1, 1, 1], 0);
+      runFloatTextureRenderTargetTest(true, gl.RG16F, gl.RG, testProgram, 2, [1000, 1000, 1, 1], 0);
+      runFloatTextureRenderTargetTest(true, gl.RGBA16F, gl.RGBA, testProgram, 4, [1000, 1000, 1000, 1000], 0);
+      runFloatTextureRenderTargetTest(true, gl.R32F, gl.RED, testProgram, 1, [1000, 1, 1, 1], 0);
+      runFloatTextureRenderTargetTest(true, gl.RG32F, gl.RG, testProgram, 2, [1000, 1000, 1, 1], 0);
+      runFloatTextureRenderTargetTest(true, gl.RGBA32F, gl.RGBA, testProgram, 4, [1000, 1000, 1000, 1000], 0);
+      runFloatTextureRenderTargetTest(true, gl.R11F_G11F_B10F, gl.RGB, testProgram, 3, [1000, 1000, 1000, 1], 0);
+      runFloatTextureRenderTargetTest(true, gl.RGBA32F, gl.RGBA, testProgram, 4, [1000, 1000, 1000, 1000], 1);
+      runFloatTextureRenderTargetTest(true, gl.RGBA32F, gl.RGBA, testProgram, 4, [1000, 1000, 1000, 1000], 0.5);
+
+      runFloatRenderbufferRenderTargetTest(true, gl.R16F, testProgram, 1, [1000, 1, 1, 1]);
+      runFloatRenderbufferRenderTargetTest(true, gl.RG16F, testProgram, 2, [1000, 1000, 1, 1]);
+      runFloatRenderbufferRenderTargetTest(true, gl.RGBA16F, testProgram, 4, [1000, 1000, 1000, 1000]);
+      runFloatRenderbufferRenderTargetTest(true, gl.R32F, testProgram, 1, [1000, 1, 1, 1]);
+      runFloatRenderbufferRenderTargetTest(true, gl.RG32F, testProgram, 2, [1000, 1000, 1, 1]);
+      runFloatRenderbufferRenderTargetTest(true, gl.RGBA32F, testProgram, 4, [1000, 1000, 1000, 1000]);
+      runFloatRenderbufferRenderTargetTest(true, gl.R11F_G11F_B10F, testProgram, 3, [1000, 1000, 1000, 1]);
+
+      runUniqueObjectTest();
+  }
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This is largely a copy of the OES_texture_float extension test, but with the format creation checks removed (they should be implicit with WebGL 2.0) and some checks added to ensure those formats can't be bound until the extension is enabled.