### PR TITLE
Similar fix to make texturespecification/teximage2d_pbo.html pass on …

### DIFF
--- a/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContext.js
+++ b/sdk/tests/deqp/framework/opengl/simplereference/sglrReferenceContext.js
@@ -4203,14 +4203,16 @@ goog.scope(function() {
                 textureCube.allocLevel(level, face, storageFmt, width, height);
 
             if (data) {
-                var rowPitch = deMath.deAlign32(width * transferFmt.getPixelSize(), this.m_pixelUnpackAlignment);
+                var rowLen = this.m_pixelUnpackRowLength > 0 ? this.m_pixelUnpackRowLength : width;
+                var rowPitch = deMath.deAlign32(rowLen * transferFmt.getPixelSize(), this.m_pixelUnpackAlignment);
+                var skip = this.m_pixelUnpackSkipRows * rowPitch + this.m_pixelUnpackSkipPixels * transferFmt.getPixelSize();
                 src = new tcuTexture.ConstPixelBufferAccess({
                     format: transferFmt,
                     width: width,
                     height: height,
                     rowPitch: rowPitch,
                     data: data,
-                    offset: offset});
+                    offset: offset + skip});
 
                 dst = textureCube.getFace(level, face);
 

--- a/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
@@ -3731,7 +3731,7 @@ goog.scope(function() {
         var height = this.m_height + this.m_skipRows;
         var buf = null;
         var tex = null;
-        var data = new ArrayBuffer(rowPitch * height + this.m_offset);
+        var data = new ArrayBuffer(rowPitch * height + this.m_skipPixels * pixelSize + this.m_offset);
 
         assertMsgOptions(
             this.m_numLevels == 1, 'Number of levels different than 1',
@@ -3834,7 +3834,7 @@ goog.scope(function() {
         );
         var height = this.m_size + this.m_skipRows;
 
-        var data = new ArrayBuffer(rowPitch * height + this.m_offset);
+        var data = new ArrayBuffer(rowPitch * height + this.m_skipPixels * pixelSize + this.m_offset);
         var access = new tcuTexture.PixelBufferAccess({
                             format: this.m_texFormat,
                             width: this.m_size,


### PR DESCRIPTION
…Mac.

It still fails on Linux with GL errors. Will look into that separately.