### PR TITLE
Fixed expected errors in WEBGL_draw_buffers conformance test.

### DIFF
--- a/conformance-suites/1.0.3/conformance/extensions/webgl-draw-buffers.html
+++ b/conformance-suites/1.0.3/conformance/extensions/webgl-draw-buffers.html
@@ -230,8 +230,8 @@ function runEnumTestEnabled() {
 
   debug("Testing drawBuffersWEBGL with default drawing buffer");
   shouldBe("gl.getParameter(ext.DRAW_BUFFER0_WEBGL)", "gl.BACK");
-  wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "ext.drawBuffersWEBGL([])");
-  wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "ext.drawBuffersWEBGL([gl.NONE, gl.NONE])");
+  wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "ext.drawBuffersWEBGL([])");
+  wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "ext.drawBuffersWEBGL([gl.NONE, gl.NONE])");
   wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "ext.drawBuffersWEBGL([ext.COLOR_ATTACHMENT0_WEBGL])");
   shouldBe("gl.getParameter(ext.DRAW_BUFFER0_WEBGL)", "gl.BACK");
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "ext.drawBuffersWEBGL([gl.NONE])");

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -228,8 +228,8 @@ function runEnumTestEnabled() {
 
   debug("Testing drawBuffersWEBGL with default drawing buffer");
   shouldBe("gl.getParameter(ext.DRAW_BUFFER0_WEBGL)", "gl.BACK");
-  wtu.shouldGenerateGLErrorIn(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "ext.drawBuffersWEBGL([])");
-  wtu.shouldGenerateGLErrorIn(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "ext.drawBuffersWEBGL([gl.NONE, gl.NONE])");
+  wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "ext.drawBuffersWEBGL([])");
+  wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "ext.drawBuffersWEBGL([gl.NONE, gl.NONE])");
   wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "ext.drawBuffersWEBGL([ext.COLOR_ATTACHMENT0_WEBGL])");
   shouldBe("gl.getParameter(ext.DRAW_BUFFER0_WEBGL)", "gl.BACK");
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "ext.drawBuffersWEBGL([gl.NONE])");


### PR DESCRIPTION
When the default framebuffer is bound, EXT_draw_buffers defines certain
error cases as generating INVALID_OPERATION, not INVALID_VALUE. Thanks
to @jdashg for discovering this issue in #1303. This test fix has been
backported to 1.0.3, where the test was introduced. It causes Chrome and
Firefox to begin to fail the test, but the browsers must be fixed.