### PR TITLE
Suppress some shader texture function tests

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuSkipList.js
+++ b/sdk/tests/deqp/framework/common/tcuSkipList.js
@@ -79,6 +79,13 @@ goog.scope(function() {
         _skip("texture_functions.textureprojoffset.sampler3d_fixed_fragment");
         _skip("texture_functions.textureprojoffset.isampler3d_fragment");
         _skip("texture_functions.textureprojoffset.usampler3d_fragment");
+        // Please see https://android.googlesource.com/platform/external/deqp/+/master/android/cts/master/src/gles3-test-issues.txt
+        _skip("texture_functions.textureprojlodoffset.usampler3d_vertex");
+        _skip("texture_functions.textureoffset.sampler3d_float_fragment");
+        _skip("texture_functions.textureprojoffset.sampler3d_float_fragment");
+        // Please see https://android.googlesource.com/platform/external/deqp/+/master/android/cts/master/src/gles3-driver-issues.txt
+        _skip("texture_functions.texturegrad.samplercubeshadow_vertex");
+        _skip("texture_functions.texturegrad.samplercubeshadow_fragment");
     } // if (!runSkippedTests)
 
     /*


### PR DESCRIPTION
Native dEQP also fails on these tests. Please refer:
https://android.googlesource.com/platform/external/deqp/+/master/android/cts/master/src/gles3-test-issues.txt
https://android.googlesource.com/platform/external/deqp/+/master/android/cts/master/src/gles3-driver-issues.txt