### PR TITLE
fix the builtin precision related bugs for arc trig funcs

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
+++ b/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
@@ -5043,6 +5043,29 @@ var setParentClass = function(child, parent) {
      * @constructor
      * @extends {glsBuiltinPrecisionTests.CFloatFunc1}
      */
+    glsBuiltinPrecisionTests.ASin = function() {
+        glsBuiltinPrecisionTests.CFloatFunc1.call(this, 'asin', Math.asin);
+    };
+
+    setParentClass(glsBuiltinPrecisionTests.ASin, glsBuiltinPrecisionTests.CFloatFunc1);
+
+    glsBuiltinPrecisionTests.ASin.prototype.precision = function(ctx, ret, x) {
+        if (!deMath.deInBounds32(x, -1.0, 1.0))
+            return NaN;
+
+        if (ctx.floatPrecision == gluShaderUtil.precision.PRECISION_HIGHP) {
+            // Absolute error of 2^-11
+            return deMath.deLdExp(1.0, -11);
+        } else {
+            // Absolute error of 2^-8
+            return deMath.deLdExp(1.0, -8);
+        }
+    };
+
+    /**
+     * @constructor
+     * @extends {glsBuiltinPrecisionTests.CFloatFunc1}
+     */
     glsBuiltinPrecisionTests.ArcTrigFunc = function(name, func, precisionULPs, domain, coddomain) {
         glsBuiltinPrecisionTests.CFloatFunc1.call(this, name, func);
         this.m_precision = precisionULPs;
@@ -5069,20 +5092,8 @@ var setParentClass = function(child, parent) {
      * @constructor
      * @extends {glsBuiltinPrecisionTests.ArcTrigFunc}
      */
-    glsBuiltinPrecisionTests.ASin = function() {
-        glsBuiltinPrecisionTests.ArcTrigFunc.call(this, 'asin', Math.asin, 4,
-                                                tcuInterval.withNumbers(-1, 1),
-                                                tcuInterval.withNumbers(-Math.PI * 0.5, Math.PI * 0.5));
-    };
-
-    setParentClass(glsBuiltinPrecisionTests.ASin, glsBuiltinPrecisionTests.ArcTrigFunc);
-
-    /**
-     * @constructor
-     * @extends {glsBuiltinPrecisionTests.ArcTrigFunc}
-     */
     glsBuiltinPrecisionTests.ACos = function() {
-        glsBuiltinPrecisionTests.ArcTrigFunc.call(this, 'acos', Math.acos, 4,
+        glsBuiltinPrecisionTests.ArcTrigFunc.call(this, 'acos', Math.acos, 4096.0,
                                                 tcuInterval.withNumbers(-1, 1),
                                                 tcuInterval.withNumbers(0, Math.PI));
     };
@@ -5094,7 +5105,7 @@ var setParentClass = function(child, parent) {
      * @extends {glsBuiltinPrecisionTests.ArcTrigFunc}
      */
     glsBuiltinPrecisionTests.ATan = function() {
-        glsBuiltinPrecisionTests.ArcTrigFunc.call(this, 'atan', Math.atan, 5,
+        glsBuiltinPrecisionTests.ArcTrigFunc.call(this, 'atan', Math.atan, 4096.0,
                                                 tcuInterval.unbounded(),
                                                 tcuInterval.withNumbers(-Math.PI * 0.5, Math.PI * 0.5));
     };
@@ -5126,7 +5137,7 @@ var setParentClass = function(child, parent) {
 
     glsBuiltinPrecisionTests.ATan2.prototype.precision = function(ctx, ret, x, y) {
         if (ctx.floatPrecision == gluShaderUtil.precision.PRECISION_HIGHP)
-            return ctx.format.ulp(ret, 6.0);
+            return ctx.format.ulp(ret, 4096.0);
         else
             return ctx.format.ulp(ret, 2.0);
     };


### PR DESCRIPTION
There are failures in arc trig funcs under deqp builtin precision, for example, asin, acos, atan. The corresponding native code has been updated a lot. For example, the Math.PI used by Web side equals to 3.141592653589793 in browsers (tested against Chrome and Firefox). It is not so accurate as that in native C++ code, which is defined to DE_PI_DOUBLE (3.14159265358979323846), see https://android.googlesource.com/platform/external/deqp/+/deqp-dev/framework/delibs/debase/deMath.h#42. But the C++ variables can not hold such an accurate PI too. 

Finally, it turns out that the native deqp has landed a patch to relax the restrictions for the precision, so the native tests can pass. In fact, the results calculated by builtin functions in WebGL shader and GLES shader are exactly the same. The results calculated by JS / C++ libs are exactly the same too. So, after applied the same restriction for the range of the precision, the WebGL cases can pass too. 

PTAL. Thanks a lot! 