### PR TITLE
Fix unintentional error in undefined index test shaders

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/undefined-index-should-not-crash.html
+++ b/sdk/tests/conformance/glsl/bugs/undefined-index-should-not-crash.html
@@ -52,7 +52,7 @@ uniform float uniformArray[4];
 void main()
 {
   vec4 tempVec = vec4(0.0);
-  vec4 tempMat = mat4(0.0);
+  mat4 tempMat = mat4(0.0);
   float tempArray[4];
   gl_FragColor = vec4($(indexed)[int()]);
 }


### PR DESCRIPTION
The shaders contained an invalid assignment, even though they were only
intended to contain invalid indexing with "int()".