### PR TITLE
fix bugs for atan2 and inversesqrt in builtin precision

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuFloatFormat.js
+++ b/sdk/tests/deqp/framework/common/tcuFloatFormat.js
@@ -125,6 +125,13 @@ goog.require('framework.delibs.debase.deMath');
      };
 
      /**
+      * @return {tcuFloatFormat.YesNoMaybe}
+      */
+     tcuFloatFormat.FloatFormat.prototype.hasInf = function() {
+         return this.m_hasInf;
+     };
+
+     /**
       * @param {number} x
       * @param {number} count
       * @return {number}

--- a/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
+++ b/sdk/tests/deqp/modules/shared/glsBuiltinPrecisionTests.js
@@ -1621,7 +1621,7 @@ var setParentClass = function(child, parent) {
     };
 
     glsBuiltinPrecisionTests.InverseSqrt.prototype.precision = function(ctx, ret, x) {
-        if (x < 0)
+        if (x <= 0)
             return NaN;
         return ctx.format.ulp(ret, 2.0);
     };
@@ -5119,6 +5119,11 @@ var setParentClass = function(child, parent) {
                 ret.operatorOrAssignBinary(tcuInterval.NAN);
             if (xi.intersects(tcuInterval.withNumbers(-Infinity, 0)))
                 ret.operatorOrAssignBinary(tcuInterval.withNumbers(-Math.PI, Math.PI));
+        }
+
+        if (ctx.format.hasInf() != tcuFloatFormat.YesNoMaybe.YES && (!yi.isFinite() || !xi.isFinite())) {
+            // Infinities may not be supported, allow anything, including NaN
+            ret.operatorOrAssignBinary(tcuInterval.NAN);
         }
 
         return ret;


### PR DESCRIPTION
Fix more bugs against builtin precision. This change is aligned with the corresponding native code. With this change applied, most cases in inversesqrt.html and atan2.html can pass. 

PTAL. Thanks a lot!