### PR TITLE
Move tests around to reduce code duplication.

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-into-pixel-pack-buffer.html
+++ b/sdk/tests/conformance2/reading/read-pixels-into-pixel-pack-buffer.html
@@ -146,116 +146,6 @@ function validatePixelPackBufferAndParameters(canvasWidth, canvasHeight)
     gl.deleteBuffer(buffer);
 }
 
-function calculatePaddingBytes(bytesPerPixel, packAlignment, width)
-{
-    var padding = 0;
-    switch (packAlignment) {
-    case 1:
-    case 2:
-    case 4:
-    case 8:
-        padding = (bytesPerPixel * width) % packAlignment;
-        if (padding > 0)
-            padding = packAlignment - padding;
-        return padding;
-    default:
-        testFailed("should not reach here");
-        return;
-    }
-}
-
-function runTestIteration(width, height, packParams)
-{
-    if (!("alignment" in packParams))
-        packParams.alignment = 4;
-    if (!("rowLength" in packParams))
-        packParams.rowLength = 0;
-    if (!("skipPixels" in packParams))
-        packParams.skipPixels = 0;
-    if (!("skipRows" in packParams))
-        packParams.skipRows = 0;
-    debug("Testing width = " + width + ", height = " + height +
-          ", PACK_ALIGNMENT = " + packParams.alignment + ", PACK_ROW_LENGTH = " + packParams.rowLength +
-          ", PACK_SKIP_PIXELS = " + packParams.skipPixels + " , PACK_SKIP_ROWS = " + packParams.skipRows);
-    gl.pixelStorei(gl.PACK_ALIGNMENT, packParams.alignment);
-    gl.pixelStorei(gl.PACK_ROW_LENGTH, packParams.rowLength);
-    gl.pixelStorei(gl.PACK_SKIP_PIXELS, packParams.skipPixels);
-    gl.pixelStorei(gl.PACK_SKIP_ROWS, packParams.skipRows);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-
-    gl.clearColor(expectedColor[0] / 255.0, expectedColor[1] / 255.0, expectedColor[2] / 255.0, expectedColor[3] / 255.0);
-    gl.clear(gl.COLOR_BUFFER_BIT);
-
-    var actualWidth = packParams.rowLength > 0 ? packParams.rowLength : width;
-
-    var bytesPerPixel = 4; // see readPixels' parameters below, the format is gl.RGBA, type is gl.UNSIGNED_BYTE
-    var padding = calculatePaddingBytes(bytesPerPixel, packParams.alignment, actualWidth);
-
-    var size = bytesPerPixel * actualWidth * height + padding * (height - 1);
-    if (size < 0)
-        size = 0;
-    var skipSize = (packParams.skipPixels * bytesPerPixel +
-                    packParams.skipRows * (bytesPerPixel * actualWidth + padding));
-    var buffer = gl.createBuffer();
-    gl.bindBuffer(gl.PIXEL_PACK_BUFFER, buffer);
-    gl.bufferData(gl.PIXEL_PACK_BUFFER, size + skipSize, gl.STATIC_DRAW);
-    var offset = 0;
-    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, offset);
-    if (packParams.rowLength > 0 && packParams.rowLength < width) {
-        // Revisit this if spec goes the other way.
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
-        return;
-    }
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-
-    if (!size)
-        return;
-    var arrBuffer = new ArrayBuffer(size);
-    gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, skipSize, arrBuffer);
-    var array = new Uint8Array(arrBuffer);
-
-    // Check the last pixel of the last row.
-    var bytesPerRow = actualWidth * bytesPerPixel + padding;
-    var pos = skipSize + bytesPerRow * (height - 1) + (width - 1) * bytesPerPixel;
-    for (var i = 0; i < bytesPerPixel; ++i)
-        pixel[i] = array[pos + i];
-    shouldBe("pixel", "expectedColor");
-}
-
-function testPackParameters()
-{
-    debug("");
-    debug("Verify that reading pixels to PIXEL_PACK buffer works fine with various pack alignments.");
-    runTestIteration(1, 3, {alignment:1});
-    runTestIteration(1, 3, {alignment:2});
-    runTestIteration(1, 3, {alignment:4});
-    runTestIteration(1, 3, {alignment:8});
-    runTestIteration(2, 3, {alignment:4});
-    runTestIteration(2, 3, {alignment:8});
-    runTestIteration(3, 3, {alignment:4});
-    runTestIteration(3, 3, {alignment:8});
-    runTestIteration(0, 0, {alignment:1});
-    runTestIteration(1, 3, {alignment:4});
-    runTestIteration(1, 3, {alignment:8});
-
-    debug("");
-    debug("Verify that reading pixels to PIXEL_PACK buffer works fine with pack row length.");
-    // PACK_ROW_LENGTH < width case, pending working group decision.
-    // runTestIteration(3, 3, {alignment:8, rowLength:2});  // PACK_ROW_LENTH < width
-    runTestIteration(3, 3, {alignment:8, rowLength:3});  // PACK_ROW_LENTH == width
-    runTestIteration(3, 3, {alignment:8, rowLength:4});  // PACK_ROW_LENTH > width, no padding
-    runTestIteration(3, 3, {alignment:8, rowLength:5});  // PACK_ROW_LENTH > width, extra padding
-
-    debug("");
-    debug("Verify that reading pixels to PIXEL_PACK buffer works fine with pack skip parameters.");
-    runTestIteration(3, 3, {alignment:8, skipPixels:2});
-    runTestIteration(3, 3, {alignment:8, skipPixels:1, skipRows:3});
-    runTestIteration(3, 3, {alignment:8, skipRows:3});
-    runTestIteration(2, 3, {alignment:8, skipPixels:2});
-    runTestIteration(2, 3, {alignment:8, skipPixels:1, skipRows:3});
-    runTestIteration(2, 3, {alignment:8, skipRows:3});
-}
-
 debug("");
 debug("Canvas.getContext");
 
