### PR TITLE
Add premultiplyApha=false for ImageBitmap from HTMLImageElement and Canvas

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -26,6 +26,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
+    var halfRedColor = [128, 0, 0];
+    var halfGreenColor = [0, 128, 0];
     var redColor = [255, 0, 0];
     var greenColor = [0, 255, 0];
     var bitmaps = [];
@@ -58,12 +60,18 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
+        var testCanvas = document.createElement('canvas');
+        var ctx = testCanvas.getContext("2d");
+        setCanvasToRedGreen(ctx);
+
         var image = new Image();
         image.onload = function() {
             var p1 = createImageBitmap(image).then(function(imageBitmap) { bitmaps.defaultOption = imageBitmap });
-            var p2 = createImageBitmap(image, {imageOrientation: "none"}).then(function(imageBitmap) { bitmaps.noFlipY = imageBitmap });
-            var p3 = createImageBitmap(image, {imageOrientation: "flipY"}).then(function(imageBitmap) { bitmaps.flipY = imageBitmap });
-            Promise.all([p1, p2, p3]).then(function() {
+            var p2 = createImageBitmap(image, {imageOrientation: "none", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
+            var p3 = createImageBitmap(image, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
+            var p4 = createImageBitmap(image, {imageOrientation: "flipY", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
+            var p5 = createImageBitmap(image, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
+            Promise.all([p1, p2, p3, p4, p5]).then(function() {
                 runTest();
             }, function() {
                 // createImageBitmap with options could be rejected if it is not supported
@@ -71,12 +79,30 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                 return;
             });
         }
-        image.src = resourcePath + "red-green.png";
+        image.src = testCanvas.toDataURL();
     }
 
-    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY)
+    function setCanvasToRedGreen(ctx) {
+      ctx.canvas.width = 2;
+      ctx.canvas.height = 2;
+      var width = ctx.canvas.width;
+      var halfWidth = Math.floor(width / 2);
+      var height = ctx.canvas.height;
+      var halfHeight = Math.floor(height / 2);
+      ctx.fillStyle = "rgba(255, 0, 0, 1)";
+      ctx.fillRect(0, 0, halfWidth, halfHeight);
+      ctx.fillStyle = "rgba(255, 0, 0, 0.5)";
+      ctx.fillRect(halfWidth, 0, halfWidth, halfHeight);
+      ctx.fillStyle = "rgba(0, 255, 0, 1)";
+      ctx.fillRect(0, halfHeight, halfWidth, halfHeight);
+      ctx.fillStyle = "rgba(0, 255, 0, 0.5)";
+      ctx.fillRect(halfWidth, halfHeight, halfWidth, halfHeight);
+    }
+
+    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY, premultiplyAlpha)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
+              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
               ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Enable writes to the RGBA channels
@@ -109,8 +135,20 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             }
         }
 
-        var topColor = flipY ? redColor : greenColor;
-        var bottomColor = flipY ? greenColor : redColor;
+        var width = gl.canvas.width;
+        var halfWidth = Math.floor(width / 2);
+        var quaterWidth = Math.floor(halfWidth / 2);
+        var height = gl.canvas.height;
+        var halfHeight = Math.floor(height / 2);
+        var quaterHeight = Math.floor(halfHeight / 2);
+
+        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
+        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
+
+        var tl = redColor;
+        var tr = premultiplyAlpha ? halfRedColor : redColor;
+        var bl = greenColor;
+        var br = premultiplyAlpha ? halfGreenColor : greenColor;
 
         var loc;
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
@@ -126,10 +164,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
             // Check a few pixels near the top and bottom and make sure they have
             // the right color.
-            debug("Checking lower left corner");
-            wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor, "shouldBe " + bottomColor);
-            debug("Checking upper left corner");
-            wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor, "shouldBe " + topColor);
+            var tolerance = 10;
+            debug("Checking " + (flipY ? "top" : "bottom"));
+            wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
+            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
+            debug("Checking " + (flipY ? "bottom" : "top"));
+            wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
+            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
         }
     }
 
