### PR TITLE
indexing to shader output is not correct in outerproduct

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
+++ b/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
@@ -2986,7 +2986,7 @@ var setParentClass = function(child, parent) {
             var size = reference.rows * reference.cols;
             for (var i = 0; i < reference.rows; i++)
                 for (var j = 0; j < reference.cols; j++)
-                    ret.set(i, j, output[size * index + j * reference.cols + i]);
+                    ret.set(i, j, output[size * index + j * reference.rows + i]);
             return ret;
         }
 


### PR DESCRIPTION
I have come back to office this week from honeymoon, :). Long time not to touch the code. Please take a look at this small patch, @zhenyao and @kenrussell . It can fix all failures for outerproduct.html against vertex shader tests. 

Thanks a lot!