### PR TITLE
Add sample function for Texture2DArray to run texturespecification25.html

### DIFF
--- a/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContext.js
+++ b/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContext.js
@@ -476,7 +476,7 @@ goog.scope(function() {
      * @return {Array<number>}
      */
     sglrReferenceContext.Texture2D.prototype.sample = function(pos, lod) {
-     return this.m_view.sample(this.getSampler(), pos, lod);
+        return this.m_view.sample(this.getSampler(), pos, lod);
     };
 
     /**
@@ -713,6 +713,15 @@ goog.scope(function() {
             this.m_view = new tcuTexture.Texture2DArrayView(numLevels, this.m_levels.getLevels().slice(baseLevel));
         } else
             this.m_view = new tcuTexture.Texture2DArrayView(0, null);
+    };
+
+    /**
+     * @param {Array<number>} pos
+     * @param {number=} lod
+     * @return {Array<number>}
+     */
+    sglrReferenceContext.Texture2DArray.prototype.sample = function(pos, lod) {
+        return this.m_view.sample(this.getSampler(), pos, lod);
     };
 
     /**


### PR DESCRIPTION
"Intentionally empty. Call method from child class instead" error was
reported when running deqp/functional/gles3/texturespecification25.html.
Add sample() for sglrReferenceContext.Texture2DArray. This also aligns
with C++ code: https://android.googlesource.com/platform/external/deqp/+/master/framework/opengl/simplereference/sglrReferenceContext.cpp#5133.