### PR TITLE
Add a new case to uninitialized-test.html

### DIFF
--- a/sdk/tests/conformance/misc/uninitialized-test.html
+++ b/sdk/tests/conformance/misc/uninitialized-test.html
@@ -120,6 +120,26 @@ gl.finish();
 wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
 debug("");
+debug("Reading a partially initialized texture (texImage2D) should succeed with all uninitialized bytes set to 0 and initialized bytes untouched.");
+
+var tex = setupTexture(width, height);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+var data = new Uint8Array(4);
+var r = 108;
+var g = 72;
+var b = 36;
+var a = 9;
+data[0] = r;
+data[1] = g;
+data[2] = b;
+data[3] = a;
+gl.texSubImage2D(gl.TEXTURE_2D, 0, width/2, height/2, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, data);
+checkNonZeroPixels(tex, width, height, width/2, height/2, 1, 1, r, g, b, a);
+gl.deleteTexture(tex);
+gl.finish();
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+debug("");
 debug("Reading an uninitialized portion of a texture (copyTexImage2D) should succeed with all bytes set to 0.");
 
 var tex = setupTexture(width, height);


### PR DESCRIPTION
If we create texture using TexImage2D with null data, and then
initialize part of it using TexSubImage2D, and then ReadPixels() the
entire texture. The uninitialized part should be cleared to 0, and the
initialized part should stay untouched.

Chrome has a bug where the initialized part will also be cleared to 0.

This is fixed in https://codereview.chromium.org/1706773003/