### PR TITLE
Some anti-alias algorithms may not effect on diagonal line pixels,

### DIFF
--- a/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
@@ -39,6 +39,8 @@ var successfullyParsed = false;
 var webGL = null;
 var contextAttribs = null;
 var pixel = [0, 0, 0, 1];
+var pixel_1 = [0, 0, 0, 1];
+var pixel_2 = [0, 0, 0, 1];
 var correctColor = null;
 
 function init()
@@ -195,9 +197,18 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255,
         255, 0, 0, 255]);
-    var buf = drawAndReadPixel(webGL, vertices, colors, 0, 0);
-    pixel[0] = buf[0];
-    shouldBe("pixel[0] != 255 && pixel[0] != 0", "contextAttribs.antialias");
+    drawAndReadPixel(webGL, vertices, colors, 0, 0);
+    var buf_1 = new Uint8Array(1 * 1 * 4);
+    var buf_2 = new Uint8Array(1 * 1 * 4);
+    webGL.readPixels(0, 0, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_1);
+    webGL.readPixels(0, 1, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_2);
+    pixel_1[0] = buf_1[0];
+    pixel_2[0] = buf_2[0];
+    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
+    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
+    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
+    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
+        "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -40,6 +40,8 @@ var successfullyParsed = false;
 var webGL = null;
 var contextAttribs = null;
 var pixel = [0, 0, 0, 1];
+var pixel_1 = [0, 0, 0, 1];
+var pixel_2 = [0, 0, 0, 1];
 var correctColor = null;
 var value;
 
@@ -216,9 +218,18 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255,
         255, 0, 0, 255]);
-    var buf = drawAndReadPixel(webGL, vertices, colors, 0, 0);
-    pixel[0] = buf[0];
-    shouldBe("pixel[0] != 255 && pixel[0] != 0", "contextAttribs.antialias");
+    drawAndReadPixel(webGL, vertices, colors, 0, 0);
+    var buf_1 = new Uint8Array(1 * 1 * 4);
+    var buf_2 = new Uint8Array(1 * 1 * 4);
+    webGL.readPixels(0, 0, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_1);
+    webGL.readPixels(0, 1, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_2);
+    pixel_1[0] = buf_1[0];
+    pixel_2[0] = buf_2[0];
+    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
+    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
+    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
+    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
+        "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -63,7 +63,8 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var pixel = [0, 0, 0, 1];
+var pixel_1 = [0, 0, 0, 1];
+var pixel_2 = [0, 0, 0, 1];
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -311,10 +312,17 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(1 * 1 * 4);
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    pixel[0] = buf[0];
-    shouldBe("pixel[0] != 255 && pixel[0] != 0", "contextAttribs.antialias");
+    var buf_1 = new Uint8Array(1 * 1 * 4);
+    var buf_2 = new Uint8Array(1 * 1 * 4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_1);
+    gl.readPixels(0, 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_2);
+    pixel_1[0] = buf_1[0];
+    pixel_2[0] = buf_2[0];
+    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
+    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
+    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
+    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
+        "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -62,7 +62,8 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var pixel = [0, 0, 0, 1];
+var pixel_1 = [0, 0, 0, 1];
+var pixel_2 = [0, 0, 0, 1];
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -316,10 +317,17 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(1 * 1 * 4);
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    pixel[0] = buf[0];
-    shouldBe("pixel[0] != 255 && pixel[0] != 0", "contextAttribs.antialias");
+    var buf_1 = new Uint8Array(1 * 1 * 4);
+    var buf_2 = new Uint8Array(1 * 1 * 4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_1);
+    gl.readPixels(0, 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_2);
+    pixel_1[0] = buf_1[0];
+    pixel_2[0] = buf_2[0];
+    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
+    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
+    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
+    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
+        "contextAttribs.antialias");
 }
 
 function runTest()


### PR DESCRIPTION
add this change to suite1.0.3

Hi, zhenyao  & ken,
Because we test anti-alias feature based on suite1.0.3, I am not sure that it is suitable to add the anti-alias change to suite1.0.3. If not, please ignore this patch. Thank you.