### PR TITLE
Add DO NOT EDIT warning to each texturefiltering auto generated test.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_combinations_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_06.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_06.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_07.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_07.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_08.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_08.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_09.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_09.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_10.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_10.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_11.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_11.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_12.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_12.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_13.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_13.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_14.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_14.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_15.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_15.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_16.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_16.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_17.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_17.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_18.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_18.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_19.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_19.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_20.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_20.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_21.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_21.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_22.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_22.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_23.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_23.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_24.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_24.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_25.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_25.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_26.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_26.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_27.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_27.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_28.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_28.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_29.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_29.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_30.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_30.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_31.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_31.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_32.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_32.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_33.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_33.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_34.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_34.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_35.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_35.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_36.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_36.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_37.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_37.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_38.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_38.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_39.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_39.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_40.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_40.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_41.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_41.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_42.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_42.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_43.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_43.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_44.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_44.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_45.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_45.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_46.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_46.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_47.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_47.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_48.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_48.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_49.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_49.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_50.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_50.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_51.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_51.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_52.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_52.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_53.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_53.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_54.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_54.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_55.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_55.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_56.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_56.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_57.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_57.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_58.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_58.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_59.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_formats_59.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_array_sizes_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_combinations_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_06.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_06.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_07.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_07.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_08.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_08.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_09.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_formats_09.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_2d_sizes_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_06.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_06.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_07.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_07.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_08.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_08.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_09.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_09.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_10.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_10.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_11.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_11.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_12.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_12.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_13.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_13.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_14.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_14.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_15.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_15.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_16.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_16.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_17.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_17.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_18.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_18.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_19.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_19.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_20.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_20.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_21.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_21.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_22.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_22.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_23.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_23.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_24.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_24.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_25.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_25.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_26.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_26.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_27.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_27.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_28.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_28.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_29.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_29.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_30.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_30.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_31.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_31.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_32.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_32.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_33.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_33.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_34.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_34.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_35.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_combinations_35.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_06.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_06.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_07.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_07.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_08.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_08.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_09.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_09.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_10.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_10.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_11.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_11.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_12.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_12.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_13.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_13.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_14.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_14.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_15.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_15.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_16.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_16.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_17.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_17.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_18.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_18.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_19.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_19.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_20.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_20.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_21.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_21.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_22.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_22.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_23.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_23.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_24.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_24.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_25.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_25.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_26.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_26.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_27.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_27.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_28.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_28.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_29.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_29.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_30.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_30.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_31.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_31.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_32.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_32.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_33.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_33.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_34.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_34.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_35.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_35.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_36.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_36.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_37.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_37.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_38.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_38.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_39.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_39.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_40.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_40.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_41.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_41.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_42.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_42.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_43.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_43.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_44.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_44.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_45.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_45.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_46.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_46.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_47.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_47.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_48.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_48.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_49.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_49.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_50.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_50.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_51.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_51.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_52.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_52.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_53.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_53.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_54.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_54.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_55.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_55.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_56.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_56.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_57.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_57.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_58.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_58.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_59.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_formats_59.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_3d_sizes_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_combinations_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_05.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_05.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_06.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_06.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_07.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_07.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_08.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_08.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_09.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_formats_09.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_no_edges_visible.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_no_edges_visible.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_00.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_00.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_01.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_01.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_02.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_02.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_03.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_03.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_04.html
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_cube_sizes_04.html
@@ -1,3 +1,10 @@
+<!--
+
+This file is auto-generated from texturefiltering_test_generator.py
+DO NOT EDIT!
+
+-->
+
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/sdk/tests/deqp/functional/gles3/texturefiltering_test_generator.py
+++ b/sdk/tests/deqp/functional/gles3/texturefiltering_test_generator.py
@@ -26,8 +26,6 @@
   This file needs to be run in its folder.
 """
 
-import os
-import os.path
 import sys
 
 _DO_NOT_EDIT_WARNING = """<!--
@@ -129,6 +127,7 @@ def GenerateFilename(group, count, index):
 def WriteTest(filename, start, end):
   """Write one test."""
   file = open(filename, "wb")
+  file.write(_DO_NOT_EDIT_WARNING)
   file.write(_HTML_TEMPLATE % {
     'start': start,
     'end': end


### PR DESCRIPTION
This is the last patching in splitting texturefiltering tests.