@@ -274,7 +164,6 @@ if (!gl) {
   debug("");
   description('ReadPixels into PIXEL_PACK buffer');
   validatePixelPackBufferAndParameters(4, 4);
-  testPackParameters();
 }
 
 debug("");

--- a/sdk/tests/conformance2/reading/read-pixels-pack-parameters.html
+++ b/sdk/tests/conformance2/reading/read-pixels-pack-parameters.html
@@ -56,7 +56,7 @@ function calculatePaddingBytes(bytesPerPixel, packAlignment, width)
     }
 }
 
-function runTestIteration(width, height, packParams)
+function runTestIteration(width, height, packParams, usePixelPackBuffer)
 {
     if (!("alignment" in packParams))
         packParams.alignment = 4;
@@ -88,8 +88,17 @@ function runTestIteration(width, height, packParams)
         size = 0;
     var skipSize = (packParams.skipPixels * bytesPerPixel +
                     packParams.skipRows * (bytesPerPixel * actualWidth + padding));
-    var buffer = new Uint8Array(size + skipSize);
-    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buffer);
+    var array;
+    if (usePixelPackBuffer) {
+        var buffer = gl.createBuffer();
+        gl.bindBuffer(gl.PIXEL_PACK_BUFFER, buffer);
+        gl.bufferData(gl.PIXEL_PACK_BUFFER, size + skipSize, gl.STATIC_DRAW);
+        var offset = 0;
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, offset);
+    } else {
+        array = new Uint8Array(size + skipSize);
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, array);
+    }
     if (packParams.rowLength > 0 && packParams.rowLength < width) {
         // Revisit this if spec goes the other way.
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
@@ -100,46 +109,53 @@ function runTestIteration(width, height, packParams)
     if (!size)
         return;
 
+    if (usePixelPackBuffer) {
+        var arrBuffer = new ArrayBuffer(size);
+        gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, skipSize, arrBuffer);
+        var array = new Uint8Array(arrBuffer);
+    }
+
     // Check the last pixel of the last row.
     var bytesPerRow = actualWidth * bytesPerPixel + padding;
     var pos = skipSize + bytesPerRow * (height - 1) + (width - 1) * bytesPerPixel;
     for (var i = 0; i < bytesPerPixel; ++i)
-        pixel[i] = buffer[pos + i];
+        pixel[i] = array[pos + i];
     shouldBe("pixel", "expectedColor");
 }
 
