### PR TITLE
Fix wrong parameter passed to glsTextureTestUtil.sampleTexture2DArray

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureFormatTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureFormatTests.js
@@ -429,7 +429,7 @@ es3fTextureFormatTests.Texture2DArrayFormatCase.prototype.testLayer = function(l
 
     // // Compute reference.
     glsTextureTestUtil.sampleTexture2DArray(new glsTextureTestUtil.SurfaceAccess(referenceFrame, undefined /*m_renderCtx.getRenderTarget().getPixelFormat()*/),
-        this.m_texture.getRefTexture(), texCoord, renderParams);
+        this.m_texture.getRefTexture().getView(), texCoord, renderParams);
 
     // Compare and log.
     var isOk = glsTextureTestUtil.compareImages(referenceFrame, renderedFrame, threshold);


### PR DESCRIPTION
glsTextureTestUtil.sampleTexture2DArray requires a
tcuTexture.Texture2DArrayView object but a tcuTexture.Texture2DArray
object is passed in. In the native dEQP test, there is an implicit type
conversion from Texture2DArray to Texture2DArrayView. This patch does
explict type conversion in js.