### PR TITLE
Fix ambiguous texture input test.

### DIFF
--- a/sdk/tests/js/tests/tex-input-validation.js
+++ b/sdk/tests/js/tests/tex-input-validation.js
@@ -292,7 +292,7 @@ var testCases = [
     border: 0,
     format: 0x1903, // GL_RED
     type: gl.UNSIGNED_BYTE,
-    expectedError: gl.INVALID_ENUM },
+    expectedError: [gl.INVALID_ENUM, gl.INVALID_VALUE] },
   { target: gl.TEXTURE_2D,
     internalFormat: gl.RGBA,
     border: 1,


### PR DESCRIPTION
According to the spec https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexImage2D.xml. GL_INVALID_VALUE is generated if internalformat is not an accepted format and GL_INVALID_ENUM is generated if format or type is not an accepted value. So this expectedError should be INVALID_VALUE or gl.INVALID_ENUM.