### PR TITLE
WebGL 2.0 supports INT/UINT/FIXED, so we don't want to run these test…

### DIFF
--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
@@ -67,7 +67,7 @@ if (!gl) {
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(0), gl.STATIC_DRAW);
   
-  if(getUrlOptions().webglVersion < 2) {
+  if (wtu.getDefault3DContextVersion() < 2) {
     gl.vertexAttribPointer(0, 1, gl.INT, 0, 0, 0);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
 	    "vertexAttribPointer should not support INT");

--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
@@ -66,16 +66,18 @@ if (!gl) {
   var vertexObject = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(0), gl.STATIC_DRAW);
-
-  gl.vertexAttribPointer(0, 1, gl.INT, 0, 0, 0);
-  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
-      "vertexAttribPointer should not support INT");
-  gl.vertexAttribPointer(0, 1, gl.UNSIGNED_INT, 0, 0, 0);
-  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
-      "vertexAttribPointer should not support UNSIGNED_INT");
-  gl.vertexAttribPointer(0, 1, gl.FIXED, 0, 0, 0);
-  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
-      "vertexAttribPointer should not support FIXED");
+  
+  if(getUrlOptions().webglVersion < 2) {
+    gl.vertexAttribPointer(0, 1, gl.INT, 0, 0, 0);
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
+	    "vertexAttribPointer should not support INT");
+    gl.vertexAttribPointer(0, 1, gl.UNSIGNED_INT, 0, 0, 0);
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
+	    "vertexAttribPointer should not support UNSIGNED_INT");
+    gl.vertexAttribPointer(0, 1, gl.FIXED, 0, 0, 0);
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
+	    "vertexAttribPointer should not support FIXED");
+  }
 
   var checkVertexAttribPointer = function(
       gl, err, reason, size, type, normalize, stride, offset) {


### PR DESCRIPTION
WebGL 2.0 supports INT/UINT/FIXED, so we don't want to run these tests when the GL version is 2.