### PR TITLE
Fix #1600: WebGL2: Web IDL typedef definitions cannot be nested insid…

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1158,6 +1158,14 @@ for (var i = 0; i < numVertices; i++) {
     See <a href="#CONTEXT_LOST">the context lost event</a> for further details.
     </p>
     <pre class="idl">
+typedef (ArrayBuffer or ArrayBufferView) BufferDataSource;
+typedef (ImageBitmap or
+         ImageData or
+         HTMLImageElement or
+         HTMLCanvasElement or
+         HTMLVideoElement) TexImageSource;
+typedef (Float32Array or sequence&lt;GLfloat&gt;) VertexAttribFVSource;
+
 [NoInterfaceObject]
 interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 {
@@ -1605,7 +1613,6 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void blendFuncSeparate(GLenum srcRGB, GLenum dstRGB,
                            GLenum srcAlpha, GLenum dstAlpha);
 
-    typedef (ArrayBuffer or ArrayBufferView) BufferDataSource;
     void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
     void bufferData(GLenum target, BufferDataSource? data, GLenum usage);
     void bufferSubData(GLenum target, GLintptr offset, BufferDataSource? data);
@@ -1732,11 +1739,6 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
     void stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass);
 
-    typedef (ImageBitmap or
-             ImageData or
-             HTMLImageElement or
-             HTMLCanvasElement or
-             HTMLVideoElement) TexImageSource;
     void texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLsizei width, GLsizei height, GLint border, GLenum format,
                     GLenum type, ArrayBufferView? pixels);
@@ -1794,7 +1796,6 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void validateProgram(WebGLProgram? program);
 
     void vertexAttrib1f(GLuint indx, GLfloat x);
-    typedef (Float32Array or sequence&lt;GLfloat&gt;) VertexAttribFVSource;
     void vertexAttrib1fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
     void vertexAttrib2fv(GLuint indx, VertexAttribFVSource values);

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -70,6 +70,14 @@ interface WebGLShaderPrecisionFormat {
     readonly attribute GLint precision;
 };
 
+typedef (ArrayBuffer or ArrayBufferView) BufferDataSource;
+typedef (ImageBitmap or
+         ImageData or
+         HTMLImageElement or
+         HTMLCanvasElement or
+         HTMLVideoElement) TexImageSource;
+typedef (Float32Array or sequence<GLfloat>) VertexAttribFVSource;
+
 [NoInterfaceObject]
 interface WebGLRenderingContextBase
 {
@@ -517,7 +525,6 @@ interface WebGLRenderingContextBase
     void blendFuncSeparate(GLenum srcRGB, GLenum dstRGB,
                            GLenum srcAlpha, GLenum dstAlpha);
 
-    typedef (ArrayBuffer or ArrayBufferView) BufferDataSource;
     void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
     void bufferData(GLenum target, BufferDataSource? data, GLenum usage);
     void bufferSubData(GLenum target, GLintptr offset, BufferDataSource? data);
@@ -644,11 +651,6 @@ interface WebGLRenderingContextBase
     void stencilOp(GLenum fail, GLenum zfail, GLenum zpass);
     void stencilOpSeparate(GLenum face, GLenum fail, GLenum zfail, GLenum zpass);
 
-    typedef (ImageBitmap or
-             ImageData or
-             HTMLImageElement or
-             HTMLCanvasElement or
-             HTMLVideoElement) TexImageSource;
     void texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLsizei width, GLsizei height, GLint border, GLenum format,
                     GLenum type, ArrayBufferView? pixels);
@@ -706,7 +708,6 @@ interface WebGLRenderingContextBase
     void validateProgram(WebGLProgram? program);
 
     void vertexAttrib1f(GLuint indx, GLfloat x);
-    typedef (Float32Array or sequence<GLfloat>) VertexAttribFVSource;
     void vertexAttrib1fv(GLuint indx, VertexAttribFVSource values);
     void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
     void vertexAttrib2fv(GLuint indx, VertexAttribFVSource values);

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -408,6 +408,14 @@ typedef long long GLint64;
     </p>
 
     <pre class="idl">
+typedef (Uint32Array or sequence&lt;GLuint&gt;) UniformUIVSource;
+typedef (Float32Array or sequence&lt;GLfloat&gt;) UniformMatrixFVSource;
+typedef (Int32Array or sequence&lt;GLint&gt;) VertexAttribIVSource;
+typedef (Uint32Array or sequence&lt;GLuint&gt;) VertexAttribUIVSource;
+typedef (Int32Array or sequence&lt;GLint&gt;) ClearBufferIVSource;
+typedef (Uint32Array or sequence&lt;GLuint&gt;) ClearBufferUIVSource;
+typedef (Float32Array or sequence&lt;GLfloat&gt;) ClearBufferFVSource;
+
 [NoInterfaceObject]
 interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
 {
@@ -742,12 +750,10 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   void uniform2ui(WebGLUniformLocation? location, GLuint v0, GLuint v1);
   void uniform3ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2);
   void uniform4ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
