### PR TITLE
Fix sync status for WebGL

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fSyncTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fSyncTests.js
@@ -206,9 +206,9 @@ goog.scope(function() {
 
         gl.finish();
 
-        if (this.m_caseOptions & es3fSyncTests.CaseOptions.FINISH_BEFORE_WAIT && waitValue != gl.ALREADY_SIGNALED) {
+        if (this.m_caseOptions & es3fSyncTests.CaseOptions.FINISH_BEFORE_WAIT && waitValue == gl.ALREADY_SIGNALED) {
             testOk = false;
-            bufferedLogToConsole('Expected glClientWaitSync to return gl.ALREADY_SIGNALED.');
+            bufferedLogToConsole('glClientWaitSync should not return gl.ALREADY_SIGNALED in the same frame as glFinish issued.');
         }
 
         // Delete sync object


### PR DESCRIPTION
For WebGL, sync status should not be signaled in the same frame as
glFinish issued. See section 5.23 "Queries' result must not be made
available in the current frame" in WebGL 2.0 spec.

There are some discussions in https://codereview.chromium.org/1736433003/. glFinish in WebGL issues glFlush to driver other than real glFinish.