### PR TITLE
Add missing precision qualifiers for samplers in shaders

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-utils.js
@@ -49,7 +49,7 @@ var TexImageUtils = (function() {
   var simpleUintTextureFragmentShaderES3 = [
     '#version 300 es',
     'precision mediump float;',
-    'uniform usampler2D tex;',
+    'uniform mediump usampler2D tex;',
     'in vec2 texCoord;',
     'out vec4 fragData;',
     'void main() {',
@@ -69,7 +69,7 @@ var TexImageUtils = (function() {
   var simpleCubeMapUintTextureFragmentShaderES3 = [
     '#version 300 es',
     'precision mediump float;',
-    'uniform usamplerCube tex;',
+    'uniform mediump usamplerCube tex;',
     'uniform int face;',
     'in vec2 texCoord;',
     'out vec4 fragData;',
@@ -106,7 +106,7 @@ var TexImageUtils = (function() {
   var simple3DTextureFragmentShaderES3 = [
     '#version 300 es',
     'precision mediump float;',
-    'uniform sampler3D tex;',
+    'uniform mediump sampler3D tex;',
     'in vec2 texCoord;',
     'out vec4 fragData;',
     'void main() {',
@@ -123,7 +123,7 @@ var TexImageUtils = (function() {
   var simple3DUintTextureFragmentShaderES3 = [
     '#version 300 es',
     'precision mediump float;',
-    'uniform usampler3D tex;',
+    'uniform mediump usampler3D tex;',
     'in vec2 texCoord;',
     'out vec4 fragData;',
     'void main() {',
@@ -142,7 +142,7 @@ var TexImageUtils = (function() {
   var simple2DArrayTextureFragmentShaderES3 = [
     '#version 300 es',
     'precision mediump float;',
-    'uniform sampler2DArray tex;',
+    'uniform mediump sampler2DArray tex;',
     'in vec2 texCoord;',
     'out vec4 fragData;',
     'void main() {',
@@ -159,7 +159,7 @@ var TexImageUtils = (function() {
   var simple2DArrayUintTextureFragmentShaderES3 = [
     '#version 300 es',
     'precision mediump float;',
-    'uniform usampler2DArray tex;',
+    'uniform mediump usampler2DArray tex;',
     'in vec2 texCoord;',
     'out vec4 fragData;',
     'void main() {',

--- a/sdk/tests/resources/samplerForWebGL2UniformShader.frag
+++ b/sdk/tests/resources/samplerForWebGL2UniformShader.frag
@@ -24,8 +24,8 @@
 */
 
 precision mediump float;
-uniform sampler3D s3D;
-uniform sampler2DArray s2DArray;
+uniform mediump sampler3D s3D;
+uniform mediump sampler2DArray s2DArray;
 out vec4 fragColor;
 void main()
 {


### PR DESCRIPTION
New sampler types introduced in ESSL 3.00 don't have a default precision
qualifier according to ESSL 3.00.4 section 4.5.4.