### PR TITLE
Restructure ImageBitmap tests

### DIFF
--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r32f-red-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg32f-rg-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb32f-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba32f-rgba-float.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,6 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
@@ -52,7 +52,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            generateImageBitmap(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         }
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
@@ -26,11 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var halfRedColor = [128, 0, 0];
-    var halfGreenColor = [0, 128, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -48,15 +43,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -66,117 +52,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            var p1 = createImageBitmap(blob, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-            var p2 = createImageBitmap(blob, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-            var p3 = createImageBitmap(blob, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-            var p4 = createImageBitmap(blob, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-            Promise.all([p1, p2, p3, p4]).then(function() {
-                runTest();
-            }, function() {
-                // createImageBitmap with options could be rejected if it is not supported
-                finishTest();
-                return;
-            });
-        }
-    }
-
-    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        var targets = [gl.TEXTURE_2D];
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
-        }
-        // Upload the image into the texture
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (useTexSubImage2D) {
-                // Initialize the texture to black first
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], bitmap.width, bitmap.height, 0,
-                              gl[pixelFormat], gl[pixelType], null);
-                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-            } else {
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
-            }
-        }
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var quaterWidth = Math.floor(halfWidth / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-        var quaterHeight = Math.floor(halfHeight / 2);
-
-        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? halfRedColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? halfGreenColor : greenColor;
-
-        var loc;
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            loc = gl.getUniformLocation(program, "face");
-        }
-
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-                gl.uniform1i(loc, targets[tt]);
-            }
-            // Draw the triangles
-            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-            // Check a few pixels near the top and bottom and make sure they have
-            // the right color.
-            var tolerance = 8;
-            debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-            debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
-        }
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D, program);
-        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        var cases = [
-            { sub: false },
-            { sub: true },
-        ];
-
-        for (var i in cases) {
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYPremul, false, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYUnpremul, false, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYPremul, true, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYUnpremul, true, false);
+            generateImageBitmap(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            finishTest();
         }
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
@@ -26,11 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var halfRedColor = [128, 0, 0];
-    var halfGreenColor = [0, 128, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -48,38 +43,17 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        var p1 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.minNoFlipYPremul = imageBitmap });
-        var p2 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.minNoFlipYUnpremul = imageBitmap });
-        var p3 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.minFlipYPremul = imageBitmap });
-        var p4 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.minFlipYUnpremul = imageBitmap });
+        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
 
-        setCanvasTo257x257(ctx);
-        var p5 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.bigNoFlipYPremul = imageBitmap });
-        var p6 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.bigNoFlipYUnpremul = imageBitmap });
-        var p7 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.bigFlipYPremul = imageBitmap });
-        var p8 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.bigFlipYUnpremul = imageBitmap });
-        Promise.all([p1, p2, p3, p4, p5, p6, p7, p8]).then(function() {
-            runTest();
-        }, function() {
-            // createImageBitmap with options could be rejected if it is not supported
-            finishTest();
-            return;
-        });
+        setCanvasTo256x256(ctx);
+        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        finishTest();
     }
 
     function setCanvasToRedGreen(ctx) {
@@ -103,116 +77,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         setCanvasToRedGreen(ctx);
     }
 
-    function setCanvasTo257x257(ctx) {
-        ctx.canvas.width = 257;
-        ctx.canvas.height = 257;
+    function setCanvasTo256x256(ctx) {
+        ctx.canvas.width = 256;
+        ctx.canvas.height = 256;
         setCanvasToRedGreen(ctx);
-    }
-
-    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        //gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-        var targets = [gl.TEXTURE_2D];
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
-        }
-        // Upload the image into the texture
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (useTexSubImage2D) {
-                // Initialize the texture to black first
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], bitmap.width, bitmap.height, 0,
-                              gl[pixelFormat], gl[pixelType], null);
-                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-            } else {
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
-            }
-        }
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var quaterWidth = Math.floor(halfWidth / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-        var quaterHeight = Math.floor(halfHeight / 2);
-
-        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? halfRedColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? halfGreenColor : greenColor;
-
-        var loc;
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            loc = gl.getUniformLocation(program, "face");
-        }
-
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-                gl.uniform1i(loc, targets[tt]);
-            }
-            // Draw the triangles
-            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-            // Check the top pixel and bottom pixel and make sure they have
-            // the right color.
-            var tolerance = 10;
-            debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-            debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
-        }
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D, program);
-        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        var cases = [
-            { sub: false },
-            { sub: true },
-        ];
-
-        for (var i in cases) {
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.bigNoFlipYPremul, false, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.bigNoFlipYUnpremul, false, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.bigFlipYPremul, true, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.bigFlipYUnpremul, true, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.minNoFlipYPremul, false, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.minNoFlipYUnpremul, false, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.minFlipYPremul, true, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.minFlipYUnpremul, true, false);
-        }
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
@@ -49,10 +49,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
 
