### PR TITLE
Fix array index bug in WebGL 2.0

### DIFF
--- a/sdk/tests/conformance/rendering/line-loop-tri-fan.html
+++ b/sdk/tests/conformance/rendering/line-loop-tri-fan.html
@@ -182,13 +182,13 @@ function runTest() {
         degenInd[j] = j;
     }
     degenInd = degenInd.concat([252, 253, 254, 255]);
-    indices = new Uint8Array(degenInd);
+    indices = new Uint16Array(degenInd);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indBuf);
     gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
 
     debug('Draw a square using an ubyte indexed line loop with 256 indices and verify that it draws all four sides and nothing else.');
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-    gl.drawElements(gl.LINE_LOOP, indices.length, gl.UNSIGNED_BYTE, 0);
+    gl.drawElements(gl.LINE_LOOP, indices.length, gl.UNSIGNED_SHORT, 0);
     checkLineLoop(gl, w);
 
     //---------- TRIANGLE_FAN ----------

--- a/sdk/tests/js/tests/out-of-bounds-test.js
+++ b/sdk/tests/js/tests/out-of-bounds-test.js
@@ -133,6 +133,7 @@ var runDrawArraysTest = function(callTemplate, gl, wtu, ext) {
 
 var runDrawElementsTest = function(callTemplate, gl, wtu, ext) {
     var program = setupProgramAndBindVertexArray(gl, wtu);
+    var contextVersion = wtu.getDefault3DContextVersion();
 
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0.5,0, -0.5,-0.5,0, 0.5,-0.5,0 ]), gl.STATIC_DRAW);
     gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
@@ -190,14 +191,27 @@ var runDrawElementsTest = function(callTemplate, gl, wtu, ext) {
 
     var ebo = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ebo);
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(
-        [ 0, 1, 2,
-          1, 2, 0,
-          2, 0, 1,
-          200, 200, 200,
-          0x7fff, 0x7fff, 0x7fff,
-          0xffff, 0xffff, 0xffff ]),
-        gl.STATIC_DRAW);
+    // For WebGL 2, PRIMITIVE_RESTART_FIXED_INDEX is always enabled.
+    // 0xffff will be handled as a primitive restart.
+    if (contextVersion <= 1) {
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(
+            [ 0, 1, 2,
+              1, 2, 0,
+              2, 0, 1,
+              201, 202, 203,
+              0x7fff, 0x7fff, 0x7fff,
+              0xffff, 0xffff, 0xffff ]),
+            gl.STATIC_DRAW);
+    } else {
+        gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(
+            [ 0, 1, 2,
+              1, 2, 0,
+              2, 0, 1,
+              201, 202, 203,
+              0x7fff, 0x7fff, 0x7fff,
+              0xffff - 1, 0xffff - 1, 0xffff - 1 ]),
+            gl.STATIC_DRAW);
+    }
 
     wtu.shouldGenerateGLError(gl, gl.NO_ERROR, wtu.replaceParams(callTemplate, {count: 9, type: 'gl.UNSIGNED_SHORT', offset: 0}));
 


### PR DESCRIPTION
In WebGL 2.0, primitive restart is always enabled. Avoid using primitive
restart fixed index for element index.