### PR TITLE
Fix a bug in es3fTextureSpecificationTests.js

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
@@ -2639,8 +2639,7 @@ goog.scope(function() {
                 format: this.m_texFormat,
                 width: this.m_width,
                 height: this.m_height,
-                data: data,
-                offset: this.m_texFormat.getPixelSize() * this.m_width * this.m_height
+                data: data
             });
         tcuTextureUtil.fillWithComponentGradients(access, [0, 0, 0, 0], [1, 1, 1, 1]);
 


### PR DESCRIPTION
The offset should be 0, but instead, it is set to the buffer size.
So the ArrayBufferView passed to the teximage call become size 0.