### PR TITLE
Upgrade ReadPixels to take into consideration ES3 pack parameters.

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-into-pixel-pack-buffer.html
+++ b/sdk/tests/conformance2/reading/read-pixels-into-pixel-pack-buffer.html
@@ -164,31 +164,48 @@ function calculatePaddingBytes(bytesPerPixel, packAlignment, width)
     }
 }
 
-function runTestIteration(packAlignment, width, height)
+function runTestIteration(
+    width, height, packAlignment, packRowLength, packSkipPixels, packSkipRows)
 {
-    debug("Testing PACK_ALIGNMENT = " + packAlignment + ", width = " + width + ", height = " + height);
+    debug("Testing width = " + width + ", height = " + height +
+          ", PACK_ALIGNMENT = " + packAlignment + ", ROW_LENGTH = " + packRowLength +
+          ", SKIP_PIXELS = " + packSkipPixels + " , SKIP_ROWS = " + packSkipRows);
+
+    gl.pixelStorei(gl.PACK_ALIGNMENT, packAlignment);
+    gl.pixelStorei(gl.PACK_ROW_LENGTH, packRowLength);
+    gl.pixelStorei(gl.PACK_SKIP_PIXELS, packSkipPixels);
+    gl.pixelStorei(gl.PACK_SKIP_ROWS, packSkipRows);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
     gl.clearColor(expectedColor[0] / 255.0, expectedColor[1] / 255.0, expectedColor[2] / 255.0, expectedColor[3] / 255.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    var bytesPerPixel = 4; // see readPixels' parameters below, the format is gl.RGBA, type is gl.UNSIGNED_BYTE
-    var padding = calculatePaddingBytes(bytesPerPixel, packAlignment, width);
-    gl.pixelStorei(gl.PACK_ALIGNMENT, packAlignment);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+    var actualWidth = packRowLength > 0 ? packRowLength : width;
 
-    var size = bytesPerPixel * width * height + padding * (height - 1);
+    var bytesPerPixel = 4; // see readPixels' parameters below, the format is gl.RED, type is gl.UNSIGNED_BYTE
+    var padding = calculatePaddingBytes(bytesPerPixel, packAlignment, actualWidth);
+
+    var size = bytesPerPixel * actualWidth * height + padding * (height - 1);
     if (size < 0)
         size = 0;
+    var skipSize = (packSkipPixels * bytesPerPixel +
+                    packSkipRows * (bytesPerPixel * actualWidth + padding));
     var buffer = gl.createBuffer();
     gl.bindBuffer(gl.PIXEL_PACK_BUFFER, buffer);
-    gl.bufferData(gl.PIXEL_PACK_BUFFER, size, gl.STATIC_DRAW);
+    gl.bufferData(gl.PIXEL_PACK_BUFFER, size + skipSize, gl.STATIC_DRAW);
     var offset = 0;
     gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, offset);
+    if (packRowLength > 0 && packRowLength < width) {
+        // Revisit this if spec goes the other way.
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
+        return;
+    }
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
     if (!size)
         return;
     var arrBuffer = new ArrayBuffer(size);
-    gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, 0, arrBuffer);
+    gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, skipSize, arrBuffer);
     var array = new Uint8Array(arrBuffer);
 
     // Check the last pixel of the last row.
@@ -202,19 +219,34 @@ function runTestIteration(packAlignment, width, height)
 function testPackAlignment()
 {
     debug("");
-    debug("Verify that reading pixels to PIXEL_PACK buffer works fine with various PACK_ALIGNMENT values.");
+    debug("Verify that reading pixels to PIXEL_PACK buffer works fine with various pack alignments.");
+    runTestIteration(1, 3, 1, 0, 0, 0);
+    runTestIteration(1, 3, 2, 0, 0, 0);
+    runTestIteration(1, 3, 4, 0, 0, 0);
+    runTestIteration(1, 3, 8, 0, 0, 0);
+    runTestIteration(2, 3, 4, 0, 0, 0);
+    runTestIteration(2, 3, 8, 0, 0, 0);
+    runTestIteration(3, 3, 4, 0, 0, 0);
+    runTestIteration(3, 3, 8, 0, 0, 0);
+    runTestIteration(0, 0, 1, 0, 0, 0);
+    runTestIteration(1, 3, 4, 0, 0, 0);
+    runTestIteration(1, 3, 8, 0, 0, 0);
 
-    runTestIteration(1, 1, 2);
-    runTestIteration(2, 1, 2);
-    runTestIteration(4, 1, 2);
-    runTestIteration(8, 1, 2);
-    runTestIteration(4, 2, 2);
-    runTestIteration(8, 2, 2);
-    runTestIteration(4, 3, 2);
-    runTestIteration(8, 3, 2);
-    runTestIteration(1, 0, 0);
-    runTestIteration(4, 1, 1);
-    runTestIteration(8, 1, 1);
+    debug("");
+    debug("Verify that reading pixels to PIXEL_PACK buffer works fine with pack row length.");
+    runTestIteration(3, 3, 8, 2, 0, 0);  // PACK_ROW_LENTH < width
+    runTestIteration(3, 3, 8, 3, 0, 0);  // PACK_ROW_LENTH == width
+    runTestIteration(3, 3, 8, 4, 0, 0);  // PACK_ROW_LENTH > width, no padding
+    runTestIteration(3, 3, 8, 5, 0, 0);  // PACK_ROW_LENTH > width, extra padding
+
+    debug("");
+    debug("Verify that reading pixels to PIXEL_PACK buffer works fine with pack skip parameters.");
+    runTestIteration(3, 3, 8, 0, 2, 0);
+    runTestIteration(3, 3, 8, 0, 1, 3);
+    runTestIteration(3, 3, 8, 0, 0, 3);
+    runTestIteration(2, 3, 8, 0, 2, 0);
+    runTestIteration(2, 3, 8, 0, 1, 3);
+    runTestIteration(2, 3, 8, 0, 0, 3);
 }
 
 debug("");


### PR DESCRIPTION
This is the ReadPixels with a bound PIXEL_PACK_BUFFER case.

I'll add another test for ReadPixels with no bound PIXEL_PACK_BUFFER in a followup CL.