### PR TITLE
fix a bug about uniform1fv

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboTestUtil.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestUtil.js
@@ -1004,8 +1004,8 @@ es3fFboTestUtil.FboIncompleteException.prototype.getReason = function() {return 
      */
     es3fFboTestUtil.DepthGradientShader.prototype.setUniforms = function(ctx, program, gradientMin, gradientMax, color) {
         ctx.useProgram(program);
-        ctx.uniform1fv(ctx.getUniformLocation(program, 'u_minGradient'), gradientMin);
-        ctx.uniform1fv(ctx.getUniformLocation(program, 'u_maxGradient'), gradientMax);
+        ctx.uniform1fv(ctx.getUniformLocation(program, 'u_minGradient'), [gradientMin]);
+        ctx.uniform1fv(ctx.getUniformLocation(program, 'u_maxGradient'), [gradientMax]);
         ctx.uniform4fv(ctx.getUniformLocation(program, 'u_color'), color);
     };
 


### PR DESCRIPTION
This small change fixed a bug about uniform1fv. The data type of the original code is not correct, we should use an array. 

Attach the native code FYI: https://android.googlesource.com/platform/external/deqp/+/deqp-dev/modules/gles3/functional/es3fFboTestUtil.cpp#821