### PR TITLE
Simplify WebGLTestUtils shader program setup functionality

### DIFF
--- a/sdk/tests/conformance/attribs/gl-bindAttribLocation-aliasing.html
+++ b/sdk/tests/conformance/attribs/gl-bindAttribLocation-aliasing.html
@@ -49,7 +49,7 @@ description("This test verifies combinations of valid, active attribute types ca
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
-var glFragmentShader = wtu.setupSimpleColorFragmentShader(gl);
+var glFragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShader, gl.FRAGMENT_SHADER);
 var typeInfo = [
     { type: 'float',    asVec4: 'vec4(0.0, $(var), 0.0, 1.0)' },
     { type: 'vec2',     asVec4: 'vec4($(var), 0.0, 1.0)' },

--- a/sdk/tests/conformance/attribs/gl-bindAttribLocation-matrix.html
+++ b/sdk/tests/conformance/attribs/gl-bindAttribLocation-matrix.html
@@ -50,7 +50,7 @@ var maxAttributes = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
 debug('MAX_VERTEX_ATTRIBUTES is ' + maxAttributes);
 shouldBeGreaterThanOrEqual('maxAttributes', '4');
 
-var glFragmentShader = wtu.setupSimpleColorFragmentShader(gl);
+var glFragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShader, gl.FRAGMENT_SHADER);
 
 // Given a matrix dimension, load a vertex shader with a matrix of that dimension
 // and a vector. Ensure that both the vector and matrix are active attributes.

--- a/sdk/tests/conformance/attribs/gl-matrix-attributes.html
+++ b/sdk/tests/conformance/attribs/gl-matrix-attributes.html
@@ -50,7 +50,7 @@ var maxAttributes = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
 debug('MAX_VERTEX_ATTRIBUTES is ' + maxAttributes);
 shouldBeGreaterThanOrEqual('maxAttributes', '4');
 
-var glFragmentShader = wtu.setupSimpleColorFragmentShader(gl);
+var glFragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShader, gl.FRAGMENT_SHADER);
 
 // prepareMatrixProgram creates a program with glFragmentShader as the fragment shader.
 // The vertex shader has numVector number of vectors and a matrix with numMatrixDimensions

--- a/sdk/tests/conformance/extensions/oes-texture-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float.html
@@ -87,7 +87,7 @@ if (!gl) {
   testPassed("WebGL context exists");
 
   var texturedShaders = [
-      wtu.setupSimpleTextureVertexShader(gl),
+      wtu.simpleTextureVertexShader,
       "testFragmentShader"
   ];
   var testProgram =

--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -58,13 +58,6 @@ void main()
 }
 </script>
 <!-- Shaders for testing half-floating-point render targets -->
