### PR TITLE
Fix sRGB formatted output comparison

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuImageCompare.js
+++ b/sdk/tests/deqp/framework/common/tcuImageCompare.js
@@ -340,6 +340,7 @@ tcuImageCompare.floatUlpThresholdCompare = function(imageSetName, imageSetDesc, 
  * @return {boolean}
  */
 tcuImageCompare.floatThresholdCompare = function(imageSetName, imageSetDesc, reference, result, threshold) {
+    /** @type {boolean} */ var isSRGB = reference.getFormat().order == tcuTexture.ChannelOrder.sRGB || reference.getFormat().order == tcuTexture.ChannelOrder.sRGBA;
     /** @type {number} */ var width = reference.getWidth();
     /** @type {number} */ var height = reference.getHeight();
     /** @type {number} */ var depth = reference.getDepth();
@@ -358,7 +359,7 @@ tcuImageCompare.floatThresholdCompare = function(imageSetName, imageSetDesc, ref
                 var refPix = reference.getPixel(x, y, z); // Vec4
                 var cmpPix = result.getPixel(x, y, z); // Vec4
 
-                /** @type {Array<number>} */ var diff = deMath.absDiff(refPix, cmpPix); // Vec4
+                /** @type {Array<number>} */ var diff = deMath.absDiff(isSRGB ? tcuTextureUtil.sRGBToLinear(refPix) : refPix, cmpPix); // Vec4
                 /** @type {boolean} */ var isOk = deMath.boolAll(deMath.lessThanEqual(diff, threshold));
 
                 maxDiff = deMath.max(maxDiff, diff);


### PR DESCRIPTION
When we do gl.readPixels from a renderbuffer with SRGB8_ALPHA8 internal
format, due readPixels doesn't support SRGB8_ALPHA8 format reading, RGBA
read format is used. So, the result of readPixels is in RGBA format.
Reference pixels and result pixels should be in same format before doing
comparison. This patch converts reference pixels to RGBA format and
keeps threshold unchanged. Otherwise, if we change RGBA pixels to sRGB,
we should also change the threshold.

This is different behavior with C++ dEQP. In C++ dEQP, glReadPixels can
return sRGB results depends on if FRAMEBUFFER_SRGB was enabled or not.
I refered https://github.com/KhronosGroup/WebGL/pull/1558 to implement
patch.