### PR TITLE
Attach buffer to VAO before draw call

### DIFF
--- a/sdk/tests/conformance/misc/webgl-specific.html
+++ b/sdk/tests/conformance/misc/webgl-specific.html
@@ -49,6 +49,7 @@ gl.useProgram(program);
 var vertexObject = gl.createBuffer();
 gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
 gl.enableVertexAttribArray(0);
+gl.vertexAttribPointer(0, 4, gl.FLOAT, false, 0, 0);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setup should succeed");
 
 debug("");


### PR DESCRIPTION
If no buffer is bound to enabled attribution, draw call will genetate
invalid operation error. Refer section 6.5 Enabled Vertex Attributes and
Range Checking in WebGL 1.0 spec.

See some discussion in https://codereview.chromium.org/2019513004/ 