### PR TITLE
Correct reference number of vector

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
@@ -93,7 +93,7 @@ goog.scope(function() {
     es3fShaderBuiltinVarTests.getVectorsFromComps = function(pname) {
         var value = /** @type {number} */ (gl.getParameter(pname));
         assertMsgOptions(value%4 === 0, 'Expected value to be divisible by 4.', false, true);
-        return value;
+        return value / 4;
     };
 
     /**


### PR DESCRIPTION
The number of vectors is number of components divided by four.
getVectorsFromComps checks "value%4 === 0", but it forgets doing the
division.

C++ code for reference: https://android.googlesource.com/platform/external/deqp/+/master/modules/gles3/functional/es3fShaderBuiltinVarTests.cpp#71