### PR TITLE
Relax pixel comparison tolerance.

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
+++ b/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
@@ -142,11 +142,14 @@ function denormalizeColor(srcInternalFormat, destType, color) {
     case gl.RGB565:
     case gl.RGBA8:
     case gl.RGB5_A1:
-    case gl.RGBA4:
     case gl.SRGB8_ALPHA8:
     case gl.RGB10_A2:
       srcIsNormalized = true;
       tol = 5;
+      break;
+    case gl.RGBA4:
+      srcIsNormalized = true;
+      tol = 10;
       break;
   }
 


### PR DESCRIPTION
0.5 maps to 127 or 128, but in RGBA4, if it's 8, 8 / 15 * 255 is 136.

This makes some test cases pass on Mac OSX.