### PR TITLE
Fix ambiguous texture input test in older snapshot

### DIFF
--- a/conformance-suites/1.0.1/conformance/textures/tex-input-validation.html
+++ b/conformance-suites/1.0.1/conformance/textures/tex-input-validation.html
@@ -185,7 +185,7 @@ var testCases =
      border: 0,
      format: 0x1903, // GL_RED
      type: gl.UNSIGNED_BYTE,
-     expectedError: gl.INVALID_ENUM},
+     expectedError: [gl.INVALID_ENUM, gl.INVALID_VALUE] },
     {target: gl.TEXTURE_2D,
      internalFormat: gl.RGBA,
      border: 1,

--- a/conformance-suites/1.0.2/conformance/textures/tex-input-validation.html
+++ b/conformance-suites/1.0.2/conformance/textures/tex-input-validation.html
@@ -208,7 +208,7 @@ var testCases =
      border: 0,
      format: 0x1903, // GL_RED
      type: gl.UNSIGNED_BYTE,
-     expectedError: gl.INVALID_ENUM},
+     expectedError: [gl.INVALID_ENUM, gl.INVALID_VALUE] },
     {target: gl.TEXTURE_2D,
      internalFormat: gl.RGBA,
      border: 1,

--- a/conformance-suites/1.0.3/conformance/textures/tex-input-validation.html
+++ b/conformance-suites/1.0.3/conformance/textures/tex-input-validation.html
@@ -207,7 +207,7 @@ var testCases =
      border: 0,
      format: 0x1903, // GL_RED
      type: gl.UNSIGNED_BYTE,
-     expectedError: gl.INVALID_ENUM},
+     expectedError: [gl.INVALID_ENUM, gl.INVALID_VALUE] },
     {target: gl.TEXTURE_2D,
      internalFormat: gl.RGBA,
      border: 1,


### PR DESCRIPTION
Backport https://github.com/KhronosGroup/WebGL/pull/1408 to older snapshot to align with spec change in https://github.com/KhronosGroup/WebGL/pull/1402.