### PR TITLE
FboMultisample Fix

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuBilinearImageCompare.js
+++ b/sdk/tests/deqp/framework/common/tcuBilinearImageCompare.js
@@ -43,16 +43,16 @@ goog.scope(function() {
     // tcu::RGBA::*_SHIFT values.
 
     function UintRGBA8_R(color) {
-        return (color >> 24) && 0xff;
+        return (color >> 24) & 0xff;
     }
     function UintRGBA8_G(color) {
-        return (color >> 16) && 0xff;
+        return (color >> 16) & 0xff;
     }
     function UintRGBA8_B(color) {
-        return (color >> 8) && 0xff;
+        return (color >> 8) & 0xff;
     }
     function UintRGBA8_A(color) {
-        return color && 0xff;
+        return color & 0xff;
     }
 
     /**

--- a/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
@@ -165,6 +165,10 @@ var DE_ASSERT = function(x) {
 
         // Render random-colored quads.
         /** @const {number} */ var numQuads = 8;
+
+        // The choice of random seed affects the correctness of the tests,
+        // because there are some boundary conditions which aren't handled
+        // correctly even in the C++ dEQP tests.
         /** @type {deRandom.Random} */ var rnd = new deRandom.Random(7);
 
         ctx.depthFunc(gl.ALWAYS);

--- a/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
@@ -165,7 +165,7 @@ var DE_ASSERT = function(x) {
 
         // Render random-colored quads.
         /** @const {number} */ var numQuads = 8;
-        /** @type {deRandom.Random} */ var rnd = new deRandom.Random(9);
+        /** @type {deRandom.Random} */ var rnd = new deRandom.Random(7);
 
         ctx.depthFunc(gl.ALWAYS);
         ctx.enable(gl.STENCIL_TEST);


### PR DESCRIPTION
- Fixing the masks which extracts the different channels on bilinearCompare.
- Using a different random seed because the bilinearCompare (even in C++'s deqp) does not handle a few boundary cases correctly.