### PR TITLE
Fix transform feedback boolean output varying

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsShaderExecUtil.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderExecUtil.js
@@ -356,8 +356,13 @@ goog.scope(function() {
      */
     glsShaderExecUtil.getTFVaryings = function(outputs) {
         var names = [];
-        for (var i = 0; i < outputs.length; i++)
-            names.push(outputs[i].name);
+        for (var i = 0; i < outputs.length; i++) {
+            if (gluShaderUtil.isDataTypeBoolOrBVec(outputs[i].varType.getBasicType())) {
+                names.push('o_' + outputs[i].name);
+            } else {
+                names.push(outputs[i].name);
+            }
+        }
         return new gluShaderProgram.TransformFeedbackVaryings(names);
     };
 


### PR DESCRIPTION
Boolean output is converted to an int type varying whose name is
constructed by adding 'o_' before the original name. Correct name should
be specified for transform feedback output.

C++ code: 
https://android.googlesource.com/platform/external/deqp/+/master/modules/glshared/glsShaderExecUtil.cpp#446

Also see code about creating vertex shader in line 156 of glsShaderExecUtil.js:
https://www.khronos.org/registry/webgl/sdk/tests/deqp/modules/shared/glsShaderExecUtil.js