### PR TITLE
Let WebGL spec points to whatwg specs of ImageBitmapOptions

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3583,7 +3583,7 @@ is <code>BROWSER_DEFAULT_WEBGL</code>.
 <p>
 If the <code>TexImageSource</code> is an <code>ImageBitmap</code>, then these three parameters will
 be ignored. Instead the equivalent
-<a href="https://wiki.whatwg.org/wiki/ImageBitmap_Options">ImageBitmapOptions</a> should be used to
+<a href="https://html.spec.whatwg.org/multipage/webappapis.html#imagebitmapoptions">ImageBitmapOptions</a> should be used to
 create an <code>ImageBitmap</code> with the desired format.
 
 <h3><a name="READS_OUTSIDE_FRAMEBUFFER">Reading Pixels Outside the Framebuffer</a></h3>


### PR DESCRIPTION
At this moment, the WebGL spec has a statement that is pointing to a whatwg wiki for ImageBitmapOptions, now that ImageBitmapOptions is in the whatwg specs, let's change that statement to point to the whatwg spec instead of wiki.

Please review. @kenrussell @zhenyao @toji 