### PR TITLE
Fixed duplicate "the".

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -2468,7 +2468,7 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             of bits of precision from the image data, this loss of precision must occur. <br><br>
 
             The first pixel transferred from the source to the WebGL implementation corresponds to
-            the upper left corner of the source. This behavior is modified by the
+            the upper left corner of the source. This behavior is modified by
             the <code>UNPACK_FLIP_Y_WEBGL</code> <a href="#PIXEL_STORAGE_PARAMETERS">pixel storage
             parameter</a>. <br><br>
 


### PR DESCRIPTION
Pointed out in #1469 .
