### PR TITLE
test cases of bufSize < 0 for getActiveUniform and getActiveAttrib are not necessary

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeStateApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeStateApiTests.js
@@ -274,10 +274,6 @@ goog.scope(function() {
             gl.getActiveUniform(program.getProgram(), numActiveUniforms);
             this.expectError(gl.INVALID_VALUE);
 
-            bufferedLogToConsole('gl.INVALID_VALUE is generated if bufSize is less than 0.');
-            gl.getActiveUniform(program.getProgram(), 0);
-            this.expectError(gl.INVALID_VALUE);
-
             gl.useProgram(null);
             gl.deleteShader(shader);
         }));
@@ -377,10 +373,6 @@ goog.scope(function() {
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if index is greater than or equal to gl.ACTIVE_ATTRIBUTES.');
             activeInfo = gl.getActiveAttrib(program.getProgram(), numActiveAttributes);
-            this.expectError(gl.INVALID_VALUE);
-
-            bufferedLogToConsole('gl.INVALID_VALUE is generated if bufSize is less than 0.');
-            activeInfo = gl.getActiveAttrib(program.getProgram(), 0);
             this.expectError(gl.INVALID_VALUE);
 
             gl.useProgram(null);


### PR DESCRIPTION
getActiveUniform and getActiveAttrib have no bufSize argument at all. This feature is different from that in native API. I suppose the implementation in browser always allocate memory and set a correct bufSize to call into native API, no glError will be generated. 

This patch deleted these 2 code snippets to fix failures in negativestateapi.html in WebGL dEQP conformance test. Here is the crbug: http://code.google.com/p/chromium/issues/detail?id=565347

PTAL. Thanks a lot!  