### PR TITLE
fix read-pixels-from-fbo-test.

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
+++ b/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
@@ -224,7 +224,7 @@ var textureTestCases = [
   {
     texInternalFormat: 'SRGB8_ALPHA8', texFormat: 'RGBA', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0, 1, 0.7], readBackColor: [127, 0, 255, 178], tol: [3, 0, 0, 3],
+    clearColor: [0.5, 0, 1, 0.7], readBackColor: [188, 0, 255, 178], tol: [3, 0, 0, 3],
   },
   {
     texInternalFormat: 'RGB5_A1', texFormat: 'RGBA', texType: 'UNSIGNED_BYTE',

--- a/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
+++ b/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
@@ -456,6 +456,34 @@ function testReadPixels(gl, readFormat, readType, expectedColor, tol, colorCheck
   }
 }
 
+function isFloatOrInteger(gl, texInternalFormat) {
+  var value;
+  switch (texInternalFormat) {
+    case gl.R8UI:
+    case gl.R16UI:
+    case gl.R32UI:
+    case gl.RG8UI:
+    case gl.RG16UI:
+    case gl.RG32UI:
+    case gl.RGBA8UI:
+    case gl.RGBA16UI:
+    case gl.RGBA32UI:
+    case gl.RGB10_A2UI:
+    case gl.R8I:
+    case gl.R16I:
+    case gl.R32I:
+    case gl.RG8I:
+    case gl.RG16I:
+    case gl.RG32I:
+    case gl.RGBA8I:
+    case gl.RGBA16I:
+    case gl.RGBA32I:
+      return true;
+    default:
+      return false;
+  }
+}
+
 function clearBuffer(gl, texInternalFormat, clearColor) {
   var value;
   switch (texInternalFormat) {
@@ -521,8 +549,14 @@ for (var tt = 0; tt < textureTestCases.length; ++tt) {
   wtu.glErrorShouldBe(
       gl, gl.NO_ERROR, "Clear color should generate no error");
 
-  var implFormat = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT);
-  var implType = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE);
+  if (!isFloatOrInteger(gl, gl[test.texInternalFormat])) {
+    var implFormat = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT);
+    var implType = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE);
+  } else {
+    var implFormat = 0;
+    var implType = 0;
+  }
+
   var implFormatString = getFormatString(gl, implFormat);
   var implTypeString = getTypeString(gl, implType);
 
@@ -565,18 +599,20 @@ for (var tt = 0; tt < textureTestCases.length; ++tt) {
     testReadPixels(gl, gl[test.readFormat], gl[test.readType], test.readBackColor, test.tol,
                    selectPixelCompareFunc(gl, gl[test.texFormat], gl[test.readFormat]));
 
-    debug("Testing implementation dependent color read format = " + implFormatString +
-          ", type = " + implTypeString);
-    if (implFormatString == '') {
-      testFailed("Invalid IMPLEMENTATION_COLOR_READ_FORMAT = " + implFormat);
-      continue;
+    if (!isFloatOrInteger(gl, gl[test.texInternalFormat])) {
+      debug("Testing implementation dependent color read format = " + implFormatString +
+            ", type = " + implTypeString);
+      if (implFormatString == '') {
+        testFailed("Invalid IMPLEMENTATION_COLOR_READ_FORMAT = " + implFormat);
+        continue;
+      }
+      if (implTypeString == '') {
+        testFailed("Invalid IMPLEMENTATION_COLOR_READ_TYPE = " + implType);
+        continue;
+      }
+      testReadPixels(gl, implFormat, implType, test.readBackColor, test.tol,
+                     selectPixelCompareFunc(gl, gl[test.texFormat], implFormat));
     }
-    if (implTypeString == '') {
-      testFailed("Invalid IMPLEMENTATION_COLOR_READ_TYPE = " + implType);
-      continue;
-    }
-    testReadPixels(gl, implFormat, implType, test.readBackColor, test.tol,
-                   selectPixelCompareFunc(gl, gl[test.texFormat], implFormat));
 
     gl.deleteTexture(colorImage);
     gl.deleteFramebuffer(fbo);


### PR DESCRIPTION
There are 2 problems in this test.
1. The readback value of SRGB8_ALPHA8 didn't consider sRGB conversion.
2. If type is integer or float, calling getParameter with IMPLEMENTATION_COLOR_READ_FORMAT/TYPE would cause gl error then test will fail.