### PR TITLE
Add texSubImage3D tests

### DIFF
--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-2d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-image-and-sub-image-3d-with-image-bitmap-from-blob-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-2d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-image-and-sub-image-3d-with-image-bitmap-from-image-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-2d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r16f-red-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r32f-red-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r32f-red-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8-red-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-r8ui-red_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg16f-rg-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg32f-rg-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg32f-rg-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8-rg-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rg8ui-rg_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb16f-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb32f-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb32f-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb565-rgb-unsigned_short_5_6_5.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb8ui-rgb_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgb9_e5-rgb-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba16f-rgba-half_float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba32f-rgba-float.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba32f-rgba-float.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba4-rgba-unsigned_short_4_4_4_4.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-rgba8ui-rgba_integer-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8-rgb-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-image-and-sub-image-3d-with-image-bitmap-from-video-srgb8_alpha8-rgba-unsigned_byte.html
@@ -39,7 +39,7 @@ DO NOT EDIT!
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
 <script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
 </head>
 <body>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
@@ -54,7 +54,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
             finishTest();
         }
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
@@ -51,10 +51,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
 
         setCanvasTo257x257(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
         finishTest();
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
@@ -58,7 +58,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
             // bitmap is in unpremultiplied form
-            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
             finishTest();
         });
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -56,7 +56,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
         finishTest();
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -50,7 +50,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var image = new Image();
         image.onload = function() {
-            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
             finishTest();
         }
         image.src = resourcePath + "red-green-semi-transparent.png";

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -50,7 +50,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var video = document.createElement("video");
         video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
             finishTest();
         }
         video.src = resourcePath + "red-green.theora.ogv";

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
@@ -54,7 +54,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
             finishTest();
         }
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -51,10 +51,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
 
         setCanvasTo257x257(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
         finishTest();
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
@@ -58,7 +58,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
             // bitmap is in unpremultiplied form
-            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
             finishTest();
         });
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
@@ -26,10 +26,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var tiu = TexImageUtils;
     var gl = null;
     var successfullyParsed = false;
-    var blackColor = [0, 0, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
-    var bitmaps = [];
 
     function init()
     {
@@ -49,15 +45,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
         gl.disable(gl.BLEND);
@@ -69,80 +56,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        var p1 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-        var p2 = createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-        var p3 = createImageBitmap(imageData, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-        var p4 = createImageBitmap(imageData, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-        Promise.all([p1, p2, p3, p4]).then(function() {
-            runTest();
-        }, function() {
-            // createImageBitmap with options could be rejected if it is not supported
-            finishTest();
-            return;
-        });
-    }
-
-    function runOneIteration(bindingTarget, program, bitmap, flipY, premultiplyAlpha)
-    {
-        debug('Testing ' + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        // Enable writes to the RGBA channels
-        gl.colorMask(1, 1, 1, 0);
-        var texture = gl.createTexture();
-        // Bind the texture to texture unit 0
-        gl.bindTexture(bindingTarget, texture);
-        // Set up texture parameters
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-        gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-
-        // Upload the image into the texture
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], bitmap.width, bitmap.height, 1 /* depth */, 0,
-                      gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], bitmap);
-
-        var width = gl.canvas.width;
-        var halfWidth = Math.floor(width / 2);
-        var height = gl.canvas.height;
-        var halfHeight = Math.floor(height / 2);
-
-        var top = flipY ? 0 : (height - halfHeight);
-        var bottom = flipY ? (height - halfHeight) : 0;
-
-        var tl = redColor;
-        var tr = premultiplyAlpha ? blackColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? blackColor : greenColor;
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-        // Check the top pixel and bottom pixel and make sure they have
-        // the right color.
-        debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, 0, bottom, halfWidth, halfHeight, tl, "shouldBe " + tl);
-        wtu.checkCanvasRect(gl, halfWidth, bottom, halfWidth, halfHeight, tr, "shouldBe " + tr);
-        debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, 0, top, halfWidth, halfHeight, bl, "shouldBe " + bl);
-        wtu.checkCanvasRect(gl, halfWidth, top, halfWidth, halfHeight, br, "shouldBe " + br);
-    }
-
-    function runTest()
-    {
-        var program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_3D, program);
-        program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-        runTestOnBindingTarget(gl.TEXTURE_2D_ARRAY, program);
-
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
         finishTest();
-    }
-
-    function runTestOnBindingTarget(bindingTarget, program) {
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYPremul, false, true);
-        runOneIteration(bindingTarget, program, bitmaps.noFlipYUnpremul, false, false);
-        runOneIteration(bindingTarget, program, bitmaps.flipYPremul, true, true);
-        runOneIteration(bindingTarget, program, bitmaps.flipYUnpremul, true, false);
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
@@ -50,7 +50,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var image = new Image();
         image.onload = function() {
-            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
             finishTest();
         }
         image.src = resourcePath + "red-green-semi-transparent.png";

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -50,7 +50,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         video = document.createElement("video");
         video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
             finishTest();
         }
         video.src = resourcePath + "red-green.theora.ogv";

--- a/sdk/tests/py/tex_image_test_generator.py
+++ b/sdk/tests/py/tex_image_test_generator.py
@@ -149,7 +149,7 @@ def WriteTest(filename, dimension, element_type, internal_format, format, type, 
      element_type == 'image-bitmap-from-video' or element_type == 'image-bitmap-from-canvas' or \
      element_type == 'image-bitmap-from-blob' or element_type == 'image-bitmap-from-image-bitmap':
     code += """
-<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-utils.js"></script>"""
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>"""
   code += """
 <script src="../../../js/tests/tex-image-and-sub-image-%(dimension)sd-with-%(element_type)s.js"></script>
 </head>


### PR DESCRIPTION
In a previous pull request which re-structure the ImageBitmap test, there was a mistake where all texSubImage3D tests were left out. This change brings the tests for texSubImage3D back in the util.js. Locally all these tests pass.

Please review. @kenrussell @zhenyao @toji 