### PR TITLE
Fix the ES3 IntegerStateQuery blendfunc tests reset

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fIntegerStateQueryTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fIntegerStateQueryTests.js
@@ -883,12 +883,12 @@ goog.scope(function() {
 		switch (this.m_testTargetName) {
 			case gl.BLEND_SRC_RGB:
 			case gl.BLEND_SRC_ALPHA:
-				gl.blendFunc(func, gl.ZERO);
+				gl.blendFunc(func, gl.getParameter(gl.BLEND_DST_RGB));
 				break;
 
 			case gl.BLEND_DST_RGB:
 			case gl.BLEND_DST_ALPHA:
-				gl.blendFunc(gl.ZERO, func);
+				gl.blendFunc(gl.getParameter(gl.BLEND_SRC_RGB), func);
 				break;
 
 			default:
@@ -897,7 +897,7 @@ goog.scope(function() {
 	};
 
 	es3fIntegerStateQueryTests.BlendFuncTestCase.prototype.deinit = function() {
-		gl.blendFunc(this.m_initialValue, this.m_initialValue);
+		this.setBlendFunc(this.m_initialValue);
 	};
 
 	/**
@@ -921,21 +921,25 @@ goog.scope(function() {
 	 * @param  {number} func
 	 */
 	es3fIntegerStateQueryTests.BlendFuncSeparateTestCase.prototype.setBlendFunc = function(func) {
+		var srcRgb = gl.getParameter(gl.BLEND_SRC_RGB);
+		var dstRgb = gl.getParameter(gl.BLEND_DST_RGB);
+		var srcAlpha = gl.getParameter(gl.BLEND_SRC_ALPHA);
+		var dstAlpha = gl.getParameter(gl.BLEND_DST_ALPHA);
 		switch (this.m_testTargetName) {
 			case gl.BLEND_SRC_RGB:
-				gl.blendFuncSeparate(func, gl.ZERO, gl.ZERO, gl.ZERO);
+				gl.blendFuncSeparate(func, dstRgb, srcAlpha, dstAlpha);
 				break;
 
 			case gl.BLEND_DST_RGB:
-				gl.blendFuncSeparate(gl.ZERO, func, gl.ZERO, gl.ZERO);
+				gl.blendFuncSeparate(srcRgb, func, srcAlpha, dstAlpha);
 				break;
 
 			case gl.BLEND_SRC_ALPHA:
-				gl.blendFuncSeparate(gl.ZERO, gl.ZERO, func, gl.ZERO);
+				gl.blendFuncSeparate(srcRgb, dstRgb, func, dstAlpha);
 				break;
 
 			case gl.BLEND_DST_ALPHA:
-				gl.blendFuncSeparate(gl.ZERO, gl.ZERO, gl.ZERO, func);
+				gl.blendFuncSeparate(srcRgb, dstRgb, srcAlpha, func);
 				break;
 
 			default:
@@ -944,7 +948,7 @@ goog.scope(function() {
 	};
 
 	es3fIntegerStateQueryTests.BlendFuncSeparateTestCase.prototype.deinit = function() {
-		gl.blendFuncSeparate(this.m_initialValue, this.m_initialValue, this.m_initialValue, this.m_initialValue);
+		this.setBlendFunc(this.m_initialValue);
 	};
 
 	/**


### PR DESCRIPTION
Previously the initial value for that blendfunc parameter was used to
reset all of the blendfunc parameters, which was wrong because the
default for SRC parameters is ONE while the DST parameters's is ZERO

Here we take care to only touch the one parameter being modified. If we wanted to stay 100% close to dEQP could instead not use an initial value and reset the blendfunc with the known default values. I didn't choose this approach because it would make the testing of the initial value of blendfunc useless as it would be reset just before.