### PR TITLE
Throw exception if pixels data is null for CompressedTex{Sub}Image

### DIFF
--- a/sdk/tests/conformance2/textures/misc/compressed-tex-image.html
+++ b/sdk/tests/conformance2/textures/misc/compressed-tex-image.html
@@ -76,6 +76,12 @@ if (!gl) {
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "formats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS)");
   shouldBeNonNull("formats");
   shouldBe("formats.length", "10");
+
+  debug("");
+  shouldThrow("gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.COMPRESSED_R11_EAC, 4, 4, 0, null)");
+  shouldThrow("gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, gl.COMPRESSED_R11_EAC, null)");
+  shouldThrow("gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, 0, gl.COMPRESSED_R11_EAC, 4, 4, 4, 0, null)");
+  shouldThrow("gl.compressedTexSubImage3D(gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, 0, 0, 0, gl.COMPRESSED_R11_EAC, null)");
 }
 
 var successfullyParsed = true;


### PR DESCRIPTION
https://codereview.chromium.org/1527723003/ fixes this test.