### PR TITLE
fix error to make builtinprecision31.html pass

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
+++ b/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
@@ -4811,7 +4811,7 @@ var setParentClass = function(child, parent) {
      * @extends {glsBuiltinPrecisionTests.PreciseFunc1}
      */
     glsBuiltinPrecisionTests.RoundEven = function() {
-        glsBuiltinPrecisionTests.PreciseFunc1.call(this, 'roundeven', deMath.rint);
+        glsBuiltinPrecisionTests.PreciseFunc1.call(this, 'roundEven', deMath.rint);
     };
     setParentClass(glsBuiltinPrecisionTests.RoundEven, glsBuiltinPrecisionTests.PreciseFunc1);
 


### PR DESCRIPTION
A small change. The builtin function should be 'roundEven', instead of 'roundeven'. After the change applied, builtinprecision31.html can pass in Chromium.