### PR TITLE
Add a helpful post-commit hook for spec editing

### DIFF
--- a/other/post-commit
+++ b/other/post-commit
@@ -1,0 +1,38 @@
+#!/bin/sh
+#
+# Copyright (c) 2016 The Khronos Group Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and/or associated documentation files (the
+# "Materials"), to deal in the Materials without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Materials, and to
+# permit persons to whom the Materials are furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Materials.
+#
+# THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+against=HEAD~1
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Check that spec is not updated without updating the date
+if test $(git diff --cached --name-status -z $against -- "specs/latest/*/index.html" | wc -c) != 0 &&
+	test $(git diff --cached -z $against -- "specs/latest/*/index.html" | grep "Editor's Draft" | wc -c) = 0
+then
+	echo "${RED}Warning: Edited spec without changing the date.${NC}"
+	exit 1
+fi


### PR DESCRIPTION
The hook notifies the user if they've changed
specs/latest/*/index.html files but haven't changed the line with the
date, identified by the "Editor's Draft" string in the script.

It's implemented as a post-commit hook so it also runs on git commit
--amend. Users should link or copy it to their .git/hooks/ directory.