### PR TITLE
add point-size-varyings.html

### DIFF
--- a/sdk/tests/conformance/rendering/00_test_list.txt
+++ b/sdk/tests/conformance/rendering/00_test_list.txt
@@ -18,6 +18,7 @@ multisample-corruption.html
 --min-version 1.0.3 negative-one-index.html
 --min-version 1.0.3 point-no-attributes.html
 point-size.html
+--min-version 1.0.4 point-size-varyings.html
 --min-version 1.0.3 point-with-gl-pointcoord-in-fragment-shader.html
 --min-version 1.0.3 polygon-offset.html
 --min-version 1.0.2 simple.html

--- a/sdk/tests/conformance/rendering/point-size-varyings.html
+++ b/sdk/tests/conformance/rendering/point-size-varyings.html
@@ -1,0 +1,111 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Rendering Test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="example" width="50" height="50">
+There is supposed to be an example drawing here, but it's not important.
+</canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">
+precision highp float;
+uniform float isCloud; // never set
+attribute vec4 vPosition;
+varying vec2 vUV;
+void main()
+{
+    gl_Position = vPosition;
+    vUV = vPosition.xy * 2.0;
+    if (isCloud == 1.0) {
+      gl_PointSize = 1.0;
+    }
+}
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">
+precision highp float;
+varying vec2 vUV;
+uniform float isCloud; // never set
+void main()
+{
+    gl_FragColor = vec4(vUV.xy,0.0,1.0);
+    if (isCloud == 1.0) {
+      gl_FragColor = vec4(gl_PointCoord.xy,0.0,1.0);
+    }
+}
+</script>
+
+<script>
+"use strict";
+function init()
+{
+    description(document.title);
+
+    var wtu = WebGLTestUtils;
+    var gl = wtu.create3DContext("example");
+    var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
+
+    var vertexObject = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0.5,0, -0.5,-0.5,0, 0.5,-0.5,0 ]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+    // Test several locations
+    // First line should be all black
+    wtu.checkCanvasRect(gl, 0, 0, 50, 1, [0, 0, 0, 0]);
+
+    // Check color gradient
+    wtu.checkCanvasRect(gl, 24, 36, 1, 1, [0, 235, 0, 255]);
+    wtu.checkCanvasRect(gl, 24, 35, 1, 1, [0, 214, 0, 255]);
+    wtu.checkCanvasRect(gl, 28, 28, 1, 1, [71, 71, 0, 255]);
+    wtu.checkCanvasRect(gl, 35, 15, 1, 1, [214, 0, 0, 255]);
+    wtu.checkCanvasRect(gl, 36, 13, 1, 1, [235, 0, 0, 255]);
+
+    // Last line should be all black
+    wtu.checkCanvasRect(gl, 0, 49, 50, 1, [0, 0, 0, 0]);
+}
+
+init();
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This check attempts to provoke a [bug in ANGLE](https://bugs.chromium.org/p/angleproject/issues/detail?id=1380) on Windows. 

The test passes in Edge on Windows and in Firefox and Chrome on Linux, and fails in Chrome (version 50.0.2661.102) on Windows and in Firefox (version 46.0.1) on Windows. I heard it also fails in Chrome on OS X. 

When gl_PointSize is mentioned but not set in vertex shader and gl_PointCoord is mentioned but not read in fragment shader, rendering a triangle coloured with varyings fails. The check is based on triangle.html in same folder.