### PR TITLE
fix bug for primitive restart test

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fPrimitiveRestartTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fPrimitiveRestartTests.js
@@ -187,7 +187,7 @@ var gluTextureUtil = framework.opengl.gluTextureUtil;
         gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, bufferIndex, gl.STATIC_DRAW);
 
         if (this.m_function == es3fPrimitiveRestartTests.DrawFunction.FUNCTION_DRAW_ELEMENTS) {
-            gl.drawElements(primTypeGL, count - 1, indexTypeGL, 0);
+            gl.drawElements(primTypeGL, count, indexTypeGL, 0);
         } else if (this.m_function == es3fPrimitiveRestartTests.DrawFunction.FUNCTION_DRAW_ELEMENTS_INSTANCED) {
             gl.drawElementsInstanced(primTypeGL, count, indexTypeGL, 0, 1);
         } else {


### PR DESCRIPTION
I suppose that this is a typo. See the original code in native deqp: https://android.googlesource.com/platform/external/deqp/+/deqp-dev/modules/gles3/functional/es3fPrimitiveRestartTests.cpp#545. 

This small change can fix bugs in primitiverestart.html in webgl deqp. 

PTAL. Thanks!