### PR TITLE
Run EXT_disjoint_timer_query test against WebGL 2.0 contexts.

### DIFF
--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -1,7 +1,7 @@
 --min-version 1.0.3 --max-version 1.9.9 angle-instanced-arrays.html
 --min-version 1.0.3 --max-version 1.9.9 angle-instanced-arrays-out-of-bounds.html
 --min-version 1.0.3 --max-version 1.9.9 ext-blend-minmax.html
---min-version 1.0.4 --max-version 1.9.9 ext-disjoint-timer-query.html
+--min-version 1.0.4 ext-disjoint-timer-query.html
 --min-version 1.0.3 --max-version 1.9.9 ext-frag-depth.html
 --min-version 1.0.3 --max-version 1.9.9 ext-shader-texture-lod.html
 --min-version 1.0.3 --max-version 1.9.9 ext-sRGB.html


### PR DESCRIPTION
This extension is exposed against the WebGL 2.0 context as well as the 1.0 context and the test should be run there as well.