### PR TITLE
Changed error checking in fbo completeness tests.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/fbocompleteness.html
+++ b/sdk/tests/deqp/functional/gles3/fbocompleteness.html
@@ -17,7 +17,7 @@
 <script>
 
     var wtu = WebGLTestUtils;
-    var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+    var gl = wtu.create3DContext('canvas', null, 2);
 
     try {
         functional.gles3.es3fFboCompletenessTests.initGlDependents(gl);


### PR DESCRIPTION
Before this patch, any GL error caused a test failure.
However, some of the tests expect GL errors.

Removed throwing exceptions when a GL error occurs in fbo completeness
tests.

Signed-off-by: Janusz Sobczak <janusz.sobczak@mobica.com>