### PR TITLE
Fix ext-SRGB test

### DIFF
--- a/sdk/tests/conformance/extensions/ext-sRGB.html
+++ b/sdk/tests/conformance/extensions/ext-sRGB.html
@@ -336,9 +336,9 @@ function runFramebufferTextureConversionTest(format) {
     // Draw
     var conversions = [
       [   0,   0 ],
-      [  13,  63 ],
-      [  54, 127 ],
-      [ 133, 191 ],
+      [  13,  13 ],
+      [  54,  54 ],
+      [ 133, 133 ],
       [ 255, 255 ]
     ];
 
@@ -387,9 +387,9 @@ function runFramebufferRenderbufferConversionTest() {
   // Draw
   var conversions = [
     [   0,   0 ],
-    [  13,  63 ],
-    [  54, 127 ],
-    [ 133, 191 ],
+    [  13,  13 ],
+    [  54,  54 ],
+    [ 133, 133 ],
     [ 255, 255 ]
   ];
 


### PR DESCRIPTION
The tests intend to testing color conversion when writing to frame
buffer backed with sRGB texture attachment. But gl.readPixels doesn't
support sRGB reading. sRGB color is converted to RGAB after readPixels.
So we can only test after tow rounds conversion of RGBA->sRGB->RGBA, the
color keeps unchanged. See
https://github.com/KhronosGroup/WebGL/pull/1558 and
https://github.com/KhronosGroup/WebGL/pull/1765 which have similar issue.