### PR TITLE
fix the ambiguous test cases for instanced drawing in NegativeVertexArrayAPI

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
@@ -525,7 +525,6 @@ goog.scope(function() {
 
         testGroup.addChild(new es3fApiCase.ApiCaseCallback('draw_arrays_instanced_invalid_program', 'Invalid gl.drawArraysInstanced() usage', gl, function() {
             gl.useProgram(null);
-            /** @type{WebGLFramebuffer} */ var fbo;
 
             /** @type{WebGLBuffer} */ var bufElements = gl.createBuffer();
             gl.bindBuffer(gl.ARRAY_BUFFER, bufElements);
@@ -533,28 +532,9 @@ goog.scope(function() {
             gl.vertexAttribDivisor(0, 1);
             this.expectError(gl.NO_ERROR);
 
-            bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawArraysInstanced(-1, 0, 1, 1);
-            this.expectError(gl.INVALID_ENUM);
-
-            bufferedLogToConsole('gl.INVALID_VALUE is generated if count or primcount are negative.');
-            gl.drawArraysInstanced(gl.POINTS, 0, -1, 1);
-            this.expectError(gl.INVALID_VALUE);
-            gl.drawArraysInstanced(gl.POINTS, 0, 1, -1);
-            this.expectError(gl.INVALID_VALUE);
-
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) is set.');
             gl.drawArraysInstanced(gl.POINTS, 0, 1, 1);
             this.expectError(gl.INVALID_OPERATION);
-
-            bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
-            fbo = gl.createFramebuffer();
-            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-            gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawArraysInstanced(gl.POINTS, 0, 1, 1);
-            this.expectError([gl.INVALID_FRAMEBUFFER_OPERATION, gl.INVALID_OPERATION]);
-            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-            gl.deleteFramebuffer(fbo);
 
             gl.deleteBuffer(bufElements);
 
@@ -673,7 +653,6 @@ goog.scope(function() {
 
         testGroup.addChild(new es3fApiCase.ApiCaseCallback('draw_elements_instanced_invalid_program', 'Invalid gl.drawElementsInstanced() usage', gl, function() {
             gl.useProgram(null);
-            /** @type{WebGLFramebuffer} */ var fbo;
             /** @type{number} */ var vertices = 0;
 
             /** @type{WebGLBuffer} */ var bufElements;
@@ -683,34 +662,10 @@ goog.scope(function() {
             gl.vertexAttribDivisor(0, 1);
             this.expectError(gl.NO_ERROR);
 
-            bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElementsInstanced(-1, 1, gl.UNSIGNED_BYTE, vertices, 1);
-            this.expectError(gl.INVALID_ENUM);
-
-            bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElementsInstanced(gl.POINTS, 1, -1, vertices, 1);
-            this.expectError(gl.INVALID_ENUM);
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.FLOAT, vertices, 1);
-            this.expectError(gl.INVALID_ENUM);
-
-            bufferedLogToConsole('gl.INVALID_VALUE is generated if count or primcount are negative.');
-            gl.drawElementsInstanced(gl.POINTS, -1, gl.UNSIGNED_BYTE, vertices, 1);
-            this.expectError(gl.INVALID_VALUE);
-            gl.drawElementsInstanced(gl.POINTS, 11, gl.UNSIGNED_BYTE, vertices, -1);
-            this.expectError(gl.INVALID_VALUE);
-
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) is set.');
             gl.drawElementsInstanced(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_OPERATION);
 
-            bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
-            fbo = gl.createFramebuffer();
-            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-            gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
-            this.expectError([gl.INVALID_FRAMEBUFFER_OPERATION, gl.INVALID_OPERATION]);
-            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-            gl.deleteFramebuffer(fbo);
             gl.deleteBuffer(bufElements);
 
         }));
@@ -870,7 +825,6 @@ goog.scope(function() {
 
         testGroup.addChild(new es3fApiCase.ApiCaseCallback('draw_range_elements_invalid_program', 'Invalid gl.drawRangeElements() usage', gl, function() {
             gl.useProgram(null);
-            /** @type{WebGLFramebuffer} */ var fbo;
             /** @type{number} */ var vertices = 0;
 
             /** @type{WebGLBuffer} */ var bufElements;
@@ -878,36 +832,10 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
             gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
-            bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawRangeElements(-1, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
-            this.expectError(gl.INVALID_ENUM);
-
-            bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, -1, vertices);
-            this.expectError(gl.INVALID_ENUM);
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.FLOAT, vertices);
-            this.expectError(gl.INVALID_ENUM);
-
-            bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
-            gl.drawRangeElements(gl.POINTS, 0, 1, -1, gl.UNSIGNED_BYTE, vertices);
-            this.expectError(gl.INVALID_VALUE);
-
-            bufferedLogToConsole('gl.INVALID_VALUE is generated if end < start.');
-            gl.drawRangeElements(gl.POINTS, 1, 0, 1, gl.UNSIGNED_BYTE, vertices);
-            this.expectError(gl.INVALID_VALUE);
-
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) is set.');
             gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_OPERATION);
 
-            bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
-            fbo = gl.createFramebuffer();
-            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-            gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
-            this.expectError([gl.INVALID_FRAMEBUFFER_OPERATION, gl.INVALID_OPERATION]);
-            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-            gl.deleteFramebuffer(fbo);
             gl.deleteBuffer(bufElements);
 
         }));


### PR DESCRIPTION
The original code uses 'null' program for instanced drawing. It always generate INVALID_OPERATION. This is ambiguous for many other case to generate appropriate glError, except the one that need to test this feature. 

When count or primcount are negative in drawArraysInstanced/drawElementsInstanced,  Chromium should generates INVALID_VALUE, but it generated INVALID_OPERATION because the original code uses 'null' program for all cases. Now it is fixed. 

I think the original deqp code need to be revised too: https://android.googlesource.com/platform/external/deqp/+/deqp-dev/modules/gles3/functional/es3fNegativeVertexArrayApiTests.cpp

PTAL. Thanks.