### PR TITLE
Optimize texturespecification tests.

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuTexture.js
+++ b/sdk/tests/deqp/framework/common/tcuTexture.js
@@ -2033,6 +2033,12 @@ tcuTexture.PixelBufferAccess.prototype.clear = function(color, x, y, z) {
     var width = range_x[1] - range_x[0];
     var height = range_y[1] - range_y[0];
     var depth = range_z[1] - range_z[0];
+    if (x === undefined && y === undefined && z == undefined &&
+        c[0] == 0 && c[1] == 0 && c[2] == 0 && c[3] == 0) {
+        var pixelPtr = new arrayType(this.m_data, this.m_offset);
+        pixelPtr.fill(0);
+        return;
+    }
 
     //copy first pixel over other pixels in the row
     var fillRow = function(pixelPtr, numElements, width) {

--- a/sdk/tests/deqp/framework/common/tcuTextureUtil.js
+++ b/sdk/tests/deqp/framework/common/tcuTextureUtil.js
@@ -151,9 +151,9 @@ tcuTextureUtil.fillWithComponentGradients1D = function(access, minVal, maxVal) {
  */
 tcuTextureUtil.fillWithComponentGradients2D = function(access, minVal, maxVal) {
     for (var y = 0; y < access.getHeight(); y++) {
+        var t = (y + 0.5) / access.getHeight();
         for (var x = 0; x < access.getWidth(); x++) {
             var s = (x + 0.5) / access.getWidth();
-            var t = (y + 0.5) / access.getHeight();
 
             var r = tcuTextureUtil.linearInterpolate((s + t) * 0.5, minVal[0], maxVal[0]);
             var g = tcuTextureUtil.linearInterpolate((s + (1 - t)) * 0.5, minVal[1], maxVal[1]);
@@ -172,15 +172,14 @@ tcuTextureUtil.fillWithComponentGradients2D = function(access, minVal, maxVal) {
  */
 tcuTextureUtil.fillWithComponentGradients3D = function(dst, minVal, maxVal) {
     for (var z = 0; z < dst.getDepth(); z++) {
+        var p = (z + 0.5) / dst.getDepth();
+        var b = tcuTextureUtil.linearInterpolate(p, minVal[2], maxVal[2]);
         for (var y = 0; y < dst.getHeight(); y++) {
+            var t = (y + 0.5) / dst.getHeight();
+            var g = tcuTextureUtil.linearInterpolate(t, minVal[1], maxVal[1]);
             for (var x = 0; x < dst.getWidth(); x++) {
                 var s = (x + 0.5) / dst.getWidth();
-                var t = (y + 0.5) / dst.getHeight();
-                var p = (z + 0.5) / dst.getDepth();
-
                 var r = tcuTextureUtil.linearInterpolate(s, minVal[0], maxVal[0]);
-                var g = tcuTextureUtil.linearInterpolate(t, minVal[1], maxVal[1]);
-                var b = tcuTextureUtil.linearInterpolate(p, minVal[2], maxVal[2]);
                 var a = tcuTextureUtil.linearInterpolate(1 - (s + t + p) / 3, minVal[3], maxVal[3]);
                 dst.setPixel([r, g, b, a], x, y, z);
             }

--- a/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureSpecificationTests.js
@@ -285,7 +285,9 @@ goog.scope(function() {
         // Clear color buffer.
         for (var ndx = 0; ndx < 2; ndx++) {
             this.m_context = ndx ? refContext : webgl2Context;
-            this.m_context.clearColor(0.125, 0.25, 0.5, 1.0);
+            // C++ port uses (0.125, 0.25, 0.5, 1.0), but here we use (0, 0, 0, 0)
+            // in order to optimize the `clear' op in ReferenceContext.
+            this.m_context.clearColor(0, 0, 0, 0);
             this.m_context.clear(
                 gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT |
                 gl.STENCIL_BUFFER_BIT


### PR DESCRIPTION
THis cuts running time from 645s to 568s on my local Linux,
about 12% gain.