### PR TITLE
Don't return drawingBufferWidth/Height from glEnumToString

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -63,6 +63,9 @@ var glEnumToString = function(gl, value) {
   }
   for (var p in gl) {
     if (gl[p] == value) {
+      if (p == 'drawingBufferWidth' || p == 'drawingBufferHeight') {
+        continue;
+      }
       return p;
     }
   }


### PR DESCRIPTION
They're not enums but have numerical values.