### PR TITLE
deqp/f/gles3/pbo: Check framebuffer completness before rendering

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fPixelBufferObjectTest.js
+++ b/sdk/tests/deqp/functional/gles3/es3fPixelBufferObjectTest.js
@@ -287,6 +287,11 @@ var tcuImageCompare = framework.common.tcuImageCompare;
                 break;
         }
 
+        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+            testSkippedOptions("Cannot test pixel buffer readPixels on an incomplete framebuffer", true);
+            return tcuTestCase.IterateResult.STOP;
+        }
+
         this.clearColor(this.m_colorScale * 0.4, this.m_colorScale * 1.0, this.m_colorScale * 0.5, this.m_colorScale * 1.0);
 
         if (this.m_useColorClears) {


### PR DESCRIPTION
This fixes a failure on Chrome on OSX where the rgb5_a1 framebuffer is
not complete.