### PR TITLE
More bug fixes in TextureShadowTests

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuTexCompareVerifier.js
+++ b/sdk/tests/deqp/framework/common/tcuTexCompareVerifier.js
@@ -192,8 +192,8 @@ tcuTexCompareVerifier.isLinearCompareValid = function(compareMode, prec, depths,
 
         var v0 = ref0 * (1 - f0) + ref1 * f0;
         var v1 = ref0 * (1 - f1) + ref1 * f1;
-        var minV = deMath.min(v0, v1);
-        var maxV = deMath.max(v0, v1);
+        var minV = Math.min(v0, v1);
+        var maxV = Math.max(v0, v1);
         var minR = minV - totalErr;
         var maxR = maxV + totalErr;
 

--- a/sdk/tests/deqp/functional/gles3/es3fTextureShadowTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureShadowTests.js
@@ -106,7 +106,7 @@ var deUtil = framework.delibs.debase.deUtil;
      */
     es3fTextureShadowTests.clampFloatingPointTextureCube = function(target) {
         for (var level = 0; level < target.getNumLevels(); ++level)
-            for (var face = tcuTexture.CubeFace.CUBEFACE_POSITIVE_X; face < Object.keys(tcuTexture.CubeFace).length; face++)
+            for (var face = tcuTexture.CubeFace.CUBEFACE_NEGATIVE_X; face < Object.keys(tcuTexture.CubeFace).length; face++)
                 es3fTextureShadowTests.clampFloatingPointTexture(target.getLevelFace(level, face));
     };
 


### PR DESCRIPTION
1. deMath.max and deMath.min should be used to compare arrays instead of numbers
2. Add missed tcuTexture.CubeFace.CUBEFACE_NEGATIVE_X in function es3fTextureShadowTests.clampFloatingPointTextureCube()

All cases in TextureShadowTests can pass with this patch.