### PR TITLE
fix ambiguous test for blitFramebuffer

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeBufferApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeBufferApiTests.js
@@ -818,9 +818,10 @@ goog.scope(function() {
                 gl.bindTexture(gl.TEXTURE_2D, texture[0]);
                 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32UI, 32, 32, 0, gl.RGBA_INTEGER, gl.UNSIGNED_INT, null);
                 gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture[0], 0);
-                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 32, 32, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+                gl.bindTexture(gl.TEXTURE_2D, texture[1]);
+                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32UI, 32, 32, 0, gl.RGBA_INTEGER, gl.UNSIGNED_INT, null);
                 gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture[1], 0);
-                bufferedLogToConsole('// Read buffer: gl.RGBA32I, draw buffer: gl.RGBA8');
+                bufferedLogToConsole('// Read buffer: gl.RGBA32UI, filter: gl.LINEAR');
                 gl.blitFramebuffer(0, 0, 16, 16, 0, 0, 16, 16, gl.COLOR_BUFFER_BIT, gl.LINEAR);
                 this.expectError(gl.INVALID_OPERATION);
 


### PR DESCRIPTION
This test is ambiguous:
1. the read buffer contains unsigned integer, while the draw buffer contain floating-point data. It should generate INVALID_OPERATION.
2. the linear interpolation will be applied to unsigned integer data. It should generate INVALID_OPERATION.

This case tend to test 2#, so 1# is not necessary. This small change make sure that the format of the read buffer is the same with the format of the draw buffer. 

PTAL. Thanks!

The native dEQP have the same problem too. See https://android.googlesource.com/platform/external/deqp/+/deqp-dev/modules/gles3/functional/es3fNegativeBufferApiTests.cpp#1157. 