### PR TITLE
Realize function deinit() in tcuTestCase.js

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboColorbufferTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboColorbufferTests.js
@@ -114,6 +114,46 @@ es3fFboColorbufferTests.FboColorbufferCase.prototype.compare = function(referenc
     };
 
 /**
+ * Deinit. Clear some GL state variables
+ */
+es3fFboColorbufferTests.FboColorbufferCase.prototype.deinit = function() {
+        // Texture state
+        {
+            // Only TEXTURE0 and TEXTURE1 are used in this test
+            var numTexUnits = 2;
+
+            for (var ndx = 0; ndx < numTexUnits; ndx++) {
+                gl.activeTexture(gl.TEXTURE0 + ndx);
+
+                // Reset 2D texture
+                gl.bindTexture(gl.TEXTURE_2D, null);
+
+                // Reset cube map texture
+                gl.bindTexture(gl.TEXTURE_CUBE_MAP, null);
+
+                // Reset 2D array texture
+                gl.bindTexture(gl.TEXTURE_2D_ARRAY, null);
+
+                // Reset 3D texture
+                gl.bindTexture(gl.TEXTURE_3D, null);
+            }
+
+            gl.activeTexture(gl.TEXTURE0);
+        }
+
+        // Pixel operations
+        {
+            gl.disable(gl.SCISSOR_TEST);
+            gl.disable(gl.BLEND);
+        }
+
+        // Framebuffer control
+        {
+            gl.clearColor(0.0, 0.0, 0.0, 0.0);
+        }
+    };
+
+/**
  * @constructor
  * @extends {es3fFboColorbufferTests.FboColorbufferCase}
  * @param {string} name

--- a/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
@@ -101,12 +101,12 @@ var DE_ASSERT = function(x) {
         /** @type {es3fFboTestUtil.FlatColorShader} */ var flatShader = new es3fFboTestUtil.FlatColorShader(es3fFboTestUtil.getFragmentOutputType(colorFmt));
         var gradShaderID = this.getCurrentContext().createProgram(gradShader);
         var flatShaderID = this.getCurrentContext().createProgram(flatShader);
-        var msaaFbo = 0;
-        var resolveFbo = 0;
-        var msaaColorRbo = 0;
-        var resolveColorRbo = 0;
-        var msaaDepthStencilRbo = 0;
-        var resolveDepthStencilRbo = 0;
+        var msaaFbo = null;
+        var resolveFbo = null;
+        var msaaColorRbo = null;
+        var resolveColorRbo = null;
+        var msaaDepthStencilRbo = null;
+        var resolveDepthStencilRbo = null;
 
         // Create framebuffers.
         msaaColorRbo = ctx.createRenderbuffer();

