### PR TITLE
Test depth_stencil attachment for framebufferTexture2D|Layer

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/framebuffer-object-attachment.html
+++ b/sdk/tests/conformance2/renderbuffers/framebuffer-object-attachment.html
@@ -188,6 +188,13 @@ function testDepthStencilAttachmentBehaviors() {
     checkBufferBits(gl.DEPTH_STENCIL_ATTACHMENT);
 
     debug("color + depth_stencil");
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH24_STENCIL8, size, size, 0, gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8, null);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, texture, 0);
+    checkFramebuffer([gl.FRAMEBUFFER_COMPLETE]);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, null, 0);
+
     gl.framebufferRenderbuffer(
         gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, depthStencilBuffer);
     checkFramebuffer([gl.FRAMEBUFFER_COMPLETE]);

--- a/sdk/tests/conformance2/renderbuffers/framebuffer-texture-layer.html
+++ b/sdk/tests/conformance2/renderbuffers/framebuffer-texture-layer.html
@@ -123,10 +123,31 @@ function testFramebufferTextureLayer() {
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
         "attaching a 2d texture to a framebuffer should generate INVALID_OPERATION.");
 
+    var texDepthStencil = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D_ARRAY, texDepthStencil);
+    var fbDepthStencil = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbDepthStencil);
+    gl.texImage3D(gl.TEXTURE_2D_ARRAY,
+                  0,                                          // level
+                  gl.DEPTH24_STENCIL8,                        // internalFormat
+                  1,                                          // width
+                  1,                                          // height
+                  1,                                          // depth
+                  0,                                          // border
+                  gl.DEPTH_STENCIL,                           // format
+                  gl.UNSIGNED_INT_24_8,                       // type
+                  new Uint32Array([0]));                      // data
+    gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, texDepthStencil, 0, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+        "attaching a depth_stencil texture to a framebuffer should succeed.");
+    checkFramebuffer([gl.FRAMEBUFFER_COMPLETE]);
+
     // Clean up
     gl.deleteTexture(tex3d);
+    gl.deleteTexture(texDepthStencil);
     gl.deleteTexture(tex2d);
     gl.deleteFramebuffer(fb);
+    gl.deleteFramebuffer(fbDepthStencil);
 }
 
 description("This tests framebufferTextureLayer.");


### PR DESCRIPTION
https://codereview.chromium.org/1584723003/ fixes this pull request in chrome. Without the CL, these two tests will crash for chrome debug version.