### PR TITLE
fix the ambiguous test case of getActiveUniformBlockParameter

### DIFF
--- a/sdk/tests/js/tests/gl-enum-tests.js
+++ b/sdk/tests/js/tests/gl-enum-tests.js
@@ -85,7 +85,6 @@ if (!gl) {
       "gl.bindTexture(desktopGL['TEXTURE_RECTANGLE_EXT'], tex)",
       "gl.enable(desktopGL['PRIMITIVE_RESTART_FIXED_INDEX'])",
       "gl.getActiveUniforms(program, [0], desktopGL['UNIFORM_NAME_LENGTH'])",
-      "gl.getActiveUniformBlockParameter(program, 0, desktopGL['UNIFORM_BLOCK_NAME_LENGTH'])",
       "gl.getProgramParameter(program, desktopGL['ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH'])",
       "gl.getProgramParameter(program, desktopGL['TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH'])",
       "gl.getProgramParameter(program, desktopGL['PROGRAM_BINARY_RETRIEVABLE_HINT'])",
@@ -126,6 +125,14 @@ if (!gl) {
   for (var ii = 0; ii < tests.length; ++ii) {
     TestEval(tests[ii]);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, tests[ii] + " should return INVALID_ENUM.");
+  }
+  if (contextVersion >= 2) {
+    var uniformBlockProgram = wtu.loadUniformBlockProgram(gl);
+    gl.linkProgram(uniformBlockProgram);
+    shouldBe('gl.getProgramParameter(uniformBlockProgram, gl.LINK_STATUS)', 'true');
+    shouldBe('gl.getError()', 'gl.NO_ERROR');
+    gl.getActiveUniformBlockParameter(uniformBlockProgram, 0, desktopGL['UNIFORM_BLOCK_NAME_LENGTH']);
+    shouldBe('gl.getError()', 'gl.INVALID_ENUM');
   }
 }
 


### PR DESCRIPTION
The original test case use a standard program, which have no uniformBlock at all. When call into
getActiveUniformBlockParameter(program, 0, desktopGL['UNIFORM_BLOCK_NAME_LENGTH'])
, both the index and pname are invalid. We should generate INVALID_VALUE and INVALID_ENUM for invalid index and invalid pname respectively. But the original test case expect an INVALID_ENUM. This lead to my CL(https://chromiumcodereview.appspot.com/1495113004/) failed.

See the [Errors] section in gles3 man page for invalid index and invalid pname: https://www.khronos.org/opengles/sdk/docs/man3/html/glGetActiveUniformBlockiv.xhtml. 
"GL_INVALID_VALUE is generated if uniformBlockIndex is greater than or equal to the value of GL_ACTIVE_UNIFORM_BLOCKS or is not the index of an active uniform block in program"

This change tests getActiveUniformBlockParameter against a uniformBlockProgram. So the uniformBlockIndex is correct, this test is specific for 'pname' of this function. 

PTAL. Thanks a lot!