--- a/sdk/tests/deqp/functional/gles3/es3fFboRenderTest.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboRenderTest.js
@@ -708,44 +708,14 @@ goog.scope(function() {
      * deinit
      */
     es3fFboRenderTest.FboRenderCase.prototype.deinit = function() {
-        gl.colorMask(true, true, true, true);
-        gl.depthMask(true);
-
         gl.clearColor(0.0, 0.0, 0.0, 0.0);
         gl.clearDepth(1.0);
         gl.clearStencil(0);
 
         gl.disable(gl.STENCIL_TEST);
         gl.disable(gl.DEPTH_TEST);
-        gl.disable(gl.BLEND)
-        gl.disable(gl.SAMPLE_COVERAGE);
-        gl.disable(gl.SAMPLE_ALPHA_TO_COVERAGE);
+        gl.disable(gl.BLEND);
 
-        if (this.m_program) {
-            gl.deleteProgram(this.m_program.getProgram());
-            this.m_program = null;
-        }
-        if (this.m_msColorRbo) {
-          gl.deleteRenderbuffer(this.m_msColorRbo);
-          this.m_msColorRbo = null;
-        }
-        if (this.m_msDepthStencilRbo) {
-          gl.deleteRenderbuffer(this.m_msDepthStencilRbo);
-          this.m_msDepthStencilRbo = null;
-        }
-        if (this.m_resolveColorRbo) {
-          gl.deleteRenderbuffer(this.m_resolveColorRbo);
-          this.m_resolveColorRbo = null;
-        }
-
-        if (this.m_msFbo) {
-          gl.deleteFramebuffer(this.m_msFbo);
-          this.m_msFbo = null;
-        }
-        if (this.m_resolveFbo) {
-          gl.deleteFramebuffer(this.m_resolveFbo);
-          this.m_resolveFbo = null;
-        }
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.bindRenderbuffer(gl.RENDERBUFFER, null);
     };

--- a/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
@@ -205,23 +205,6 @@ var DE_ASSERT = function(x) {
         if (this.preCheck)
             this.preCheck();
 
-        // clear some GL state variables
-        // TODO: maybe we should place in tuTestCase.js
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
-        gl.bindTexture(gl.TEXTURE_2D, null);
-        gl.depthFunc(gl.LESS);
-        gl.disable(gl.DEPTH_TEST);
-        gl.stencilOp(gl.KEEP, gl.KEEP, gl.REPLACE);
-        gl.stencilFunc(gl.ALWAYS, 0, 0xffff);
-        gl.disable(gl.STENCIL_TEST);
-        gl.blendFunc(gl.ONE, gl.ZERO);
-        gl.blendEquation(gl.FUNC_ADD);
-        gl.disable(gl.BLEND);
-        gl.clearColor(0, 0, 0, 0);
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-        gl.scissor(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
-
         // Render using GLES3.
         try {
             /** @type {sglrGLContext.GLContext} */ var context = new sglrGLContext.GLContext(
@@ -275,6 +258,42 @@ var DE_ASSERT = function(x) {
         assertMsgOptions(isOk, '', true, false);
 
         return tcuTestCase.IterateResult.STOP;
+    };
+
+    /**
+    * Deinit. Clear some GL state variables
+    */
+    es3fFboTestCase.FboTestCase.prototype.deinit = function () {
+        // Pixel operations
+        {
+            gl.disable(gl.SCISSOR_TEST);
+
+            gl.disable(gl.STENCIL_TEST);
+            gl.stencilFunc(gl.ALWAYS, 0, 0xffff);
+            gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+
+            gl.disable(gl.DEPTH_TEST);
+            gl.depthFunc(gl.LESS);
+
+            gl.disable(gl.BLEND);
+            gl.blendFunc(gl.ONE, gl.ZERO);
+            gl.blendEquation(gl.FUNC_ADD);
+            gl.blendColor(0.0, 0.0, 0.0, 0.0);
+
+            gl.enable(gl.DITHER);
+        }
+
+        // Framebuffer control
+        {
+            gl.colorMask(true, true, true, true);
+            gl.depthMask(true);
+            gl.stencilMask(0xffff);
+
+            gl.clearColor(0.0, 0.0, 0.0, 0.0);
+            gl.clearDepth(1.0);
+            gl.clearStencil(0.0);
+            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+        }
     };
 
     /**

--- a/sdk/tests/deqp/functional/gles3/es3fNegativeTextureApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeTextureApiTests.js
@@ -2461,10 +2461,12 @@ goog.scope(function() {
         function() {
 
             /** @type{Array<WebGLTexture>} */ var texture = [];
+
+            // We have to create and bind textures to each target for the test because default textures are not supported by WebGL.
             texture[0] = gl.createTexture();
             texture[1] = gl.createTexture();
-            // gl.bindTexture (gl.TEXTURE_CUBE_MAP, texture[0]);
-            // gl.bindTexture (gl.TEXTURE_2D_ARRAY, texture[1]);
+            gl.bindTexture (gl.TEXTURE_CUBE_MAP, texture[0]);
+            gl.bindTexture (gl.TEXTURE_2D_ARRAY, texture[1]);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if target is invalid.');
             gl.compressedTexImage3D(0, 0, gl.COMPRESSED_RGBA8_ETC2_EAC, 0, 0, 0, 0, new Uint8Array(0));

--- a/sdk/tests/deqp/functional/gles3/es3fShaderStateQueryTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderStateQueryTests.js
@@ -230,7 +230,7 @@ es3fShaderStateQueryTests.CurrentVertexAttribInitialCase.prototype.test = functi
 
     for (var index = 0; index < attribute_count; ++index) {
         var attrib = gl.getVertexAttrib(index, gl.CURRENT_VERTEX_ATTRIB);
-        this.check(glsStateQuery.compare(attrib, initial), 'Initial attrib value should be [0, 0, 0, 0]');
+        this.check(glsStateQuery.compare(attrib, initial), 'Initial attrib value should be [0, 0, 0, 1]');
     }
 };
 


### PR DESCRIPTION
Many cases fail because some related gl states fail to be reset after the completion of last case, such as cases in FboRender and FboMultisamples, etc. 
Original deinit() functions in es3fFboRenderTest.js and es3fFboTestCase.js are moved to function deinit() in tcuTestCase.js.
16 (of 46) cases in FboMultisample will pass after this patch
