### PR TITLE
Remove unsupported attribute aliasing tests

### DIFF
--- a/sdk/tests/deqp/framework/opengl/gluShaderUtil.js
+++ b/sdk/tests/deqp/framework/opengl/gluShaderUtil.js
@@ -37,6 +37,15 @@ gluShaderUtil.GLSLVersion = {
 };
 
 /**
+ * gluShaderUtil.glslVersionUsesInOutQualifiers
+ * @param {gluShaderUtil.GLSLVersion} version
+ * @return {boolean}
+ */
+gluShaderUtil.glslVersionUsesInOutQualifiers = function(version) {
+    return version == gluShaderUtil.GLSLVersion.V300_ES;
+};
+
+/**
  * gluShaderUtil.isGLSLVersionSupported
  * @param {WebGL2RenderingContext|WebGLRenderingContextBase} ctx
  * @param {gluShaderUtil.GLSLVersion} version

--- a/sdk/tests/deqp/functional/gles3/es3fAttribLocationTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fAttribLocationTests.js
@@ -108,29 +108,6 @@ goog.scope(function() {
             bindMaxAttributeGroup.addChild(new glsAttributeLocationTests.BindMaxAttributesTest(type));
         }
 
-        // Test aliasing
-        /** @type {tcuTestCase.DeqpTest} */
-        var aliasingGroup = tcuTestCase.newTest('bind_aliasing', 'Test binding aliasing locations.');
-
-        root.addChild(aliasingGroup);
-
-        for (typeNdx = 0; typeNdx < es2Types.length; typeNdx++) {
-            type = es2Types[typeNdx];
-
-            // Simple aliasing cases
-            aliasingGroup.addChild(new glsAttributeLocationTests.BindAliasingAttributeTest(type));
-
-            // For types which occupy more than one location. Alias second location.
-            if (type.getLocationSize() > 1)
-                aliasingGroup.addChild(new glsAttributeLocationTests.BindAliasingAttributeTest(type, 1));
-
-            // Use more than maximum attributes with aliasing
-            aliasingGroup.addChild(new glsAttributeLocationTests.BindMaxAliasingAttributeTest(type));
-
-            // Use more than maximum attributes but inactive
-            aliasingGroup.addChild(new glsAttributeLocationTests.BindInactiveAliasingAttributeTest(type));
-        }
-
         // Test filling holes in attribute location
         /** @type {tcuTestCase.DeqpTest} */
         var holeGroup = tcuTestCase.newTest('bind_hole', 'Bind all, but one attribute and leave hole in location space for it.');


### PR DESCRIPTION
Vertex attribute aliasing causes link error (WebGl 2.0 spec section 5.17
Vertex Attribute Aliasing). So remove related tests. Also align shader
source code generation with C++ code. 
deqp/functional/gles3/attriblocation.html passed with this patch.

C++ code: https://android.googlesource.com/platform/external/deqp/+/master/modules/glshared/glsAttributeLocationTests.cpp#254