### PR TITLE
Create WebGL 2 context by default in conformance2 tests using js/tests

### DIFF
--- a/sdk/tests/js/tests/gl-enum-tests.js
+++ b/sdk/tests/js/tests/gl-enum-tests.js
@@ -32,7 +32,7 @@ debug("");
 debug("Canvas.getContext");
 
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
+var gl = wtu.create3DContext("canvas", undefined, contextVersion);
 if (!gl) {
   testFailed("context does not exist");
 } else {

--- a/sdk/tests/js/tests/gl-get-tex-parameter.js
+++ b/sdk/tests/js/tests/gl-get-tex-parameter.js
@@ -28,7 +28,7 @@
 "use strict";
 description();
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("example");
+var gl = wtu.create3DContext("example", undefined, contextVersion);
 
 // NOTE: We explicitly do this in a funky order
 // to hopefully find subtle bugs.

--- a/sdk/tests/js/tests/gl-object-get-calls.js
+++ b/sdk/tests/js/tests/gl-object-get-calls.js
@@ -29,7 +29,7 @@
 var wtu = WebGLTestUtils;
 description("Test of get calls against GL objects like getBufferParameter, etc.");
 
-var gl = wtu.create3DContext();
+var gl = wtu.create3DContext(undefined, undefined, contextVersion);
 
 function testInvalidArgument(funcName, argumentName, validArgumentArray, func) {
   var validArguments = {};
@@ -101,9 +101,9 @@ for (var run = 0; run < testCases.length; ++run) {
   debug("Test getFramebufferAttachmentParameter with stencil " + testCases[run].contextStencil);
 
   if (testCases[run].contextStencil) {
-    gl = wtu.create3DContext(null, {stencil: true});
+    gl = wtu.create3DContext(null, {stencil: true}, contextVersion);
   } else {
-    gl = wtu.create3DContext(null, {stencil: false});
+    gl = wtu.create3DContext(null, {stencil: false}, contextVersion);
   }
 
   var texture = gl.createTexture();

--- a/sdk/tests/js/tests/gl-vertex-attrib.js
+++ b/sdk/tests/js/tests/gl-vertex-attrib.js
@@ -32,7 +32,7 @@ debug("");
 debug("Canvas.getContext");
 
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
+var gl = wtu.create3DContext("canvas", undefined, contextVersion);
 if (!gl) {
   testFailed("context does not exist");
 } else {

--- a/sdk/tests/js/tests/instanceof-test.js
+++ b/sdk/tests/js/tests/instanceof-test.js
@@ -38,7 +38,7 @@ function checkGLError(message) {
   }
 }
 
-var gl = wtu.create3DContext("canvas");
+var gl = wtu.create3DContext("canvas", undefined, contextVersion);
 if (contextVersion === 1) {
   shouldBeTrue('gl instanceof WebGLRenderingContext');
 } else if (contextVersion === 2) {

--- a/sdk/tests/js/tests/tex-input-validation.js
+++ b/sdk/tests/js/tests/tex-input-validation.js
@@ -33,7 +33,7 @@ var gl = null;
 var tex = null;
 var error = 0;
 
-shouldBeNonNull("gl = wtu.create3DContext()");
+shouldBeNonNull("gl = wtu.create3DContext(undefined, undefined, contextVersion)");
 shouldBeNonNull("tex = gl.createTexture()");
 gl.bindTexture(gl.TEXTURE_2D, tex);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR);
@@ -149,9 +149,9 @@ function testCopyFromInternalFBO(testCase) {
             " internalFormat: " + enumToString(testCase.internalFormat);
 
   if (testCase.contextAlpha) {
-    gl = wtu.create3DContext(null, { alpha: true });
+    gl = wtu.create3DContext(null, { alpha: true }, contextVersion);
   } else {
-    gl = wtu.create3DContext(null, { alpha: false });
+    gl = wtu.create3DContext(null, { alpha: false }, contextVersion);
   }
   shouldBeNonNull("gl");
   shouldBeNonNull("tex = gl.createTexture()");


### PR DESCRIPTION
Some WebGL 2 tests would default to a WebGL 1 context if
?webglVersion=2 was not added to the URL. Fix this to make the tests
easier to run standalone.