### PR TITLE
Expand tests for S3TC compressed textures to cover TexStorage2D.

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
@@ -213,13 +213,15 @@ function testDXT1_RGB() {
             height: 4,
             channels: 3,
             data: img_4x4_rgb_dxt1,
-            format: ext.COMPRESSED_RGB_S3TC_DXT1_EXT
+            format: ext.COMPRESSED_RGB_S3TC_DXT1_EXT,
+            hasAlpha: false,
         },
         {   width: 8,
             height: 8,
             channels: 3,
             data: img_8x8_rgb_dxt1,
-            format: ext.COMPRESSED_RGB_S3TC_DXT1_EXT
+            format: ext.COMPRESSED_RGB_S3TC_DXT1_EXT,
+            hasAlpha: false,
         }
     ];
     testDXTTextures(tests);
@@ -231,13 +233,19 @@ function testDXT1_RGBA() {
             height: 4,
             channels: 4,
             data: img_4x4_rgba_dxt1,
-            format: ext.COMPRESSED_RGBA_S3TC_DXT1_EXT
+            format: ext.COMPRESSED_RGBA_S3TC_DXT1_EXT,
+            // This is a special case -- the texture is still opaque
+            // though it's RGBA.
+            hasAlpha: false,
         },
         {   width: 8,
             height: 8,
             channels: 4,
             data: img_8x8_rgba_dxt1,
-            format: ext.COMPRESSED_RGBA_S3TC_DXT1_EXT
+            format: ext.COMPRESSED_RGBA_S3TC_DXT1_EXT,
+            // This is a special case -- the texture is still opaque
+            // though it's RGBA.
+            hasAlpha: false,
         }
     ];
     testDXTTextures(tests);
@@ -249,13 +257,15 @@ function testDXT3_RGBA() {
             height: 4,
             channels: 4,
             data: img_4x4_rgba_dxt3,
-            format: ext.COMPRESSED_RGBA_S3TC_DXT3_EXT
+            format: ext.COMPRESSED_RGBA_S3TC_DXT3_EXT,
+            hasAlpha: true,
         },
         {   width: 8,
             height: 8,
             channels: 4,
             data: img_8x8_rgba_dxt3,
-            format: ext.COMPRESSED_RGBA_S3TC_DXT3_EXT
+            format: ext.COMPRESSED_RGBA_S3TC_DXT3_EXT,
+            hasAlpha: true,
         }
     ];
     testDXTTextures(tests);
@@ -267,13 +277,15 @@ function testDXT5_RGBA() {
             height: 4,
             channels: 4,
             data: img_4x4_rgba_dxt5,
-            format: ext.COMPRESSED_RGBA_S3TC_DXT5_EXT
+            format: ext.COMPRESSED_RGBA_S3TC_DXT5_EXT,
+            hasAlpha: true,
         },
         {   width: 8,
             height: 8,
             channels: 4,
             data: img_8x8_rgba_dxt5,
-            format: ext.COMPRESSED_RGBA_S3TC_DXT5_EXT
+            format: ext.COMPRESSED_RGBA_S3TC_DXT5_EXT,
+            hasAlpha: true,
         }
     ];
     testDXTTextures(tests);
@@ -282,7 +294,11 @@ function testDXT5_RGBA() {
 function testDXTTextures(tests) {
     debug("<hr/>");
     for (var ii = 0; ii < tests.length; ++ii) {
-        testDXTTexture(tests[ii]);
+        testDXTTexture(tests[ii], false);
+        if (contextVersion >= 2) {
+            debug("<br/>");
+            testDXTTexture(tests[ii], true);
+        }
     }
 }
 
@@ -435,7 +451,7 @@ function copyRect(data, srcX, srcY, dstX, dstY, width, height, stride) {
   }
 }
 
-function testDXTTexture(test) {
+function testDXTTexture(test, useTexStorage) {
     var data = new Uint8Array(test.data);
     var width = test.width;
     var height = test.height;
@@ -446,7 +462,8 @@ function testDXTTexture(test) {
     canvas.width = width;
     canvas.height = height;
     gl.viewport(0, 0, width, height);
-    debug("testing " + formatToString(format) + " " + width + "x" + height);
+    debug("testing " + formatToString(format) + " " + width + "x" + height +
+          (useTexStorage ? " via texStorage2D" : " via compressedTexImage2D"));
 
     var tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex);
@@ -454,50 +471,67 @@ function testDXTTexture(test) {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height, 0, data);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uploading compressed texture");
+    if (useTexStorage) {
+        gl.texStorage2D(gl.TEXTURE_2D, 1, format, width, height);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "allocating compressed texture via texStorage2D");
+        wtu.clearAndDrawUnitQuad(gl);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad");
+        var clearColor = (test.hasAlpha ? [0, 0, 0, 0] : [0, 0, 0, 255]);
+        wtu.checkCanvas(gl, clearColor, "texture should be initialized to black");
+        gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, format, data);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uploading compressed texture data via compressedTexSubImage2D");
+    } else {
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height, 0, data);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uploading compressed texture");
+    }
     gl.generateMipmap(gl.TEXTURE_2D);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "trying to generate mipmaps from compressed texture");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after clearing generateMipmap error");
     wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad 1");
     compareRect(width, height, test.channels, width, height, uncompressedData, data, format, "NEAREST");
     // Test again with linear filtering.
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
     wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad 2");
     compareRect(width, height, test.channels, width, height, uncompressedData, data, format, "LINEAR");
 
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height, 1, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "non 0 border");
+    if (!useTexStorage) {
+        // It's not allowed to redefine textures defined via texStorage2D.
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height, 1, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "non 0 border");
 
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width + 4, height, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height + 4, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 4, height, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height - 4, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width + 4, height, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height + 4, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 4, height, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height - 4, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
 
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 1, height, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 2, height, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height - 1, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
-    gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height - 2, 0, data);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 1, height, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 2, height, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height - 1, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
+        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height - 2, 0, data);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
 
-    if (width == 4) {
-      gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 1, height, 0, data);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
-      gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 2, height, 0, data);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
-    }
-    if (height == 4) {
-      gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 1, 0, data);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
-      gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 2, 0, data);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+        if (width == 4) {
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 1, height, 0, data);
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 2, height, 0, data);
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+        }
+        if (height == 4) {
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 1, 0, data);
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 2, 0, data);
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+        }
     }
 
     // pick a wrong format that uses the same amount of data.
@@ -563,10 +597,12 @@ function testDXTTexture(test) {
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
             wtu.clearAndDrawUnitQuad(gl);
             compareRect(width, height, test.channels, width, height, uncompressedData, data, format, "NEAREST");
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad");
             // Next test LINEAR filtering.
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             wtu.clearAndDrawUnitQuad(gl);
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad");
             compareRect(width, height, test.channels, width, height, uncompressedData, data, format, "LINEAR");
         }
     }
@@ -607,6 +643,7 @@ function compareRect(
     var actual = new Uint8Array(actualWidth * actualHeight * 4);
     gl.readPixels(
             0, 0, actualWidth, actualHeight, gl.RGBA, gl.UNSIGNED_BYTE, actual);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "reading back pixels");
 
     var div = document.createElement("div");
     div.className = "testimages";


### PR DESCRIPTION
This is the first time that uninitialized compressed textures can be
exposed to the JavaScript level, and they must be tested. The new
tests assert that the texture contains either transparent or opaque
black, depending on the specific DXT internal format.

See http://crbug.com/605129 for fixes for this test in Chromium.