### PR TITLE
Convert expected colors from linear -> SRGB when reading from an SRGB texture.

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
+++ b/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
@@ -129,7 +129,7 @@ function convertToSRGB(val) {
   }
 }
 
-function denormalizeColor(srcInternalFormat, destFormat, destType, color) {
+function denormalizeColor(srcInternalFormat, destType, color) {
   var result = color.slice();
   var tol = 0;
 
@@ -154,7 +154,7 @@ function denormalizeColor(srcInternalFormat, destFormat, destType, color) {
     return { color: result, tol: tol };
   }
 
-  if (destFormat == gl.SRGB8_ALPHA8) {
+  if (srcInternalFormat == gl.SRGB8_ALPHA8) {
     for (var i = 0; i < 3; ++i) {
       result[i] = convertToSRGB(result[i]);
     }
@@ -210,7 +210,7 @@ function compareColor(buf, index, expectedColor, srcInternalFormat,
   var readChannelCount = getChannelCount(readFormat);
 
   var color = getColor(buf, index, readFormat, readType);
-  expectedColor = denormalizeColor(srcInternalFormat, readFormat, readType, expectedColor);
+  expectedColor = denormalizeColor(srcInternalFormat, readType, expectedColor);
 
   var minChannel = Math.min(srcChannelCount, readChannelCount);
   for (var i = 0; i < minChannel; ++i) {


### PR DESCRIPTION
When we have a texture with internal format SRGB8_ALPHA8, the texture uses SRGB color encoding, and doing a glClearColor/glClear operation converts from linear to SRGB. When we do a glReadPixels, the read format is RGBA, as glReadPixels doesn't support SRGB8_ALPHA8 reads, so no SRGB -> linear conversion occurs. When we compare against the expected color, we must convert linear -> SRGB. We must convert depending on the internal format (as the internal type tells us if the pixels are in SRGB format), and regardless of the read type (since the read type can't be SRGB8_ALPHA8 anyways).