@@ -155,9 +196,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         ];
 
         for (var i in cases) {
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.defaultOption, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipY, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipY, true);
+            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.defaultOption, false, true);
+            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYPremul, false, true);
+            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYUnpremul, false, false);
+            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYPremul, true, true);
+            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYUnpremul, true, false);
         }
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -26,6 +26,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
+    var halfRedColor = [128, 0, 0];
+    var halfGreenColor = [0, 128, 0];
     var redColor = [255, 0, 0];
     var greenColor = [0, 255, 0];
     var bitmaps = [];
@@ -62,13 +64,18 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
         var p1 = createImageBitmap(testCanvas).then(function(imageBitmap) { bitmaps.minDefaultOption = imageBitmap });
-        var p2 = createImageBitmap(testCanvas, {imageOrientation: "none"}).then(function(imageBitmap) { bitmaps.minNoFlipY = imageBitmap });
-        var p3 = createImageBitmap(testCanvas, {imageOrientation: "flipY"}).then(function(imageBitmap) { bitmaps.minFlipY = imageBitmap });
+        var p2 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.minNoFlipYPremul = imageBitmap });
+        var p3 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.minNoFlipYUnpremul = imageBitmap });
+        var p4 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.minFlipYPremul = imageBitmap });
+        var p5 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.minFlipYUnpremul = imageBitmap });
+
         setCanvasTo257x257(ctx);
-        var p4 = createImageBitmap(testCanvas).then(function(imageBitmap) { bitmaps.bigDefaultOption = imageBitmap });
-        var p5 = createImageBitmap(testCanvas, {imageOrientation: "none"}).then(function(imageBitmap) { bitmaps.bigNoFlipY = imageBitmap });
-        var p6 = createImageBitmap(testCanvas, {imageOrientation: "flipY"}).then(function(imageBitmap) { bitmaps.bigFlipY = imageBitmap });
-        Promise.all([p1, p2, p3, p4, p5, p6]).then(function() {
+        var p6 = createImageBitmap(testCanvas).then(function(imageBitmap) { bitmaps.bigDefaultOption = imageBitmap });
+        var p7 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.bigNoFlipYPremul = imageBitmap });
+        var p8 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.bigNoFlipYUnpremul = imageBitmap });
+        var p9 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.bigFlipYPremul = imageBitmap });
+        var p10 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.bigFlipYUnpremul = imageBitmap });
+        Promise.all([p1, p2, p3, p4, p5, p6, p7, p8, p9, p10]).then(function() {
             runTest();
         }, function() {
             // createImageBitmap with options could be rejected if it is not supported
@@ -79,12 +86,17 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function setCanvasToRedGreen(ctx) {
         var width = ctx.canvas.width;
+        var halfWidth = Math.floor(width / 2);
         var height = ctx.canvas.height;
         var halfHeight = Math.floor(height / 2);
-        ctx.fillStyle = "#ff0000";
-        ctx.fillRect(0, 0, width, halfHeight);
-        ctx.fillStyle = "#00ff00";
-        ctx.fillRect(0, halfHeight, width, height - halfHeight);
+        ctx.fillStyle = "rgba(255, 0, 0, 1)";
+        ctx.fillRect(0, 0, halfWidth, halfHeight);
+        ctx.fillStyle = "rgba(255, 0, 0, 0.5)";
+        ctx.fillRect(halfWidth, 0, halfWidth, halfHeight);
+        ctx.fillStyle = "rgba(0, 255, 0, 1)";
+        ctx.fillRect(0, halfHeight, halfWidth, halfHeight);
+        ctx.fillStyle = "rgba(0, 255, 0, 0.5)";
+        ctx.fillRect(halfWidth, halfHeight, halfWidth, halfHeight);
     }
 
     function setCanvasToMin(ctx) {
@@ -99,9 +111,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         setCanvasToRedGreen(ctx);
     }
 
-    function runOneIteration(bindingTarget, program, bitmap, flipY)
+    function runOneIteration(bindingTarget, program, bitmap, flipY, premultiplyAlpha)
     {
-        debug('Testing ' + ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
+        debug('Testing ' + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
+              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Enable writes to the RGBA channels
         //gl.colorMask(1, 1, 1, 0);
@@ -120,20 +133,32 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
 
         var width = gl.canvas.width;
+        var halfWidth = Math.floor(width / 2);
+        var quaterWidth = Math.floor(halfWidth / 2);
         var height = gl.canvas.height;
         var halfHeight = Math.floor(height / 2);
-        var top = flipY ? 0 : (height - halfHeight);
-        var bottom = flipY ? (height - halfHeight) : 0;
+        var quaterHeight = Math.floor(halfHeight / 2);
+
+        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
+        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
+
+        var tl = redColor;
+        var tr = premultiplyAlpha ? halfRedColor : redColor;
+        var bl = greenColor;
+        var br = premultiplyAlpha ? halfGreenColor : greenColor;
 
         // Draw the triangles
         wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
 
         // Check the top pixel and bottom pixel and make sure they have
         // the right color.
+        var tolerance = 10;
         debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, redColor, "shouldBe " + redColor);
+        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
+        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
         debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, 0, top, width, halfHeight, greenColor, "shouldBe " + greenColor);
+        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
+        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
     }
 
     function runTest()
@@ -148,12 +173,16 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     }
 
     function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program, bitmaps.minDefaultOption, false);
