### PR TITLE
Deleted objects should not exist

### DIFF
--- a/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
+++ b/sdk/tests/conformance2/vertex_arrays/vertex-array-object.html
@@ -586,13 +586,8 @@ function runBoundDeleteTests() {
       var isPositionBuffer = gl.isBuffer(positionBuffer);
       var isColorBuffer    = gl.isBuffer(colorBuffer);
 
-      if(ii < 3) {
-        if(!isPositionBuffer) testFailed("Position buffer should still exist until last ref removed");
-        if(!isColorBuffer)    testFailed("Color buffer should still exist until last ref removed");
-      } else {
-        if(isPositionBuffer)  testFailed("Position buffer should no longer exist after last ref removed");
-        if(isColorBuffer)     testFailed("Color buffer should no longer exist after last ref removed");
-      }
+      if(isPositionBuffer)  testFailed("Position buffer should no longer exist after last ref removed");
+      if(isColorBuffer)     testFailed("Color buffer should no longer exist after last ref removed");
     }
 }
 


### PR DESCRIPTION
Name of deleted buffer immediately becomes invalid. Though the
underlying container which the deleted buffer is attached to may
continue using the object ("D.1.3 Deleted Object and Object Name
Lifetimes", page 315 ES spec 3.0.4).

Also in section 3 "WebGL Resources" in WebGL 1.0 spec,
"If authors wish to control when the underlying
resource is released then the delete call can be made explicity".
So the deleted object cannot be used any more.