### PR TITLE
Correct name of skipped tests

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuTestCase.js
+++ b/sdk/tests/deqp/framework/common/tcuTestCase.js
@@ -242,6 +242,7 @@ goog.scope(function() {
                 var skipDisposition = tcuSkipList.getSkipStatus(fullTestName);
                 if (skipDisposition.skip) {
                     tryAgain = true;
+                    setCurrentTestName(fullTestName);
                     checkMessage(false, 'Skipping test due to tcuSkipList: ' + fullTestName);
                 }
             }
@@ -271,7 +272,6 @@ goog.scope(function() {
 
         // If no more children, get the next brother
         if (test == null && this.parentTest != null) {
-            this.currentTestNdx = 0;
             test = this.parentTest._nextIgnoringSkipList(null);
         }
 


### PR DESCRIPTION
This fixes the wrong name of skipped tests and extra skip info at the
end of result page of each html file.

@kenrussell  I found some bugs about the skipped list. PTAL.