### PR TITLE
Fix occlusion query test

### DIFF
--- a/sdk/tests/deqp/functional/gles3/occlusionquery.html
+++ b/sdk/tests/deqp/functional/gles3/occlusionquery.html
@@ -16,7 +16,7 @@
 <canvas id="canvas" width="256" height="256"> </canvas>
 <script>
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {stencil: true}, 2);
+var gl = wtu.create3DContextWithWrapperThatThrowsOnGLError('canvas', {stencil: true, preserveDrawingBuffer: true}, 2);
     try {
         functional.gles3.es3fOcclusionQueryTests.run(gl);
     }


### PR DESCRIPTION
Query's result must not be made available in the current frame. So
occlusion query test does query result check in next frame, so does
pixles check. By default, color buffer should be cleared before a new
frame. So set preserveDrawingBuffer as true when creating WebGL context
to preserve color buffer in next frame. Please refer section 2.2 "The
Drawing Buffer" in WebGL 1.o spec and section 5.23 "Queries' results
must not be make available in the current frame" in WebGL 2.0 spec.