### PR TITLE
Unbind vao before delete position buffer.

### DIFF
--- a/conformance-suites/1.0.2/conformance/extensions/oes-vertex-array-object.html
+++ b/conformance-suites/1.0.2/conformance/extensions/oes-vertex-array-object.html
@@ -539,6 +539,8 @@ function runDeleteTests() {
         testFailed("buffer removed too early");
       }
     }
+
+    ext.bindVertexArrayOES(null);
     gl.deleteBuffer(positionBuffer);
 
     // Render with the deleted buffers. As they are referenced by VAOs they

--- a/conformance-suites/1.0.3/conformance/extensions/oes-vertex-array-object.html
+++ b/conformance-suites/1.0.3/conformance/extensions/oes-vertex-array-object.html
@@ -539,6 +539,8 @@ function runDeleteTests() {
         testFailed("buffer removed even though it is still attached to a VAO");
       }
     }
+
+    ext.bindVertexArrayOES(null);
     gl.deleteBuffer(positionBuffer);
 
     // Render with the deleted buffers. As they are referenced by VAOs they

--- a/sdk/tests/conformance/extensions/oes-vertex-array-object.html
+++ b/sdk/tests/conformance/extensions/oes-vertex-array-object.html
@@ -539,6 +539,8 @@ function runDeleteTests() {
         testFailed("buffer removed even though it is still attached to a VAO");
       }
     }
+
+    ext.bindVertexArrayOES(null);
     gl.deleteBuffer(positionBuffer);
 
     // Render with the deleted buffers. As they are referenced by VAOs they


### PR DESCRIPTION
In previous loop, we will bind vao for checking vertex arrtib. If we
don't unbind the vao before deleting position buffer, the link between
this vao and position buffer will be broken.