### PR TITLE
Fix texture initialization for texturespecification tests

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
@@ -1366,7 +1366,7 @@ goog.scope(function() {
 
         images = rnd.shuffle(images);
 
-        for (var ndx = 0; ndx < this.m_numLevels; ndx++) {
+        for (var ndx = 0; ndx < images.length; ndx++) {
             var levelNdx = images[ndx].ndx;
             /** @type {framework.common.tcuTexture.CubeFace} */
             var face = images[ndx].face;


### PR DESCRIPTION
This fixes texturespecification01.html on chromeOS. But
texturespecification01.html still fails on my linux desktop with nVidia
graphics card. The failure is about texture filtering. I suppose it's a
driver bug: wrong level is selected as input texture for nVidia.

C++ code:
https://android.googlesource.com/platform/external/deqp/+/master/modules/gles3/functional/es3fTextureSpecificationTests.cpp#928