### PR TITLE
Remove debug wrapper from passing tests.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/attriblocation.html
+++ b/sdk/tests/deqp/functional/gles3/attriblocation.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fAttribLocationTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fAttribLocationTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/booleanstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/booleanstatequery.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {stencil: true}, 2);
+var gl = wtu.create3DContext('canvas', {stencil: true}, 2);
 
-
-    try {
-        functional.gles3.es3fBooleanStateQuery.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fBooleanStateQuery.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/buffercopy.html
+++ b/sdk/tests/deqp/functional/gles3/buffercopy.html
@@ -16,14 +16,9 @@
 <canvas id="canvas" width="200" height="100"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-try {
-    functional.gles3.es3fBufferCopyTests.run(gl);
-}
-catch(err) {
-    bufferedLogToConsole(err);
-}
+functional.gles3.es3fBufferCopyTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/bufferobjectquery.html
+++ b/sdk/tests/deqp/functional/gles3/bufferobjectquery.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-
-    try {
-        functional.gles3.es3fBufferObjectQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fBufferObjectQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/clipping.html
+++ b/sdk/tests/deqp/functional/gles3/clipping.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="128" height="128"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-
-    try {
-        functional.gles3.es3fClippingTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fClippingTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/defaultvertexattribute.html
+++ b/sdk/tests/deqp/functional/gles3/defaultvertexattribute.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-
-    try {
-        functional.gles3.es3fDefaultVertexAttributeTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fDefaultVertexAttributeTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/es3fPrimitiveRestartTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fPrimitiveRestartTests.js
@@ -209,24 +209,15 @@ var gluTextureUtil = framework.opengl.gluTextureUtil;
     };
 
     es3fPrimitiveRestartTests.PrimitiveRestartCase.prototype.renderWithRestart = function() {
-        bufferedLogToConsole('renderWithRestart() begin');
-
         // Primitive Restart is always on in WebGL2
         //gl.enable(gl.PRIMITIVE_RESTART_FIXED_INDEX);
-        //bufferedLogToConsole('Enable primitive restart');
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-        bufferedLogToConsole('Clear in renderWithRestart()');
 
         this.draw(0, this.getNumIndices());
-        bufferedLogToConsole('Draw in renderWithRestart()');
-
-        bufferedLogToConsole('renderWithRestart() end');
     };
 
     es3fPrimitiveRestartTests.PrimitiveRestartCase.prototype.renderWithoutRestart = function() {
-        bufferedLogToConsole('renderWithoutRestart() begin');
-
         /** @type {number} */ var restartIndex = this.m_indexType == es3fPrimitiveRestartTests.IndexType.INDEX_UNSIGNED_BYTE ? es3fPrimitiveRestartTests.RESTART_INDEX_UNSIGNED_BYTE :
                                                  this.m_indexType == es3fPrimitiveRestartTests.IndexType.INDEX_UNSIGNED_SHORT ? es3fPrimitiveRestartTests.RESTART_INDEX_UNSIGNED_SHORT :
                                                  this.m_indexType == es3fPrimitiveRestartTests.IndexType.INDEX_UNSIGNED_INT ? es3fPrimitiveRestartTests.RESTART_INDEX_UNSIGNED_INT :
@@ -235,10 +226,8 @@ var gluTextureUtil = framework.opengl.gluTextureUtil;
         DE_ASSERT(restartIndex != 0);
         // Primitive Restart is always on in WebGL2
         //gl.disable(gl.PRIMITIVE_RESTART_FIXED_INDEX);
-        //bufferedLogToConsole('Disable primitive restart');
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
-        bufferedLogToConsole('Clear in renderWithoutRestart()');
 
         // Draw, emulating primitive restart.
 
@@ -254,14 +243,11 @@ var gluTextureUtil = framework.opengl.gluTextureUtil;
                     // Draw from index indexArrayStartNdx to index indexArrayNdx-1 .
 
                     this.draw(indexArrayStartNdx, indexArrayNdx - indexArrayStartNdx);
-                    bufferedLogToConsole('Draw in renderWithoutRestart()');
                 }
 
                 indexArrayStartNdx = indexArrayNdx + 1; // Next draw starts just after this restart index.
             }
         }
-
-        bufferedLogToConsole('renderWithoutRestart() end');
     };
 
     /**

--- a/sdk/tests/deqp/functional/gles3/fbostatequery.html
+++ b/sdk/tests/deqp/functional/gles3/fbostatequery.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fFboStateQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fFboStateQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/fbostencilbuffer.html
+++ b/sdk/tests/deqp/functional/gles3/fbostencilbuffer.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="200" height="100"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fFboStencilbufferTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fFboStencilbufferTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/floatstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/floatstatequery.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fFloatStateQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fFloatStateQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/fragdepth.html
+++ b/sdk/tests/deqp/functional/gles3/fragdepth.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fFragDepthTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fFragDepthTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/indexedstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/indexedstatequery.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fIndexedStateQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fIndexedStateQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/internalformatquery.html
+++ b/sdk/tests/deqp/functional/gles3/internalformatquery.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fInternalFormatQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fInternalFormatQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/negativefragmentapi.html
+++ b/sdk/tests/deqp/functional/gles3/negativefragmentapi.html
@@ -14,17 +14,10 @@
 <div id="console"></div>
 <canvas id="canvas" width="320" height="240"></canvas>
 <script>
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    var wtu = WebGLTestUtils;
-    var gl = wtu.create3DContext('canvas', null, 2);
-
-    try {
-        functional.gles3.es3fNegativeFragmentApiTests.run(gl);
-    }
-    catch(err) {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fNegativeFragmentApiTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/negativeshaderapi.html
+++ b/sdk/tests/deqp/functional/gles3/negativeshaderapi.html
@@ -17,13 +17,8 @@
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
-    try {
-        functional.gles3.es3fNegativeShaderApiTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
+
+functional.gles3.es3fNegativeShaderApiTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/negativestateapi.html
+++ b/sdk/tests/deqp/functional/gles3/negativestateapi.html
@@ -14,17 +14,10 @@
 <div id="console"></div>
 <canvas id="canvas" width="320" height="240"></canvas>
 <script>
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    var wtu = WebGLTestUtils;
-    var gl = wtu.create3DContext('canvas', null, 2);
-
-    try {
-        functional.gles3.es3fNegativeStateApiTests.run(gl);
-    }
-    catch(err) {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fNegativeStateApiTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/pixelbufferobject.html
+++ b/sdk/tests/deqp/functional/gles3/pixelbufferobject.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="200" height="100"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
+var gl = wtu.create3DContext('canvas', {preserveDrawingBuffer: true}, 2);
 
-    try {
-      functional.gles3.es3fPixelBufferObjectTest.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fPixelBufferObjectTest.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/primitiverestart.html
+++ b/sdk/tests/deqp/functional/gles3/primitiverestart.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fPrimitiveRestartTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fPrimitiveRestartTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/rasterizerdiscard.html
+++ b/sdk/tests/deqp/functional/gles3/rasterizerdiscard.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {stencil: true}, 2);
+var gl = wtu.create3DContext('canvas', {stencil: true}, 2);
 
-    try {
-        functional.gles3.es3fRasterizerDiscardTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fRasterizerDiscardTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/rbostatequery.html
+++ b/sdk/tests/deqp/functional/gles3/rbostatequery.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fRboStateQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fRboStateQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/readpixel.html
+++ b/sdk/tests/deqp/functional/gles3/readpixel.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {preserveDrawingBuffer: true}, 2);
+var gl = wtu.create3DContext('canvas', {preserveDrawingBuffer: true}, 2);
 
-
-    try {
-        functional.gles3.es3fReadPixelTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fReadPixelTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/samplerobject.html
+++ b/sdk/tests/deqp/functional/gles3/samplerobject.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="200" height="100"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fSamplerObjectTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fSamplerObjectTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/samplerstatequery.html
+++ b/sdk/tests/deqp/functional/gles3/samplerstatequery.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fSamplerStateQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fSamplerStateQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/shaderapi.html
+++ b/sdk/tests/deqp/functional/gles3/shaderapi.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-
-    try {
-        functional.gles3.es3fShaderApiTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fShaderApiTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/shaderindexing.html
+++ b/sdk/tests/deqp/functional/gles3/shaderindexing.html
@@ -16,15 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
-    try {
-        functional.gles3.es3fShaderIndexingTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
+var gl = wtu.create3DContext('canvas', null, 2);
 
+functional.gles3.es3fShaderIndexingTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/shaderprecision.html
+++ b/sdk/tests/deqp/functional/gles3/shaderprecision.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fShaderPrecisionTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fShaderPrecisionTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/shaderstruct.html
+++ b/sdk/tests/deqp/functional/gles3/shaderstruct.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fShaderStructTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fShaderStructTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/shaderswitch.html
+++ b/sdk/tests/deqp/functional/gles3/shaderswitch.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fShaderSwitchTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fShaderSwitchTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/stringquery.html
+++ b/sdk/tests/deqp/functional/gles3/stringquery.html
@@ -16,16 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fStringQueryTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fStringQueryTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/texturestatequery.html
+++ b/sdk/tests/deqp/functional/gles3/texturestatequery.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-
-    try {
-        functional.gles3.es3fTextureStateQuery.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fTextureStateQuery.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/vertexarrayobject.html
+++ b/sdk/tests/deqp/functional/gles3/vertexarrayobject.html
@@ -16,17 +16,9 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-
-    try {
-        functional.gles3.es3fVertexArrayObjectTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fVertexArrayObjectTests.run(gl);
 </script>
 </body>
 </html>

--- a/sdk/tests/deqp/functional/gles3/vertexarrays.html
+++ b/sdk/tests/deqp/functional/gles3/vertexarrays.html
@@ -15,18 +15,10 @@
 <div id="console"></div>
 <canvas id="canvas" width="200" height="100"> </canvas>
 <script>
-var canvas = document.getElementById('canvas');
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', null, 2);
+var gl = wtu.create3DContext('canvas', null, 2);
 
-    try {
-        functional.gles3.es3fVertexArrayTests.run(gl);
-    }
-    catch(err)
-    {
-        bufferedLogToConsole(err);
-    }
-
+functional.gles3.es3fVertexArrayTests.run(gl);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Also, remove debug logging to console from primitiverestart test,
because it's polluting the bot output.