### PR TITLE
dEQP: avoid duplicate elements in set emulated with array type

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsAttributeLocationTests.js
+++ b/sdk/tests/deqp/modules/shared/glsAttributeLocationTests.js
@@ -113,7 +113,8 @@ goog.scope(function() {
         for (var i = 0; i < attributes.length; i++) {
             if (attributes[i].getCondition().notEquals(glsAttributeLocationTests.NewCondWithEnum(glsAttributeLocationTests.ConstCond.NEVER)) &&
                 attributes[i].getCondition().notEquals(glsAttributeLocationTests.NewCondWithEnum(glsAttributeLocationTests.ConstCond.ALWAYS)))
-            conditions.push(attributes[i].getCondition().getName());
+                if (conditions.indexOf(attributes[i].getCondition().getName()) == -1)
+                    conditions.push(attributes[i].getCondition().getName());
         }
 
         for (var i = 0; i < conditions.length; i++)


### PR DESCRIPTION
In dEQP test, set is emulated with array type. We should avoid duplicate
elements in such set. "conditions" in the native implementation is a
set, so check if element is already in it before inserting.