### PR TITLE
Add a test for sampler variables with no precision

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -12,6 +12,7 @@ forbidden-operators.html
 frag-depth.html
 invalid-default-precision.html
 misplaced-version-directive.html
+sampler-no-precision.html
 sequence-operator-returns-non-constant.html
 shader-linking.html
 shader-with-1024-character-define.html

--- a/sdk/tests/conformance2/glsl3/sampler-no-precision.html
+++ b/sdk/tests/conformance2/glsl3/sampler-no-precision.html
@@ -1,0 +1,109 @@
+<!--
+
+/*
+** Copyright (c) 2015 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL sampler with no precision qualifier test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshaderSamplerNoPrecision" type="x-shader/x-vertex">#version 300 es
+precision mediump float;
+
+uniform $(samplerType) u_sampler;
+
+void main() {
+    gl_Position = vec4(0.0);
+}
+</script>
+<script id="fshaderSamplerNoPrecision" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+uniform $(samplerType) u_sampler;
+
+void main() {
+    my_FragColor = vec4(0.0);
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description("ESSL3 sampler with no precision qualifier should not compile.");
+
+var wtu = WebGLTestUtils;
+
+var fragmentShaderTemplate = wtu.getScript('fshaderSamplerNoPrecision');
+var vertexShaderTemplate = wtu.getScript('vshaderSamplerNoPrecision');
+
+// ESSL 3.00.4 section 4.5.4 types with no predefined precision.
+var samplerTypes = [
+    'sampler3D',
+    'samplerCubeShadow',
+    'sampler2DShadow',
+    'sampler2DArray',
+    'sampler2DArrayShadow',
+    'isampler2D',
+    'isampler3D',
+    'isamplerCube',
+    'isampler2DArray',
+    'usampler2D',
+    'usampler3D',
+    'usamplerCube',
+    'usampler2DArray'
+];
+
+var tests = [];
+
+for (var i = 0; i < samplerTypes.length; ++i) {
+    var type = samplerTypes[i];
+    var vertexShaderSrc = wtu.replaceParams(vertexShaderTemplate, {'samplerType': type});
+    tests.push({
+        vShaderSource: vertexShaderSrc,
+        vShaderSuccess: false,
+        linkSuccess: false,
+        passMsg: 'Vertex shader with a ' + type + ' uniform with no precision qualifier should not compile'
+    });
+    var fragmentShaderSrc = wtu.replaceParams(fragmentShaderTemplate, {'samplerType': type});
+    tests.push({
+        fShaderSource: fragmentShaderSrc,
+        fShaderSuccess: false,
+        linkSuccess: false,
+        passMsg: 'Fragment shader with a ' + type + ' uniform with no precision qualifier should not compile'
+    });
+}
+
+GLSLConformanceTester.runTests(tests, 2);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Sampler types introduced in ESSL3 don't have predefined default
precision. Test that trying to declare samplers with no precision
qualifier fails compilation.