### PR TITLE
Test the deletion of buffers that are attached to the currently bound VAO

### DIFF
--- a/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
+++ b/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
@@ -476,17 +476,22 @@ function runDeleteTests() {
     // delete the color buffers AND the position buffer.
     gl.bindVertexArray(null);
     for (var ii = 0; ii < colorBuffers.length; ++ii) {
-      gl.deleteBuffer(colorBuffers[ii]);
-      gl.deleteBuffer(elementBuffers[ii]);
       gl.bindVertexArray(vaos[ii]);
-      var boundBuffer = gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
+
+      gl.deleteBuffer(colorBuffers[ii]);
+      gl.deleteBuffer(positionBuffer);
+
       // The buffers should still be valid at this point, since it was attached to the VAO
-      if(boundBuffer != colorBuffers[ii]) {
+      var boundPositionBuffer = gl.getVertexAttrib(0, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
+      if(boundPositionBuffer != positionBuffer) { 
+        testFailed("buffer removed too early");
+      }
+      var boundColorBuffer = gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
+      if(boundColorBuffer != colorBuffers[ii]) { 
         testFailed("buffer removed too early");
       }
     }
-    gl.deleteBuffer(positionBuffer);
-
+	
     // Render with the deleted buffers. As they are referenced by VAOs they
     // must still be around.
     for (var ii = 0; ii < colors.length; ++ii) {
@@ -504,7 +509,7 @@ function runDeleteTests() {
     for (var ii = 0; ii < colorBuffers.length; ++ii) {
       // The buffers should no longer be valid now that the VAOs are deleted
       if(gl.isBuffer(colorBuffers[ii])) {
-        testFailed("buffer not properly cleaned up after VAO deletion");
+        testFailed("Color buffer not properly cleaned up after VAO deletion");
       }
     }
 }


### PR DESCRIPTION
We want to bind the VAO before deleting the buffers. This means the deleteBuffer calls are attempting to delete the buffers currently attached to the VAO. In this case, the spec mandates that the underlying object should not be deleted, as they are still in use. The previous code was always deleting buffers that were not attached to the current VAO. This change exposes bugs in both Chrome and Firefox.