### PR TITLE
add variables into tfVaryings to test transformFeedbackVaryings

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeShaderApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeShaderApiTests.js
@@ -1174,6 +1174,9 @@ goog.scope(function() {
 
                 bufferedLogToConsole('gl.INVALID_VALUE is generated if bufferMode is gl.SEPARATE_ATTRIBS and count is greater than gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS.');
                 maxTransformFeedbackSeparateAttribs = /** @type {number} */ (gl.getParameter(gl.MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS));
+                for (var count = 0; count < maxTransformFeedbackSeparateAttribs; ++count) {
+                    tfVarying = tfVarying.concat(['gl_Position']);
+                }
                 gl.transformFeedbackVaryings(program.getProgram(), tfVarying, gl.SEPARATE_ATTRIBS);
                 this.expectError(gl.INVALID_VALUE);
 


### PR DESCRIPTION
A small change to fix the bug. 

We need to add variables into 'tfVaryings' to make the array length exceed the max number of supported transformFeedbackVarying separate attribs.