-<script id="positionVertexShader" type="x-shader/x-vertex">
-attribute vec4 vPosition;
-void main()
-{
-    gl_Position = vPosition;
-}
-</script>
 <script id="floatingPointFragmentShader" type="x-shader/x-fragment">
 void main()
 {
@@ -305,7 +298,7 @@ function runRenderTest(format, subtractor, data)
 
         var renderProgram =
             wtu.setupProgram(gl,
-                             ["positionVertexShader", "floatingPointFragmentShader"],
+                             [wtu.simpleVertexShader, "floatingPointFragmentShader"],
                              ['vPosition'],
                              [0]);
         wtu.drawUnitQuad(gl);
@@ -314,12 +307,12 @@ function runRenderTest(format, subtractor, data)
 
     // Now sample from the half floating-point texture and verify we got the correct values.
     var texturedShaders = [
-      wtu.setupSimpleTextureVertexShader(gl),
+          wtu.simpleTextureVertexShader,
           "testFragmentShader"
       ];
     var testProgram =
         wtu.setupProgram(gl,
-                        [wtu.setupSimpleTextureVertexShader(gl), "testFragmentShader"],
+                        [wtu.simpleTextureVertexShader, "testFragmentShader"],
                         ['vPosition', 'texCoord0'],
                         [0, 1]);
     var quadParameters = wtu.setupUnitQuad(gl, 0, 1);

--- a/sdk/tests/conformance/misc/expando-loss.html
+++ b/sdk/tests/conformance/misc/expando-loss.html
@@ -130,10 +130,10 @@ function testBasicBindings() {
 function testProgramsAndShaders() {
     debug('Programs and Shaders');
 
-    var vs = wtu.setupSimpleColorVertexShader(gl);
+    var vs = wtu.loadShader(gl, wtu.simpleVertexShader, gl.VERTEX_SHADER);
     setTestExpandos(vs);
 
-    var fs = wtu.setupSimpleColorFragmentShader(gl);
+    var fs = wtu.loadShader(gl, wtu.simpleColorFragmentShader, gl.FRAGMENT_SHADER);
     setTestExpandos(fs);
 
     var program = wtu.setupProgram(gl, [vs, fs]);

--- a/sdk/tests/conformance/textures/misc/tex-sub-image-2d.html
+++ b/sdk/tests/conformance/textures/misc/tex-sub-image-2d.html
@@ -60,7 +60,7 @@ var gl = wtu.create3DContext(canvas);
 gl.disable(gl.DITHER);
 var program = wtu.setupProgram(
     gl,
-    [wtu.setupSimpleTextureVertexShader(gl), "fshader"],
+    [wtu.simpleTextureVertexShader, "fshader"],
     ['vPosition', 'texCoord0']);
 wtu.setupUnitQuad(gl);
 var textureWidth = 256;

--- a/sdk/tests/conformance/textures/misc/texture-active-bind.html
+++ b/sdk/tests/conformance/textures/misc/texture-active-bind.html
@@ -67,7 +67,7 @@ function init()
   gl = wtu.create3DContext("example");
   var program = wtu.setupProgram(
       gl,
-      ["vshader", wtu.setupSimpleTextureFragmentShader(gl)],
+      ["vshader", wtu.simpleTextureFragmentShader],
       ['vPosition', 'texCoord0']);
   wtu.setupUnitQuad(gl);
   gl.disable(gl.DEPTH_TEST);

--- a/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
+++ b/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
@@ -58,13 +58,6 @@ void main()
 }
 </script>
 <!-- Shaders for testing floating-point render targets -->
-<script id="positionVertexShader" type="x-shader/x-vertex">
-attribute vec4 vPosition;
-void main()
-{
-    gl_Position = vPosition;
-}
-</script>
 <script id="floatingPointFragmentShader" type="x-shader/x-fragment">
 void main()
 {
@@ -177,7 +170,7 @@ function runFloatTextureRenderTargetTest(enabled, internalFormat, format, testPr
 
     var renderProgram =
         wtu.setupProgram(gl,
-                         ["positionVertexShader", "floatingPointFragmentShader"],
+                         [wtu.simpleVertexShader, "floatingPointFragmentShader"],
                          ['vPosition'],
                          [0]);
     wtu.clearAndDrawUnitQuad(gl);
@@ -256,7 +249,7 @@ if (!gl) {
   testPassed("WebGL context exists");
 
   var texturedShaders = [
-      wtu.setupSimpleTextureVertexShader(gl),
+      wtu.simpleTextureVertexShader,
       "testFragmentShader"
   ];
   var testProgram =

--- a/sdk/tests/extra/slow-shader-example.html
+++ b/sdk/tests/extra/slow-shader-example.html
@@ -64,14 +64,9 @@ debug("Texture size: " + texSize);
 var shaderSource =
     document.getElementById("slow").text.replace(/\$size/g, texSize + ".0");
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after getting a context");
-var vs = wtu.setupSimpleTextureVertexShader(gl);
-var fs = wtu.loadShader(
-    gl,
-    shaderSource,
-    gl.FRAGMENT_SHADER)
 var program = wtu.setupProgram(
     gl,
-    [vs, fs],
+    [wtu.simpleTextureVertexShader, shaderSource],
     ['vPosition', 'texCoord0'],
     [0, 1]);
 wtu.setupUnitQuad(gl, 0, 1);

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -170,7 +170,7 @@ var noTexCoordTextureVertexShader = [
  * A vertex shader for a uniform color.
  * @type {string}
  */
-var simpleColorVertexShader = [
+var simpleVertexShader = [
   'attribute vec4 vPosition;',
   'void main() {',
   '    gl_Position = vPosition;',
@@ -210,82 +210,6 @@ var simpleVertexColorFragmentShader = [
   'void main() {',
   '    gl_FragData[0] = v_color;',
   '}'].join('\n');
-
-/**
- * Creates a simple texture vertex shader.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupSimpleTextureVertexShader = function(gl) {
-    return loadShader(gl, simpleTextureVertexShader, gl.VERTEX_SHADER);
-};
-
-/**
- * Creates a simple texture fragment shader.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupSimpleTextureFragmentShader = function(gl) {
-    return loadShader(
-        gl, simpleTextureFragmentShader, gl.FRAGMENT_SHADER);
-};
-
-/**
- * Creates a simple cube map texture fragment shader.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupSimpleCubeMapTextureFragmentShader = function(gl) {
-    return loadShader(
-        gl, simpleCubeMapTextureFragmentShader, gl.FRAGMENT_SHADER);
-};
-
-/**
- * Creates a texture vertex shader that doesn't need texcoords.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupNoTexCoordTextureVertexShader = function(gl) {
-    return loadShader(gl, noTexCoordTextureVertexShader, gl.VERTEX_SHADER);
-};
-
-/**
- * Creates a simple vertex color vertex shader.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupSimpleVertexColorVertexShader = function(gl) {
-    return loadShader(gl, simpleVertexColorVertexShader, gl.VERTEX_SHADER);
-};
-
-/**
- * Creates a simple vertex color fragment shader.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupSimpleVertexColorFragmentShader = function(gl) {
-    return loadShader(
-        gl, simpleVertexColorFragmentShader, gl.FRAGMENT_SHADER);
-};
-
-/**
- * Creates a simple color vertex shader.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupSimpleColorVertexShader = function(gl) {
-    return loadShader(gl, simpleColorVertexShader, gl.VERTEX_SHADER);
-};
-
-/**
- * Creates a simple color fragment shader.
- * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
- * @return {!WebGLShader}
- */
-var setupSimpleColorFragmentShader = function(gl) {
-    return loadShader(
-        gl, simpleColorFragmentShader, gl.FRAGMENT_SHADER);
-};
 
 /**
  * Creates a program, attaches shaders, binds attrib locations, links the
@@ -437,22 +361,10 @@ var setupTransformFeedbackProgram = function(
  * @return {WebGLProgram}
  */
 var setupNoTexCoordTextureProgram = function(gl) {
-  var vs = setupNoTexCoordTextureVertexShader(gl);
-  var fs = setupSimpleTextureFragmentShader(gl);
-  if (!vs || !fs) {
-    return null;
-  }
-  var program = setupProgram(
-      gl,
-      [vs, fs],
-      ['vPosition'],
-      [0]);
-  if (!program) {
-    gl.deleteShader(fs);
-    gl.deleteShader(vs);
-  }
-  gl.useProgram(program);
-  return program;
+  return setupProgram(gl,
+                      [noTexCoordTextureVertexShader, simpleTextureFragmentShader],
+                      ['vPosition'],
+                      [0]);
 };
 
 /**
@@ -466,22 +378,10 @@ var setupSimpleTextureProgram = function(
     gl, opt_positionLocation, opt_texcoordLocation) {
   opt_positionLocation = opt_positionLocation || 0;
   opt_texcoordLocation = opt_texcoordLocation || 1;
-  var vs = setupSimpleTextureVertexShader(gl);
-  var fs = setupSimpleTextureFragmentShader(gl);
-  if (!vs || !fs) {
-    return null;
-  }
-  var program = setupProgram(
-      gl,
-      [vs, fs],
-      ['vPosition', 'texCoord0'],
-      [opt_positionLocation, opt_texcoordLocation]);
-  if (!program) {
-    gl.deleteShader(fs);
-    gl.deleteShader(vs);
-  }
-  gl.useProgram(program);
-  return program;
+  return setupProgram(gl,
+                      [simpleTextureVertexShader, simpleTextureFragmentShader],
+                      ['vPosition', 'texCoord0'],
+                      [opt_positionLocation, opt_texcoordLocation]);
 };
 
 /**
@@ -495,22 +395,10 @@ var setupSimpleCubeMapTextureProgram = function(
     gl, opt_positionLocation, opt_texcoordLocation) {
   opt_positionLocation = opt_positionLocation || 0;
   opt_texcoordLocation = opt_texcoordLocation || 1;
-  var vs = setupSimpleTextureVertexShader(gl);
-  var fs = setupSimpleCubeMapTextureFragmentShader(gl);
-  if (!vs || !fs) {
-    return null;
-  }
-  var program = setupProgram(
-      gl,
-      [vs, fs],
-      ['vPosition', 'texCoord0'],
-      [opt_positionLocation, opt_texcoordLocation]);
-  if (!program) {
-    gl.deleteShader(fs);
-    gl.deleteShader(vs);
-  }
-  gl.useProgram(program);
-  return program;
+  return setupProgram(gl,
+                      [simpleTextureVertexShader, simpleCubeMapTextureFragmentShader],
+                      ['vPosition', 'texCoord0'],
+                      [opt_positionLocation, opt_texcoordLocation]);
 };
 
 /**
@@ -525,22 +413,10 @@ var setupSimpleVertexColorProgram = function(
     gl, opt_positionLocation, opt_vertexColorLocation) {
   opt_positionLocation = opt_positionLocation || 0;
   opt_vertexColorLocation = opt_vertexColorLocation || 1;
-  var vs = setupSimpleVertexColorVertexShader(gl);
-  var fs = setupSimpleVertexColorFragmentShader(gl);
-  if (!vs || !fs) {
-    return null;
-  }
-  var program = setupProgram(
-      gl,
-      [vs, fs],
-      ['vPosition', 'a_color'],
-      [opt_positionLocation, opt_vertexColorLocation]);
-  if (!program) {
-    gl.deleteShader(fs);
-    gl.deleteShader(vs);
-  }
-  gl.useProgram(program);
-  return program;
+  return setupProgram(gl,
+                      [simpleVertexColorVertexShader, simpleVertexColorFragmentShader],
+                      ['vPosition', 'a_color'],
+                      [opt_positionLocation, opt_vertexColorLocation]);
 };
 
 /**
@@ -551,22 +427,10 @@ var setupSimpleVertexColorProgram = function(
  */
 var setupSimpleColorProgram = function(gl, opt_positionLocation) {
   opt_positionLocation = opt_positionLocation || 0;
-  var vs = setupSimpleColorVertexShader(gl);
-  var fs = setupSimpleColorFragmentShader(gl);
-  if (!vs || !fs) {
-    return null;
-  }
-  var program = setupProgram(
-      gl,
-      [vs, fs],
-      ['vPosition'],
-      [opt_positionLocation]);
-  if (!program) {
-    gl.deleteShader(fs);
-    gl.deleteShader(vs);
-  }
-  gl.useProgram(program);
-  return program;
+  return setupProgram(gl,
+                      [simpleVertexShader, simpleColorFragmentShader],
+                      ['vPosition'],
+                      [opt_positionLocation]);
 };
 
 /**
@@ -3056,7 +2920,7 @@ var setupImageForCrossOriginTest = function(img, imgUrl, localUrl, callback) {
   }, false);
 }
 
-return {
+var API = {
   addShaderSource: addShaderSource,
   addShaderSources: addShaderSources,
   cancelAnimFrame: cancelAnimFrame,
@@ -3137,19 +3001,11 @@ return {
   setupQuad: setupQuad,
   setupIndexedQuad: setupIndexedQuad,
   setupIndexedQuadWithOptions: setupIndexedQuadWithOptions,
-  setupSimpleColorFragmentShader: setupSimpleColorFragmentShader,
-  setupSimpleColorVertexShader: setupSimpleColorVertexShader,
   setupSimpleColorProgram: setupSimpleColorProgram,
-  setupSimpleTextureFragmentShader: setupSimpleTextureFragmentShader,
-  setupSimpleCubeMapTextureFragmentShader: setupSimpleCubeMapTextureFragmentShader,
   setupSimpleTextureProgram: setupSimpleTextureProgram,
   setupSimpleCubeMapTextureProgram: setupSimpleCubeMapTextureProgram,
-  setupSimpleTextureVertexShader: setupSimpleTextureVertexShader,
-  setupSimpleVertexColorFragmentShader: setupSimpleVertexColorFragmentShader,
   setupSimpleVertexColorProgram: setupSimpleVertexColorProgram,
-  setupSimpleVertexColorVertexShader: setupSimpleVertexColorVertexShader,
   setupNoTexCoordTextureProgram: setupNoTexCoordTextureProgram,
-  setupNoTexCoordTextureVertexShader: setupNoTexCoordTextureVertexShader,
   setupTexturedQuad: setupTexturedQuad,
   setupTexturedQuadWithTexCoords: setupTexturedQuadWithTexCoords,
   setupTexturedQuadWithCubeMap: setupTexturedQuadWithCubeMap,
@@ -3179,5 +3035,19 @@ return {
 
   none: false
 };
+
+Object.defineProperties(API, {
+  noTexCoordTextureVertexShader: { value: noTexCoordTextureVertexShader, writable: false },
+  simpleTextureVertexShader: { value: simpleTextureVertexShader, writable: false },
+  simpleColorFragmentShader: { value: simpleColorFragmentShader, writable: false },
+  simpleVertexShader: { value: simpleVertexShader, writable: false },
+  simpleTextureFragmentShader: { value: simpleTextureFragmentShader, writable: false },
+  simpleCubeMapTextureFragmentShader: { value: simpleCubeMapTextureFragmentShader, writable: false },
+  simpleTextureVertexShader: { value: simpleTextureVertexShader, writable: false },
+  simpleVertexColorFragmentShader: { value: simpleVertexColorFragmentShader, writable: false },
+  simpleVertexColorVertexShader: { value: simpleVertexColorVertexShader, writable: false }
+});
+
+return API;
 
 }());


### PR DESCRIPTION
Instead of exposing a lot of rarely used functions that simply load a
predefined shader from source, expose WTU collection of shader source as
read-only string properties on the WTU API. These are simple to use with
loadShader() or setupProgram().

Also rely on setupProgram() more in WTU functions that load a shader
program based on predefined shader sources to reduce complexity.