### PR TITLE
Fix the gl_VertexID test reference not being rendered.

### DIFF
--- a/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContext.js
+++ b/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContext.js
@@ -3785,7 +3785,7 @@ goog.scope(function() {
 
         var primitiveType = sglrReferenceUtils.mapGLPrimitiveType(primitive);
 
-        var renderFunction = rrRenderer.drawQuads;
+        var renderFunction = rrRenderer.drawTriangles;
         if (primitiveType == rrRenderer.PrimitiveType.LINES ||
             primitiveType == rrRenderer.PrimitiveType.LINE_STRIP ||
             primitiveType == rrRenderer.PrimitiveType.LINE_LOOP)

--- a/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContextTest.js
+++ b/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContextTest.js
@@ -696,7 +696,8 @@ goog.scope(function() {
         var pixelsTotest = [
             // location, color
             [2, 1], [0, 0, 255, 255],
-            [50, 140], [255, 0, 0, 255],
+            // The red vertex is between 140 and 141 so account for some blending with the white vertex
+            [50, 140], [255, 5, 5, 255],
             [50, 28], [255, 0, 255, 255],
             [139, 28], [0, 0, 0, 255],
             [50, 102], [255, 255, 255, 255],

--- a/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
@@ -538,7 +538,7 @@ goog.scope(function() {
 
         // /** @type {gluDrawUtil.VertexArrayBinding} */ var posBinding = gluDrawUtil.newFloatVertexArrayBinding('a_positionSize', 3, coords.length, 0, coords);
         /** @type {gluDrawUtil.VertexArrayBinding} */
-        var posBinding = gluDrawUtil.newFloatVertexArrayBinding('a_positionSize', 3, coords.length, 3, newCoords);
+        var posBinding = gluDrawUtil.newFloatVertexArrayBinding('a_positionSize', 3, coords.length, 12, newCoords);
         /** @type {number} */ var viewportX = rnd.getInt(0, gl.drawingBufferWidth - width);
         /** @type {number} */ var viewportY = rnd.getInt(0, gl.drawingBufferHeight - height);
 

--- a/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
@@ -917,7 +917,7 @@ goog.scope(function() {
         attribs[1].stride = 0;
         attribs[1].instanceDivisor = 0;
         attribs[1].pointer = colors.buffer;
-        rrRenderer.drawQuads(referenceState, referenceTarget, referenceShaderProgram,
+        rrRenderer.drawTriangles(referenceState, referenceTarget, referenceShaderProgram,
             attribs, rrRenderer.PrimitiveType.TRIANGLES, 0, indices.length, /*instanceID = */ 0);
     };
 

--- a/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderBuiltinVarTests.js
@@ -879,7 +879,7 @@ goog.scope(function() {
     es3fShaderBuiltinVarTests.VertexIDReferenceShader.prototype.shadeFragments = function(packets, context) {
         for (var packetNdx = 0; packetNdx < packets.length; ++packetNdx) {
             /** @type {rrFragmentOperations.Fragment} */ var packet = packets[packetNdx];
-            packet.output = rrShadingContext.readVarying(packet, context, es3fShaderBuiltinVarTests.VertexIDReferenceShader.VARYINGLOC_COLOR);
+            packet.value = rrShadingContext.readVarying(packet, context, es3fShaderBuiltinVarTests.VertexIDReferenceShader.VARYINGLOC_COLOR);
         }
     };
 


### PR DESCRIPTION
PTAL, this fixes the gl_VertexID test reference in two parts:
 - Fix it not rendering anything because the software FS output to the wrong variable
 - Add triangle rasterization because quad rasterization didn't match with what the GPU produced.

The drawQuads -> drawTriangles is very significant as many tests inderectly used drawQuads to generate reference images. The dEQP functional draw test have equivalent results with Chrome stable between both version, and the simple_reference_renderer test results are more correct now.

While this is in review, I'm running the WebGL2 CTS on Chrome stable both with and without this change to see if any new failure is introduced. New failures would either point to bugs in the drawTriangles, or bugs in the tests when they used drawQuads to render triangles.

I still need to run the closure compiler to typecheck the change but I don't expect any errors.

cc @kenrussell