### PR TITLE
Broadcast writes to gl_FragColor to enabled color buffers

### DIFF
--- a/sdk/tests/conformance2/rendering/draw-buffers.html
+++ b/sdk/tests/conformance2/rendering/draw-buffers.html
@@ -223,7 +223,7 @@ function runDrawTests() {
   var nones = makeArray(maxUsable, gl.NONE);
 
   [fb, fb2, halfFB1, halfFB2, endsFB, middleFB].forEach(function(fbo) {
-    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
     gl.drawBuffers(bufs);
   });
 
@@ -386,20 +386,22 @@ function runDrawTests() {
     return (index == 0) ? [0, 0, 255, 255] : [0, 255, 0, 255];
   });
 
-  debug("test that an OpenGL ES Shading Language 3.00 shader with a single output color only writes to color number zero");
+  // By default, gl_FragColor only writes to color number zero.
+  // In GLES SL 3.00 context, drawBuffers can specify the color buffers that gl_FragColor should write into.
+  // See GLES3 spec section 4.2.1 Selecting Buffers for Writing.
+  debug("test that an OpenGL ES Shading Language 3.00 shader with a single output color writes to color buffers specified by drawBuffers");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   gl.drawBuffers(bufs);
   gl.useProgram(redProgram);
   wtu.drawUnitQuad(gl);
 
-  checkAttachmentsForColorFn(attachments, function(attachment, index) {
-    return (index == 0) ? [255, 0, 0, 255] : [0, 255, 0, 255];
-  });
+  checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
   if (maxUsable > 1) {
     // Prepare for following tests by clearing all attachments to red.
     debug("prepare by clearing all attachments to red");
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.drawBuffers(bufs);
     gl.clearColor(1, 0, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
     checkAttachmentsForColor(attachments, [255, 0, 0, 255]);


### PR DESCRIPTION
Without specifying draw buffers, gl_FragColor only writes to color
number zero (GLES3 spec section 3.9.2 Shader Outputs). But with
specifying draw buffers with drawBuffer, gl_FragColor should write to
all enabled color buffers (GLES3 spec section 4.2.1 Selecting Buffers
for Writing). Also refer Issues 3) in Ext_draw_buffers extension.