### PR TITLE
Add default value of "" to WebGLContextEventInit::statusMessage.

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3138,7 +3138,7 @@ interface <dfn id="WebGLContextLostEvent">WebGLContextEvent</dfn> : <a href="htt
 
 // EventInit is defined in the DOM4 specification.
 dictionary WebGLContextEventInit : <a href="http://www.w3.org/TR/domcore/#eventinit">EventInit</a> {
-    DOMString statusMessage;
+    DOMString statusMessage = "";
 };</pre>
 
     <p>

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -734,5 +734,5 @@ interface WebGLContextEvent : Event {
 
 // EventInit is defined in the DOM4 specification.
 dictionary WebGLContextEventInit : EventInit {
-    DOMString statusMessage;
+    DOMString statusMessage = "";
 };


### PR DESCRIPTION
Members of EventInit dicts must either have default values or be 'required' values.