### PR TITLE
Add flipY to ImageBitmap created from image and video

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -28,7 +28,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var successfullyParsed = false;
     var redColor = [255, 0, 0];
     var greenColor = [0, 255, 0];
-    var bitmap;
+    var bitmaps = [];
 
     function init()
     {
@@ -60,16 +60,22 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         video = document.createElement("video");
         video.oncanplaythrough = function() {
-            createImageBitmap(video).then(imageBitmap => {
-                bitmap = imageBitmap;
+            var p1 = createImageBitmap(video).then(function(imageBitmap) { bitmaps.defaultOption = imageBitmap });
+            var p2 = createImageBitmap(video, {imageOrientation: "none"}).then(function(imageBitmap) { bitmaps.noFlipY = imageBitmap });
+            var p3 = createImageBitmap(video, {imageOrientation: "flipY"}).then(function(imageBitmap) { bitmaps.flipY = imageBitmap });
+            Promise.all([p1, p2, p3]).then(function() {
                 runTest();
+            }, function() {
+                // createImageBitmap with options could be rejected if it is not supported
+                finishTest();
+                return;
             });
         }
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);
     }
 
-    function runOneIteration(bindingTarget, program)
+    function runOneIteration(bindingTarget, program, bitmap, flipY)
     {
         debug('Testing ' + ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -90,8 +96,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                       gl[pixelFormat], gl[pixelType], null);
         gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
 
-        var topColor = greenColor;
-        var bottomColor = redColor;
+        var topColor = flipY ? redColor : greenColor;
+        var bottomColor = flipY ? greenColor : redColor;
 
         // Draw the triangles
         wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
@@ -116,7 +122,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     }
 
     function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program);
+        runOneIteration(bindingTarget, program, bitmaps.defaultOption, false);
+        runOneIteration(bindingTarget, program, bitmaps.noFlipY, false);
+        runOneIteration(bindingTarget, program, bitmaps.flipY, true);
     }
 
     return init;


### PR DESCRIPTION
This change adds flipY option to conformance(2) tests for ImageBitmap that is created from an HTMLImageElement or HTMLVideoElement. With this change, flipY is covered in all the current tests for ImageBitmap.

Please review. @kenrussell @zhenyao @toji 