-        setCanvasTo256x256(ctx);
-        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        setCanvasTo257x257(ctx);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         finishTest();
     }
 
@@ -77,9 +77,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         setCanvasToRedGreen(ctx);
     }
 
-    function setCanvasTo256x256(ctx) {
-        ctx.canvas.width = 256;
-        ctx.canvas.height = 256;
+    function setCanvasTo257x257(ctx) {
+        ctx.canvas.width = 257;
+        ctx.canvas.height = 257;
         setCanvasToRedGreen(ctx);
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
@@ -56,7 +56,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
             // bitmap is in unpremultiplied form
-            generateImageBitmap(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         });
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
@@ -26,10 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var blackColor = [0, 0, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -47,15 +43,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
         gl.disable(gl.BLEND);
@@ -67,128 +54,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        var bitmap1; // bitmap1 will be in premultiplied format
-        var bitmap2; // bitmap2 will be in unpremultiplied format
-        var p1 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmap1 = imageBitmap });
-        var p2 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmap2 = imageBitmap });
-
-        Promise.all([p1, p2]).then(function() {
-            // Now create new ImageBitmaps from the above two ImageBitmaps.
-            var p3 = createImageBitmap(bitmap1, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul1 = imageBitmap });
-            var p4 = createImageBitmap(bitmap1, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul1 = imageBitmap });
-            var p5 = createImageBitmap(bitmap2, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul2 = imageBitmap });
-            var p6 = createImageBitmap(bitmap2, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul2 = imageBitmap });
-            var p7 = createImageBitmap(bitmap2, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul2 = imageBitmap });
-            var p8 = createImageBitmap(bitmap2, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul2 = imageBitmap });
-            Promise.all([p3, p4, p5, p6, p7, p8]).then(function() {
-                runTest();
-            }, function() {
-                finishTest();
-                return;
-            });
-        }, function() {
+        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
+            // bitmap is in unpremultiplied form
+            generateImageBitmap(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
-            return;
         });
