### PR TITLE
change the specs of pixel storage parameters for ImageBitmap

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -2503,10 +2503,6 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             If this function is called with an <code>ImageBitmap</code> that has been neutered,
             an <code>INVALID_VALUE</code> error is generated. <br><br>
 
-            If this function is called with an <code>ImageBitmap</code>, the
-            <a href="#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> associated with this
-            function are ignored. <br><br>
-
             If this function is called with an <code>HTMLImageElement</code>
             or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing
             Document, or with an <code>HTMLCanvasElement</code> or <code>ImageBitmap</code> whose
@@ -2579,10 +2575,6 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
 
             If this function is called with an <code>ImageBitmap</code> that has been neutered,
             an <code>INVALID_VALUE</code> error is generated. <br><br>
-
-            If this function is called with an <code>ImageBitmap</code>, the
-            <a href="#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> associated with this
-            function are ignored. <br><br>
 
             If this function is called with an <code>HTMLImageElement</code>
             or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing
@@ -3582,6 +3574,11 @@ and file type. If set to <code>NONE</code>, no colorspace conversion is applied.
 is <code>BROWSER_DEFAULT_WEBGL</code>.
 
 </dl>
+
+<p>
+If the TexImageSource is an ImageBitmap, then these three parameters will be ignored. Instead
+the equivalent <a href="https://html.spec.whatwg.org/multipage/webappapis.html#imagebitmapfactories">createImageBitmap</a>
+parameters should be used to obtain an ImageBitmap with desired format.
 
 <h3><a name="READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the Framebuffer</a></h3>
 

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 11 January 2016</h2>
+    <h2 class="no-toc">Editor's Draft 9 February 2016</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -2503,6 +2503,10 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             If this function is called with an <code>ImageBitmap</code> that has been neutered,
             an <code>INVALID_VALUE</code> error is generated. <br><br>
 
+            If this function is called with an <code>ImageBitmap</code>, the
+            <a href="#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> associated with this
+            function are ignored. <br><br>
+
             If this function is called with an <code>HTMLImageElement</code>
             or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing
             Document, or with an <code>HTMLCanvasElement</code> or <code>ImageBitmap</code> whose
@@ -2575,6 +2579,10 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
 
             If this function is called with an <code>ImageBitmap</code> that has been neutered,
             an <code>INVALID_VALUE</code> error is generated. <br><br>
+
+            If this function is called with an <code>ImageBitmap</code>, the
+            <a href="#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> associated with this
+            function are ignored. <br><br>
 
             If this function is called with an <code>HTMLImageElement</code>
             or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -28,7 +28,7 @@
     <!--end-logo-->
 
     <h1>WebGL Specification</h1>
-    <h2 class="no-toc">Editor's Draft 9 February 2016</h2>
+    <h2 class="no-toc">Editor's Draft 19 February 2016</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -3577,8 +3577,8 @@ is <code>BROWSER_DEFAULT_WEBGL</code>.
 
 <p>
 If the TexImageSource is an ImageBitmap, then these three parameters will be ignored. Instead
-the equivalent <a href="https://html.spec.whatwg.org/multipage/webappapis.html#imagebitmapfactories">createImageBitmap</a>
-parameters should be used to obtain an ImageBitmap with desired format.
+the equivalent <a href="https://wiki.whatwg.org/wiki/ImageBitmap_Options">ImageBitmapOptions</a>
+should be used to create an ImageBitmap with desired format.
 
 <h3><a name="READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the Framebuffer</a></h3>
 

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 9 February 2016</h2>
+    <h2 class="no-toc">Editor's Draft 2 February 2016</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -1525,7 +1525,6 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         <p>If a WebGLBuffer is bound to the <code>PIXEL_UNPACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If this function is called with an <code>ImageData</code> whose <code>data</code> attribute has been neutered, an <code>INVALID_VALUE</code> error is generated. </p>
         <p>If this function is called with an <code>ImageBitmap</code> that has been neutered, an <code>INVALID_VALUE</code> error is generated. </p>
-        <p>If this function is called with an <code>ImageBitmap</code>, the <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> associated with this function are ignored. </p>
         <p>If this function is called with an <code>HTMLImageElement</code> or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing Document, or with an <code>HTMLCanvasElement</code> or <code>ImageBitmap</code> whose bitmap's <i>origin-clean</i> flag is set to false, a <code>SECURITY_ERR</code> exception must be thrown. See <a href="../1.0/index.html#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.</p>
         <p>If <code>source</code> is null then generates an <code>INVALID_VALUE</code> error.</p>
         <p>See <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific pixel storage parameters that affect the behavior of this function.</p>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -27,7 +27,7 @@
     <!--end-logo-->
 
     <h1>WebGL 2 Specification</h1>
-    <h2 class="no-toc">Editor's Draft 2 February 2016</h2>
+    <h2 class="no-toc">Editor's Draft 9 February 2016</h2>
     <dl>
         <dt>This version:
             <dd>
@@ -1525,6 +1525,7 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         <p>If a WebGLBuffer is bound to the <code>PIXEL_UNPACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If this function is called with an <code>ImageData</code> whose <code>data</code> attribute has been neutered, an <code>INVALID_VALUE</code> error is generated. </p>
         <p>If this function is called with an <code>ImageBitmap</code> that has been neutered, an <code>INVALID_VALUE</code> error is generated. </p>
+        <p>If this function is called with an <code>ImageBitmap</code>, the <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> associated with this function are ignored. </p>
         <p>If this function is called with an <code>HTMLImageElement</code> or <code>HTMLVideoElement</code> whose origin differs from the origin of the containing Document, or with an <code>HTMLCanvasElement</code> or <code>ImageBitmap</code> whose bitmap's <i>origin-clean</i> flag is set to false, a <code>SECURITY_ERR</code> exception must be thrown. See <a href="../1.0/index.html#ORIGIN_RESTRICTIONS">Origin Restrictions</a>.</p>
         <p>If <code>source</code> is null then generates an <code>INVALID_VALUE</code> error.</p>
         <p>See <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific pixel storage parameters that affect the behavior of this function.</p>


### PR DESCRIPTION
We basically add a note for the parameters of UNPACK_FLIP_Y_WEBGL, UNPACK_PREMULTIPLY_ALPHA_WEBGL and UNPACK_COLORSPACE_CONVERSION_WEBGL, stating that these three parameters will be ignored if the texImageSource is an ImageBitmap.

Please review @kenrussell @zhenyao @toji 