### PR TITLE
Issue a warning instead of fail in fbo completeness checking.

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsFboCompletenessTests.js
+++ b/sdk/tests/deqp/modules/shared/glsFboCompletenessTests.js
@@ -737,7 +737,7 @@ goog.scope(function() {
                     testFailedOptions('Framebuffer checked as incomplete, but with wrong status', true);
                 }
             } else if (fboStatus != gl.FRAMEBUFFER_COMPLETE && statuses.isFBOStatusValid(gl.FRAMEBUFFER_COMPLETE)) {
-                testFailedOptions('Framebuffer object could have checked as complete but did not.', true);
+                testPassedOptions('Warning: framebuffer object could have checked as complete but did not.', true);
             } else {
                 // pass
                 testPassed();


### PR DESCRIPTION
The c++ code does the same.