### PR TITLE
Fixed typo in name of constant in sync tests.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fSyncTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fSyncTests.js
@@ -33,7 +33,7 @@ goog.scope(function() {
     var deString = framework.delibs.debase.deString;
 
     /** @const {number} */ es3fSyncTests.NUM_CASE_ITERATIONS = 5;
-    /** @const {number} */ es3fSyncTests.MAX_VERIRY_WAIT = 5;
+    /** @const {number} */ es3fSyncTests.MAX_VERIFY_WAIT = 5;
 
     /**
      * @enum


### PR DESCRIPTION
This bug would cause the comparison "[number] > undefined" to be
repeatedly reevaluated, which would always return false. Thus the
timeout would never be applied.