### PR TITLE
Fix bugs in nearest_mipmap_linear cases in es3fTextureShadowTests

### DIFF
--- a/sdk/tests/deqp/framework/delibs/debase/deMath.js
+++ b/sdk/tests/deqp/framework/delibs/debase/deMath.js
@@ -48,6 +48,22 @@ deMath.deInBounds32 = function(a, mn, mx) {
 deMath.deFloatFrac = function(a) { return a - Math.floor(a); };
 
 /**
+ * Transform a 64-bit float number into a 32-bit float number.
+ * Native dEQP uses 32-bit numbers, so sometimes 64-bit floating numbers in JS should be transformed into 32-bit ones to ensure the correctness of the result.
+ * @param {number} a
+ * @return {number}
+ */
+deMath.toFloat32 = (function() {
+    var FLOAT32ARRAY1 = new Float32Array(1);
+    return function(a) {
+        FLOAT32ARRAY1[0] = a;
+        return FLOAT32ARRAY1[0];
+    };
+})();
+
+/** @const */ deMath.INV_LOG_2_FLOAT32 = deMath.toFloat32(1.44269504089); /** 1.0 / log_e(2.0) */
+
+/**
  * Check if a value is a power-of-two.
  * @param {number} a Input value.
  * @return {boolean} return True if input is a power-of-two value, false otherwise.

--- a/sdk/tests/deqp/functional/gles3/es3fTextureShadowTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureShadowTests.js
@@ -123,7 +123,7 @@ var deUtil = framework.delibs.debase.deUtil;
     es3fTextureShadowTests.verifyTexCompareResult = function(textureType, result, src, texCoord, sampleParams, comparePrec, lodPrecision, pixelFormat) {
         var reference = new tcuSurface.Surface(result.getWidth(), result.getHeight());
         var errorMask = new tcuSurface.Surface(result.getWidth(), result.getHeight());
-        var nonShadowThreshold = deMath.swizzle(tcuTexLookupVerifier.computeFixedPointThreshold(glsTextureTestUtil.getBitsVec(pixelFormat)), [1, 2, 3]);
+        var nonShadowThreshold = deMath.swizzle(tcuTexLookupVerifier.computeFixedPointThreshold(deMath.subtract(glsTextureTestUtil.getBitsVec(pixelFormat), [1, 1, 1, 1])), [1, 2, 3]);
         var numFailedPixels;
 
         if (es3fTextureShadowTests.isFloatingPointDepthFormat(src.getFormat())) {


### PR DESCRIPTION
Realize function isNearestMipmapLinearCompareResultValid() to ensure the correctness of result comparisons in nearest_mipmap_linear related cases.
With this patch, all the nearest_mipmap_linear related cases in es3fTextureShadowTests will pass.