### PR TITLE
Generate -0 for roundeven reference value in shadercommonfunction.html

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fShaderCommonFunctionTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderCommonFunctionTests.js
@@ -587,11 +587,11 @@ goog.scope(function() {
      */
     es3fShaderCommonFunctionTests.roundEven = function(v) {
         /** @type {number} */ var q = deMath.deFloatFrac(v);
-        /** @type {number} */ var truncated = Math.floor(v - q);
+        /** @type {number} */ var truncated = Math.trunc(v - q);
         /** @type {number} */ var rounded = (q > 0.5) ? (truncated + 1) : // Rounded up
             (q == 0.5 && (truncated % 2 != 0)) ? (truncated + 1) : // Round to nearest even at 0.5
             truncated; // Rounded down
-        return rounded;
+        return rounded === 0 && v < 0 ? -0 : rounded;
     };
 
     /**


### PR DESCRIPTION
-0 is treated as different with 0 for high precision case. WebGL do
return -0 but the reference output is still 0. This patch updates the
reference output calculation. 

C++ dEQP also has such bug, but due to the
input isn't set correctly -0 case will not appear in C++ dEQP.
For input initialization bug, please see discussion in https://github.com/KhronosGroup/WebGL/pull/1565.