### PR TITLE
Change spec for readPixels/copySubImage2D out of bounds read.

### DIFF
--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -75,11 +75,11 @@ function continueTestAfterContextRestored() {
 }
 
 function continueTestPart1() {
-  gl.clearColor(0.5, 0.7, 1.0, 1);
+  gl.clearColor(0.2, 0.6, 0.4, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
-  var innerColor = [0.5, 0.7, 1.0, 1];
-  var outerColor = [0, 0, 0, 0];
+  var innerColor = [51, 153, 102, 255]; // (0.2, 0.6, 0.4, 1)
+  var outerColor = [19, 72, 0, 198]; // Random color other than [0, 0, 0, 0]
 
   var tests = [
     { msg: 'in range', checkColor: innerColor, x:  0, y:  0,
@@ -110,18 +110,31 @@ function continueTestPart1() {
 
   function checkBuffer(checkColor, x, y, oneColor, oneX, oneY) {
     var buf = new Uint8Array(width * height * 4);
+    // Initialize buf.
+    for (var ii = 0; ii < width * height; ++ii) {
+      buf[ii * 4] = outerColor[0];
+      buf[ii * 4 + 1] = outerColor[1];
+      buf[ii * 4 + 2] = outerColor[2];
+      buf[ii * 4 + 3] = outerColor[3];
+    }
     gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buf);
     for (var yy = 0; yy < height; ++yy) {
       for (var xx = 0; xx < width; ++xx) {
         var offset = (yy * width + xx) * 4;
         var expectedColors = (oneX == xx && oneY == yy) ? oneColor : checkColor;
+        var mismatch = false;
         for (var cc = 0; cc < 4; ++cc) {
-          var expectedColor = expectedColors[cc] * 255;
+          var expectedColor = expectedColors[cc];
           var color = buf[offset + cc];
           var diff = Math.abs(expectedColor - color);
-          assertMsg(diff < 3,
-                    "color pixel at " + xx + ", " + yy + " should be about " + expectedColor);
+          if (diff >= 3) {
+            mismatch = true;
+            break;
+          }
         }
+        assertMsg(!mismatch,
+                  "color pixel at " + xx + ", " + yy + " should be about " + expectedColors +
+                  ", was = " + [buf[offset], buf[offset + 1], buf[offset + 2], buf[offset + 3]]);
       }
     }
   }

--- a/sdk/tests/conformance/textures/misc/copy-tex-image-and-sub-image-2d.html
+++ b/sdk/tests/conformance/textures/misc/copy-tex-image-and-sub-image-2d.html
@@ -80,10 +80,13 @@ function runTestIteration(antialias)
       [0, 0, 1, 1],
       [0.5, 0.5, 0.5, 0.5],
     ];
+    var data = new Uint8Array(2 * 2 * 4);
+    for (var ii = 0; ii < 2 * 2 * 4; ++ii)
+      data[ii] = 136; // A random number other than 0.
     var count = 0;
     for (var yy = -2; yy <= 2; ++yy) {
       for (var xx = -2; xx <= 2; ++xx) {
-         for (var ii = 0; ii < 2; ++ii) {
+        for (var ii = 0; ii < 2; ++ii) {
           var texColor = colors[count];
           var clearColor = colors[(count + 1) % colors.length];
           // clear to some color
@@ -98,6 +101,7 @@ function runTestIteration(antialias)
                 "using copyTexImage2D: x = " + xx + ", y = " + yy);
             break;
           case 1:
+            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, data);
             gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, xx, yy, 2, 2);
             wtu.glErrorShouldBe(gl, gl.NO_ERROR,
                 "using copyTexSubImage2D: x = " + xx + ", y = " + yy);
@@ -117,7 +121,7 @@ function runTestIteration(antialias)
               var x = xx + ix;
               var y = yy + iy;
               var expectedColor = (x < 0 || y < 0 || x >= 2 || y >= 2) ?
-                  [0,0,0,0] :
+                  (ii == 0 ? [0, 0, 0, 0] : [136, 136, 136, 136]) :
                   [Math.floor(255 * texColor[0]),
                    Math.floor(255 * texColor[1]),
                    Math.floor(255 * texColor[2]),

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -2381,9 +2381,8 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             If an attempt is made to call this function with no WebGLTexture bound (see above), an
             <code>INVALID_OPERATION</code> error is generated. <br><br>
 
-            For any pixel lying outside the frame buffer, all channels of the associated texel are
-            initialized to 0; see <a href="#READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the
-            Framebuffer</a>. <br><br>
+            For any pixel lying outside the frame buffer, the corresponding destination pixel remains untouched;
+            see <a href="#READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the Framebuffer</a>. <br><br>
 
             If this function attempts to read from a complete framebuffer with a missing attachment,
             an <code>INVALID_OPERATION</code> error is generated
@@ -3004,8 +3003,9 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             error is generated.
             <br><br>
 
-            For any pixel lying outside the frame buffer, the value read contains 0 in all channels;
-            see <a href="#READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the Framebuffer</a>.
+            For any pixel lying outside the frame buffer, the corresponding destination buffer range
+            remains untouched; see <a href="#READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the
+            Framebuffer</a>.
             <br><br>
 
             If this function attempts to read from a complete framebuffer with a missing color
@@ -3568,10 +3568,11 @@ is <code>BROWSER_DEFAULT_WEBGL</code>.
 <h3><a name="READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the Framebuffer</a></h3>
 
 <p>
-In the WebGL API, functions which read the framebuffer
-(<code>copyTexImage2D</code>, <code>copyTexSubImage2D</code>, and <code>readPixels</code>) are
-defined to generate the RGBA value (0, 0, 0, 0) for any pixel which is outside of the bound
-framebuffer.
+In the WebGL API, three functions read the framebuffer: <code>copyTexImage2D</code>,
+<code>copyTexSubImage2D</code>, and <code>readPixels</code>. <code>copyTexImage2D</code> is defined to
+generate the RGBA value (0, 0, 0, 0) for any pixel outside of the bound framebuffer.
+<code>copyTexSubImage2D</code> and <code>readPixels</code> are defined not to touch the corresponding
+destination range for any pixel outside the bound framebuffer.
 </p>
 
 <h3><a name="STENCIL_SEPARATE_LIMIT">Stencil Separate Mask and Reference Value</a></h3>


### PR DESCRIPTION
Before we set these pixels to (0, 0, 0, 0), now the working group
decided these pixels should remain untouched.

Note that I only changed the readPixels behavior in the test.  I will change the copyTexSubImage2D behavior in the test(s) in a separate CL.