### PR TITLE
Backport: Deleted buffer should be invalid

### DIFF
--- a/conformance-suites/1.0.2/conformance/extensions/oes-vertex-array-object.html
+++ b/conformance-suites/1.0.2/conformance/extensions/oes-vertex-array-object.html
@@ -532,8 +532,10 @@ function runDeleteTests() {
     for (var ii = 0; ii < colorBuffers.length; ++ii) {
       gl.deleteBuffer(colorBuffers[ii]);
       gl.deleteBuffer(elementBuffers[ii]);
+      ext.bindVertexArrayOES(vaos[ii]);
+      var boundBuffer = gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
       // The buffers should still be valid at this point, since it was attached to the VAO
-      if(!gl.isBuffer(colorBuffers[ii])) {
+      if(boundBuffer != colorBuffers[ii]) {
         testFailed("buffer removed too early");
       }
     }

--- a/conformance-suites/1.0.3/conformance/extensions/oes-vertex-array-object.html
+++ b/conformance-suites/1.0.3/conformance/extensions/oes-vertex-array-object.html
@@ -532,8 +532,10 @@ function runDeleteTests() {
     for (var ii = 0; ii < colorBuffers.length; ++ii) {
       gl.deleteBuffer(colorBuffers[ii]);
       gl.deleteBuffer(elementBuffers[ii]);
+      ext.bindVertexArrayOES(vaos[ii]);
+      var boundBuffer = gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
       // The buffers should still be valid at this point, since it was attached to the VAO
-      if(!gl.isBuffer(colorBuffers[ii])) {
+      if(boundBuffer != colorBuffers[ii]) {
         testFailed("buffer removed even though it is still attached to a VAO");
       }
     }


### PR DESCRIPTION
When a buffer is deleted, its name immediately becomes invalid. But the
underlying container which the deleted buffer is attached to may
continue using the object.