### PR TITLE
Remove unnecessary logging from previous debugging

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -2728,7 +2728,6 @@ var requestAnimFrame = function(callback) {
         return window.setTimeout(callback, 1000 / 70);
       };
   }
-  log("requestAnimFrame: document.hidden = " + document.hidden);
   _requestAnimFrame.call(window, callback);
 };
 


### PR DESCRIPTION
The bug was already fixed (where RAF can be dropped in Chrome)

This makes log much longer on our bots.  Remove it.