-    }
-
-    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        var targets = [gl.TEXTURE_2D];
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
-        }
-        // Upload the image into the texture
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (useTexSubImage2D) {
-                // Initialize the texture to black first
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], bitmap.width, bitmap.height, 0,
-                              gl[pixelFormat], gl[pixelType], null);
-                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-            } else {
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
-            }
-        }
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-
-        var top = flipY ? 0 : (height - halfHeight);
-        var bottom = flipY ? (height - halfHeight) : 0;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? blackColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? blackColor : greenColor;
-
-        var loc;
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            loc = gl.getUniformLocation(program, "face");
-        }
-
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-                gl.uniform1i(loc, targets[tt]);
-            }
-            // Draw the triangles
-            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-            // Check the top pixel and bottom pixel and make sure they have
-            // the right color.
-            debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, 0, bottom, halfWidth, halfHeight, tl, "shouldBe " + tl);
-            wtu.checkCanvasRect(gl, halfWidth, bottom, halfWidth, halfHeight, tr, "shouldBe " + tr);
-            debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, 0, top, halfWidth, halfHeight, bl, "shouldBe " + bl);
-            wtu.checkCanvasRect(gl, halfWidth, top, halfWidth, halfHeight, br, "shouldBe " + br);
-        }
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D, program);
-        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        var cases = [
-            { sub: false },
-            { sub: true },
-        ];
-
-        for (var i in cases) {
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYPremul1, false, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYPremul1, true, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYPremul2, false, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYPremul2, true, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYUnpremul2, false, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYUnpremul2, true, false);
-        }
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -26,10 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var blackColor = [0, 0, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -47,15 +43,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
         gl.disable(gl.BLEND);
@@ -67,114 +54,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        var p1 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-        var p2 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-        var p3 = createImageBitmap(imageData, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-        var p4 = createImageBitmap(imageData, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-        Promise.all([p1, p2, p3, p4]).then(function() {
-            runTest();
-        }, function() {
-            // createImageBitmap with options could be rejected if it is not supported
-            finishTest();
-            return;
-        });
-    }
-
-    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        var targets = [gl.TEXTURE_2D];
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
-        }
-        // Upload the image into the texture
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (useTexSubImage2D) {
-                // Initialize the texture to black first
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], bitmap.width, bitmap.height, 0,
-                              gl[pixelFormat], gl[pixelType], null);
-                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-            } else {
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
-            }
-        }
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-
-        var top = flipY ? 0 : (height - halfHeight);
-        var bottom = flipY ? (height - halfHeight) : 0;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? blackColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? blackColor : greenColor;
-
-        var loc;
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            loc = gl.getUniformLocation(program, "face");
-        }
-
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-                gl.uniform1i(loc, targets[tt]);
-            }
-            // Draw the triangles
-            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-            // Check the top pixel and bottom pixel and make sure they have
-            // the right color.
-            debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, 0, bottom, halfWidth, halfHeight, tl, "shouldBe " + tl);
-            wtu.checkCanvasRect(gl, halfWidth, bottom, halfWidth, halfHeight, tr, "shouldBe " + tr);
-            debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, 0, top, halfWidth, halfHeight, bl, "shouldBe " + bl);
-            wtu.checkCanvasRect(gl, halfWidth, top, halfWidth, halfHeight, br, "shouldBe " + br);
-        }
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D, program);
-        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+        generateImageBitmap(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        var cases = [
-            { sub: false },
-            { sub: true },
-        ];
-
-        for (var i in cases) {
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYPremul, false, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYUnpremul, false, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYPremul, true, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYUnpremul, true, false);
-        }
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -54,7 +54,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        generateImageBitmap(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         finishTest();
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -26,11 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var halfRedColor = [128, 0, 0];
-    var halfGreenColor = [0, 128, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -48,133 +43,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
         var image = new Image();
         image.onload = function() {
-            var p1 = createImageBitmap(image, {imageOrientation: "none", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-            var p2 = createImageBitmap(image, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-            var p3 = createImageBitmap(image, {imageOrientation: "flipY", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-            var p4 = createImageBitmap(image, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-            Promise.all([p1, p2, p3, p4]).then(function() {
-                runTest();
-            }, function() {
-                // createImageBitmap with options could be rejected if it is not supported
-                finishTest();
-                return;
-            });
+            generateImageBitmap(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            finishTest();
         }
         image.src = resourcePath + "red-green-semi-transparent.png";
-    }
-
-    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        var targets = [gl.TEXTURE_2D];
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
-        }
-        // Upload the image into the texture
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (useTexSubImage2D) {
-                // Initialize the texture to black first
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], bitmap.width, bitmap.height, 0,
-                              gl[pixelFormat], gl[pixelType], null);
-                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-            } else {
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
-            }
-        }
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var quaterWidth = Math.floor(halfWidth / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-        var quaterHeight = Math.floor(halfHeight / 2);
-
-        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? halfRedColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? halfGreenColor : greenColor;
-
-        var loc;
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            loc = gl.getUniformLocation(program, "face");
-        }
-
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-                gl.uniform1i(loc, targets[tt]);
-            }
-            // Draw the triangles
-            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-            // Check a few pixels near the top and bottom and make sure they have
-            // the right color.
-            var tolerance = 8;
-            debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-            debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
-        }
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D, program);
-        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        var cases = [
-            { sub: false },
-            { sub: true },
-        ];
-
-        for (var i in cases) {
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYPremul, false, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipYUnpremul, false, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYPremul, true, true);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipYUnpremul, true, false);
-        }
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -48,7 +48,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var image = new Image();
         image.onload = function() {
-            generateImageBitmap(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         }
         image.src = resourcePath + "red-green-semi-transparent.png";

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -26,9 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -46,120 +43,16 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
         var video = document.createElement("video");
         video.oncanplaythrough = function() {
-            var p1 = createImageBitmap(video, {imageOrientation: "none"}).then(function(imageBitmap) { bitmaps.noFlipY = imageBitmap });
-            var p2 = createImageBitmap(video, {imageOrientation: "flipY"}).then(function(imageBitmap) { bitmaps.flipY = imageBitmap });
-            Promise.all([p1, p2]).then(function() {
-                runTest();
-            }, function() {
-                // createImageBitmap with options could be rejected if it is not supported
-                finishTest();
-                return;
-            });
+            generateImageBitmap(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            finishTest();
         }
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);
-    }
-
-    function runOneIteration(useTexSubImage2D, bindingTarget, program, bitmap, flipY)
-    {
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-        var targets = [gl.TEXTURE_2D];
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
-                       gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
-                       gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
-        }
-        // Upload the image into the texture
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (useTexSubImage2D) {
-                // Initialize the texture to black first
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], bitmap.width, bitmap.height, 0,
-                              gl[pixelFormat], gl[pixelType], null);
-                gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-            } else {
-                gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
-            }
-        }
-
-        var topColor = flipY ? redColor : greenColor;
-        var bottomColor = flipY ? greenColor : redColor;
-
-        var loc;
-        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-            loc = gl.getUniformLocation(program, "face");
-        }
-
-        for (var tt = 0; tt < targets.length; ++tt) {
-            if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-                gl.uniform1i(loc, targets[tt]);
-            }
-            // Draw the triangles
-            wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-            // Check a few pixels near the top and bottom and make sure they have
-            // the right color.
-            debug("Checking lower left corner");
-            wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor, "shouldBe " + bottomColor);
-            debug("Checking upper left corner");
-            wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor, "shouldBe " + topColor);
-        }
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D, program);
-
-        // cube map texture must be square.
-        if (bitmaps.noFlipY.width == bitmaps.noFlipY.height) {
-            program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-            runTestOnBindingTarget(gl.TEXTURE_CUBE_MAP, program);
-        }
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        var cases = [
-            { sub: false },
-            { sub: true },
-        ];
-
-        for (var i in cases) {
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.noFlipY, false);
-            runOneIteration(cases[i].sub, bindingTarget, program, bitmaps.flipY, true);
-        }
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -48,7 +48,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var video = document.createElement("video");
         video.oncanplaythrough = function() {
-            generateImageBitmap(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         }
         video.src = resourcePath + "red-green.theora.ogv";

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js
@@ -135,7 +135,7 @@ function runTestOnBindingTargetImageBitmap(bindingTarget, program, bitmaps, opti
     }
 }
 
