### PR TITLE
dEQP: use same framebuffer as C++ code

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeTextureApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeTextureApiTests.js
@@ -2420,8 +2420,8 @@ goog.scope(function() {
             this.expectError(gl.NO_ERROR);
 
             fbo = gl.createFramebuffer();
-            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-            gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+            gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo);
+            gl.checkFramebufferStatus(gl.READ_FRAMEBUFFER);
             this.expectError(gl.NO_ERROR);
 
             gl.copyTexSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, 0, 0, 4, 4);


### PR DESCRIPTION
This is a follow-up patch of https://github.com/KhronosGroup/WebGL/pull/1407. Aligned with native code.