### PR TITLE
Fix a bug that UNIFORM_BUFFER_SIZE or TRANSFORM_BUFFER_SIZE should

### DIFF
--- a/sdk/tests/conformance2/buffers/bound-buffer-size-change-test.html
+++ b/sdk/tests/conformance2/buffers/bound-buffer-size-change-test.html
@@ -62,7 +62,7 @@ shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_START, 0)", "0");
 
 gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, 4, gl.STATIC_DRAW);
 shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0)", "buffer1");
-shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_SIZE, 0)", "4");
+shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_SIZE, 0)", "0");
 shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_START, 0)", "0");
 
 wtu.glErrorShouldBe(gl, gl.NO_ERROR);
@@ -80,7 +80,7 @@ shouldBe("gl.getIndexedParameter(gl.UNIFORM_BUFFER_START, 1)", "0");
 
 gl.bufferData(gl.UNIFORM_BUFFER, 8, gl.STATIC_DRAW);
 shouldBe("gl.getIndexedParameter(gl.UNIFORM_BUFFER_BINDING, 1)", "buffer2");
-shouldBe("gl.getIndexedParameter(gl.UNIFORM_BUFFER_SIZE, 1)", "8");
+shouldBe("gl.getIndexedParameter(gl.UNIFORM_BUFFER_SIZE, 1)", "0");
 shouldBe("gl.getIndexedParameter(gl.UNIFORM_BUFFER_START, 1)", "0");
 
 wtu.glErrorShouldBe(gl, gl.NO_ERROR);


### PR DESCRIPTION
return 0 if it's not specified at binding time (for example, through
BinBufferBase)