-function runImageBitmapTest(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
+function runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
 {
     var optionsVal = {alpha: alphaVal};
     var program = tiu.setupTexturedQuad(gl, internalFormat);
@@ -152,7 +152,7 @@ function runImageBitmapTest(bitmaps, alphaVal, internalFormat, pixelFormat, pixe
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
 }
 
-function generateImageBitmap(source, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
+function runImageBitmapTest(source, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
 {
     var bitmaps = [];
     var p1 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
@@ -160,7 +160,7 @@ function generateImageBitmap(source, alphaVal, internalFormat, pixelFormat, pixe
     var p3 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
     var p4 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
     Promise.all([p1, p2, p3, p4]).then(function() {
-        runImageBitmapTest(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
     }, function() {
         // createImageBitmap with options could be rejected if it is not supported
         finishTest();

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js
@@ -1,0 +1,169 @@
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+
+function runOneIterationImageBitmapTest(useTexSubImage2D, bindingTarget, program, bitmap, flipY, premultiplyAlpha, optionsVal,
+    internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
+{
+    var halfRed = [128, 0, 0];
+    var halfGreen = [0, 128, 0];
+    var redColor = [255, 0, 0];
+    var greenColor = [0, 255, 0];
+    var blackColor = [0, 0, 0];
+
+    switch (gl[pixelFormat]) {
+      case gl.RED:
+      case gl.RED_INTEGER:
+        greenColor = [0, 0, 0];
+        break;
+      default:
+        break;
+    }
+
+    debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
+          ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
+          ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    // Enable writes to the RGBA channels
+    gl.colorMask(1, 1, 1, 0);
+    var texture = gl.createTexture();
+    // Bind the texture to texture unit 0
+    gl.bindTexture(bindingTarget, texture);
+    // Set up texture parameters
+    gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+    var targets = [gl.TEXTURE_2D];
+    if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+        targets = [gl.TEXTURE_CUBE_MAP_POSITIVE_X,
+                   gl.TEXTURE_CUBE_MAP_NEGATIVE_X,
+                   gl.TEXTURE_CUBE_MAP_POSITIVE_Y,
+                   gl.TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                   gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
+                   gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
+    }
+    // Upload the image into the texture
+    for (var tt = 0; tt < targets.length; ++tt) {
+        if (useTexSubImage2D) {
+            // Initialize the texture to black first
+            gl.texImage2D(targets[tt], 0, gl[internalFormat], bitmap.width, bitmap.height, 0,
+                          gl[pixelFormat], gl[pixelType], null);
+            gl.texSubImage2D(targets[tt], 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
+        } else {
+            gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
+        }
+    }
+
+    var width = gl.canvas.width;
+    var halfWidth = Math.floor(width / 2);
+    var quaterWidth = Math.floor(halfWidth / 2);
+    var height = gl.canvas.height;
+    var halfHeight = Math.floor(height / 2);
+    var quaterHeight = Math.floor(halfHeight / 2);
+
+    var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
+    var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
+
+    var tl = redColor;
+    var tr = premultiplyAlpha ? ((optionsVal.alpha == 0.5) ? halfRed : (optionsVal.alpha == 1) ? redColor : blackColor) : redColor;
+    var bl = greenColor;
+    var br = premultiplyAlpha ? ((optionsVal.alpha == 0.5) ? halfGreen : (optionsVal.alpha == 1) ? greenColor : blackColor) : greenColor;
+
+    var loc;
+    if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+        loc = gl.getUniformLocation(program, "face");
+    }
+
+    var tolerance = 10;
+    for (var tt = 0; tt < targets.length; ++tt) {
+        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+            gl.uniform1i(loc, targets[tt]);
+        }
+        // Draw the triangles
+        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
+
+        // Check the top pixel and bottom pixel and make sure they have
+        // the right color.
+        debug("Checking " + (flipY ? "top" : "bottom"));
+        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
+        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
+        debug("Checking " + (flipY ? "bottom" : "top"));
+        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
+        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
+    }
+}
+
+function runTestOnBindingTargetImageBitmap(bindingTarget, program, bitmaps, optionsVal,
+    internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
+{
+    var cases = [
+        { sub: false, bitmap: bitmaps.noFlipYPremul, flipY: false, premultiply: true },
+        { sub: true, bitmap: bitmaps.noFlipYPremul, flipY: false, premultiply: true },
+        { sub: false, bitmap: bitmaps.noFlipYUnpremul, flipY: false, premultiply: false },
+        { sub: true, bitmap: bitmaps.noFlipYUnpremul, flipY: false, premultiply: false },
+        { sub: false, bitmap: bitmaps.flipYPremul, flipY: true, premultiply: true },
+        { sub: true, bitmap: bitmaps.flipYPremul, flipY: true, premultiply: true },
+        { sub: false, bitmap: bitmaps.flipYUnpremul, flipY: true, premultiply: false },
+        { sub: true, bitmap: bitmaps.flipYUnpremul, flipY: true, premultiply: false },
+    ];
+
+    for (var i in cases) {
+        runOneIterationImageBitmapTest(cases[i].sub, bindingTarget, program, cases[i].bitmap,
+            cases[i].flipY, cases[i].premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+    }
+}
+
+function runImageBitmapTest(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
+{
+    var optionsVal = {alpha: alphaVal};
+    var program = tiu.setupTexturedQuad(gl, internalFormat);
+    runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D, program, bitmaps, optionsVal,
+        internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+
+    // cube map texture must be square
+    if (bitmaps.noFlipYPremul.width == bitmaps.noFlipYPremul.height) {
+        program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
+        runTestOnBindingTargetImageBitmap(gl.TEXTURE_CUBE_MAP, program, bitmaps, optionsVal,
+            internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+    }
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+}
+
+function generateImageBitmap(source, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
+{
+    var bitmaps = [];
+    var p1 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
+    var p2 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
+    var p3 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
+    var p4 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
+    Promise.all([p1, p2, p3, p4]).then(function() {
+        runImageBitmapTest(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+    }, function() {
+        // createImageBitmap with options could be rejected if it is not supported
+        finishTest();
+        return;
+    });
+}

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
@@ -26,11 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var halfRedColor = [128, 0, 0];
-    var halfGreenColor = [0, 128, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -48,15 +43,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
@@ -66,84 +52,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            var p1 = createImageBitmap(blob, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-            var p2 = createImageBitmap(blob, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-            var p3 = createImageBitmap(blob, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-            var p4 = createImageBitmap(blob, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-            Promise.all([p1, p2, p3, p4]).then(function() {
-                runTest();
-            }, function() {
-                // createImageBitmap with options could be rejected if it is not supported
-                finishTest();
-                return;
-            });
+            generateImageBitmap(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            finishTest();
         }
-    }
-
-    function runOneIteration(bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        // Upload the image into the texture
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], bitmap.width, bitmap.height, 1 /* depth */, 0,
-                      gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var quaterWidth = Math.floor(halfWidth / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-        var quaterHeight = Math.floor(halfHeight / 2);
-
-        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? halfRedColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? halfGreenColor : greenColor;
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-        // Check a few pixels near the top and bottom and make sure they have
-        // the right color.
-        var tolerance = 8;
-        debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
-        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-        debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
-        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_3D, program);
-        program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D_ARRAY, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYPremul, false, true);
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYUnpremul, false, false);
-        runOneIteration(bindingTarget, program, bitmaps.flipYPremul, true, true);
-        runOneIteration(bindingTarget, program, bitmaps.flipYUnpremul, true, false);
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
@@ -52,7 +52,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            generateImageBitmap(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         }
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -49,10 +49,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
 
-        setCanvasTo256x256(ctx);
-        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        setCanvasTo257x257(ctx);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         finishTest();
     }
 
@@ -77,9 +77,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         setCanvasToRedGreen(ctx);
     }
 
-    function setCanvasTo256x256(ctx) {
-        ctx.canvas.width = 256;
-        ctx.canvas.height = 256;
+    function setCanvasTo257x257(ctx) {
+        ctx.canvas.width = 257;
+        ctx.canvas.height = 257;
         setCanvasToRedGreen(ctx);
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -26,11 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var halfRedColor = [128, 0, 0];
-    var halfGreenColor = [0, 128, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -48,38 +43,17 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        var p1 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.minNoFlipYPremul = imageBitmap });
-        var p2 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.minNoFlipYUnpremul = imageBitmap });
-        var p3 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.minFlipYPremul = imageBitmap });
-        var p4 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.minFlipYUnpremul = imageBitmap });
+        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
 
-        setCanvasTo257x257(ctx);
-        var p5 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.bigNoFlipYPremul = imageBitmap });
-        var p6 = createImageBitmap(testCanvas, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.bigNoFlipYUnpremul = imageBitmap });
-        var p7 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.bigFlipYPremul = imageBitmap });
-        var p8 = createImageBitmap(testCanvas, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.bigFlipYUnpremul = imageBitmap });
-        Promise.all([p1, p2, p3, p4, p5, p6, p7, p8]).then(function() {
-            runTest();
-        }, function() {
-            // createImageBitmap with options could be rejected if it is not supported
-            finishTest();
-            return;
-        });
+        setCanvasTo256x256(ctx);
+        generateImageBitmap(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        finishTest();
     }
 
     function setCanvasToRedGreen(ctx) {
@@ -103,82 +77,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         setCanvasToRedGreen(ctx);
     }
 
-    function setCanvasTo257x257(ctx) {
-        ctx.canvas.width = 257;
-        ctx.canvas.height = 257;
+    function setCanvasTo256x256(ctx) {
+        ctx.canvas.width = 256;
+        ctx.canvas.height = 256;
         setCanvasToRedGreen(ctx);
-    }
-
-    function runOneIteration(bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        //gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-        // Upload the image into the texture
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], bitmap.width, bitmap.height, 1 /* depth */, 0,
-                      gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var quaterWidth = Math.floor(halfWidth / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-        var quaterHeight = Math.floor(halfHeight / 2);
-
-        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? halfRedColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? halfGreenColor : greenColor;
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-        // Check the top pixel and bottom pixel and make sure they have
-        // the right color.
-        var tolerance = 10;
-        debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
-        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-        debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
-        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_3D, program);
-        program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D_ARRAY, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program, bitmaps.bigNoFlipYPremul, false, true);
-        runOneIteration(bindingTarget, program, bitmaps.bigNoFlipYUnpremul, false, false);
-        runOneIteration(bindingTarget, program, bitmaps.bigFlipYPremul, true, true);
-        runOneIteration(bindingTarget, program, bitmaps.bigFlipYUnpremul, true, false);
-        runOneIteration(bindingTarget, program, bitmaps.minNoFlipYPremul, false, true);
-        runOneIteration(bindingTarget, program, bitmaps.minNoFlipYUnpremul, false, false);
-        runOneIteration(bindingTarget, program, bitmaps.minFlipYPremul, true, true);
-        runOneIteration(bindingTarget, program, bitmaps.minFlipYUnpremul, true, false);
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
@@ -56,7 +56,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
             // bitmap is in unpremultiplied form
-            generateImageBitmap(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         });
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
@@ -26,10 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var blackColor = [0, 0, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -47,15 +43,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
         gl.disable(gl.BLEND);
@@ -67,94 +54,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        var bitmap1; // bitmap1 will be in premultiplied format
-        var bitmap2; // bitmap2 will be in unpremultiplied format
-        var p1 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmap1 = imageBitmap });
-        var p2 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmap2 = imageBitmap });
-
-        Promise.all([p1, p2]).then(function() {
-            // Now create new ImageBitmaps from the above two ImageBitmaps.
-            var p3 = createImageBitmap(bitmap1, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul1 = imageBitmap });
-            var p4 = createImageBitmap(bitmap1, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul1 = imageBitmap });
-            var p5 = createImageBitmap(bitmap2, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul2 = imageBitmap });
-            var p6 = createImageBitmap(bitmap2, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul2 = imageBitmap });
-            var p7 = createImageBitmap(bitmap2, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul2 = imageBitmap });
-            var p8 = createImageBitmap(bitmap2, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul2 = imageBitmap });
-            Promise.all([p3, p4, p5, p6, p7, p8]).then(function() {
-                runTest();
-            }, function() {
-                finishTest();
-                return;
-            });
-        }, function() {
+        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
+            // bitmap is in unpremultiplied form
+            generateImageBitmap(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
-            return;
         });
