### PR TITLE
Fix texturespecification/teximage2d_align.html

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
@@ -405,7 +405,7 @@ goog.scope(function() {
             for (var ndx = 0; ndx < 2; ndx++) {
                 /** @type {tcuSurface.Surface} */
                 var dst = ndx ? reference : result;
-                ctx = ndx ? refContext : webgl2Context;
+                var ctx = ndx ? refContext : webgl2Context;
                 var shaderID = ndx ? shaderIDRef : shaderIDgles;
 
                 this.m_context = ctx;
@@ -1415,10 +1415,7 @@ goog.scope(function() {
         es3fTextureSpecificationTests.Texture2DSpecCase.call(
             this, name, desc, gluTextureUtil.mapGLTransferFormat(
                 format, dataType
-            ), width, height,
-            es3fTextureSpecificationTests.maxLevelCount(
-                width, height
-            )
+            ), width, height, numLevels
         );
 
         this.m_internalFormat = format;


### PR DESCRIPTION
The c++ tests specifies number of levels, whereas the js tests compute number
of levels based on width/height. So js tests include the 1 pixel level, which
caused rendering to 3x1 or 2x1 destinations failing.