### PR TITLE
Check single transform feedback output

### DIFF
--- a/sdk/tests/conformance2/transform_feedback/transform_feedback.html
+++ b/sdk/tests/conformance2/transform_feedback/transform_feedback.html
@@ -78,7 +78,8 @@ if (!gl) {
 
     runBindingTest();
     runObjectTest();
-    runFeedbackTest();
+    runOneOutFeedbackTest();
+    runTwoOutFeedbackTest();
 }
 
 function runBindingTest() {
@@ -133,7 +134,66 @@ function runObjectTest() {
     tf = null;
 }
 
-function runFeedbackTest() {
+function runOneOutFeedbackTest() {
+    debug("");
+    debug("Testing transform feedback processing");
+
+    // Build the input and output buffers
+    var in_data = [
+        1.0, 2.0, 3.0, 4.0,
+        2.0, 4.0, 8.0, 16.0,
+        0.75, 0.5, 0.25, 0.0
+    ];
+
+    var in_buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(in_data), gl.STATIC_DRAW);
+
+    var out_add_buffer = gl.createBuffer();
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length, gl.STATIC_DRAW);
+
+    // Create the transform feedback shader
+    program = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
+        ["out_add"], gl.SEPARATE_ATTRIBS,
+        ["in_data"]);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking transform feedback shader should not set an error");
+    shouldBeNonNull("program");
+
+    // Draw the the transform feedback buffers
+    tf = gl.createTransformFeedback();
+
+    gl.enableVertexAttribArray(0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
+    gl.vertexAttribPointer(0, 4, gl.FLOAT, false, 16, 0);
+
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_add_buffer);
+
+    gl.enable(gl.RASTERIZER_DISCARD);
+    gl.beginTransformFeedback(gl.POINTS);
+
+    gl.drawArrays(gl.POINTS, 0, 3);
+
+    gl.endTransformFeedback();
+    gl.disable(gl.RASTERIZER_DISCARD);
+
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+
+    // Verify the output buffer contents
+    var add_expected = [
+        3.0, 5.0, 7.0, 9.0,
+        4.0, 7.0, 12.0, 21.0,
+        2.75, 3.5, 4.25, 5.0
+    ];
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, add_expected);
+
+    tf = null;
+    program = null;
+}
+
+function runTwoOutFeedbackTest() {
     debug("");
     debug("Testing transform feedback processing");
 


### PR DESCRIPTION
This exposes a bug of bindBufferBase in chrome. Between two calls of
"gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);"
bound_transform_feedback_buffer_ doesn't change, so
GLES2Implementation::BindBufferHelper doesn't issue bindBuffer to
command buffer server side.
Please refer chrome command buffer client code: https://code.google.com/p/chromium/codesearch#chromium/src/gpu/command_buffer/client/gles2_implementation.cc&q=BindBufferHelper&sq=package:chromium&type=cs&l=3811