### PR TITLE
Fix wrong texture 2d array view

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureFilteringTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureFilteringTests.js
@@ -1228,7 +1228,7 @@ goog.scope(function() {
             glsTextureTestUtil.getCompareMask(pixelFormat);
 
         var isHighQuality = glsTextureTestUtil.verifyTexture2DArrayResult(
-            rendered.getAccess(), curCase.texture.getRefTexture(),
+            rendered.getAccess(), curCase.texture.getRefTexture().getView(),
             texCoord, refParams, lookupPrecision, lodPrecision, pixelFormat);
 
         if (!isHighQuality) {
@@ -1243,7 +1243,7 @@ goog.scope(function() {
             );
 
             var isOk = glsTextureTestUtil.verifyTexture2DArrayResult(
-                rendered.getAccess(), curCase.texture.getRefTexture(),
+                rendered.getAccess(), curCase.texture.getRefTexture().getView(),
                 texCoord, refParams, lookupPrecision, lodPrecision, pixelFormat
             );
 


### PR DESCRIPTION
deqp/functional/gles3/texturefiltering09.html complains
"src.sample is not a function".
glsTextureTestUtil.verifyTexture2DArrayResult requires
tcuTexture.Texture2DArrayView object for the second argument. This patch
fixes the bug which is similar to https://github.com/KhronosGroup/WebGL/pull/1340.