-        runOneIteration(bindingTarget, program, bitmaps.minNoFlipY, false);
-        runOneIteration(bindingTarget, program, bitmaps.minFlipY, true);
-        runOneIteration(bindingTarget, program, bitmaps.bigDefaultOption, false);
-        runOneIteration(bindingTarget, program, bitmaps.bigNoFlipY, false);
-        runOneIteration(bindingTarget, program, bitmaps.bigFlipY, true);
+        runOneIteration(bindingTarget, program, bitmaps.bigDefaultOption, false, true);
+        runOneIteration(bindingTarget, program, bitmaps.bigNoFlipYPremul, false, true);
+        runOneIteration(bindingTarget, program, bitmaps.bigNoFlipYUnpremul, false, false);
+        runOneIteration(bindingTarget, program, bitmaps.bigFlipYPremul, true, true);
+        runOneIteration(bindingTarget, program, bitmaps.bigFlipYUnpremul, true, false);
+        runOneIteration(bindingTarget, program, bitmaps.minDefaultOption, false, true);
+        runOneIteration(bindingTarget, program, bitmaps.minNoFlipYPremul, false, true);
+        runOneIteration(bindingTarget, program, bitmaps.minNoFlipYUnpremul, false, false);
+        runOneIteration(bindingTarget, program, bitmaps.minFlipYPremul, true, true);
+        runOneIteration(bindingTarget, program, bitmaps.minFlipYUnpremul, true, false);
     }
 
     return init;


### PR DESCRIPTION
Using HTMLCanvasElement as example, I set canvas to be rgba(255, 0, 0, 0.5) and create an ImageBitmap from it. When premultiplyAlpha=default, the color we see should be somewhere around 128 (usually won't be exactly 128 because of rounding error). Now if we create an ImageBitmap from it with premultiplyAlpha=false, we should see solid red color.

In the case of HTMLImageElement, I use canvas.toDataURL to obtain an img element and create ImageBitmap from it.

Locally conformance tests all pass, the tests always fail for 7 format under conformance2:
r8_red_unsigned_byte
r16f_red_half_float
r16f_red_float
r32f_red_float
r8ui_red_integer_unsigned_byte
srgb8_rgb_unsigned_byte
srgb8_alpha8_rgba_unsigned_byte

I don't know exactly why these 7 format failed, but will investigate later. What I plan to do next is to add new tests for ImageBitmap created from a Blob and from an ImageBitmap. After that, we have full coverage for all valid sources.

Please review. @kenrussell @zhenyao @toji 