### PR TITLE
3D targt should be INVALID_ENUM for 2d texture apis

### DIFF
--- a/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
+++ b/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
@@ -78,6 +78,10 @@ wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "too high leve
 
 gl.texSubImage2D(gl.FLOAT, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "bad target");
+if (contextVersion > 1) {
+    gl.texSubImage2D(gl.TEXTURE_3D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "bad target");
+}
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "good args");
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGB, gl.UNSIGNED_BYTE, c);

--- a/sdk/tests/conformance2/textures/misc/compressed-tex-image.html
+++ b/sdk/tests/conformance2/textures/misc/compressed-tex-image.html
@@ -62,7 +62,10 @@ if (!gl) {
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.ETC1_RGB8_OES, 4, 4, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");
+  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_3D, 0, gl.COMPRESSED_R11_EAC, 4, 4, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.COMPRESSED_R11_EAC, 4, 4, 0, new Uint8Array(8))");
+  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexSubImage2D(gl.TEXTURE_3D, 0, 0, 0, 4, 4, gl.COMPRESSED_R11_EAC, new Uint8Array(8))");
+  wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 4, 4, gl.COMPRESSED_R11_EAC, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.COMPRESSED_SIGNED_R11_EAC, 4, 4, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.COMPRESSED_RG11_EAC, 4, 4, 0, new Uint8Array(16))");
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, gl.COMPRESSED_SIGNED_RG11_EAC, 4, 4, 0, new Uint8Array(16))");

--- a/sdk/tests/js/tests/tex-input-validation.js
+++ b/sdk/tests/js/tests/tex-input-validation.js
@@ -329,7 +329,13 @@ if (contextVersion < 2) {
       border: 0,
       format: gl.RGBA,
       type: gl.BYTE,
-      expectedError: gl.INVALID_OPERATION }
+      expectedError: gl.INVALID_OPERATION },
+    { target: gl.TEXTURE_3D,
+      internalFormat: gl.RGBA,
+      border: 0,
+      format: gl.RGBA,
+      type: gl.UNSIGNED_BYTE,
+      expectedError: gl.INVALID_ENUM }
   ]);
 }
 
@@ -367,7 +373,11 @@ if (contextVersion < 2) {
     { target: gl.TEXTURE_2D,
       format: gl.RGBA,
       type: gl.BYTE,
-      expectedError: gl.INVALID_OPERATION }
+      expectedError: gl.INVALID_OPERATION },
+    { target: gl.TEXTURE_3D,
+      format: gl.RGBA,
+      type: gl.UNSIGNED_BYTE,
+      expectedError: gl.INVALID_ENUM },
   ]);
 }
 
@@ -410,6 +420,16 @@ testCases = [
     border: 0,
     expectedError: gl.NO_ERROR }
 ];
+
+if (contextVersion > 1) {
+  testCases = testCases.concat([
+    { target: gl.TEXTURE_3D,
+      colorBufferFormat: gl.RGB5_A1,
+      internalFormat: gl.RGBA,
+      border: 0,
+      expectedError: gl.INVALID_ENUM }
+  ]);
+}
 
 for (var ii = 0; ii < testCases.length; ++ii) {
   testCopyTexImage2D(testCases[ii]);


### PR DESCRIPTION
This patch valids TEXTURE_3D is invalid enum for 2d texture apis.
deqp/functional/gles3/negativetextureapi.html already covers validation
of TEXTURE_2D target for 3d texture apis.