### PR TITLE
Fix bugs in multisample.html

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuTestCase.js
+++ b/sdk/tests/deqp/framework/common/tcuTestCase.js
@@ -349,21 +349,28 @@ goog.scope(function() {
             try {
                 // If proceeding with the next test, prepare it.
                 var fullTestName = state.currentTest.fullName();
+                var inited = true;
                 if (tcuTestCase.lastResult == tcuTestCase.IterateResult.STOP) {
                     // Update current test name
                     setCurrentTestName(fullTestName);
                     bufferedLogToConsole('Init testcase: ' + fullTestName); //Show also in console so we can see which test crashed the browser's tab
 
                     // Initialize particular test
-                    state.currentTest.init();
+                    inited = state.currentTest.init();
+                    inited = inited === undefined ? true : inited;
 
                     //If it's a leaf test, notify of it's execution.
-                    if (state.currentTest.isLeaf())
+                    if (state.currentTest.isLeaf() && inited)
                         debug('<hr/><br/>Start testcase: ' + fullTestName);
                 }
 
-                // Run the test, save the result.
-                tcuTestCase.lastResult = state.currentTest.iterate();
+                if (inited) {
+                    // Run the test, save the result.
+                    tcuTestCase.lastResult = state.currentTest.iterate();
+                } else {
+                    // Skip uninitialized test.
+                    tcuTestCase.lastResult = tcuTestCase.IterateResult.STOP;
+                }
 
                 // Cleanup
                 if (tcuTestCase.lastResult == tcuTestCase.IterateResult.STOP)

--- a/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
@@ -212,6 +212,51 @@ goog.scope(function() {
     /** Copy the constructor */
     es3fMultisampleTests.MultisampleCase.prototype.constructor = es3fMultisampleTests.MultisampleCase;
 
+    /* Rest states */
+    es3fMultisampleTests.MultisampleCase.prototype.deinit = function() {
+        gl.colorMask(true, true, true, true);
+        gl.depthMask(true);
+
+        gl.clearColor(0.0, 0.0, 0.0, 0.0);
+        gl.clearDepth(1.0);
+        gl.clearStencil(0);
+
+        gl.disable(gl.STENCIL_TEST);
+        gl.disable(gl.DEPTH_TEST);
+        gl.disable(gl.BLEND)
+        gl.disable(gl.SAMPLE_COVERAGE);
+        gl.disable(gl.SAMPLE_ALPHA_TO_COVERAGE);
+
+        if (this.m_program) {
+            gl.deleteProgram(this.m_program.getProgram());
+            this.m_program = null;
+        }
+        if (this.m_msColorRbo) {
+          gl.deleteRenderbuffer(this.m_msColorRbo);
+          this.m_msColorRbo = null;
+        }
+        if (this.m_msDepthStencilRbo) {
+          gl.deleteRenderbuffer(this.m_msDepthStencilRbo);
+          this.m_msDepthStencilRbo = null;
+        }
+        if (this.m_resolveColorRbo) {
+          gl.deleteRenderbuffer(this.m_resolveColorRbo);
+          this.m_resolveColorRbo = null;
+        }
+
+        if (this.m_msFbo) {
+          gl.deleteFramebuffer(this.m_msFbo);
+          this.m_msFbo = null;
+        }
+        if (this.m_resolveFbo) {
+          gl.deleteFramebuffer(this.m_resolveFbo);
+          this.m_resolveFbo = null;
+        }
+
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    }
+
     /**
      * @protected
      * @param  {Array<number>} p0
@@ -427,8 +472,11 @@ goog.scope(function() {
 
 
         var numSamples = /** @type {number} */  (gl.getParameter(gl.SAMPLES));
-        if (!this.m_fboParams.useFbo && numSamples <= 1)
-            throw new Error('No multisample buffers');
+        if (!this.m_fboParams.useFbo && numSamples <= 1) {
+            var msg = 'No multisample buffers';
+            testSkippedOptions(msg, true);
+            return false;
+        }
 
         if (this.m_fboParams.useFbo) {
             if (this.m_fboParams.numSamples > 0)
@@ -723,7 +771,10 @@ goog.scope(function() {
     };
 
     es3fMultisampleTests.CommonEdgeCase.prototype.init = function() {
-        es3fMultisampleTests.MultisampleCase.prototype.init.call(this);
+        var inited = es3fMultisampleTests.MultisampleCase.prototype.init.call(this);
+        if (!inited) {
+            return false;
+        }
 
         if (this.m_caseType === es3fMultisampleTests.CommonEdgeCase.CaseType.SMALL_QUADS) {
             // Check for a big enough viewport. With too small viewports the test case can't analyze the resulting image well enough.
@@ -1005,7 +1056,10 @@ goog.scope(function() {
     es3fMultisampleTests.SampleDepthCase.prototype.constructor = es3fMultisampleTests.SampleDepthCase;
 
     es3fMultisampleTests.SampleDepthCase.prototype.init = function() {
-        es3fMultisampleTests.MultisampleCase.prototype.init.call(this);
+        var inited = es3fMultisampleTests.MultisampleCase.prototype.init.call(this);
+        if (!inited) {
+            return false;
+        }
 
         gl.enable(gl.DEPTH_TEST);
         gl.depthFunc(gl.LESS);
@@ -1183,7 +1237,10 @@ goog.scope(function() {
     };
 
     es3fMultisampleTests.MaskProportionalityCase.prototype.init = function() {
-        es3fMultisampleTests.MultisampleCase.prototype.init.call(this);
+        var inited = es3fMultisampleTests.MultisampleCase.prototype.init.call(this);
+        if (!inited) {
+            return false;
+        }
 
         if (this.m_type == es3fMultisampleTests.MaskProportionalityCase.CaseType.ALPHA_TO_COVERAGE) {
             gl.enable(gl.SAMPLE_ALPHA_TO_COVERAGE);

--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -117,6 +117,12 @@ function reportTestResultsToHarness(success, msg) {
   }
 }
 
+function reportSkippedTestResultsToHarness(success, msg) {
+  if (window.parent.webglTestHarness) {
+    window.parent.webglTestHarness.reportResults(window.location.pathname, success, msg, true);
+  }
+}
+
 function notifyFinishedToHarness() {
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
@@ -277,6 +283,23 @@ function testPassedOptions(msg, addSpan)
 	}
     if (_jsTestPreVerboseLogging) {
 		_bufferedLogToConsole('PASS ' + msg);
+    }
+}
+
+/**
+ * Report skipped tests.
+ * @param {string} msg The message to be shown in the skip result.
+ * @param {boolean} addSpan Indicates whether the message will be visible (thus counted in the results) or not.
+ */
+function testSkippedOptions(msg, addSpan)
+{
+    if (addSpan && !quietMode())
+	{
+        reportSkippedTestResultsToHarness(true, _currentTestName + ": " + msg);
+        _addSpan('<span><span class="warn">SKIP</span> ' + escapeHTML(_currentTestName) + ": " + escapeHTML(msg) + '</span>');
+	}
+    if (_jsTestPreVerboseLogging) {
+		_bufferedLogToConsole('SKIP' + msg);
     }
 }
 


### PR DESCRIPTION
1. Add support to skip unavailable tests.
2. Reset GL states in deinit to avoid affecting subsequent tests.

With this patch, all tests passed in multisample.html.
C++ code:
https://android.googlesource.com/platform/external/deqp/+/master/modules/gles3/tes3TestPackage.cpp#69
https://android.googlesource.com/platform/external/deqp/+/master/modules/gles3/functional/es3fMultisampleTests.cpp#281