### PR TITLE
Remove duplicate test case for constants in loop conditions

### DIFF
--- a/sdk/tests/conformance/glsl/misc/shaders-with-constant-expression-loop-conditions.html
+++ b/sdk/tests/conformance/glsl/misc/shaders-with-constant-expression-loop-conditions.html
@@ -113,14 +113,6 @@ tests.push({
     passMsg: "Shaders with constant variables in the loop condition should compile and link.",
 });
 tests.push({
-    vShaderSource: wtu.getScript("vertexShaderConstVarLoopCondition"),
-    vShaderSuccess: true,
-    fShaderSource: wtu.getScript("fragmentShaderConstVarLoopCondition"),
-    fShaderSuccess: true,
-    linkSuccess: true,
-    passMsg: "Shaders with constant variables in the loop condition should compile and link.",
-});
-tests.push({
     vShaderSource: wtu.getScript("vertexShaderNonConstVarLoopCondition"),
     vShaderSuccess: false,
     fShaderSource: wtu.getScript("fragmentShaderLiteralLoopCondition"),


### PR DESCRIPTION
The same identical test should only be run once.