### PR TITLE
Fix bugs in fbomultisample.html

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
@@ -305,13 +305,14 @@ var DE_ASSERT = function(x) {
             gl.R8,
 
             // gl.EXT_color_buffer_float
-            gl.RGBA32F,
-            gl.RGBA16F,
-            gl.R11F_G11F_B10F,
-            gl.RG32F,
-            gl.RG16F,
-            gl.R32F,
-            gl.R16F
+            // Multi-sample floating-point color buffers are not supported, see https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
+            // gl.RGBA32F,
+            // gl.RGBA16F,
+            // gl.R11F_G11F_B10F,
+            // gl.RG32F,
+            // gl.RG16F,
+            // gl.R32F,
+            // gl.R16F
         ];
 
         /** @const {Array<number>} */ var depthStencilFormats = [

--- a/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
@@ -392,8 +392,11 @@ var DE_ASSERT = function(x) {
         for (var iter in requiredExts) {
             /** @const @type {string} */ var extension = requiredExts[iter];
 
-            if (sglrGLContext.isExtensionSupported(gl, extension))
+            if (sglrGLContext.isExtensionSupported(gl, extension)) {
+                // enable the extension
+                gl.getExtension(extension);
                 return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
Multi-sample floating-point color buffers are not supported.
Skip tests against those color formats.