### PR TITLE
Set test time for skipped case to 0

### DIFF
--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -336,7 +336,13 @@ function start() {
   };
 
   Page.prototype.finishPage = function(success) {
-    this.totalTime = Date.now() - this.startTime;
+    var shouldRun = this.check.checked && this.folder.checked();
+    if (shouldRun) {
+      this.totalTime = Date.now() - this.startTime;
+    } else {
+      this.totalTime = 0;
+    }
+
     if(this.totalSkipped) {
       var msg = ' (' + this.totalSkipped + ' of ' + this.totalTests + ' skipped in ' + this.totalTime.toFixed(1) + ' ms )';
     } else {


### PR DESCRIPTION
The startTime of skipped case is always 0, thus the totalTime for
it would be wrongly a very large number.