### PR TITLE
Experimental: Please do not merge

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
@@ -27,6 +27,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var gl = null;
     var successfullyParsed = false;
     var imageData = null;
+    var halfRedColor = [128, 0, 0];
+    var halfGreenColor = [0, 128, 0];
     var blackColor = [0, 0, 0];
     var redColor = [255, 0, 0];
     var greenColor = [0, 255, 0];
@@ -66,7 +68,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         data[4] = 255;
         data[5] = 0;
         data[6] = 0;
-        data[7] = 0;
+        data[7] = 128;
         data[8] = 0;
         data[9] = 255;
         data[10] = 0;
@@ -74,7 +76,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         data[12] = 0;
         data[13] = 255;
         data[14] = 0;
-        data[15] = 0;
+        data[15] = 128;
 
         runTest();
     }
@@ -126,9 +128,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var bottom = flipY ? (height - halfHeight) : 0;
 
         var tl = redColor;
-        var tr = premultiplyAlpha ? blackColor : redColor;
+        var tr = premultiplyAlpha ? halfRedColor : redColor;
         var bl = greenColor;
-        var br = premultiplyAlpha ? blackColor : greenColor;
+        var br = premultiplyAlpha ? halfGreenColor : greenColor;
 
         var loc;
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {


### PR DESCRIPTION
This is a better example than the previous one.

What I did here is changing the "tex-image-and-sub-image-2d-with-image-data.js", and set two pixels in the ImageData to be alpha=128 instead of 0. In this case, when the pixel store parameter of premultiplyAlpha=true, the expected color should be very close to 128.

Here is what I get locally:
rgb_rgb_unsigned_short_5_6_5: [132, 0, 0]
rgba_rgba_unsigned_short_4_4_4_4: [136, 0, 0]
rgba_rgba_unsigned_short_5_5_5_1: [132, 0, 0]

PTAL. @kenrussell @zhenyao 