### PR TITLE
Improve global variable initialization test

### DIFF
--- a/sdk/tests/conformance/glsl/misc/global-variable-init.html
+++ b/sdk/tests/conformance/glsl/misc/global-variable-init.html
@@ -186,6 +186,30 @@ void main() {
     gl_FragColor = vec4(0.0, f, 0.0, 1.0);
 }
 </script>
+<script id="globalUniformTernary2" type="x-shader/x-fragment">
+precision mediump float;
+uniform float u_zero;
+float green = 1.0;
+float f = (u_zero < 0.1) ? green : 0.0;
+
+void main() {
+    gl_FragColor = vec4(0.0, f, 0.0, 1.0);
+}
+</script>
+<script id="globalUniformStruct" type="x-shader/x-fragment">
+precision mediump float;
+struct S {
+    float zero;
+    int one;
+};
+uniform S us;
+S s = us;
+
+void main() {
+    float green = (s.one == 1) ? 1.0 : 0.0;
+    gl_FragColor = vec4(0.0, green, 0.0, 1.0);
+}
+</script>
 <script type="application/javascript">
 "use strict";
 description();
@@ -264,7 +288,24 @@ GLSLConformanceTester.runTests([
     fShaderSuccess: true,
     linkSuccess: true,
     render: true,
-    passMsg: "An uniform as an operand for a ternary operator in a global variable initializer should be accepted by WebGL."
+    passMsg: "A uniform as the second operand for a ternary operator in a global variable initializer should be accepted by WebGL."
+  },
+  {
+    fShaderId: "globalUniformTernary2",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Referencing a uniform inside the first operand for a ternary operator in a global variable initializer should be accepted by WebGL."
+  },
+  {
+    fShaderId: "globalUniformStruct",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    uniforms: [
+        { name: 'us.one', functionName: 'uniform1i', value: 1 }
+    ],
+    passMsg: "A global struct initialized with a uniform struct should be accepted by WebGL."
   }
 ]);
 var successfullyParsed = true;

--- a/sdk/tests/js/glsl-conformance-test.js
+++ b/sdk/tests/js/glsl-conformance-test.js
@@ -70,15 +70,25 @@ var fShaderDB = {};
  * the parameters for one shader out, in which case the default shader will be
  * used.
  * vShaderSource: the source code for vertex shader
+ * vShaderId: id of an element containing vertex shader source code. Used if
+ *   vShaderSource is not specified.
  * vShaderSuccess: true if vertex shader compilation should
  *   succeed.
  * fShaderSource: the source code for fragment shader
+ * fShaderId: id of an element containing fragment shader source code. Used if
+ *   fShaderSource is not specified.
  * fShaderSuccess: true if fragment shader compilation should
  *   succeed.
  * linkSuccess: true if link should succeed
  * passMsg: msg to describe success condition.
  * render: if true render to unit quad. Green = success
- *
+ * uniforms: an array of objects specifying uniforms to set prior to rendering.
+ *   Each object should have the following keys:
+ *     name: uniform variable name in the shader source. Uniform location will
+ *       be queried based on its name.
+ *     functionName: name of the function used to set the uniform. For example:
+ *       'uniform1i'
+ *     value: value of the uniform to set.
  */
 function runOneTest(gl, info) {
   var passMsg = info.passMsg
@@ -256,6 +266,15 @@ function runOneTest(gl, info) {
   }
 
   gl.useProgram(program);
+
+  if (info.uniforms !== undefined) {
+    for (var i = 0; i < info.uniforms.length; ++i) {
+      var uniformLocation = gl.getUniformLocation(program, info.uniforms[i].name);
+      gl[info.uniforms[i].functionName](uniformLocation, info.uniforms[i].value);
+      debug(info.uniforms[i].name + ' set to ' + info.uniforms[i].value);
+    }
+  }
+
   wtu.setupUnitQuad(gl);
   wtu.clearAndDrawUnitQuad(gl);
 


### PR DESCRIPTION
Add a test where a ternary operation condition references a uniform,
and another test where a uniform struct is assigned to a global.

An option to specify uniform values for GLSL tests is added for the
second test. This could be also used to refactor other existing tests
that currently are not using the GLSL test helpers because they need
to set uniforms.