### PR TITLE
fix bug in shaderstatequery when query vertex attribute offset

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsStateQuery.js
+++ b/sdk/tests/deqp/modules/shared/glsStateQuery.js
@@ -99,7 +99,9 @@ glsStateQuery.verifyCurrentVertexAttrib = function(index, reference) {
  * @return {boolean}
  */
 glsStateQuery.verifyVertexAttrib = function(index, param, reference) {
-    var value = gl.getVertexAttrib(index, param);
+    var value = (param == gl.VERTEX_ATTRIB_ARRAY_POINTER) ?
+        gl.getVertexAttribOffset(index, param) :
+        gl.getVertexAttrib(index, param);
     var result = glsStateQuery.compare(value, reference);
     if (!result) {
         bufferedLogToConsole('Result: ' + value + ' Expected: ' + reference);


### PR DESCRIPTION
The test vertex_attrib_offset in shaderstatequery.html need to get the gl.VERTEX_ATTRIB_ARRAY_POINTER info, we should use getVertexAttribOffset(), instead of getVertexAttrib(). Otherwise, the pname is invalid. 

This change fixed this bug.