### PR TITLE
Update compressed texture extension tests for WebGL 2.0

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-atc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-atc.html
@@ -114,6 +114,7 @@ var img_8x8_rgba_atc_interpolated = new Uint8Array([
 ]);
 
 var wtu = WebGLTestUtils;
+var contextVersion = wtu.getDefault3DContextVersion();
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
 var program = wtu.setupTexturedQuad(gl);
@@ -169,7 +170,12 @@ function runSupportedTest(extensionEnabled) {
 function runTestDisabled() {
     debug("Testing binding enum with extension disabled");
 
-    shouldBe('gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS)', '[]');
+    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
+    if (contextVersion < 2) {
+        shouldBe("supportedFormats", "[]");
+    } else {
+        shouldBe("supportedFormats.length", "10");
+    }
 }
 
 function formatExists(format, supportedFormats) {
@@ -202,8 +208,12 @@ function runTestExtension() {
     }
 
     supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 3 formats
-    shouldBe("supportedFormats.length", "3");
+    // There should be exactly 3 formats for WebGL 1.0 and 13 formats for WebGL 2.0.
+    if (contextVersion < 2) {
+        shouldBe("supportedFormats.length", "3");
+    } else {
+        shouldBe("supportedFormats.length", "13");
+    }
 
     // check that all 3 formats exist
     for (var name in validFormats.length) {

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-pvrtc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-pvrtc.html
@@ -86,6 +86,7 @@ var pvrtc_4x4_rgb_decoded = new Uint8Array([
 ]);
 
 var wtu = WebGLTestUtils;
+var contextVersion = wtu.getDefault3DContextVersion();
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
 var program = wtu.setupTexturedQuad(gl);
@@ -142,7 +143,12 @@ function runSupportedTest(extensionEnabled) {
 function runTestDisabled() {
     debug("Testing binding enum with extension disabled");
 
-    shouldBe('gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS)', '[]');
+    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
+    if (contextVersion < 2) {
+        shouldBe("supportedFormats", "[]");
+    } else {
+        shouldBe("supportedFormats.length", "10");
+    }
 }
 
 function formatExists(format, supportedFormats) {
@@ -175,8 +181,12 @@ function runTestExtension() {
     }
 
     supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 4 formats
-    shouldBe("supportedFormats.length", "4");
+    // There should be exactly 4 formats for WebGL 1.0 and 14 formats for WebGL 2.0.
+    if (contextVersion < 2) {
+        shouldBe("supportedFormats.length", "4");
+    } else {
+        shouldBe("supportedFormats.length", "14");
+    }
 
     // check that all 4 formats exist
     for (var name in validFormats.length) {

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
@@ -93,6 +93,7 @@ var img_8x8_rgba_dxt5 = new Uint8Array([
 ]);
 
 var wtu = WebGLTestUtils;
+var contextVersion = wtu.getDefault3DContextVersion();
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
 var program = wtu.setupTexturedQuad(gl);
@@ -149,7 +150,12 @@ function runSupportedTest(extensionEnabled) {
 function runTestDisabled() {
     debug("Testing binding enum with extension disabled");
 
-    shouldBe('gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS)', '[]');
+    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
+    if (contextVersion < 2) {
+        shouldBe("supportedFormats", "[]");
+    } else {
+        shouldBe("supportedFormats.length", "10");
+    }
 }
 
 function formatExists(format, supportedFormats) {
@@ -182,8 +188,12 @@ function runTestExtension() {
     }
 
     supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 4 formats
-    shouldBe("supportedFormats.length", "4");
+    // There should be exactly 4 formats for WebGL 1.0 and 14 formats for WebGL 2.0.
+    if (contextVersion < 2) {
+        shouldBe("supportedFormats.length", "4");
+    } else {
+        shouldBe("supportedFormats.length", "14");
+    }
 
     // check that all 4 formats exist
     for (var name in validFormats.length) {


### PR DESCRIPTION
WebGL 2.0 supports 10 new compressed texture formats.