### PR TITLE
Fix sRGB format cube texture lookup

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuTexLookupVerifier.js
+++ b/sdk/tests/deqp/framework/common/tcuTexLookupVerifier.js
@@ -702,7 +702,12 @@ goog.scope(function() {
 
         for (var i = minI; i <= maxI; i++) {
             /** @type {number} */ var x = tcuTexVerifierUtil.wrap(sampler.wrapS, i, level.getWidth());
-            /** @type {Array<number>} */ var color = tcuTexLookupVerifier.lookupScalar(level, sampler, x, coordY, 0);
+            /** @type {Array<number>} */ var color;
+            if (tcuTexLookupVerifier.isSRGB(level.getFormat())) {
+                color = tcuTexLookupVerifier.lookupFloat(level, sampler, x, coordY, 0);
+            } else {
+                color = tcuTexLookupVerifier.lookupScalar(level, sampler, x, coordY, 0);
+            }
 
             if (tcuTexLookupVerifier.isColorValid(prec, color, result))
                 return true;
@@ -740,7 +745,12 @@ goog.scope(function() {
         for (var i = minI; i <= maxI; i++) {
             /** @type {number} */ var x = tcuTexVerifierUtil.wrap(sampler.wrapS, i, level.getWidth());
             /** @type {number} */ var y = tcuTexVerifierUtil.wrap(sampler.wrapT, j, level.getHeight());
-            /** @type {Array<number>} */ var color = tcuTexLookupVerifier.lookupScalar(level, sampler, x, y, coordZ);
+            /** @type {Array<number>} */ var color;
+            if (tcuTexLookupVerifier.isSRGB(level.getFormat())) {
+                color = tcuTexLookupVerifier.lookupFloat(level, sampler, x, y, coordZ);
+            } else {
+                color = tcuTexLookupVerifier.lookupScalar(level, sampler, x, y, coordZ);
+            }
 
             if (tcuTexLookupVerifier.isColorValid(prec, color, result))
                 return true;
@@ -784,7 +794,12 @@ goog.scope(function() {
                     /** @type {number} */ var x = tcuTexVerifierUtil.wrap(sampler.wrapS, i, level.getWidth());
                     /** @type {number} */ var y = tcuTexVerifierUtil.wrap(sampler.wrapT, j, level.getHeight());
                     /** @type {number} */ var z = tcuTexVerifierUtil.wrap(sampler.wrapR, k, level.getDepth());
-                    /** @type {Array<number>} */ var color = tcuTexLookupVerifier.lookupScalar(level, sampler, x, y, z);
+                    /** @type {Array<number>} */ var color;
+                    if (tcuTexLookupVerifier.isSRGB(level.getFormat())) {
+                        color = tcuTexLookupVerifier.lookupFloat(level, sampler, x, y, z);
+                    } else {
+                        color = tcuTexLookupVerifier.lookupScalar(level, sampler, x, y, z);
+                    }
 
                     if (tcuTexLookupVerifier.isColorValid(prec, color, result))
                         return true;


### PR DESCRIPTION
This fixes deqp/functional/gles3/texturefiltering_cube_formats_08.html.

C++ code:
isNearestSampleResultValid() call lookup<ScalarType>(level, sampler, x, y, coordZ). Due looup is a C++ template funciton the function really call is "inline Vector<float, 4> lookup (const ConstPixelBufferAccess& access, const Sampler& sampler, int i, int j, int k)". 

https://android.googlesource.com/platform/external/deqp/+/master/framework/common/tcuTexLookupVerifier.cpp#541
https://android.googlesource.com/platform/external/deqp/+/master/framework/common/tcuTexLookupVerifier.cpp#65

This patch isn't aligned with C++ code because JS doesn't support template function. Any suggestions about the fix?
