### PR TITLE
Fix transform feedback buffer binding issue

### DIFF
--- a/sdk/tests/deqp/functional/gles3/lifetime.html
+++ b/sdk/tests/deqp/functional/gles3/lifetime.html
@@ -20,7 +20,7 @@ setCurrentTestName(testName);
 description("Functional test: " + testName + ".");
 
 var wtu = WebGLTestUtils;
-/** @type {WebGL2RenderingContext} */ var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+/** @type {WebGL2RenderingContext} */ var gl = wtu.create3DContext('canvas', null, 2);
 
     try{
         functional.gles3.es3fLifetimeTests.run(gl);

--- a/sdk/tests/deqp/modules/shared/glsLifetimeTests.js
+++ b/sdk/tests/deqp/modules/shared/glsLifetimeTests.js
@@ -996,7 +996,12 @@ glsLifetimeTests.OutputAttachmentTest.prototype.iterate = function() {
 
     // For reference purposes, make note of what refSeed looks like.
     this.m_outputAttacher.setupContainer(refSeed, container);
+    // Since in WebGL, buffer bound to TRANSFORM_FEEDBACK_BUFFER can not be bound to other targets.
+    // Unfortunately, element will be bound again in drawAttachment() for drawing.
+    // Detach element from container before drawing, then reattach it after drawing.
+    attacher.detach(element, container);
     this.m_outputAttacher.drawAttachment(element, refSurface);
+    attacher.attach(element, container);
     elementType.release(element);
 
     bufferedLogToConsole('Writing to a container after deletion of attachment');


### PR DESCRIPTION
In WebGL, a buffer bound to TRANSFORM_FEEDBACK_BUFFER cannot be bound to
any other targets. See section 5.1 Buffer Object Binding in WebGL 2.0
spec. This is a difference between GLES and WebGL. This patch detaches
the buffer from TRANSFORM_FEEDBACK_BUFFER before other binding, then
reattaches it after other binding.