### PR TITLE
Temporary remove the ImageBitmap tests

### DIFF
--- a/sdk/tests/conformance/textures/00_test_list.txt
+++ b/sdk/tests/conformance/textures/00_test_list.txt
@@ -5,4 +5,3 @@ image_data/00_test_list.txt
 --min-version 1.0.4 svg_image/00_test_list.txt
 video/00_test_list.txt
 webgl_canvas/00_test_list.txt
-image_bitmap/00_test_list.txt


### PR DESCRIPTION
It appears that the ImageBitmap tests are failing, I didn't catch it in the early pull request. We should disable them for them, and re-enable them once I fix the tests.

@zhenyao: please review.