-    }
-
-    function runOneIteration(bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        // Upload the image into the texture
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], bitmap.width, bitmap.height, 1 /* depth */, 0,
-                      gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-
-        var top = flipY ? 0 : (height - halfHeight);
-        var bottom = flipY ? (height - halfHeight) : 0;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? blackColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? blackColor : greenColor;
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-        // Check the top pixel and bottom pixel and make sure they have
-        // the right color.
-        debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, 0, bottom, halfWidth, halfHeight, tl, "shouldBe " + tl);
-        wtu.checkCanvasRect(gl, halfWidth, bottom, halfWidth, halfHeight, tr, "shouldBe " + tr);
-        debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, 0, top, halfWidth, halfHeight, bl, "shouldBe " + bl);
-        wtu.checkCanvasRect(gl, halfWidth, top, halfWidth, halfHeight, br, "shouldBe " + br);
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_3D, program);
-        program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D_ARRAY, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYPremul1, false, true);
-        runOneIteration(bindingTarget, program, bitmaps.flipYPremul1, true, true);
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYPremul2, false, true);
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYUnpremul2, false, false);
-        runOneIteration(bindingTarget, program, bitmaps.flipYPremul2, true, true);
-        runOneIteration(bindingTarget, program, bitmaps.flipYUnpremul2, true, false);
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
@@ -48,7 +48,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var image = new Image();
         image.onload = function() {
-            generateImageBitmap(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         }
         image.src = resourcePath + "red-green-semi-transparent.png";

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
@@ -26,11 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var halfRedColor = [128, 0, 0];
-    var halfGreenColor = [0, 128, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -48,99 +43,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
         var image = new Image();
         image.onload = function() {
-            var p1 = createImageBitmap(image, {imageOrientation: "none", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-            var p2 = createImageBitmap(image, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-            var p3 = createImageBitmap(image, {imageOrientation: "flipY", premultiplyAlpha: "default"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-            var p4 = createImageBitmap(image, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-            Promise.all([p1, p2, p3, p4]).then(function() {
-                runTest();
-            }, function() {
-                // createImageBitmap with options could be rejected if it is not supported
-                finishTest();
-                return;
-            });
+            generateImageBitmap(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            finishTest();
         }
         image.src = resourcePath + "red-green-semi-transparent.png";
-    }
-
-    function runOneIteration(bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        // Upload the image into the texture
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], bitmap.width, bitmap.height, 1 /* depth */, 0,
-                      gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var quaterWidth = Math.floor(halfWidth / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-        var quaterHeight = Math.floor(halfHeight / 2);
-
-        var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-        var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? halfRedColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? halfGreenColor : greenColor;
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-        // Check a few pixels near the top and bottom and make sure they have
-        // the right color.
-        var tolerance = 8;
-        debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
-        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-        debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
-        wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_3D, program);
-        program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D_ARRAY, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYPremul, false, true);
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYUnpremul, false, false);
-        runOneIteration(bindingTarget, program, bitmaps.flipYPremul, true, true);
-        runOneIteration(bindingTarget, program, bitmaps.flipYUnpremul, true, false);
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -26,9 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -46,83 +43,16 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
         video = document.createElement("video");
         video.oncanplaythrough = function() {
-            var p1 = createImageBitmap(video, {imageOrientation: "none"}).then(function(imageBitmap) { bitmaps.noFlipY = imageBitmap });
-            var p2 = createImageBitmap(video, {imageOrientation: "flipY"}).then(function(imageBitmap) { bitmaps.flipY = imageBitmap });
-            Promise.all([p1, p2]).then(function() {
-                runTest();
-            }, function() {
-                // createImageBitmap with options could be rejected if it is not supported
-                finishTest();
-                return;
-            });
+            generateImageBitmap(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            finishTest();
         }
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);
-    }
-
-    function runOneIteration(bindingTarget, program, bitmap, flipY)
-    {
-        debug('Testing ' + ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-
-        // Upload the image into the texture
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], bitmap.width, bitmap.height, 1 /* depth */, 0,
-                      gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-
-        var topColor = flipY ? redColor : greenColor;
-        var bottomColor = flipY ? greenColor : redColor;
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-        // Check a few pixels near the top and bottom and make sure they have
-        // the right color.
-        debug("Checking lower left corner");
-        wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor, "shouldBe " + bottomColor);
-        debug("Checking upper left corner");
-        wtu.checkCanvasRect(gl, 4, gl.canvas.height - 8, 2, 2, topColor, "shouldBe " + topColor);
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_3D, program);
-        program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D_ARRAY, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-        finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program, bitmaps.noFlipY, false);
-        runOneIteration(bindingTarget, program, bitmaps.flipY, true);
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -48,7 +48,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         video = document.createElement("video");
         video.oncanplaythrough = function() {
-            generateImageBitmap(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
             finishTest();
         }
         video.src = resourcePath + "red-green.theora.ogv";

--- a/sdk/tests/py/tex_image_test_generator.py
+++ b/sdk/tests/py/tex_image_test_generator.py
@@ -144,7 +144,13 @@ def WriteTest(filename, dimension, element_type, internal_format, format, type):
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>"""
+  if element_type == 'image-bitmap-from-image-data' or element_type == 'image-bitmap-from-image' or \
+     element_type == 'image-bitmap-from-video' or element_type == 'image-bitmap-from-canvas' or \
+     element_type == 'image-bitmap-from-blob' or element_type == 'image-bitmap-from-image-bitmap':
+    code += """
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>"""
+  code += """
 <script src="../../../js/tests/tex-image-and-sub-image-%(dimension)sd-with-%(element_type)s.js"></script>
 </head>
 <body>"""


### PR DESCRIPTION
At this moment, there are quite some repetitive code resides in the ImageBitmap testing scripts. This change extract those common functions into a "tex-image-and-sub-image-2d-with-image-bitmap-utils.js", and simplify the testing scripts a lot.

Locally, the testing results are the same as what it is without this change.

Please review. @kenrussell @zhenyao @toji 