### PR TITLE
bind buffer to ARRAY_BUFFER target for vertexAttribIPointer

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
@@ -170,6 +170,9 @@ goog.scope(function() {
         }));
 
         testGroup.addChild(new es3fApiCase.ApiCaseCallback('vertex_attrib_i_pointer', 'Invalid gl.vertexAttribIPointer() usage', gl, function() {
+            /** @type{WebGLBuffer} */ var buffer = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not an accepted value.');
             gl.vertexAttribIPointer(0, 1, 0, 0, 0);
             this.expectError(gl.INVALID_ENUM);


### PR DESCRIPTION
According to the WebGL spec, If no buffer bound to ARRAY_BUFFER object, INVALID_OPERATION should be generated against vertexAttribIPointer. This is ambiguous to test other invalid operations. 

See the similar one https://github.com/KhronosGroup/WebGL/pull/1378. 

PTAL. Thanks! 