### PR TITLE
Add detection for createImageBitmap and ImageBitmap

### DIFF
--- a/sdk/tests/conformance/textures/00_test_list.txt
+++ b/sdk/tests/conformance/textures/00_test_list.txt
@@ -5,3 +5,4 @@ image_data/00_test_list.txt
 --min-version 1.0.4 svg_image/00_test_list.txt
 video/00_test_list.txt
 webgl_canvas/00_test_list.txt
+image_bitmap/00_test_list.txt

--- a/sdk/tests/conformance/textures/image_bitmap/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_bitmap/00_test_list.txt
@@ -1,0 +1,5 @@
+tex-image-and-sub-image-2d-with-image-bitmap-rgba-rgba-unsigned_byte.html
+tex-image-and-sub-image-2d-with-image-bitmap-rgba-rgba-unsigned_short_4_4_4_4.html
+tex-image-and-sub-image-2d-with-image-bitmap-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-image-and-sub-image-2d-with-image-bitmap-rgb-rgb-unsigned_byte.html
+tex-image-and-sub-image-2d-with-image-bitmap-rgb-rgb-unsigned_short_5_6_5.html

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap.js
@@ -26,7 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var imageData = null;
     var blackColor = [0, 0, 0];
     var redColor = [255, 0, 0];
     var greenColor = [0, 255, 0];
@@ -35,6 +34,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking ImageBitmap (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
+
+        if(!window.createImageBitmap || !window.ImageBitmap) {
+            finishTest();
+            return;
+        }
 
         gl = wtu.create3DContext("example");
 
@@ -56,26 +60,12 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.clearDepth(1);
         gl.disable(gl.BLEND);
 
-        var canvas2d = document.getElementById("texcanvas");
-        var context2d = canvas2d.getContext("2d");
-        imageData = context2d.createImageData(2, 2);
-        var data = imageData.data;
-        data[0] = 255;
-        data[1] = 0;
-        data[2] = 0;
-        data[3] = 255;
-        data[4] = 255;
-        data[5] = 0;
-        data[6] = 0;
-        data[7] = 0;
-        data[8] = 0;
-        data[9] = 255;
-        data[10] = 0;
-        data[11] = 255;
-        data[12] = 0;
-        data[13] = 255;
-        data[14] = 0;
-        data[15] = 0;
+        var imageData = new ImageData(new Uint8ClampedArray(
+                                      [255, 0, 0, 255,
+                                      255, 0, 0, 0,
+                                      0, 255, 0, 255,
+                                      0, 255, 0, 0]),
+                                      2, 2);
 
         createImageBitmap(imageData).then(imageBitmap => {
             bitmap = imageBitmap;


### PR DESCRIPTION
We need to add a detection in the conformance test for ImageBitmap to detect whether or not createImageBitmap and ImageBitmap is available. If not, then we should quit the test right away. Also, we add the 00_test_list.txt for the ImageBitmap test so that they can be picked up by the bot.