### PR TITLE
fix read-pixels-from-fbo-test. 

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
+++ b/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
@@ -45,252 +45,345 @@ var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
 gl.pixelStorei(gl.PACK_ALIGNMENT, 1);
 
-function r(buf, index, expectedColor, tol) {
-  var color = [buf[index]];
-  if (Math.abs(color[0] - expectedColor[0]) > tol[0]) {
-    testFailed("Expected red = " + expectedColor + ", was = " + color);
-    return false;
+function getChannelCount(format) {
+  switch (format) {
+    case gl.RED:
+    case gl.RED_INTEGER:
+    case gl.ALPHA:
+    case gl.LUMINANCE:
+      return 1;
+    case gl.RB:
+    case gl.RB_INTEGER:
+    case gl.LUMINANCE_ALPHA:
+      return 2;
+    case gl.RGB:
+    case gl.RGB_INTEGER:
+      return 3;
+    case gl.RGBA:
+    case gl.RGBA_INTEGER:
+      return 4;
+    default:
+      return 0;
   }
-  return true;
 }
 
-function rg(buf, index, expectedColor, tol) {
-  var color = [buf[index], buf[index + 1]];
-  if (Math.abs(color[0] - expectedColor[0]) > tol[0] ||
-      Math.abs(color[1] - expectedColor[1]) > tol[1]) {
-    testFailed("Expected rg = " + expectedColor + ", was = " + color);
-    return false;
+function getUnpackInfo(type) {
+  switch (type) {
+    case gl.UNSIGNED_SHORT_5_6_5:
+      return {bitsCount: [5, 6, 5], isReverse: false};
+    case gl.UNSIGNED_SHORT_4_4_4_4:
+      return {bitsCount: [4, 4, 4, 4], isReverse: false};
+    case gl.UNSIGNED_SHORT_5_5_5_1:
+      return {bitsCount: [5, 5, 5, 1], isReverse: false};
+    case gl.UNSIGNED_INT_2_10_10_10_REV:
+      return {bitsCount: [2, 10, 10, 10], isReverse: true};
+    case gl.UNSIGNED_INT_10F_11F_11F_REV:
+      return {bitsCount: [10, 11, 11], isReverse: true};
+    case gl.UNSIGNED_INT_5_9_9_9_REV:
+      return {bitsCount: [5, 9, 9, 9], isReverse: true};
+    default:
+      return null;
   }
-  return true;
 }
 
-function rgb(buf, index, expectedColor, tol) {
-  var color = [buf[index], buf[index + 1], buf[index + 2]];
-  if (Math.abs(color[0] - expectedColor[0]) > tol[0] ||
-      Math.abs(color[1] - expectedColor[1]) > tol[1] ||
-      Math.abs(color[2] - expectedColor[2]) > tol[2]) {
-    testFailed("Expected rgb = " + expectedColor + ", was = " + color);
-    return false;
+// bitsCount is an array contains bit count for each component.
+function unpack(value, channelCount, bitsCount, isReverse) {
+  var result = new Array(channelCount);
+
+  var accumBitsCount = 0;
+  for (var i = channelCount - 1; i >= 0; --i) {
+    var currentChannel = isReverse ? (channelCount - i - 1) : i;
+    var mask = 0xFFFFFFFF >>> (32 - bitsCount[i]);
+    result[currentChannel] = ((value >> accumBitsCount) & mask);
+    accumBitsCount += bitsCount[i];
   }
-  return true;
+
+  return result;
 }
 
-function rgba_compare(color, expectedColor, tol) {
-  if (Math.abs(color[0] - expectedColor[0]) > tol[0] ||
-      Math.abs(color[1] - expectedColor[1]) > tol[1] ||
-      Math.abs(color[2] - expectedColor[2]) > tol[2] ||
-      Math.abs(color[3] - expectedColor[3]) > tol[3]) {
-    testFailed("Expected rgba = " + expectedColor + ", was = " + color);
-    return false;
+function getColor(buf, index, readFormat, readType) {
+  var channelCount = getChannelCount(readFormat);
+  var result = new Array(channelCount);
+
+  var unpackInfo = getUnpackInfo(readType);
+  if (unpackInfo) {
+    result = unpack(buf[index], channelCount, unpackInfo.bitsCount, unpackInfo.isReverse);
+  } else {
+    for (var i = 0; i < channelCount; ++i) {
+      result[i] = buf[index + i];
+    }
   }
+
+  return result;
+}
+
+function convertToSRGB(val) {
+  if (val <= 0) {
+    return 0;
+  } else if (val < 0.0031308) {
+    return 12.92 * val;
+  } else if (val < 1) {
+    return 1.055 * Math.pow(val, 0.41666) - 0.055;
+  } else {
+    return 1;
+  }
+}
+
+function denormalizeColor(srcInternalFormat, destFormat, destType, color) {
+  var result = color.slice();
+  var tol = 0;
+
+  var srcIsNormalized = false;
+
+  switch (srcInternalFormat) {
+    case gl.R8:
+    case gl.RG8:
+    case gl.RGB8:
+    case gl.RGB565:
+    case gl.RGBA8:
+    case gl.RGB5_A1:
+    case gl.RGBA4:
+    case gl.SRGB8_ALPHA8:
+    case gl.RGB10_A2:
+      srcIsNormalized = true;
+      tol = 5;
+      break;
+  }
+
+  if (!srcIsNormalized) {
+    return { color: result, tol: tol };
+  }
+
+  if (srcInternalFormat == gl.SRGB8_ALPHA8) {
+    for (var i = 0; i < 3; ++i) {
+      result[i] = convertToSRGB(result[i]);
+    }
+  }
+
+  switch (destType) {
+    case gl.UNSIGNED_BYTE:
+      result = result.map(val => { return val * 0xFF});
+      break;
+    case gl.UNSIGNED_SHORT:
+      result = result.map(val => { return val * 0xFFFF});
+      break;
+    case gl.UNSIGNED_INT:
+      result = result.map(val => { return val * 0xFFFFFFFF});
+      break;
+    case gl.UNSIGNED_SHORT_4_4_4_4:
+      result = result.map(val => { return val * 0xF});
+      break;
+    case gl.UNSIGNED_SHORT_5_5_5_1:
+      result[0] = result[0] * 0x1F;
+      result[1] = result[1] * 0x1F;
+      result[2] = result[2] * 0x1F;
+      result[3] = result[3] * 0x1;
+      break;
+    case gl.UNSIGNED_SHORT_5_6_5:
+      result[0] = result[0] * 0x1F;
+      result[1] = result[1] * 0x3F;
+      result[2] = result[2] * 0x1F;
+      break;
+    case gl.UNSIGNED_INT_2_10_10_10_REV:
+      result[0] = result[0] * 0x3FF;
+      result[1] = result[1] * 0x3FF;
+      result[2] = result[2] * 0x3FF;
+      result[3] = result[3] * 0x3;
+      break;
+    case gl.UNSIGNED_INT_5_9_9_9_REV:
+      result[0] = result[0] * 0x1FF;
+      result[1] = result[1] * 0x1FF;
+      result[2] = result[2] * 0x1FF;
+      result[3] = result[3] * 0x1F;
+      break;
+  }
+
+  return { color: result, tol: tol };
+}
+
+function compareColor(buf, index, expectedColor, srcInternalFormat,
+                      srcFormat, srcType, readFormat, readType) {
+  var srcChannelCount = getChannelCount(srcFormat);
+  var readChannelCount = getChannelCount(readFormat);
+
+  var color = getColor(buf, index, readFormat, readType);
+  expectedColor = denormalizeColor(srcInternalFormat, readFormat, readType, expectedColor);
+
+  var minChannel = Math.min(srcChannelCount, readChannelCount);
+  for (var i = 0; i < minChannel; ++i) {
+    if (Math.abs(expectedColor.color[i] - color[i]) > expectedColor.tol) {
+      testFailed("Expected color = " + expectedColor.color + ", was = " + color);
+      return false;
+    }
+  }
+
   return true;
-}
-
-function rgba(buf, index, expectedColor, tol) {
-  var color = [buf[index], buf[index + 1], buf[index + 2], buf[index + 3]];
-  return rgba_compare(color, expectedColor, tol);
-}
-
-function r10g10b10a2_ubyte(buf, index, expectedColor, tol) {
-  var r = buf[index] / 255.0;
-  var g = buf[index + 1] / 255.0;
-  var b = buf[index + 2] / 255.0;
-  var a = buf[index + 3] / 255.0;
-  var color = [r, g, b, a];
-  return rgba_compare(color, expectedColor, tol);
-}
-
-function r10g10b10a2_ushort(buf, index, expectedColor, tol) {
-  var r = buf[index] / 65535.0;
-  var g = buf[index + 1] / 65535.0;
-  var b = buf[index + 2] / 65535.0;
-  var a = buf[index + 3] / 65535.0;
-  var color = [r, g, b, a];
-  return rgba_compare(color, expectedColor, tol);
-}
-
-function r10g10b10a2_uint(buf, index, expectedColor, tol) {
-  var r = buf[index] / 4294967295.0;
-  var g = buf[index + 1] / 4294967295.0;
-  var b = buf[index + 2] / 4294967295.0;
-  var a = buf[index + 3] / 4294967295.0;
-  var color = [r, g, b, a];
-  return rgba_compare(color, expectedColor, tol);
-}
-
-function r10g10b10a2_uint32(buf, index, expectedColor, tol) {
-  var r = (buf[index] & 0x3FF) / 1023.0;
-  var g = ((buf[index] >> 10) & 0x3FF) / 1023.0;
-  var b = ((buf[index] >> 20) & 0x3FF) / 1023.0;
-  var a = ((buf[index] >> 30) & 0x3) / 3.0;
-  var color = [r, g, b, a];
-  return rgba_compare(color, expectedColor, tol);
 }
 
 var textureTestCases = [
   {
     texInternalFormat: 'R8', texFormat: 'RED', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0.0, 0.0, 0], readBackColor: [127, 0, 0, 0], tol: [3, 0, 0, 0],
+    clearColor: [0.5, 0.0, 0.0, 0],
   },
   {
     texInternalFormat: 'R8UI', texFormat: 'RED_INTEGER', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [250, 0, 0, 0], readBackColor: [250, 0, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [250, 0, 0, 0],
   },
   {
     texInternalFormat: 'R8I', texFormat: 'RED_INTEGER', texType: 'BYTE',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [-126, 0, 0, 0], readBackColor: [-126, 0, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [-126, 0, 0, 0],
   },
   {
     texInternalFormat: 'R16UI', texFormat: 'RED_INTEGER', texType: 'UNSIGNED_SHORT',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [30001, 0, 0, 0], readBackColor: [30001, 0, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [30001, 0, 0, 0],
   },
   {
     texInternalFormat: 'R16I', texFormat: 'RED_INTEGER', texType: 'SHORT',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [-14189, 0, 0, 0], readBackColor: [-14189, 0, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [-14189, 0, 0, 0],
   },
   {
     texInternalFormat: 'R32UI', texFormat: 'RED_INTEGER', texType: 'UNSIGNED_INT',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [126726, 0, 0, 0], readBackColor: [126726, 0, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [126726, 0, 0, 0],
   },
   {
     texInternalFormat: 'R32I', texFormat: 'RED_INTEGER', texType: 'INT',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [-126726, 0, 0, 0], readBackColor: [-126726, 0, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [-126726, 0, 0, 0],
   },
 
   {
     texInternalFormat: 'RG8', texFormat: 'RG', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0.7, 0.0, 0], readBackColor: [127, 178, 0, 0], tol: [3, 3, 0, 0],
+    clearColor: [0.5, 0.7, 0.0, 0],
   },
   {
     texInternalFormat: 'RG8UI', texFormat: 'RG_INTEGER', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [250, 124, 0, 0], readBackColor: [250, 124, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [250, 124, 0, 0],
   },
   {
     texInternalFormat: 'RG8I', texFormat: 'RG_INTEGER', texType: 'BYTE',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [-55, 124, 0, 0], readBackColor: [-55, 124, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [-55, 124, 0, 0],
   },
   {
     texInternalFormat: 'RG16UI', texFormat: 'RG_INTEGER', texType: 'UNSIGNED_SHORT',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [30001, 18, 0, 0], readBackColor: [30001, 18, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [30001, 18, 0, 0],
   },
   {
     texInternalFormat: 'RG16I', texFormat: 'RG_INTEGER', texType: 'SHORT',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [-14189, 6735, 0, 0], readBackColor: [-14189, 6735, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [-14189, 6735, 0, 0],
   },
   {
     texInternalFormat: 'RG32UI', texFormat: 'RG_INTEGER', texType: 'UNSIGNED_INT',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [126726, 1976, 0, 0], readBackColor: [126726, 1976, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [126726, 1976, 0, 0],
   },
   {
     texInternalFormat: 'RG32I', texFormat: 'RG_INTEGER', texType: 'INT',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [-126726, 126726, 0, 0], readBackColor: [-126726, 126726, 0, 0], tol: [0, 0, 0, 0],
+    clearColor: [-126726, 126726, 0, 0],
   },
 
   {
     texInternalFormat: 'RGB8', texFormat: 'RGB', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 1, 0, 0], readBackColor: [127, 255, 0, 0], tol: [3, 0, 0, 0],
+    clearColor: [0.5, 1, 0, 0],
   },
   {
     texInternalFormat: 'RGB565', texFormat: 'RGB', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0.7, 0.2, 0], readBackColor: [127, 178, 51, 0], tol: [17, 9, 17, 0],
+    clearColor: [0.5, 0.7, 0.2, 0],
   },
   {
     texInternalFormat: 'RGB565', texFormat: 'RGB', texType: 'UNSIGNED_SHORT_5_6_5',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0.7, 0.2, 0], readBackColor: [127, 178, 51, 0], tol: [17, 9, 17, 0],
+    clearColor: [0.5, 0.7, 0.2, 0],
   },
 
   {
     texInternalFormat: 'RGBA8', texFormat: 'RGBA', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0, 1, 0.7], readBackColor: [127, 0, 255, 178], tol: [3, 0, 0, 3],
+    clearColor: [0.5, 0, 1, 0.7],
   },
   {
     texInternalFormat: 'SRGB8_ALPHA8', texFormat: 'RGBA', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0, 1, 0.7], readBackColor: [127, 0, 255, 178], tol: [3, 0, 0, 3],
+    clearColor: [0.5, 0, 1, 0.7],
   },
   {
     texInternalFormat: 'RGB5_A1', texFormat: 'RGBA', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0, 0.7, 1], readBackColor: [127, 0, 178, 255], tol: [17, 0, 17, 0],
+    clearColor: [0.5, 0, 0.7, 1],
   },
   {
     texInternalFormat: 'RGB5_A1', texFormat: 'RGBA', texType: 'UNSIGNED_SHORT_5_5_5_1',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0.7, 1, 0], readBackColor: [127, 178, 255, 0], tol: [17, 17, 0, 0],
+    clearColor: [0.5, 0.7, 1, 0],
   },
   {
     texInternalFormat: 'RGB5_A1', texFormat: 'RGBA', texType: 'UNSIGNED_INT_2_10_10_10_REV',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0.7, 0, 1], readBackColor: [127, 178, 0, 255], tol: [17, 17, 0, 0],
+    clearColor: [0.5, 0.7, 0, 1],
   },
   {
     texInternalFormat: 'RGBA4', texFormat: 'RGBA', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.5, 0.7, 1, 0], readBackColor: [127, 178, 255, 0], tol: [34, 34, 0, 0],
+    clearColor: [0.5, 0.7, 1, 0],
   },
   {
     texInternalFormat: 'RGBA4', texFormat: 'RGBA', texType: 'UNSIGNED_SHORT_4_4_4_4',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [1, 0, 0.5, 0.7], readBackColor: [255, 0, 127, 178], tol: [0, 0, 34, 34],
+    clearColor: [1, 0, 0.5, 0.7],
   },
   {
     texInternalFormat: 'RGBA8UI', texFormat: 'RGBA_INTEGER', texType: 'UNSIGNED_BYTE',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [127, 0, 255, 178], readBackColor: [127, 0, 255, 178], tol: [0, 0, 0, 0],
+    clearColor: [127, 0, 255, 178],
   },
   {
     texInternalFormat: 'RGBA8I', texFormat: 'RGBA_INTEGER', texType: 'BYTE',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [-55, 56, 80, 127], readBackColor: [-55, 56, 80, 127], tol: [0, 0, 0, 0],
+    clearColor: [-55, 56, 80, 127],
   },
   {
     texInternalFormat: 'RGB10_A2UI', texFormat: 'RGBA_INTEGER', texType: 'UNSIGNED_INT_2_10_10_10_REV',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [178, 0, 127, 3], readBackColor: [178, 0, 127, 3], tol: [0, 0, 0, 0],
+    clearColor: [178, 0, 127, 3],
   },
   {
     texInternalFormat: 'RGBA16UI', texFormat: 'RGBA_INTEGER', texType: 'UNSIGNED_SHORT',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [14189, 6735, 0, 19], readBackColor: [14189, 6735, 0, 19], tol: [0, 0, 0, 0],
+    clearColor: [14189, 6735, 0, 19],
   },
   {
     texInternalFormat: 'RGBA16I', texFormat: 'RGBA_INTEGER', texType: 'SHORT',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [14189, -6735, 0, 19], readBackColor: [14189, -6735, 0, 19], tol: [0, 0, 0, 0],
+    clearColor: [14189, -6735, 0, 19],
   },
   {
     texInternalFormat: 'RGBA32UI', texFormat: 'RGBA_INTEGER', texType: 'UNSIGNED_INT',
     readFormat: 'RGBA_INTEGER', readType: 'UNSIGNED_INT',
-    clearColor: [126726, 6726, 98765, 2015], readBackColor: [126726, 6726, 98765, 2015], tol: [0, 0, 0, 0],
+    clearColor: [126726, 6726, 98765, 2015],
   },
   {
     texInternalFormat: 'RGBA32I', texFormat: 'RGBA_INTEGER', texType: 'INT',
     readFormat: 'RGBA_INTEGER', readType: 'INT',
-    clearColor: [126726, -6726, -98765, 2015], readBackColor: [126726, -6726, -98765, 2015], tol: [0, 0, 0, 0],
+    clearColor: [126726, -6726, -98765, 2015],
   },
 
   {
     texInternalFormat: 'RGB10_A2', texFormat: 'RGBA', texType: 'UNSIGNED_INT_2_10_10_10_REV',
     readFormat: 'RGBA', readType: 'UNSIGNED_BYTE',
-    clearColor: [0.7, 0, 0.5, 1], readBackColor: [0.7, 0, 0.5, 1], tol: [1/255.0, 0, 1/255.0, 0],
+    clearColor: [0.7, 0, 0.5, 1],
   },
 
   // TODO(zmo): add float/half_float test cases with extension supports.
@@ -369,9 +462,12 @@ function getTypeString(gl, type) {
     case gl.INT:
       return 'INT';
     case gl.UNSIGNED_SHORT_5_6_5:
-    case gl.UNSIGNED_SHORT_4_4_4_4:
+      return 'UNSIGNED_SHORT_5_6_5';
     case gl.UNSIGNED_SHORT_5_5_5_1:
+      return 'UNSIGNED_SHORT_5_5_5_1';
     case gl.UNSIGNED_INT_2_10_10_10_REV:
+      return 'UNSIGNED_INT_2_10_10_10_REV';
+    case gl.UNSIGNED_SHORT_4_4_4_4:
     case gl.UNSIGNED_INT_10F_11F_11F_REV:
     case gl.UNSIGNED_INT_5_9_9_9_REV:
       // TODO(zmo): Implement handling these implementation specific types.
@@ -397,7 +493,7 @@ function elementCountPerPixel(gl, readFormat, readType) {
       switch (readType) {
         case gl.UNSIGNED_SHORT_5_6_5:
           return 1;
-        default: 
+        default:
           return 3;
       }
     case gl.RGBA:
@@ -418,26 +514,8 @@ function elementCountPerPixel(gl, readFormat, readType) {
   }
 }
 
-function selectPixelCompareFunc(gl, texFormat, readFormat, readType) {
-  var texElementCount = elementCountPerPixel(gl, texFormat, gl.UNSIGNED_BYTE);
-  var readFormatElementCount = elementCountPerPixel(gl, readFormat, gl.UNSIGNED_BYTE);
-  var less = Math.min(texElementCount, readFormatElementCount);
-  switch (less) {
-    case 1:
-      return r;
-    case 2:
-      return rg;
-    case 3:
-      return rgb;
-    case 4:
-      return rgba;
-    default:
-      testFailed("Something is wrong in selectPixelCompareFunc()")
-      return rgba;
-  }
-}
-
-function testReadPixels(gl, readFormat, readType, expectedColor, tol, colorCheckFunc) {
+function testReadPixels(gl, srcInternalFormat, srcFormat, srcType,
+                        readFormat, readType, expectedColor) {
   var arrayType = getArrayTypeFromReadPixelsType(gl, readType);
   var buf = new arrayType(width * height * 4);
   gl.readPixels(0, 0, width, height, readFormat, readType, buf);
@@ -446,7 +524,8 @@ function testReadPixels(gl, readFormat, readType, expectedColor, tol, colorCheck
   var diffFound = false;
   for (var ii = 0; ii < width * height; ++ii) {
     var offset = ii * elementCountPerPixel(gl, readFormat, readType);
-    if (!colorCheckFunc(buf, offset, expectedColor, tol)) {
+    if (!compareColor(buf, offset, expectedColor, srcInternalFormat, srcFormat, srcType,
+                      readFormat, readType)) {
       diffFound = true;
       break;
     }
@@ -538,32 +617,13 @@ for (var tt = 0; tt < textureTestCases.length; ++tt) {
                  implFormat + "/" + implType);
     }
     for (var rr = 0; rr < readTypes.length; ++rr) {
-      var compareFunc = null;
-      switch (readTypes[rr]) {
-        case gl.UNSIGNED_BYTE:
-          compareFunc = r10g10b10a2_ubyte;
-          break;
-        case gl.UNSIGNED_SHORT:
-          compareFunc = r10g10b10a2_ushort;
-          break;
-        case gl.UNSIGNED_INT:
-          compareFunc = r10g10b10a2_uint;
-          break;
-        case gl.UNSIGNED_INT_2_10_10_10_REV:
-          compareFunc = r10g10b10a2_uint32;
-          break;
-        default:
-          testFailed("Unimplemented decoding for RGB10_A2 read type " + readType[rr]);
-          break;
-      }
-      if (!compareFunc)
-        continue;
       debug("Special case RGB10_A2, format = RGBA, type = " + readTypeStrings[rr]);
-      testReadPixels(gl, gl.RGBA, readTypes[rr], test.readBackColor, test.tol, compareFunc);
+      testReadPixels(gl, gl[test.texInternalFormat], gl[test.texFormat], gl[test.texType],
+                     gl.RGBA, readTypes[rr], test.clearColor);
     }
   } else {
-    testReadPixels(gl, gl[test.readFormat], gl[test.readType], test.readBackColor, test.tol,
-                   selectPixelCompareFunc(gl, gl[test.texFormat], gl[test.readFormat]));
+    testReadPixels(gl, gl[test.texInternalFormat], gl[test.texFormat], gl[test.texType],
+                   gl[test.readFormat], gl[test.readType], test.clearColor);
 
     debug("Testing implementation dependent color read format = " + implFormatString +
           ", type = " + implTypeString);
@@ -575,8 +635,8 @@ for (var tt = 0; tt < textureTestCases.length; ++tt) {
       testFailed("Invalid IMPLEMENTATION_COLOR_READ_TYPE = " + implType);
       continue;
     }
-    testReadPixels(gl, implFormat, implType, test.readBackColor, test.tol,
-                   selectPixelCompareFunc(gl, gl[test.texFormat], implFormat));
+    testReadPixels(gl, gl[test.texInternalFormat], gl[test.texFormat], gl[test.texType],
+                   implFormat, implType, test.clearColor);
 
     gl.deleteTexture(colorImage);
     gl.deleteFramebuffer(fbo);


### PR DESCRIPTION
In the chromium, IMPLEMENTATION_COLOR_READ_TYPE/FORMAT always return pre defined value if there is no extension GL_OES_read_format. (see https://chromium.googlesource.com/chromium/src/gpu/+/master/command_buffer/service/gles2_cmd_decoder.cc#5111)

In my machine, GL_OES_read_format doesn't exist. But I still able to query this parameter because I have ES2_compatibility extension or latest OpenGL(seems latest OpenGL supports this without extension). And the value I queried is different from the pre defined value created by chromium.

So I add more functions for handling the extra formats that I've found. I think those changes would break the test result of chromium because of the problem I mentioned in first paragraph.