### PR TITLE
Add test for ANGLE ambiguous function call bug

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 1.0.4 angle-ambiguous-function-call.html
 --min-version 1.0.4 angle-constructor-invalid-parameters.html
 --min-version 1.0.3 angle-d3d11-compiler-error.html
 --min-version 1.0.3 angle-dx-variable-bug.html

--- a/sdk/tests/conformance/glsl/bugs/angle-ambiguous-function-call.html
+++ b/sdk/tests/conformance/glsl/bugs/angle-ambiguous-function-call.html
@@ -1,0 +1,70 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>ANGLE ambiguous function call test</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderAmbiguousHLSLFunctionCall" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec4 uv;
+uniform mat2 um;
+vec4 foo(vec4 v) {
+    return v;
+}
+vec4 foo(mat2 m) {
+    return vec4(m);
+}
+void main()
+{
+    gl_FragColor = foo(uv) + foo(um);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Test overloaded functions with vec4 and mat2 parameters that have had issues in ANGLE. Issues were due to HLSL compiler treating float4 and float2x2 as the same type when resolving which overloaded function to call.");
+
+GLSLConformanceTester.runTests([
+{
+  fShaderId: 'fshaderAmbiguousHLSLFunctionCall',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Disambiguate correctly between overloaded function calls"
+}
+]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
HLSL compiler can't resolve between float4 and float2x2 parameters
when determining which overloaded function is being called. ANGLE
exposes this property to ESSL, but ESSL should be able to resolve
which function is being called in this case. Add a test for this.