### PR TITLE
Add conformance test for extensions no longer available in WebGL 2.0.

### DIFF
--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -17,6 +17,8 @@
     <api version="1.0"/>
 
     <ext name="OES_texture_half_float" require="true"/>
+
+    <subsumed version="2.0" by="EXT_color_buffer_float" />
   </depends>
 
   <overview>
@@ -133,6 +135,10 @@ interface EXT_color_buffer_half_float {
 
     <revision date="2014/11/24">
       <change>Move to community approved.</change>
+    </revision>
+
+    <revision date="2016/05/05">
+      <change>Subsumed in WebGL 2.0 by EXT_color_buffer_float.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -19,6 +19,8 @@
     <ext name="EXT_color_buffer_half_float"/>
 
     <ext name="OES_texture_float" require="true"/>
+
+    <subsumed version="2.0" by="EXT_color_buffer_float" />
   </depends>
 
   <overview>
@@ -119,6 +121,10 @@ interface WEBGL_color_buffer_float {
 
     <revision date="2014/11/24">
       <change>Move to community approved.</change>
+    </revision>
+
+    <revision date="2016/05/05">
+      <change>Subsumed in WebGL 2.0 by EXT_color_buffer_float.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -221,6 +221,10 @@
   </xsl:choose>
 </xsl:template>
 
+<xsl:template match="subsumed" mode="depends">
+  <p> <xsl:apply-templates select="."/> </p>
+</xsl:template>
+
 <xsl:template match="removed" mode="depends">
   <p> No longer available as of the <xsl:apply-templates select="."/> specification. </p>
 </xsl:template>

--- a/extensions/standards.xsl
+++ b/extensions/standards.xsl
@@ -7,6 +7,10 @@
     <a href="http://www.khronos.org/registry/webgl/specs/{@version}/">WebGL API <xsl:value-of select="@version"/></a>
   </xsl:template>
 
+  <xsl:template match="subsumed">
+    No longer available as of the <a href="http://www.khronos.org/registry/webgl/specs/latest/{@version}/">WebGL API <xsl:value-of select="@version"/></a> specification. Subsumed by the <a href="../{@by}/"><xsl:value-of select="@by"/></a> extension.
+  </xsl:template>
+
   <xsl:template match="ext">
     <a href="http://www.khronos.org/registry/webgl/extensions/{@name}/">
       <xsl:value-of select="@name"/>

--- a/sdk/tests/conformance2/extensions/00_test_list.txt
+++ b/sdk/tests/conformance2/extensions/00_test_list.txt
@@ -1,2 +1,3 @@
 ext-color-buffer-float.html
+promoted-extensions.html
 promoted-extensions-in-shaders.html

--- a/sdk/tests/conformance2/extensions/promoted-extensions.html
+++ b/sdk/tests/conformance2/extensions/promoted-extensions.html
@@ -1,0 +1,86 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+"use strict";
+var wtu = WebGLTestUtils;
+var gl;
+
+function checkExtensionNotAvailable(extension, extensions) {
+    if (extensions.indexOf(extension) >= 0) {
+        testFailed(extension + " was exposed in the WebGL 2.0 context but should not have been");
+    } else {
+        testPassed(extension + " was not exposed in the WebGL 2.0 context");
+    }
+}
+
+description("Promoted extensions from WebGL 1.0 should not be exposed in WebGL 2.0");
+
+shouldBeNonNull("gl = wtu.create3DContext(undefined, undefined, 2)");
+
+var exts = gl.getSupportedExtensions();
+
+var promotedExtensions = [
+    "ANGLE_instanced_arrays",
+    "EXT_blend_minmax",
+    "EXT_color_buffer_half_float",
+    "EXT_frag_depth",
+    "EXT_shader_texture_lod",
+    "EXT_sRGB",
+    "OES_element_index_uint",
+    "OES_standard_derivatives",
+    "OES_texture_float",
+    "OES_texture_half_float",
+    "OES_texture_half_float_linear",
+    "OES_vertex_array_object",
+    "WEBGL_depth_texture",
+    "WEBGL_draw_buffers",
+]
+
+for (var i = 0; i < promotedExtensions.length; ++i) {
+    checkExtensionNotAvailable(promotedExtensions[i], exts);
+}
+
+debug("")
+var successfullyParsed = true;
+</script>
+
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
These include both extensions promoted to core, and extensions subsumed by other extensions.

Explicitly point out that EXT_color_buffer_half_float and WEBGL_color_buffer_float are no longer available in WebGL 2.0, subsumed by EXT_color_buffer_float.