### PR TITLE
Only delete buffers that are not bound in the current context

### DIFF
--- a/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
+++ b/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
@@ -485,6 +485,7 @@ function runDeleteTests() {
         testFailed("buffer removed too early");
       }
     }
+    gl.bindVertexArray(null);
     gl.deleteBuffer(positionBuffer);
 
     // Render with the deleted buffers. As they are referenced by VAOs they


### PR DESCRIPTION
When the loop ends, vao[2] is bound to the current context, so when we delete the position buffer, it should be unbound, and therefore unusable in the subsequent draw call for vao[2]. Since all VAOs have a position buffer attached, we bind null before deleting the position buffer, so that all VAOs still have a bound position buffer for the draw call.
