### PR TITLE
Change numVertexAttribs to a valid value when testing invalid array lengths

### DIFF
--- a/sdk/tests/js/tests/gl-vertex-attrib.js
+++ b/sdk/tests/js/tests/gl-vertex-attrib.js
@@ -236,6 +236,7 @@ if (!gl) {
 
   debug("");
   debug("Checking invalid array lengths");
+  numVertexAttribs = numVertexAttribs - 1;
   gl.vertexAttrib1fv(numVertexAttribs, []);
   wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
 


### PR DESCRIPTION
The second-last block of tests checks out-of-range vertexAttrib indexes, by passing in the MAX_VERTEX_ATTRIBS as the index.  The last block of tests is meant to check invalid array lengths, but it still uses numVertexAttribs as the max.  We only want the last block of tests to be testing one invalid parameter at a time, not two, so we change the numVertexAttribs to a valid value.