### PR TITLE
Use correct integer type

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
@@ -156,7 +156,7 @@ goog.scope(function() {
         shaderExecutor.useProgram();
 
         shaderExecutorResult = shaderExecutor.execute(1, null);
-        result = new Uint32Array(shaderExecutorResult[0].buffer)[0];
+        result = new Int32Array(shaderExecutorResult[0].buffer)[0];
 
         bufferedLogToConsole(this.m_varName + ' = ' + result);
 


### PR DESCRIPTION
This aligns with int type for result in C++ code. Some constant values
can be negative, e.g. MIN_PROGRAM_TEXEL_OFFSET in
deqp/functional/gles3/shaderbuiltinvar.html.

C++ code: https://android.googlesource.com/platform/external/deqp/+/master/modules/gles3/functional/es3fShaderBuiltinVarTests.cpp#133