### PR TITLE
Revert "use the max samples supported for the specific internalformat"

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fRboStateQueryTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fRboStateQueryTests.js
@@ -245,9 +245,7 @@ es3fRboStateQueryTests.RboSamplesCase.prototype.test = function() {
 
     this.check(glsStateQuery.verifyRenderbuffer(gl.RENDERBUFFER_SAMPLES, 0));
 
-    /** @type {Int32Array} */ var samplesSupportedRGBA8 = /** @type {Int32Array} */ gl.getInternalformatParameter(gl.RENDERBUFFER, gl.RGBA8, gl.SAMPLES);
-    // supported samples are written in descending numeric order, so the first one is the max samples
-    var max_samples = samplesSupportedRGBA8[0];
+    var max_samples = /** @type {number} */ (gl.getParameter(gl.MAX_SAMPLES));
 
     // 0 samples is a special case
     gl.renderbufferStorageMultisample(gl.RENDERBUFFER, 0, gl.RGBA8, 128, 128);


### PR DESCRIPTION
Reverts KhronosGroup/WebGL#1368