-  typedef (Uint32Array or sequence&lt;GLuint&gt;) UniformUIVSource;
   void uniform1uiv(WebGLUniformLocation? location, UniformUIVSource value);
   void uniform2uiv(WebGLUniformLocation? location, UniformUIVSource value);
   void uniform3uiv(WebGLUniformLocation? location, UniformUIVSource value);
   void uniform4uiv(WebGLUniformLocation? location, UniformUIVSource value);
-  typedef (Float32Array or sequence&lt;GLfloat&gt;) UniformMatrixFVSource;
   void uniformMatrix2x3fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void uniformMatrix3x2fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void uniformMatrix2x4fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
@@ -755,10 +761,8 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   void uniformMatrix3x4fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
-  typedef (Int32Array or sequence&lt;GLint&gt;) VertexAttribIVSource;
   void vertexAttribI4iv(GLuint index, VertexAttribIVSource values);
   void vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
-  typedef (Uint32Array or sequence&lt;GLuint&gt;) VertexAttribUIVSource;
   void vertexAttribI4uiv(GLuint index, VertexAttribUIVSource values);
   void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
 
@@ -772,9 +776,6 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
 
   /* Multiple Render Targets */
   void drawBuffers(sequence&lt;GLenum&gt; buffers);
-  typedef (Int32Array or sequence&lt;GLint&gt;) ClearBufferIVSource;
-  typedef (Uint32Array or sequence&lt;GLuint&gt;) ClearBufferUIVSource;
-  typedef (Float32Array or sequence&lt;GLfloat&gt;) ClearBufferFVSource;
   void clearBufferiv(GLenum buffer, GLint drawbuffer, ClearBufferIVSource value);
   void clearBufferuiv(GLenum buffer, GLint drawbuffer, ClearBufferUIVSource value);
   void clearBufferfv(GLenum buffer, GLint drawbuffer, ClearBufferFVSource value);

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -24,6 +24,14 @@ interface WebGLTransformFeedback : WebGLObject {
 interface WebGLVertexArrayObject : WebGLObject {
 };
 
+typedef (Uint32Array or sequence<GLuint>) UniformUIVSource;
+typedef (Float32Array or sequence<GLfloat>) UniformMatrixFVSource;
+typedef (Int32Array or sequence<GLint>) VertexAttribIVSource;
+typedef (Uint32Array or sequence<GLuint>) VertexAttribUIVSource;
+typedef (Int32Array or sequence<GLint>) ClearBufferIVSource;
+typedef (Uint32Array or sequence<GLuint>) ClearBufferUIVSource;
+typedef (Float32Array or sequence<GLfloat>) ClearBufferFVSource;
+
 [NoInterfaceObject]
 interface WebGL2RenderingContextBase
 {
@@ -358,12 +366,10 @@ interface WebGL2RenderingContextBase
   void uniform2ui(WebGLUniformLocation? location, GLuint v0, GLuint v1);
   void uniform3ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2);
   void uniform4ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
-  typedef (Uint32Array or sequence<GLuint>) UniformUIVSource;
   void uniform1uiv(WebGLUniformLocation? location, UniformUIVSource value);
   void uniform2uiv(WebGLUniformLocation? location, UniformUIVSource value);
   void uniform3uiv(WebGLUniformLocation? location, UniformUIVSource value);
   void uniform4uiv(WebGLUniformLocation? location, UniformUIVSource value);
-  typedef (Float32Array or sequence<GLfloat>) UniformMatrixFVSource;
   void uniformMatrix2x3fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void uniformMatrix3x2fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void uniformMatrix2x4fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
@@ -371,10 +377,8 @@ interface WebGL2RenderingContextBase
   void uniformMatrix3x4fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, UniformMatrixFVSource value);
   void vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
-  typedef (Int32Array or sequence<GLint>) VertexAttribIVSource;
   void vertexAttribI4iv(GLuint index, VertexAttribIVSource values);
   void vertexAttribI4ui(GLuint index, GLuint x, GLuint y, GLuint z, GLuint w);
-  typedef (Uint32Array or sequence<GLuint>) VertexAttribUIVSource;
   void vertexAttribI4uiv(GLuint index, VertexAttribUIVSource values);
   void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset);
 
@@ -388,9 +392,6 @@ interface WebGL2RenderingContextBase
 
   /* Multiple Render Targets */
   void drawBuffers(sequence<GLenum> buffers);
-  typedef (Int32Array or sequence<GLint>) ClearBufferIVSource;
-  typedef (Uint32Array or sequence<GLuint>) ClearBufferUIVSource;
-  typedef (Float32Array or sequence<GLfloat>) ClearBufferFVSource;
   void clearBufferiv(GLenum buffer, GLint drawbuffer, ClearBufferIVSource value);
   void clearBufferuiv(GLenum buffer, GLint drawbuffer, ClearBufferUIVSource value);
   void clearBufferfv(GLenum buffer, GLint drawbuffer, ClearBufferFVSource value);


### PR DESCRIPTION
…e interfaces

Both the 1.0 and 2.0 specs contained typedefs inside interface definitions, which isn't explicitly called out but appears to be illegal according to the Web IDL grammar at https://heycam.github.io/webidl/ . Pull them outside the interface definitions.