### PR TITLE
Generate INVALID_VALUE for TexImage with invalid internalformat

### DIFF
--- a/sdk/tests/js/tests/tex-input-validation.js
+++ b/sdk/tests/js/tests/tex-input-validation.js
@@ -514,7 +514,7 @@ var testCases = [
     border: 0,
     format: gl.RGBA,
     type: gl.UNSIGNED_BYTE,
-    expectedError: gl.INVALID_ENUM},
+    expectedError: gl.INVALID_VALUE},
   { target: gl.TEXTURE_3D,
     internalFormat: gl.RGBA,
     border: 0,


### PR DESCRIPTION
Align with spec change in https://github.com/KhronosGroup/WebGL/pull/1402. 