### PR TITLE
Add ImageBitmap to TexImageSource

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 30 December 2015</h2>
+    <h2 class="no-toc">Editor's Draft 11 January 2016</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -503,14 +503,15 @@ gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
         <ul>
         <li> Image or video elements whose origin is not the same as the origin of the Document that
              contains the WebGLRenderingContext's canvas element
-        <li> Canvas elements whose <i>origin-clean</i> flag is set to false
+        <li> Canvas elements whose bitmap's <i>origin-clean</i> flag is set to false
+        <li> ImageBitmap objects whose bitmap's <i>origin-clean</i> flag is set to false
         </ul>
     </p>
     <p>
         If the <code>texImage2D</code> or <code>texSubImage2D</code> method is called with otherwise
         correct arguments and an <code>HTMLImageElement</code>, <code>HTMLVideoElement</code>,
-        or <code>HTMLCanvasElement</code> violating these restrictions, a <code>SECURITY_ERR</code>
-        exception must be thrown.
+        <code>HTMLCanvasElement</code>, or <code>ImageBitmap</code> violating these restrictions, a
+        <code>SECURITY_ERR</code> exception must be thrown.
     </p>
     <div class="note">
         <p>
@@ -1731,7 +1732,8 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
     void stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass);
 
-    typedef (ImageData or
+    typedef (ImageBitmap or
+             ImageData or
              HTMLImageElement or
              HTMLCanvasElement or
              HTMLVideoElement) TexImageSource;
@@ -2495,13 +2497,17 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             If an attempt is made to call this function with no WebGLTexture bound (see above), an
             <code>INVALID_OPERATION</code> error is generated. <br><br>
 
-            If this function is called with an <code>ImageData</code> whose <code>data</code> attribute has been neutered, an <code>INVALID_VALUE</code> error is generated. <br><br>
+            If this function is called with an <code>ImageData</code> whose <code>data</code>
+            attribute has been neutered, an <code>INVALID_VALUE</code> error is generated. <br><br>
+
+            If this function is called with an <code>ImageBitmap</code> that has been neutered,
+            an <code>INVALID_VALUE</code> error is generated. <br><br>
 
             If this function is called with an <code>HTMLImageElement</code>
             or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing
-            Document, or with an <code>HTMLCanvasElement</code> whose <i>origin-clean</i> flag is
-            set to false, a <code>SECURITY_ERR</code> exception must be
-            thrown. See <a href="#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.<br><br>
+            Document, or with an <code>HTMLCanvasElement</code> or <code>ImageBitmap</code> whose
+            bitmap's <i>origin-clean</i> flag is set to false, a <code>SECURITY_ERR</code> exception
+            must be thrown. See <a href="#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.<br><br>
 
             If <code>source</code> is null then an <code>INVALID_VALUE</code> error is
             generated. <br><br>
@@ -2564,13 +2570,17 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             If <em>type</em> does not match the type originally used to define the texture, an
             <code>INVALID_OPERATION</code> error is generated. <br><br>
 
-            If this function is called with an <code>ImageData</code> whose <code>data</code> attribute has been neutered, an <code>INVALID_VALUE</code> error is generated. <br><br>
+            If this function is called with an <code>ImageData</code> whose <code>data</code>
+            attribute has been neutered, an <code>INVALID_VALUE</code> error is generated. <br><br>
+
+            If this function is called with an <code>ImageBitmap</code> that has been neutered,
+            an <code>INVALID_VALUE</code> error is generated. <br><br>
 
             If this function is called with an <code>HTMLImageElement</code>
             or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing
-            Document, or with an <code>HTMLCanvasElement</code> whose <i>origin-clean</i> flag is
-            set to false, a <code>SECURITY_ERR</code> exception must be
-            thrown. See <a href="#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.<br><br>
+            Document, or with an <code>HTMLCanvasElement</code> or <code>ImageBitmap</code> whose
+            bitmap's <i>origin-clean</i> flag is set to false, a <code>SECURITY_ERR</code> exception
+            must be thrown. See <a href="#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.<br><br>
 
             If <code>source</code> is null then an <code>INVALID_VALUE</code> error is
             generated. <br><br>

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -644,7 +644,8 @@ interface WebGLRenderingContextBase
     void stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
     void stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass);
 
-    typedef (ImageData or
+    typedef (ImageBitmap or
+             ImageData or
              HTMLImageElement or
              HTMLCanvasElement or
              HTMLVideoElement) TexImageSource;

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 30 December 2015</h2>
+    <h2 class="no-toc">Editor's Draft 11 January 2016</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -1524,7 +1524,8 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         <p>If an attempt is made to call this function with no WebGLTexture bound (see above), generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If a WebGLBuffer is bound to the <code>PIXEL_UNPACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If this function is called with an <code>ImageData</code> whose <code>data</code> attribute has been neutered, an <code>INVALID_VALUE</code> error is generated. </p>
-        <p>If this function is called with an <code>HTMLImageElement</code> or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing Document, or with an <code>HTMLCanvasElement</code> whose <i>origin-clean</i> flag is set to false, a <code>SECURITY_ERR</code> exception must be thrown. See <a href="../1.0/index.html#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.</p>
+        <p>If this function is called with an <code>ImageBitmap</code> that has been neutered, an <code>INVALID_VALUE</code> error is generated. </p>
+        <p>If this function is called with an <code>HTMLImageElement</code> or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing Document, or with an <code>HTMLCanvasElement</code> or <code>ImageBitmap</code> whose bitmap's <i>origin-clean</i> flag is set to false, a <code>SECURITY_ERR</code> exception must be thrown. See <a href="../1.0/index.html#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.</p>
         <p>If <code>source</code> is null then generates an <code>INVALID_VALUE</code> error.</p>
         <p>See <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific pixel storage parameters that affect the behavior of this function.</p>
       </dd>


### PR DESCRIPTION
This change adds ImageBitmap support to texImage2D and
texSubImage2D. The origin restrictions logic was updated to take
into account the origin-clean flag of an ImageBitmap's bitmap.
The terminology for the origin-clean flag was tweaked to match the
language used in the HTML spec: "the origin-clean flag of an
HTMLCanvasElement" becomes "the origin-clean flag of an
HTMLCanvasElement's bitmap".