### PR TITLE
At least one enabled attribute with 0 divisor for instanced drawing

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
@@ -600,8 +600,10 @@ goog.scope(function() {
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
+                // WebGL has different limitation on divisor of zero from C++ code.
+                // In the WebGL 2.0 API, instanced drawing needs at leas one enabled attribute with divisor zero.
                 gl.drawElementsInstanced (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
-                this.expectError (gl.NO_ERROR);
+                this.expectError (gl.INVALID_OPERATION);
 
                 gl.endTransformFeedback ();
                 gl.deleteBuffer(buf);
@@ -696,8 +698,10 @@ goog.scope(function() {
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
+                // WebGL has different limitation on divisor of zero from C++ code.
+                // In the WebGL 2.0 API, instanced drawing needs at leas one enabled attribute with divisor zero.
                 gl.drawElementsInstanced (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices, 1);
-                this.expectError (gl.NO_ERROR);
+                this.expectError (gl.INVALID_OPERATION);
 
                 gl.endTransformFeedback ();
                 gl.deleteBuffer(buf);


### PR DESCRIPTION
This is a WebGL 2.0 limitation different from C++ code. See section 5.6
Enabled Attribute in WebGL 2.0 spec.