### PR TITLE
Fix the error against builtinprecision30.html in webgl deqp.

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
+++ b/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
@@ -1655,7 +1655,10 @@ var setParentClass = function(child, parent) {
         var fract = x - truncated;
         var ret = new tcuInterval.Interval();
 
-        if (Math.abs(fract) <= 0.5)
+        // When x is inf or -inf, truncated would be inf or -inf too. Then fract
+        // would be NaN (inf - inf). While in native c code, it would be 0 (inf) or -0 (-inf).
+        // This behavior in JS differs from that in native c code.
+        if (Math.abs(fract) <= 0.5 || isNaN(fract))
             ret.operatorOrAssignBinary(new tcuInterval.Interval(truncated));
         if (Math.abs(fract) >= 0.5)
             ret.operatorOrAssignBinary(new tcuInterval.Interval(truncated + deMath.deSign(fract)));


### PR DESCRIPTION
In JS implementation of round(), (-inf) - (-inf) equals to NaN.
While it is -0 in native deqp case.

So when the input of round() is inf or -inf, the fract part is neither >=0.5 nor <= 0.5. Then it returns a wrong result to the caller. 

PTAL, thanks!