### PR TITLE
update the precision for trigomometric functions

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
+++ b/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
@@ -4959,6 +4959,14 @@ var setParentClass = function(child, parent) {
                 // 2^-11 at x == pi.
                 return deMath.deLdExp(Math.abs(arg), -12);
             }
+        } else if (ctx.floatPrecision == gluShaderUtil.precision.PRECISION_MEDIUMP) {
+            if (-Math.PI <= arg && arg <= Math.PI) {
+                // from OpenCL half-float extension specification
+                return ctx.format.ulp(ret, 2.0);
+            } else {
+                // |x| * 2^-10 , slightly larger than 2 ULP at x == pi
+                return deMath.deLdExp(Math.abs(arg), -10);
+            }
         } else {
             // from OpenCL half-float extension specification
             return ctx.format.ulp(ret, 2.0);


### PR DESCRIPTION
The precision calculated by JS against trigomometric functions is not accurate, making some cases failed. This change updates the precision for trigomometric functions according to the latest native deqp: https://android.googlesource.com/platform/external/deqp/+/deqp-dev/modules/glshared/glsBuiltinPrecisionTests.cpp#2290. It can fix a number of failures in webgl deqp files, say, sin.html, cos.html, tan.html, and so on. 

PTAL. Thanks!