### PR TITLE
Add more test cases for uninitialized-test-2.html

### DIFF
--- a/sdk/tests/conformance2/misc/uninitialized-test-2.html
+++ b/sdk/tests/conformance2/misc/uninitialized-test-2.html
@@ -179,126 +179,389 @@ function checkNonZeroPixels(texture, target, format, type, texWidth, texHeight, 
     }
 }
 
-var width = 512;
-var height = 512;
-var depth = 2;
+function testTexImage3D() {
 
-var targets = [ "TEXTURE_2D", "TEXTURE_CUBE_MAP" ];
-for (var ii = 0; ii < targets.length; ++ii) {
-    debug("");
-    debug("Reading an uninitialized texture (texStorage2D) should succeed with all bytes set to 0 : target = " + targets[ii]);
-    var tex = setupTexture(gl[targets[ii]], width, height, 1);
-    var levels = 5;
-    gl.texStorage2D(gl[targets[ii]], levels, gl.RGBA8, width, height);
-    for (var level = 0; level < levels; ++level) {
-        if (gl[targets[ii]] == gl.TEXTURE_2D) {
-            checkNonZeroPixels(tex, gl[targets[ii]], gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
-        } else {
-            checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_POSITIVE_X, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
-            checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_NEGATIVE_X, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
-            checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_POSITIVE_Y, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
-            checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_NEGATIVE_Y, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
-            checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_POSITIVE_Z, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
-            checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_NEGATIVE_Z, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
-        }
-    }
-    gl.deleteTexture(tex);
-    gl.finish();
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-}
+    var max_3d_texture_size = Math.min(gl.getParameter(gl.MAX_3D_TEXTURE_SIZE), 1024);
 
-// The minimum max_texture_3d is 256.
-width = 256;
-height = 256;
-depth = 8;
+    var test_cases = [
+      // TEXTURE_3D + RGBA8
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: 256, // minimum MAX_3D_TEXTURE_SIZE is 256
+        height: 256,
+        depth: 8,
+        exceptions: [ { x: 0, y: 0, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: 256, // minimum MAX_3D_TEXTURE_SIZE is 256
+        height: 256,
+        depth: 8,
+        exceptions: [],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: max_3d_texture_size,
+        height: max_3d_texture_size,
+        depth: 4,
+        exceptions: [ { x: 0, y: 128, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: max_3d_texture_size,
+        height: max_3d_texture_size,
+        depth: 4,
+        exceptions: [],
+      },
 
-targets = [ "TEXTURE_3D", "TEXTURE_2D_ARRAY" ];
-var internal_formats = [ "RGBA8", "RGBA8UI", "RGBA8I" ];
-var formats = [ gl.RGBA, gl.RGBA_INTEGER, gl.RGBA_INTEGER ];
-var types = [ gl.UNSIGNED_BYTE, gl.UNSIGNED_BYTE, gl.BYTE ];
-var read_types = [ gl.UNSIGNED_BYTE, gl.UNSIGNED_INT, gl.INT ];
+      // TEXTURE_3D + RGBA8UI
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: 256, // minimum MAX_3D_TEXTURE_SIZE is 256
+        height: 256,
+        depth: 8,
+        exceptions: [ { x: 0, y: 255, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: 256, // minimum MAX_3D_TEXTURE_SIZE is 256
+        height: 256,
+        depth: 8,
+        exceptions: [],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: max_3d_texture_size,
+        height: max_3d_texture_size,
+        depth: 4,
+        exceptions: [ { x: 128, y: 0, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: max_3d_texture_size,
+        height: max_3d_texture_size,
+        depth: 4,
+        exceptions: [],
+      },
 
-for (var ii = 0; ii < targets.length; ++ii) {
-    debug("");
-    debug("Reading an uninitialized texture (texImage3D) should succeed with all bytes set to 0 : target = " + targets[ii]);
-    for (var jj = 0; jj < internal_formats.length; ++jj) {
+      // TEXTURE_3D + RGBA8I
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: 256, // minimum MAX_3D_TEXTURE_SIZE is 256
+        height: 256,
+        depth: 8,
+        exceptions: [ { x: 128, y: 255, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: 256, // minimum MAX_3D_TEXTURE_SIZE is 256
+        height: 256,
+        depth: 8,
+        exceptions: [],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: max_3d_texture_size,
+        height: max_3d_texture_size,
+        depth: 4,
+        exceptions: [ { x: 128, y: 128, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_3D",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: max_3d_texture_size,
+        height: max_3d_texture_size,
+        depth: 4,
+        exceptions: [],
+      },
+
+      // TEXTURE_2D_ARRAY + RGBA8
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: 1024,
+        height: 1024,
+        depth: 8,
+        exceptions: [ { x: 1023, y: 0, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: 1024,
+        height: 1024,
+        depth: 8,
+        exceptions: [],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: 64,
+        height: 64,
+        depth: 256,  // minimum MAX_ARRAY_TEXTURE_LAYERS is 256
+        exceptions: [ { x: 63, y: 32, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8",
+        format: gl.RGBA,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_BYTE,
+        width: 64,
+        height: 64,
+        depth: 256,  // minimum MAX_ARRAY_TEXTURE_LAYERS is 256
+        exceptions: [],
+      },
+
+      // TEXTURE_2D_ARRAY + RGBA8UI
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: 1024,
+        height: 1024,
+        depth: 8,
+        exceptions: [ { x: 1023, y: 1023, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: 1024,
+        height: 1024,
+        depth: 8,
+        exceptions: [],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: 64,
+        height: 64,
+        depth: 256,  // minimum MAX_ARRAY_TEXTURE_LAYERS is 256
+        exceptions: [ { x: 0, y: 0, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8UI",
+        format: gl.RGBA_INTEGER,
+        type: gl.UNSIGNED_BYTE,
+        read_type: gl.UNSIGNED_INT,
+        width: 64,
+        height: 64,
+        depth: 256,  // minimum MAX_ARRAY_TEXTURE_LAYERS is 256
+        exceptions: [],
+      },
+
+      // TEXTURE_2D_ARRAY + RGBA8I
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: 1024,
+        height: 1024,
+        depth: 8,
+        exceptions: [ { x: 512, y: 1023, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: 1024,
+        height: 1024,
+        depth: 8,
+        exceptions: [],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: 64,
+        height: 64,
+        depth: 256,  // minimum MAX_ARRAY_TEXTURE_LAYERS is 256
+        exceptions: [ { x: 63, y: 32, r: 108, g: 72, b: 36, a: 9 } ],
+      },
+      {
+        target: "TEXTURE_2D_ARRAY",
+        internal_format: "RGBA8I",
+        format: gl.RGBA_INTEGER,
+        type: gl.BYTE,
+        read_type: gl.INT,
+        width: 64,
+        height: 64,
+        depth: 256,  // minimum MAX_ARRAY_TEXTURE_LAYERS is 256
+        exceptions: [],
+      },
+    ];
+
+    for (var ii = 0; ii < test_cases.length; ++ii) {
         debug("");
-        debug("Internal format : " + internal_formats[jj]);
-        var tex = setupTexture(gl[targets[ii]], width, height, depth);
-        gl.texImage3D(gl[targets[ii]], 0, gl[internal_formats[jj]], width, height, depth, 0, formats[jj], types[jj], null);
-        for (var layer = 0; layer < depth; ++layer)
-            checkNonZeroPixels(tex, gl[targets[ii]], formats[jj], read_types[jj], width, height, 0, layer, []);
-        gl.deleteTexture(tex);
-        gl.finish();
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-    }
-}
-
-for (var ii = 0; ii < targets.length; ++ii) {
-    debug("");
-    debug("Reading a partially initialized texture (texImage3D) should succeed with all uninitialized bytes set to 0 " +
-          "and initialized untouched: target = " + targets[ii]);
-    for (var jj = 0; jj < internal_formats.length; ++jj) {
-        debug("");
-        debug("Internal format : " + internal_formats[jj]);
-        var tex = setupTexture(gl[targets[ii]], width, height, depth);
-        gl.texImage3D(gl[targets[ii]], 0, gl[internal_formats[jj]], width, height, depth, 0, formats[jj], types[jj], null);
-        var data;
-        switch (types[jj]) {
-          case gl.BYTE:
-            data = new Int8Array(4 * depth);
-            break;
-          case gl.UNSIGNED_BYTE:
-          default:
-            data = new Uint8Array(4 * depth);
-            break;
-        }
-        for (var pixel = 0; pixel < depth; ++pixel) {
-            data[pixel * 4] = 108;
-            data[pixel * 4 + 1] = 72;
-            data[pixel * 4 + 2] = 36;
-            data[pixel * 4 + 3] = 9;
-        }
-        gl.texSubImage3D(gl[targets[ii]], 0, width/2, height/2, 0, 1, 1, depth, formats[jj], types[jj], data);
-        var exceptions = [];
-        exceptions.push({
-            x: width/2,
-            y: height/2,
-            r: 108,
-            g: 72,
-            b: 36,
-            a: 9
-        });
-        for (var layer = 0; layer < depth; ++layer)
-            checkNonZeroPixels(tex, gl[targets[ii]], formats[jj], read_types[jj], width, height, 0, layer, exceptions);
-        gl.deleteTexture(tex);
-        gl.finish();
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR);
-    }
-}
-
-for (var ii = 0; ii < targets.length; ++ii) {
-    debug("");
-    debug("Reading an uninitialized texture (texStorage3D) should succeed with all bytes set to 0 : target = " + targets[ii]);
-    for (var jj = 0; jj < internal_formats.length; ++jj) {
-        debug("");
-        debug("Internal format : " + internal_formats[jj]);
-        var tex = setupTexture(gl[targets[ii]], width, height, depth);
-        var levels = 5;
-        gl.texStorage3D(gl[targets[ii]], levels, gl[internal_formats[jj]], width, height, depth);
-        var level_depth = depth;
-        for (var level = 0; level < levels; ++level) {
-            for (var layer = 0; layer < level_depth; ++layer) {
-                checkNonZeroPixels(tex, gl[targets[ii]], formats[jj], read_types[jj], width, height, level, layer, []);
+        var test = test_cases[ii];
+        debug("TexImage3D with target = " + test.target + ", internal_format = " + test.internal_format +
+              ", width = " + test.width + ", height = " + test.height + ", depth = " + test.depth);
+        var tex = setupTexture(gl[test.target], test.width, test.height, test.depth);
+        gl.texImage3D(gl[test.target], 0, gl[test.internal_format], test.width, test.height, test.depth, 0, test.format, test.type, null);
+        for (var jj = 0; jj < test.exceptions.length; ++jj) {
+            var exception = test.exceptions[jj];
+            var data;
+            switch (test.type) {
+              case gl.BYTE:
+                data = new Int8Array(4 * test.depth);
+                break;
+              case gl.UNSIGNED_BYTE:
+                data = new Uint8Array(4 * test.depth);
+                break;
+              default:
+                assert(false);
             }
-            if (gl[targets[ii]] == gl.TEXTURE_3D)
-                level_depth = Math.max(1, level_depth >> 1);
+            for (var pixel = 0; pixel < test.depth; ++pixel) {
+                data[pixel * 4] = exception.r;
+                data[pixel * 4 + 1] = exception.g;
+                data[pixel * 4 + 2] = exception.b;
+                data[pixel * 4 + 3] = exception.a;
+            }
+            gl.texSubImage3D(gl[test.target], 0, exception.x, exception.y, 0, 1, 1, test.depth, test.format, test.type, data);
+        }
+        for (var layer = 0; layer < test.depth; ++layer)
+            checkNonZeroPixels(tex, gl[test.target], test.format, test.read_type, test.width, test.height, 0, layer, test.exceptions);
+        gl.deleteTexture(tex);
+        gl.finish();
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+    }
+}
+
+function testTexStorage2D() {
+    var targets = [ "TEXTURE_2D", "TEXTURE_CUBE_MAP" ];
+    var width = 512;
+    var height = 512;
+    var levels = 5;
+
+    for (var ii = 0; ii < targets.length; ++ii) {
+        debug("");
+        debug("Reading an uninitialized texture (texStorage2D) should succeed with all bytes set to 0 : target = " + targets[ii]);
+        var tex = setupTexture(gl[targets[ii]], width, height, 1);
+        gl.texStorage2D(gl[targets[ii]], levels, gl.RGBA8, width, height);
+        for (var level = 0; level < levels; ++level) {
+            if (gl[targets[ii]] == gl.TEXTURE_2D) {
+                checkNonZeroPixels(tex, gl[targets[ii]], gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
+            } else {
+                checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_POSITIVE_X, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
+                checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_NEGATIVE_X, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
+                checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_POSITIVE_Y, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
+                checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_NEGATIVE_Y, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
+                checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_POSITIVE_Z, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
+                checkNonZeroPixels(tex, gl.TEXTURE_CUBE_MAP_NEGATIVE_Z, gl.RGBA, gl.UNSIGNED_BYTE, width, height, level, 0, []);
+            }
         }
         gl.deleteTexture(tex);
         gl.finish();
         wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     }
 }
+
+function testTexStorage3D() {
+    var targets = [ "TEXTURE_3D", "TEXTURE_2D_ARRAY" ];
+    var internal_formats = [ "RGBA8", "RGBA8UI", "RGBA8I" ];
+    var formats = [ gl.RGBA, gl.RGBA_INTEGER, gl.RGBA_INTEGER ];
+    var read_types = [ gl.UNSIGNED_BYTE, gl.UNSIGNED_INT, gl.INT ];
+    var width = 256;  // minimum MAX_3D_TEXTURE_SIZE is 256
+    var height = 256;  // minimum MAX_3D_TEXTURE_SIZE is 256
+    var depth = 8;
+    var levels = 5;
+
+    for (var ii = 0; ii < targets.length; ++ii) {
+        debug("");
+        debug("Reading an uninitialized texture (texStorage3D) should succeed with all bytes set to 0 : target = " + targets[ii]);
+        for (var jj = 0; jj < internal_formats.length; ++jj) {
+            debug("");
+            debug("Internal format : " + internal_formats[jj]);
+            var tex = setupTexture(gl[targets[ii]], width, height, depth);
+            gl.texStorage3D(gl[targets[ii]], levels, gl[internal_formats[jj]], width, height, depth);
+            var level_depth = depth;
+            for (var level = 0; level < levels; ++level) {
+                for (var layer = 0; layer < level_depth; ++layer) {
+                    checkNonZeroPixels(tex, gl[targets[ii]], formats[jj], read_types[jj], width, height, level, layer, []);
+                }
+                if (gl[targets[ii]] == gl.TEXTURE_3D)
+                    level_depth = Math.max(1, level_depth >> 1);
+            }
+            gl.deleteTexture(tex);
+            gl.finish();
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+        }
+    }
+}
+
+testTexImage3D();
+testTexStorage2D();
+testTexStorage3D();
 
 debug("");
 var successfullyParsed = true;


### PR DESCRIPTION
Test with larger texture sizes.  This triggers different code paths in chrome.