### PR TITLE
Make timestamps optional in timestamp WebGL test.

### DIFF
--- a/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
+++ b/sdk/tests/conformance/extensions/ext-disjoint-timer-query.html
@@ -51,6 +51,7 @@ var elapsed_query = null;
 var timestamp_query1 = null;
 var timestamp_query2 = null;
 var availability_retry = 500;
+var timestamp_counter_bits = 0; 
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -70,7 +71,10 @@ if (!gl) {
         gl.getParameter(ext.GPU_DISJOINT_EXT);
 
         runElapsedTimeTest();
-        runTimeStampTest();
+        timestamp_counter_bits = ext.getQueryEXT(ext.TIMESTAMP_EXT, ext.QUERY_COUNTER_BITS_EXT);
+        if (timestamp_counter_bits > 0) {
+            runTimeStampTest();
+        }
         verifyQueryResultsNotAvailable();
 
         window.requestAnimationFrame(checkQueryResults);
@@ -93,7 +97,10 @@ function runSanityTests() {
 
     shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.CURRENT_QUERY_EXT)", "null");
     shouldBe("ext.getQueryEXT(ext.TIME_ELAPSED_EXT, ext.QUERY_COUNTER_BITS_EXT) >= 30", "true");
-    shouldBe("ext.getQueryEXT(ext.TIMESTAMP_EXT, ext.QUERY_COUNTER_BITS_EXT) >= 30", "true");
+
+    // Certain drivers set timestamp counter bits to 0 as they don't support timestamps
+    shouldBe("ext.getQueryEXT(ext.TIMESTAMP_EXT, ext.QUERY_COUNTER_BITS_EXT) >= 30 || " +
+             "ext.getQueryEXT(ext.TIMESTAMP_EXT, ext.QUERY_COUNTER_BITS_EXT) == 0", "true");
 
     debug("");
     debug("Testing time elapsed query lifecycle");
@@ -217,11 +224,16 @@ function verifyQueryResultsNotAvailable() {
     var startTime = Date.now();
     while (Date.now() - startTime < 2000) {
         gl.finish();
-        if (ext.getQueryObjectEXT(elapsed_query, ext.QUERY_RESULT_AVAILABLE_EXT) ||
-            ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_AVAILABLE_EXT) ||
-            ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)) {
+        if (ext.getQueryObjectEXT(elapsed_query, ext.QUERY_RESULT_AVAILABLE_EXT)) { 
             testFailed("One of the queries' results became available too early");
             return;
+        }
+        if (timestamp_counter_bits > 0) {
+            if (ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_AVAILABLE_EXT) ||
+                ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)) {
+                testFailed("One of the queries' results became available too early");
+                return;
+            }
         }
     }
 
@@ -229,7 +241,8 @@ function verifyQueryResultsNotAvailable() {
 }
 
 function checkQueryResults() {
-    if (availability_retry > 0 && !ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)) {
+    if (availability_retry > 0 && (timestamp_counter_bits == 0 ||
+        !ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT))) {
         var error = gl.getError();
         if (error != gl.NO_ERROR) {
             testFailed("getQueryObjectEXT should have no errors: " + wtu.glEnumToString(gl, error));
@@ -247,8 +260,10 @@ function checkQueryResults() {
 
     // Make sure queries are available.
     shouldBe("ext.getQueryObjectEXT(elapsed_query, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
-    shouldBe("ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
-    shouldBe("ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
+    if (timestamp_counter_bits > 0) {
+        shouldBe("ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
+        shouldBe("ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_AVAILABLE_EXT)", "true");
+    }
 
     var disjoint_value = gl.getParameter(ext.GPU_DISJOINT_EXT);
     if (disjoint_value) {
@@ -256,8 +271,10 @@ function checkQueryResults() {
         testPassed("Disjoint triggered.");
     } else {
         var elapsed_result = ext.getQueryObjectEXT(elapsed_query, ext.QUERY_RESULT_EXT);
-        var timestamp_result1 = ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_EXT);
-        var timestamp_result2 = ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_EXT);
+        if (timestamp_counter_bits > 0) {
+            var timestamp_result1 = ext.getQueryObjectEXT(timestamp_query1, ext.QUERY_RESULT_EXT);
+            var timestamp_result2 = ext.getQueryObjectEXT(timestamp_query2, ext.QUERY_RESULT_EXT);
+        }
         // Do some basic validity checking of the elapsed time query. There's no way it should
         // take more than about half a second for a no-op query.
         var halfSecondInNanos = 0.5 * 1000 * 1000 * 1000;
@@ -267,13 +284,15 @@ function checkQueryResults() {
             testPassed("Time elapsed query results were valid.");
         }
 
-        if (timestamp_result1 <= 0 ||
-            timestamp_result2 <= 0 ||
-            timestamp_result2 <= timestamp_result1) {
-            testFailed("Timestamp queries returned invalid data: timestamp_result1 = " +
-                       timestamp_result1 + ", timestamp_result2 = " + timestamp_result2);
-        } else {
-            testPassed("Timestamp query results were valid.");
+        if (timestamp_counter_bits > 0) {
+            if (timestamp_result1 <= 0 ||
+                timestamp_result2 <= 0 ||
+                timestamp_result2 <= timestamp_result1) {
+                testFailed("Timestamp queries returned invalid data: timestamp_result1 = " +
+                           timestamp_result1 + ", timestamp_result2 = " + timestamp_result2);
+            } else {
+                testPassed("Timestamp query results were valid.");
+            }
         }
     }
 


### PR DESCRIPTION
Allow the counter bits for timestamps to be 0 for the WebGL
EXT_disjoint_timer_query conformance test and disable the timestamp
portion of the test if that is the case. Certain backing drivers for
WebGL such as the OSX drivers and ANGLE on D3D11 do not support
timestamps and it is within the spec to disable timestamp functionality
in the extension by setting the number of counter bits for the
timestamps to be 0. This updates the test to check if the timestamp
counter bits is set to 0 and to skip the timestamp portion of the test
if that is the case.