### PR TITLE
Adding error checking after instanceof calls to clear any set error flags

### DIFF
--- a/sdk/tests/js/tests/instanceof-test.js
+++ b/sdk/tests/js/tests/instanceof-test.js
@@ -31,6 +31,13 @@ description(document.title);
 debug("Tests that instanceof works on WebGL objects.");
 debug("");
 
+function checkGLError(message) {
+  var error = gl.getError();
+  if (error != gl.NO_ERROR) {
+    wtu.error("Error: " + message + " caused " + wtu.glEnumToString(gl, error));
+  }
+}
+
 var gl = wtu.create3DContext("canvas");
 if (contextVersion === 1) {
   shouldBeTrue('gl instanceof WebGLRenderingContext');
@@ -39,23 +46,47 @@ if (contextVersion === 1) {
 }
 
 shouldBeTrue('gl.createBuffer() instanceof WebGLBuffer');
+checkGLError("createBuffer")
+
 shouldBeTrue('gl.createFramebuffer() instanceof WebGLFramebuffer');
+checkGLError("createFramebuffer")
+
 shouldBeTrue('gl.createProgram() instanceof WebGLProgram');
+checkGLError("createProgram")
+
 shouldBeTrue('gl.createRenderbuffer() instanceof WebGLRenderbuffer');
+checkGLError("createRenderbuffer")
+
 shouldBeTrue('gl.createShader(gl.VERTEX_SHADER) instanceof WebGLShader');
+checkGLError("createShader")
+
 shouldBeTrue('gl.createTexture() instanceof WebGLTexture');
+checkGLError("createTexture")
+
 if (contextVersion > 1) {
   shouldBeTrue('gl.createQuery() instanceof WebGLQuery');
+  checkGLError("createQuery")
+  
   shouldBeTrue('gl.createSampler() instanceof WebGLSampler');
+  checkGLError("createSampler")
+  
   shouldBeTrue('gl.createTransformFeedback() instanceof WebGLTransformFeedback');
+  checkGLError("createTransformFeedback")
+  
   shouldBeTrue('gl.createVertexArray() instanceof WebGLVertexArrayObject');
+  checkGLError("createVertexArray")
 }
 
 var program = wtu.setupProgram(gl, ['vshader', 'fshader'], ['vPosition'], [0]);
 
 shouldBeTrue('gl.getUniformLocation(program, "color") instanceof WebGLUniformLocation');
+checkGLError("getUniformLocation")
+
 shouldBeTrue('gl.getActiveAttrib(program, 0) instanceof WebGLActiveInfo');
+checkGLError("getActiveAttrib")
+
 shouldBeTrue('gl.getActiveUniform(program, 0) instanceof WebGLActiveInfo');
+checkGLError("getActiveUniform")
 
 debug("");
 debug("Tests that those WebGL objects can not be constructed through new operator");


### PR DESCRIPTION
When we load the shader source from setupProgram, we check for GL errors, assuming that they would've been set from the preceding function call.  However, a GL error that is set during one of the instanceof tests won't be caught until setting up the program, and would be incorrectly attributed to a problem with loading the shaders. To fix this, we check for errors after each GL call, if only for the purpose of clearing the flag.