### PR TITLE
Fix wrapR mode and wrong texCoord used

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureFilteringTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureFilteringTests.js
@@ -1500,7 +1500,7 @@ goog.scope(function() {
 
         // Setup params for reference.
         refParams.sampler = gluTextureUtil.mapGLSampler(
-            this.m_wrapS, this.m_wrapT, this.m_wrapT,
+            this.m_wrapS, this.m_wrapT, this.m_wrapR,
             this.m_minFilter, this.m_magFilter
         );
 

--- a/sdk/tests/deqp/modules/shared/glsTextureTestUtil.js
+++ b/sdk/tests/deqp/modules/shared/glsTextureTestUtil.js
@@ -2518,7 +2518,7 @@ glsTextureTestUtil.computeTextureLookupDiff2DArray = function(result, reference,
 
     /** @type {Array<number>} */ var sq = [texCoord[0 + 0], texCoord[3 + 0], texCoord[6 + 0], texCoord[9 + 0]];
     /** @type {Array<number>} */ var tq = [texCoord[0 + 1], texCoord[3 + 1], texCoord[6 + 1], texCoord[9 + 1]];
-    /** @type {Array<number>} */ var rq = [texCoord[0 + 2], texCoord[3 + 1], texCoord[6 + 2], texCoord[9 + 2]];
+    /** @type {Array<number>} */ var rq = [texCoord[0 + 2], texCoord[3 + 2], texCoord[6 + 2], texCoord[9 + 2]];
 
     /** @type {Array<number>} */ var dstSize = [result.getWidth(), result.getHeight()];
     /** @type {number} */ var dstW = dstSize[0];


### PR DESCRIPTION
With this patch, all texturefiltering* tests can pass now.