### PR TITLE
ES3 (ETC2/EAC) textures work with 2D_ARRAY, but not 3D.

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
@@ -87,15 +87,28 @@ function runTexCompressedFormatsTest()
         var tex = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, tex);
         gl.texStorage2D(gl.TEXTURE_2D, 1, internalformat, 1, 1);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage2D should succeed for " + enumToString(internalformat));
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+                            "texStorage2D should succeed for " + enumToString(internalformat));
         gl.deleteTexture(tex);
 
-        // Test a 3D texture.
+        // GLES 3.0.4 p147:
+        // "If internalformat is an ETC2/EAC format, CompressedTexImage3D will generate an
+        //  INVALID_OPERATION error if target is not TEXTURE_2D_ARRAY."
+
+        // Test the 3D texture targets.
         var tex3d = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_3D, tex3d);
         gl.texStorage3D(gl.TEXTURE_3D, 1, internalformat, 1, 1, 1);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage3D should succeed for " + enumToString(internalformat));
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+                            "texStorage3D(TEXTURE_3D) should fail for " + enumToString(internalformat));
         gl.deleteTexture(tex3d);
+
+        var tex2dArr = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D_ARRAY, tex2dArr);
+        gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, internalformat, 1, 1, 1);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+                            "texStorage3D(TEXTURE_2D_ARRAY) should succeed for " + enumToString(internalformat));
+        gl.deleteTexture(tex2dArr);
     });
 }
 


### PR DESCRIPTION
Trying with TEXTURE_3D is INVALID_OPERATION.
TEXTURE_2D_ARRAY should work though.