### PR TITLE
Deleted buffer should be invalid

### DIFF
--- a/sdk/tests/conformance/extensions/oes-vertex-array-object.html
+++ b/sdk/tests/conformance/extensions/oes-vertex-array-object.html
@@ -532,8 +532,10 @@ function runDeleteTests() {
     for (var ii = 0; ii < colorBuffers.length; ++ii) {
       gl.deleteBuffer(colorBuffers[ii]);
       gl.deleteBuffer(elementBuffers[ii]);
+      ext.bindVertexArrayOES(vaos[ii]);
+      var boundBuffer = gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
       // The buffers should still be valid at this point, since it was attached to the VAO
-      if(!gl.isBuffer(colorBuffers[ii])) {
+      if(boundBuffer != colorBuffers[ii]) {
         testFailed("buffer removed even though it is still attached to a VAO");
       }
     }

--- a/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
+++ b/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
@@ -478,8 +478,10 @@ function runDeleteTests() {
     for (var ii = 0; ii < colorBuffers.length; ++ii) {
       gl.deleteBuffer(colorBuffers[ii]);
       gl.deleteBuffer(elementBuffers[ii]);
+      gl.bindVertexArray(vaos[ii]);
+      var boundBuffer = gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
       // The buffers should still be valid at this point, since it was attached to the VAO
-      if(!gl.isBuffer(colorBuffers[ii])) {
+      if(boundBuffer != colorBuffers[ii]) {
         testFailed("buffer removed too early");
       }
     }


### PR DESCRIPTION
When a buffer is deleted, its name immediately becomes invalid. But the
underlying container which the deleted buffer is attached to may
continue using the object (page 315 ES spec 3.0.4).