### PR TITLE
Fix negative one index for WebGL 2.0

### DIFF
--- a/sdk/tests/conformance/rendering/negative-one-index.html
+++ b/sdk/tests/conformance/rendering/negative-one-index.html
@@ -62,6 +62,7 @@ function init()
 
     var wtu = WebGLTestUtils;
     var gl = wtu.create3DContext("example");
+    var contextVersion = wtu.getDefault3DContextVersion();
     var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
 
     var vertexObject = gl.createBuffer();
@@ -88,19 +89,25 @@ function init()
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0);
 
-    // This should render a green triangle in the middle of the canvas.
-    // Some implementations may incorrectly interpret the -1 index as
-    // a primitive restart and not render anything.
+    if (contextVersion <= 1) {
+        // This should render a green triangle in the middle of the canvas.
+        // Some implementations may incorrectly interpret the -1 index as
+        // a primitive restart and not render anything.
 
-    // Test several locations
-    // First line should be all black
-    wtu.checkCanvasRect(gl, 0, 0, 50, 1, [0, 0, 0, 0]);
+        // Test several locations
+        // First line should be all black
+        wtu.checkCanvasRect(gl, 0, 0, 50, 1, [0, 0, 0, 0]);
 
-    // Line 15 should be green for at least 10 red pixels starting 20 pixels in
-    wtu.checkCanvasRect(gl, 20, 15, 10, 1, [0, 255, 0, 255]);
+        // Line 15 should be green for at least 10 pixels starting from row 20
+        wtu.checkCanvasRect(gl, 20, 15, 10, 1, [0, 255, 0, 255]);
 
-    // Last line should be all black
-    wtu.checkCanvasRect(gl, 0, 49, 50, 1, [0, 0, 0, 0]);
+        // Last line should be all black
+        wtu.checkCanvasRect(gl, 0, 49, 50, 1, [0, 0, 0, 0]);
+    } else {
+        // For WebGL 2, PRIMITIVE_RESTART_FIXED_INDEX is always enabled.
+        // Nothing should be drawn on the canvas.
+        wtu.checkCanvasRect(gl, 0, 0, 50, 50, [0, 0, 0, 0]);
+    }
 }
 
 init();


### PR DESCRIPTION
Primitive restart is always enabled in WebGL 2.0. -1 index is treated as
a primitive restart and nothing is rendered. This is different with
WebGL 1.0.