### PR TITLE
To clear stencil buffer, we should use clearBufferiv, instead of clearBufferfv

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fRasterizerDiscardTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fRasterizerDiscardTests.js
@@ -296,7 +296,7 @@ es3fRasterizerDiscardTests.RasterizerDiscardCase.prototype.iterate = function() 
             break;
         case es3fRasterizerDiscardTests.CaseType.CLEAR_STENCIL:
             if (this.m_caseOptions.useFBO)
-                gl.clearBufferfv(gl.STENCIL, 0, [FAIL_STENCIL]);
+                gl.clearBufferiv(gl.STENCIL, 0, [FAIL_STENCIL]);
             else
                 gl.clear(gl.STENCIL_BUFFER_BIT);
             break;


### PR DESCRIPTION
To clear stencil buffer, we should use clearBufferiv, instead of clearBufferfv.  The original code will lead to INVALID_VALUE error. 

The native dEQP is correct. see https://android.googlesource.com/platform/external/deqp/+/deqp-dev/modules/gles3/functional/es3fRasterizerDiscardTests.cpp#338 