### PR TITLE
RGB16F isn't color renderable in WebGL2.

### DIFF
--- a/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
+++ b/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
@@ -133,7 +133,7 @@ function runFloatTextureRenderTargetTest(enabled, internalFormat, format, testPr
     var width = 2;
     var height = 2;
     gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, width, height, 0, format, gl.FLOAT, null);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "floating-point texture allocation should succeed if EXT_color_buffer_float is enabled");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "floating-point texture allocation should succeed");
 
     // Try to use this texture as a render target.
     var fbo = gl.createFramebuffer();
@@ -226,6 +226,41 @@ function runFloatRenderbufferRenderTargetTest(enabled, internalFormat, testProgr
     runReadbackTest(testProgram, subtractor);
 }
 
+function runRGB16FNegativeTest()
+{
+    debug("");
+    debug("testing RGB16F isn't color renderable");
+
+    var texture = allocateTexture();
+    var width = 2;
+    var height = 2;
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB16F, width, height, 0, gl.RGB, gl.FLOAT, null);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "RGB16F texture allocation should succeed");
+
+    // Try to use this texture as a render target.
+    var fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    gl.bindTexture(gl.TEXTURE_2D, null);
+
+    var completeStatus = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    if (completeStatus == gl.FRAMEBUFFER_COMPLETE)
+        testFailed("RGB16F render target should not be supported with or without enabling EXT_color_buffer_float");
+    else
+        testPassed("RGB16F render target should not be supported with or without enabling EXT_color_buffer_float");
+    gl.deleteTexture(texture);
+
+    var colorbuffer = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, colorbuffer);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGB16F, width, height);
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "RGB16F renderbuffer allocation should fail with or without enabling EXT_color_buffer_float");
+    gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+    gl.deleteRenderbuffer(colorbuffer);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.deleteFramebuffer(fbo);
+}
+
 function runUniqueObjectTest()
 {
     debug("");
@@ -276,6 +311,9 @@ if (!gl) {
   runFloatRenderbufferRenderTargetTest(false, gl.RGBA32F);
   runFloatRenderbufferRenderTargetTest(false, gl.R11F_G11F_B10F);
 
+  // Ensure RGB16F can't be used for rendering.
+  runRGB16FNegativeTest();
+
   if (!gl.getExtension("EXT_color_buffer_float")) {
       testPassed("No EXT_color_buffer_float support -- this is legal");
   } else {
@@ -297,6 +335,9 @@ if (!gl) {
       runFloatRenderbufferRenderTargetTest(true, gl.RG32F, testProgram, 2, [1000, 1000, 1, 1]);
       runFloatRenderbufferRenderTargetTest(true, gl.RGBA32F, testProgram, 4, [1000, 1000, 1000, 1000]);
       runFloatRenderbufferRenderTargetTest(true, gl.R11F_G11F_B10F, testProgram, 3, [1000, 1000, 1000, 1]);
+
+      // Ensure EXT_color_buffer_float does not enable RGB16F as color renderable.
+      runRGB16FNegativeTest();
 
       runUniqueObjectTest();
   }

--- a/sdk/tests/deqp/functional/gles3/es3fFboColorbufferTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboColorbufferTests.js
@@ -928,8 +928,8 @@ es3fFboColorbufferTests.FboColorbufferTests.prototype.init = function() {
         gl.R32F,
         gl.R16F,
 
-        // gl.EXT_color_buffer_half_float
-        gl.RGB16F
+        // gl.EXT_color_buffer_half_float is not exposed in WebGL 2.0.
+        // gl.RGB16F
     ];
 
     // .clear

--- a/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
@@ -363,7 +363,6 @@ var DE_ASSERT = function(x) {
         DE_ASSERT(!es3fFboTestCase.isRequiredFormat(format));
 
         switch (format) {
-            case gl.RGB16F:
             case gl.RGBA16F:
             case gl.RG16F:
             case gl.R16F:
@@ -373,6 +372,9 @@ var DE_ASSERT = function(x) {
             case gl.RG32F:
             case gl.R32F:
                 out.push('EXT_color_buffer_float');
+                break;
+            case gl.RGB16F:
+                // EXT_color_buffer_half_float is not exposed in WebGL 2.0.
                 break;
             default:
                 break;

--- a/sdk/tests/deqp/functional/gles3/fbocolorbuffer/blend.html
+++ b/sdk/tests/deqp/functional/gles3/fbocolorbuffer/blend.html
@@ -24,6 +24,7 @@ DO NOT EDIT!
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
+var ext = gl.getExtension('EXT_color_buffer_float');
 
 functional.gles3.es3fFboColorbufferTests.run(gl, [5, 6]);
 </script>

--- a/sdk/tests/deqp/functional/gles3/fbocolorbuffer/clear.html
+++ b/sdk/tests/deqp/functional/gles3/fbocolorbuffer/clear.html
@@ -24,6 +24,7 @@ DO NOT EDIT!
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
+var ext = gl.getExtension('EXT_color_buffer_float');
 
 functional.gles3.es3fFboColorbufferTests.run(gl, [0, 1]);
 </script>

--- a/sdk/tests/deqp/functional/gles3/fbocolorbuffer/fbocolorbuffer_test_generator.py
+++ b/sdk/tests/deqp/functional/gles3/fbocolorbuffer/fbocolorbuffer_test_generator.py
@@ -56,6 +56,7 @@ _HTML_TEMPLATE = """<html>
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
+var ext = gl.getExtension('EXT_color_buffer_float');
 
 functional.gles3.es3fFboColorbufferTests.run(gl, [%(start)s, %(end)s]);
 </script>

--- a/sdk/tests/deqp/functional/gles3/fbocolorbuffer/tex2d.html
+++ b/sdk/tests/deqp/functional/gles3/fbocolorbuffer/tex2d.html
@@ -24,6 +24,7 @@ DO NOT EDIT!
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
+var ext = gl.getExtension('EXT_color_buffer_float');
 
 functional.gles3.es3fFboColorbufferTests.run(gl, [1, 2]);
 </script>

--- a/sdk/tests/deqp/functional/gles3/fbocolorbuffer/tex2darray.html
+++ b/sdk/tests/deqp/functional/gles3/fbocolorbuffer/tex2darray.html
@@ -24,6 +24,7 @@ DO NOT EDIT!
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
+var ext = gl.getExtension('EXT_color_buffer_float');
 
 functional.gles3.es3fFboColorbufferTests.run(gl, [3, 4]);
 </script>

--- a/sdk/tests/deqp/functional/gles3/fbocolorbuffer/tex3d.html
+++ b/sdk/tests/deqp/functional/gles3/fbocolorbuffer/tex3d.html
@@ -24,6 +24,7 @@ DO NOT EDIT!
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
+var ext = gl.getExtension('EXT_color_buffer_float');
 
 functional.gles3.es3fFboColorbufferTests.run(gl, [4, 5]);
 </script>

--- a/sdk/tests/deqp/functional/gles3/fbocolorbuffer/texcube.html
+++ b/sdk/tests/deqp/functional/gles3/fbocolorbuffer/texcube.html
@@ -24,6 +24,7 @@ DO NOT EDIT!
 <script>
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext('canvas', null, 2);
+var ext = gl.getExtension('EXT_color_buffer_float');
 
 functional.gles3.es3fFboColorbufferTests.run(gl, [2, 3]);
 </script>


### PR DESCRIPTION
We don't expose EXT_color_buffer_half_float and it is not part of the
EXT_color_buffer_float extension.