### PR TITLE
Fix wrong sign bit calculation in tcuFloat.js

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuFloat.js
+++ b/sdk/tests/deqp/framework/common/tcuFloat.js
@@ -615,7 +615,7 @@ tcuFloat.convertFloat32Inline = (function() {
 
         var exponentBits = (fbits >> 23) & 0xff;
         var mantissaBits = fbits & 0x7fffff;
-        var signBit = (fbits & 0x8000000) ? 1 : 0;
+        var signBit = (fbits & 0x80000000) ? 1 : 0;
         var sign = signBit ? -1 : 1;
 
         var isZero = exponentBits == 0 && mantissaBits == 0;

--- a/sdk/tests/deqp/functional/gles3/es3fShaderDerivateTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderDerivateTests.js
@@ -1233,7 +1233,7 @@ goog.scope(function() {
                 '\tVerifying each result derivative is within its range of legal result values.');
 
             /** @type {Array<number>} */ var valueRamp = deMath.subtract(this.m_texValueMax, this.m_texValueMin);
-            /** @type {es3fShaderDerivateTests.Linear2DFunctionEvaluator} */ var function_;
+            /** @type {es3fShaderDerivateTests.Linear2DFunctionEvaluator} */ var function_ = new es3fShaderDerivateTests.Linear2DFunctionEvaluator();
 
             function_.matrix.setRow(0, [valueRamp[0] / w, 0.0, this.m_texValueMin[0]]);
             function_.matrix.setRow(1, [0.0, valueRamp[1] / h, this.m_texValueMin[1]]);


### PR DESCRIPTION
The bug causes shaderderivate.html regression. It's introduced in
https://github.com/KhronosGroup/WebGL/pull/1588. It also exposed
an uninitialization error in es3fShaderDerivateTests.js.