### PR TITLE
Fix one test case in constant-precision-qualifier.html

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
+++ b/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
@@ -72,9 +72,10 @@ void main() {
 // operations that can be constant folded at compile-time.
 // It's here to provide a point of comparison.
 uniform mediump float uTest;
+uniform highp float uTestHigh;
 
 void main() {
-    highp float c = 4096.5 + uTest;
+    highp float c = 4096.5 + uTestHigh;
     mediump float a = 0.0;
     a = fract(c + uTest);
     gl_FragColor = vec4(0.0, 2.0 * a, 0.0, 1.0);
@@ -119,6 +120,8 @@ function test() {
     debug("Testing shader where the precision qualifier of a variable affects built-in function results");
     program = wtu.setupProgram(gl, ["vshader", "fshaderNoConstants"], ["aPosition"], undefined, true);
     uniformLoc = gl.getUniformLocation(program, 'uTest');
+    gl.uniform1f(uniformLoc, 0);
+    uniformLoc = gl.getUniformLocation(program, 'uTestHigh');
     gl.uniform1f(uniformLoc, 0);
     wtu.drawUnitQuad(gl);
     wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);


### PR DESCRIPTION
All of the cases in this test try to assign highp 4096.5 to "c" and then
check that the precision qualification of that variable affects the
result of a subsequent operation. One of the cases had the error that
"4096.5 + uTest" could be evaluated at mediump due to uTest being
mediump, even if the target of the assignment was highp. Fix this by
adding a separate highp uniform variable to the test.

The earlier version of this test in 1.0.3 doesn't have this bug.