### PR TITLE
Initialize input values with correct type

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fShaderCommonFunctionTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderCommonFunctionTests.js
@@ -872,7 +872,11 @@ goog.scope(function() {
             /** @type {number} */ var sign = Math.abs(rnd.getInt()) & 0x1;
             /** @type {number} */ var value = (sign << 31) | (exp << 23) | mantissa;
 
-            // TODO: check the following assert
+            // Convert int to float.
+            var view = new DataView(new ArrayBuffer(4));
+            view.setInt32(0, value, true);
+            value = view.getFloat32(0, true);
+
             assertMsgOptions(tcuFloat.newFloat32(value).isInf() === isInf && tcuFloat.newFloat32(value).isNaN() === isNan, 'Assert error.', false, true);
 
             values[0].push(value);
@@ -967,6 +971,11 @@ goog.scope(function() {
             /** @type {number} */ var exp = !isNan && !isInf ? (Math.abs(rnd.getInt()) & 0x7f) : 0xff;
             /** @type {number} */ var sign = Math.abs(rnd.getInt()) & 0x1;
             /** @type {number} */ var value = (sign << 31) | (exp << 23) | mantissa;
+
+            // Convert int to float.
+            var view = new DataView(new ArrayBuffer(4));
+            view.setInt32(0, value, true);
+            value = view.getFloat32(0, true);
 
             assertMsgOptions(tcuFloat.newFloat32(value).isInf() === isInf && tcuFloat.newFloat32(value).isNaN() === isNan, 'Assert error.', false, true);
 


### PR DESCRIPTION
In C++ input values for isnan and isinf cases is generated in unsigned int format:
https://android.googlesource.com/platform/external/deqp/+/master/modules/gles3/functional/es3fShaderCommonFunctionTests.cpp#809

and read in float format:
https://android.googlesource.com/platform/external/deqp/+/master/modules/glshared/glsShaderExecUtil.cpp#500.

This patch does the same thing as C++: generate a unsigned int value, then use it as float32 value.