### PR TITLE
fix a bug caused by incorrect javascript operator precedence

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboCompletenessTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboCompletenessTests.js
@@ -486,7 +486,7 @@ goog.scope(function() {
         var layerTests = tcuTestCase.newTest('layer', 'Tests for layer attachments');
 
         /** @static */
-        var s_latersParams = [
+        var s_layersParams = [
             es3fFboCompletenessTests.numLayersParams(gl.TEXTURE_2D_ARRAY, 1, 0),
             es3fFboCompletenessTests.numLayersParams(gl.TEXTURE_2D_ARRAY, 1, 3),
             es3fFboCompletenessTests.numLayersParams(gl.TEXTURE_2D_ARRAY, 4, 3),
@@ -497,13 +497,13 @@ goog.scope(function() {
             es3fFboCompletenessTests.numLayersParams(gl.TEXTURE_3D, 64, 15)
         ];
 
-        for (var i = 0; i < s_latersParams.length; ++i) {
+        for (var i = 0; i < s_layersParams.length; ++i) {
             var name = 'name';
             var desc = 'desc';
             layerTests.addChild(new es3fFboCompletenessTests.NumLayersTest(
-                es3fFboCompletenessTests.numLayersParams.getName(s_latersParams[i]),
-                es3fFboCompletenessTests.numLayersParams.getDescription(s_latersParams[i]),
-                fboCtx, s_latersParams[i]
+                es3fFboCompletenessTests.numLayersParams.getName(s_layersParams[i]),
+                es3fFboCompletenessTests.numLayersParams.getDescription(s_layersParams[i]),
+                fboCtx, s_layersParams[i]
             ));
         }
         testGroup.addChild(layerTests);

--- a/sdk/tests/deqp/modules/shared/glsFboUtil.js
+++ b/sdk/tests/deqp/modules/shared/glsFboUtil.js
@@ -746,16 +746,16 @@ goog.scope(function() {
     glsFboUtil.glsup = function() {
 
         var glInit = function(cfg, gl) {
-            if (cfg.type & glsFboUtil.Config.s_types.TEXTURE_2D != 0) {
+            if ((cfg.type & glsFboUtil.Config.s_types.TEXTURE_2D) != 0) {
                 glInitFlat(cfg, glTarget(cfg, gl), gl);
 
-            } else if (cfg.type & glsFboUtil.Config.s_types.TEXTURE_CUBE_MAP != 0) {
+            } else if ((cfg.type & glsFboUtil.Config.s_types.TEXTURE_CUBE_MAP) != 0) {
                 for (var i = gl.TEXTURE_CUBE_MAP_NEGATIVE_X; i <= gl.TEXTURE_CUBE_MAP_POSITIVE_Z; ++i)
                     glInitFlat(cfg, i, gl);
-            } else if (cfg.type & glsFboUtil.Config.s_types.TEXTURE_3D != 0) {
+            } else if ((cfg.type & glsFboUtil.Config.s_types.TEXTURE_3D) != 0) {
                 glInitLayered(cfg, 2, gl);
 
-            } else if (cfg.type & glsFboUtil.Config.s_types.TEXTURE_2D_ARRAY != 0) {
+            } else if ((cfg.type & glsFboUtil.Config.s_types.TEXTURE_2D_ARRAY) != 0) {
                 glInitLayered(cfg, 1, gl);
             }
         };


### PR DESCRIPTION
and a typo: s_latersParams -> s_layersParams.

According to JavaScript operator precedence, the precedence of inequality (!=) is higher than that of bitwise-and(&). see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence

This change fixed some bugs in deqp fbo related tests, for example, test cases in fobcompleteness.html. 

PTAL. Thanks!