### PR TITLE
Add test for extensions that have been promoted to core

### DIFF
--- a/sdk/tests/conformance2/extensions/00_test_list.txt
+++ b/sdk/tests/conformance2/extensions/00_test_list.txt
@@ -1,1 +1,2 @@
 ext-color-buffer-float.html
+promoted-extensions-in-shaders.html

--- a/sdk/tests/conformance2/extensions/promoted-extensions-in-shaders.html
+++ b/sdk/tests/conformance2/extensions/promoted-extensions-in-shaders.html
@@ -1,0 +1,136 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Extensions promoted to core should not be possible to use in shaders</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragShaderRequire" type="x-shader/x-fragment">
+#extension $(ext) : require
+precision mediump float;
+void main() {
+    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script id="fragShaderIfdef" type="x-shader/x-fragment">
+precision mediump float;
+void main() {
+#ifdef $(ext)
+    gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+#else
+    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+#endif
+}
+</script>
+<script id="fragShader300Require" type="x-shader/x-fragment">#version 300 es
+#extension $(ext) : require
+precision mediump float;
+out vec4 my_FragColor;
+void main() {
+    my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script id="fragShader300Ifdef" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 my_FragColor;
+void main() {
+#ifdef $(ext)
+    my_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+#else
+    my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+#endif
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description();
+
+var wtu = WebGLTestUtils;
+
+var shaderTemplateRequire = wtu.getScript('fragShaderRequire');
+var shaderTemplate300Require = wtu.getScript('fragShader300Require');
+var shaderTemplateIfdef = wtu.getScript('fragShaderIfdef');
+var shaderTemplate300Ifdef = wtu.getScript('fragShader300Ifdef');
+
+var extensions = [
+    'GL_EXT_draw_buffers',
+    'GL_EXT_frag_depth',
+    'GL_EXT_shader_texture_lod',
+    'GL_OES_standard_derivatives'
+];
+
+var tests = [];
+
+for (var i = 0; i < extensions.length; ++i) {
+    var shaderSrcRequire = wtu.replaceParams(shaderTemplateRequire, {'ext': extensions[i]});
+    tests.push({
+        fShaderSource: shaderSrcRequire,
+        fShaderSuccess: false,
+        linkSuccess: false,
+        passMsg: "ESSL 1.00 Fragment shader that requires " + extensions[i] + " should not compile."
+    });
+    var shaderSrc300Require = wtu.replaceParams(shaderTemplate300Require, {'ext': extensions[i]});
+    tests.push({
+        fShaderSource: shaderSrc300Require,
+        fShaderSuccess: false,
+        linkSuccess: false,
+        passMsg: "ESSL 3.00 Fragment shader that requires " + extensions[i] + " should not compile."
+    });
+
+    var shaderSrcIfdef = wtu.replaceParams(shaderTemplateIfdef, {'ext': extensions[i]});
+    tests.push({
+        fShaderSource: shaderSrcIfdef,
+        fShaderSuccess: true,
+        linkSuccess: true,
+        render: true,
+        passMsg: extensions[i] + " should not be defined in ESSL 1.00 fragment shader."
+    });
+    var shaderSrc300Ifdef = wtu.replaceParams(shaderTemplate300Ifdef, {'ext': extensions[i]});
+    tests.push({
+        fShaderSource: shaderSrc300Ifdef,
+        fShaderSuccess: true,
+        linkSuccess: true,
+        render: true,
+        passMsg: extensions[i] + " should not be defined in ESSL 3.00 fragment shader."
+    });
+}
+
+GLSLConformanceTester.runTests(tests, 2);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Test that trying to enable promoted extensions in shaders results in
compilation failure, and that the compiler flags for the shaders are
not defined.