-function testPackParameters()
+function testPackParameters(usePixelPackBuffer)
 {
     debug("");
-    debug("Verify that reading pixels to array buffer works fine with various pack alignments.");
-    runTestIteration(1, 3, {alignment:1});
-    runTestIteration(1, 3, {alignment:2});
-    runTestIteration(1, 3, {alignment:4});
-    runTestIteration(1, 3, {alignment:8});
-    runTestIteration(2, 3, {alignment:4});
-    runTestIteration(2, 3, {alignment:8});
-    runTestIteration(3, 3, {alignment:4});
-    runTestIteration(3, 3, {alignment:8});
-    runTestIteration(0, 0, {alignment:1});
-    runTestIteration(1, 3, {alignment:4});
-    runTestIteration(1, 3, {alignment:8});
+    var destText = usePixelPackBuffer ? "PIXEL_PACK buffer" : "array buffer";
+    debug("Verify that reading pixels to " + destText + " works fine with various pack alignments.");
+    runTestIteration(1, 3, {alignment:1}, usePixelPackBuffer);
+    runTestIteration(1, 3, {alignment:2}, usePixelPackBuffer);
+    runTestIteration(1, 3, {alignment:4}, usePixelPackBuffer);
+    runTestIteration(1, 3, {alignment:8}, usePixelPackBuffer);
+    runTestIteration(2, 3, {alignment:4}, usePixelPackBuffer);
+    runTestIteration(2, 3, {alignment:8}, usePixelPackBuffer);
+    runTestIteration(3, 3, {alignment:4}, usePixelPackBuffer);
+    runTestIteration(3, 3, {alignment:8}, usePixelPackBuffer);
+    runTestIteration(0, 0, {alignment:1}, usePixelPackBuffer);
+    runTestIteration(1, 3, {alignment:4}, usePixelPackBuffer);
+    runTestIteration(1, 3, {alignment:8}, usePixelPackBuffer);
 
     debug("");
-    debug("Verify that reading pixels to array buffer works fine with pack row length.");
+    debug("Verify that reading pixels to " + destText + " works fine with pack row length.");
     // PACK_ROW_LENGTH < width case, pending working group decision.
-    // runTestIteration(3, 3, {alignment:8, rowLength:2});  // PACK_ROW_LENTH < width
-    runTestIteration(3, 3, {alignment:8, rowLength:3});  // PACK_ROW_LENTH == width
-    runTestIteration(3, 3, {alignment:8, rowLength:4});  // PACK_ROW_LENTH > width, no padding
-    runTestIteration(3, 3, {alignment:8, rowLength:5});  // PACK_ROW_LENTH > width, extra padding
+    // runTestIteration(3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);  // PACK_ROW_LENTH < width
+    runTestIteration(3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);  // PACK_ROW_LENTH == width
+    runTestIteration(3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);  // PACK_ROW_LENTH > width, no padding
+    runTestIteration(3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);  // PACK_ROW_LENTH > width, extra padding
 
     debug("");
-    debug("Verify that reading pixels to array buffer works fine with pack skip parameters.");
-    runTestIteration(3, 3, {alignment:8, skipPixels:2});
-    runTestIteration(3, 3, {alignment:8, skipPixels:1, skipRows:3});
-    runTestIteration(3, 3, {alignment:8, skipRows:3});
-    runTestIteration(2, 3, {alignment:8, skipPixels:2});
-    runTestIteration(2, 3, {alignment:8, skipPixels:1, skipRows:3});
-    runTestIteration(2, 3, {alignment:8, skipRows:3});
+    debug("Verify that reading pixels to " + destText + " works fine with pack skip parameters.");
+    runTestIteration(3, 3, {alignment:8, skipPixels:2}, usePixelPackBuffer);
+    runTestIteration(3, 3, {alignment:8, skipPixels:1, skipRows:3}, usePixelPackBuffer);
+    runTestIteration(3, 3, {alignment:8, skipRows:3}, usePixelPackBuffer);
+    runTestIteration(2, 3, {alignment:8, skipPixels:2}, usePixelPackBuffer);
+    runTestIteration(2, 3, {alignment:8, skipPixels:1, skipRows:3}, usePixelPackBuffer);
+    runTestIteration(2, 3, {alignment:8, skipRows:3}, usePixelPackBuffer);
 }
 
 debug("");
@@ -159,7 +175,10 @@ if (!gl) {
 
   debug("");
   description('ReadPixels into array buffer');
-  testPackParameters();
+  var usePixelPackBuffer = false;
+  testPackParameters(usePixelPackBuffer);
+  usePixelPackBuffer = true;
+  testPackParameters(usePixelPackBuffer);
 }
 
 debug("");


### PR DESCRIPTION
Now read-pixels-pack-parameters.html tests both using and not using PIXEL_PACK_BUFFER.