### PR TITLE
Set default context version for WebGL 1.0 and 2.0 texture tests.

### DIFF
--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgb-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image/tex-image-and-sub-image-2d-with-image-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgb-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/video/tex-image-and-sub-image-2d-with-video-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGBA", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 1)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-2d-with-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-image-and-sub-image-3d-with-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-2d-with-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image/tex-image-and-sub-image-3d-with-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-2d-with-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r11f_g11f_b10f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r16f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r16f-red-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r32f-red-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r8-red-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-r8ui-red_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg16f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg16f-rg-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg32f-rg-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg8-rg-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb16f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb16f-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb32f-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb565-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb9_e5-rgb-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgb9_e5-rgb-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba16f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba16f-rgba-half_float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba32f-rgba-float.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba4-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-srgb8-rgb-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-image-and-sub-image-3d-with-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -52,7 +52,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-2d-with-svg-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-image-and-sub-image-3d-with-svg-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-2d-with-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/video/tex-image-and-sub-image-3d-with-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-2d-with-webgl-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r11f_g11f_b10f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/")();
+generateTest("R11F_G11F_B10F", "RGB", "UNSIGNED_INT_10F_11F_11F_REV", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r16f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r16f-red-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("R16F", "RED", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r32f-red-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("R32F", "RED", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r8-red-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8", "RED", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-r8ui-red_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("R8UI", "RED_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg16f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg16f-rg-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG16F", "RG", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg32f-rg-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RG32F", "RG", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg8-rg-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8", "RG", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RG8UI", "RG_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb16f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb16f-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB16F", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb32f-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB32F", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb565-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/")();
+generateTest("RGB565", "RGB", "UNSIGNED_SHORT_5_6_5", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/")();
+generateTest("RGB5_A1", "RGBA", "UNSIGNED_SHORT_5_5_5_1", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGB8UI", "RGB_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb9_e5-rgb-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgb9_e5-rgb-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGB9_E5", "RGB", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba16f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba16f-rgba-half_float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA16F", "RGBA", "HALF_FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba32f-rgba-float.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/")();
+generateTest("RGBA32F", "RGBA", "FLOAT", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba4-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/")();
+generateTest("RGBA4", "RGBA", "UNSIGNED_SHORT_4_4_4_4", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("RGBA8UI", "RGBA_INTEGER", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-srgb8-rgb-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8", "RGB", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-image-and-sub-image-3d-with-webgl-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -51,7 +51,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/")();
+generateTest("SRGB8_ALPHA8", "RGBA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 2)();
 </script>
 </body>
 </html>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -34,6 +34,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage2D and texSubImage2D code paths taking canvas elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -35,6 +35,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage2D and texSubImage2D code paths taking ImageData (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -34,6 +34,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage2D and texSubImage2D code paths taking image elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -34,6 +34,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage2D and texSubImage2D code paths taking SVG image elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
@@ -32,7 +32,7 @@ var debug = function(msg) {
   old(msg);
 };
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -52,6 +52,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage2D and texSubImage2D code paths taking video elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -33,6 +33,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage2D and texSubImage2D code paths taking webgl canvas elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-canvas.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -34,6 +34,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage3D and texSubImage3D code paths taking canvas elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -40,6 +40,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -36,6 +36,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -35,6 +35,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage3D and texSubImage3D code paths taking ImageData (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -34,6 +34,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage3D and texSubImage3D code paths taking image elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-svg-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-svg-image.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -34,6 +34,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage3D and texSubImage3D code paths taking SVG image elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-video.js
@@ -32,7 +32,7 @@ var debug = function(msg) {
   old(msg);
 };
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -52,6 +52,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage3D and texSubImage3D code paths taking video elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-webgl-canvas.js
@@ -21,7 +21,7 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath) {
+function generateTest(internalFormat, pixelFormat, pixelType, prologue, resourcePath, defaultContextVersion) {
     var wtu = WebGLTestUtils;
     var tiu = TexImageUtils;
     var gl = null;
@@ -33,6 +33,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     {
         description('Verify texImage3D and texSubImage3D code paths taking webgl canvas elements (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
 
+        // Set the default context version while still allowing the webglVersion URL query string to override it.
+        wtu.setDefault3DContextVersion(defaultContextVersion);
         gl = wtu.create3DContext("example");
 
         if (!prologue(gl)) {

--- a/sdk/tests/py/tex_image_test_generator.py
+++ b/sdk/tests/py/tex_image_test_generator.py
@@ -131,7 +131,7 @@ def GenerateFilename(dimension, element_type, internal_format, format, type):
               internal_format + "-" + format + "-" + type + ".html")
   return filename.lower()
     
-def WriteTest(filename, dimension, element_type, internal_format, format, type):
+def WriteTest(filename, dimension, element_type, internal_format, format, type, default_context_version):
   """Write one test."""
   file = open(filename, "wb")
   file.write(_LICENSE)
@@ -168,7 +168,7 @@ function testPrologue(gl) {
     return true;
 }
 
-generateTest("%(internal_format)s", "%(format)s", "%(type)s", testPrologue, "../../../resources/")();
+generateTest("%(internal_format)s", "%(format)s", "%(type)s", testPrologue, "../../../resources/", %(default_context_version)s)();
 </script>
 </body>
 </html>
@@ -179,10 +179,11 @@ generateTest("%(internal_format)s", "%(format)s", "%(type)s", testPrologue, "../
     'internal_format': internal_format,
     'format': format,
     'type': type,
+    'default_context_version': default_context_version,
   })
   file.close()
 
-def GenerateTests(test_dir, test_cases, dimension):
+def GenerateTests(test_dir, test_cases, dimension, default_context_version):
   test_dir_template = test_dir + '/%s'
   for element_type in _ELEMENT_TYPES:
     os.chdir(test_dir_template % element_type.replace('-', '_'))
@@ -198,15 +199,15 @@ def GenerateTests(test_dir, test_cases, dimension):
       filename = GenerateFilename(dimension, element_type, internal_format, format, type)
       index_file.write(filename)
       index_file.write('\n')
-      WriteTest(filename, dimension, element_type, internal_format, format, type)
+      WriteTest(filename, dimension, element_type, internal_format, format, type, default_context_version)
     index_file.close();
 
 def main(argv):
   """This is the main function."""
   py_dir = os.path.dirname(os.path.realpath(__file__))
-  GenerateTests(os.path.realpath(py_dir + '/../conformance/textures'), _FORMATS_TYPES_WEBGL1, '2')
-  GenerateTests(os.path.realpath(py_dir + '/../conformance2/textures'), _FORMATS_TYPES_WEBGL2, '2')
-  GenerateTests(os.path.realpath(py_dir + '/../conformance2/textures'), _FORMATS_TYPES_WEBGL2, '3')
+  GenerateTests(os.path.realpath(py_dir + '/../conformance/textures'), _FORMATS_TYPES_WEBGL1, '2', '1')
+  GenerateTests(os.path.realpath(py_dir + '/../conformance2/textures'), _FORMATS_TYPES_WEBGL2, '2', '2')
+  GenerateTests(os.path.realpath(py_dir + '/../conformance2/textures'), _FORMATS_TYPES_WEBGL2, '3', '2')
 
 if __name__ == '__main__':
   sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This allows these tests to be run as the test harness would do so without the ?webglVersion query string, while still allowing that query string to override the default version. In this way, the WebGL 1.0 tests can still be run against WebGL 2.0 contexts.

This is a follow-on to #1556, which made a similar change to the rest of the WebGL 2.0 conformance tests.