### PR TITLE
Handle 32bit integer multiplication overflow

### DIFF
--- a/sdk/tests/deqp/framework/delibs/debase/deMath.js
+++ b/sdk/tests/deqp/framework/delibs/debase/deMath.js
@@ -568,6 +568,19 @@ deMath.split32 = function(x) {
 };
 
 /**
+ * Split a signed number's low 32bit dwords into low and high 16bit dwords.
+ * @param {number} x
+ * @return {Array<number>}
+ */
+deMath.split16 = function(x) {
+    var ret = [];
+    x = x & 0xffffffff;
+    ret[1] = Math.floor(x / 0x10000);
+    ret[0] = x - ret[1] * 0x10000;
+    return ret;
+};
+
+/**
  * Recontruct a number from high and low 32 bit dwords
  * @param {Array<number>} x
  * @return {number}

--- a/sdk/tests/deqp/functional/gles3/es3fShaderPrecisionTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderPrecisionTests.js
@@ -46,6 +46,18 @@ goog.scope(function() {
 	es3fShaderPrecisionTests.add = function(a, b) { return a + b; };
 	es3fShaderPrecisionTests.sub = function(a, b) { return a - b; };
 	es3fShaderPrecisionTests.mul = function(a, b) { return a * b; };
+	// a * b = (a1 * 2^16 + a0) * (b1 * 2^16 + b0) = a1 * b1 * 2^32 + (a0 * b1 + a1 * b0) * 2^16 + a0 * b0
+	// 32bit integer multiplication may overflow in JavaScript. Only return low 32bit of the result.
+	es3fShaderPrecisionTests.mul32 = function(a, b) {
+	  var sign = Math.sign(a) * Math.sign(b);
+	  a = Math.abs(a);
+	  b = Math.abs(b);
+	  var a1 = deMath.split16(a)[1];
+	  var a0 = deMath.split16(a)[0];
+	  var b1 = deMath.split16(b)[1];
+	  var b0 = deMath.split16(b)[0];
+	  return sign * ((a0 * b1 + a1 * b0) * 0x10000 + a0 * b0);
+	}
 	es3fShaderPrecisionTests.div = function(a, b) { if (b !== 0) return a / b; else throw new Error('division by zero.')};
 
     /**
@@ -818,7 +830,7 @@ goog.scope(function() {
         /** @type {Array<IntCase>} */ var intCases = [
             new IntCase('highp_add', 'in0 + in1', es3fShaderPrecisionTests.add, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32I, fullRange32I),
             new IntCase('highp_sub', 'in0 - in1', es3fShaderPrecisionTests.sub, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32I, fullRange32I),
-            new IntCase('highp_mul', 'in0 * in1', es3fShaderPrecisionTests.mul, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32I, fullRange32I),
+            new IntCase('highp_mul', 'in0 * in1', es3fShaderPrecisionTests.mul32, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32I, fullRange32I),
             new IntCase('highp_div', 'in0 / in1', es3fShaderPrecisionTests.div, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32I, [-10000, -1]),
             new IntCase('mediump_add', 'in0 + in1', es3fShaderPrecisionTests.add, gluShaderUtil.precision.PRECISION_MEDIUMP, 16, fullRange16I, fullRange16I),
             new IntCase('mediump_sub', 'in0 - in1', es3fShaderPrecisionTests.sub, gluShaderUtil.precision.PRECISION_MEDIUMP, 16, fullRange16I, fullRange16I),
@@ -854,7 +866,7 @@ goog.scope(function() {
         /** @type {Array<UintCase>} */ var uintCases = [
             new UintCase('highp_add', 'in0 + in1', es3fShaderPrecisionTests.add, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32U, fullRange32U),
             new UintCase('highp_sub', 'in0 - in1', es3fShaderPrecisionTests.sub, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32U, fullRange32U),
-            new UintCase('highp_mul', 'in0 * in1', es3fShaderPrecisionTests.mul, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32U, fullRange32U),
+            new UintCase('highp_mul', 'in0 * in1', es3fShaderPrecisionTests.mul32, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32U, fullRange32U),
             new UintCase('highp_div', 'in0 / in1', es3fShaderPrecisionTests.div, gluShaderUtil.precision.PRECISION_HIGHP, 32, fullRange32U, [1, 10000]),
             new UintCase('mediump_add', 'in0 + in1', es3fShaderPrecisionTests.add, gluShaderUtil.precision.PRECISION_MEDIUMP, 16, fullRange16U, fullRange16U),
             new UintCase('mediump_sub', 'in0 - in1', es3fShaderPrecisionTests.sub, gluShaderUtil.precision.PRECISION_MEDIUMP, 16, fullRange16U, fullRange16U),


### PR DESCRIPTION
Max safe integer number is 2^53 -1 in JS. Two 32bit integer
multiplication may overflow. Just return correct low 32bit of the
result which is same method used in C++. This fixes
deqp/functional/gles3/shaderprecision.html.