### PR TITLE
Implement copyTex{Sub}Image2D in sglrReferenceContext

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
@@ -3255,7 +3255,7 @@ goog.scope(function() {
             );
 
             this.m_context.texImage2D(
-                gl.TEXTURE_2D, ndx, this.m_format, levelW, levelH, this.m_format, this.m_dataType, data.getAccess().getDataPtr()
+                gl.TEXTURE_2D, ndx, this.m_format, levelW, levelH, 0, this.m_format, this.m_dataType, data.getAccess().getDataPtr()
             );
         }
 


### PR DESCRIPTION
This makes the following two tests passing (at least on Linux):
  texturespecification/basic_copyteximage2d.htm
  texturespecification/basic_copytexsubimage2d.htm