### PR TITLE
bind buffer to ARRAY_BUFFER target for vertexAttribPointer

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
@@ -122,6 +122,9 @@ goog.scope(function() {
         }));
 
         testGroup.addChild(new es3fApiCase.ApiCaseCallback('vertex_attrib_pointer', 'Invalid gl.vertexAttribPointer() usage', gl, function() {
+            /** @type{WebGLBuffer} */ var buffer = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not an accepted value.');
             gl.vertexAttribPointer(0, 1, 0, true, 0, 0);
             this.expectError(gl.INVALID_ENUM);
@@ -166,7 +169,7 @@ goog.scope(function() {
 
         }));
 
-        testGroup.addChild(new es3fApiCase.ApiCaseCallback('vertex_attrib_i_pointer', 'Invalid gl.vertexAttribPointer() usage', gl, function() {
+        testGroup.addChild(new es3fApiCase.ApiCaseCallback('vertex_attrib_i_pointer', 'Invalid gl.vertexAttribIPointer() usage', gl, function() {
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not an accepted value.');
             gl.vertexAttribIPointer(0, 1, 0, 0, 0);
             this.expectError(gl.INVALID_ENUM);


### PR DESCRIPTION
According to the WebGL spec, If no buffer bound to ARRAY_BUFFER object, INVALID_OPERATION should be generated against vertexAttribPointer. Then no tests in vertex_attrib_pointer will succeed. 

This small change create a buffer and bind it to ARRAY_BUFFER. 

PTAL. Thanks. 