### PR TITLE
fix the bugs in fboMultisample.html against sRGB color format

### DIFF
--- a/sdk/tests/deqp/framework/referencerenderer/rrRenderer.js
+++ b/sdk/tests/deqp/framework/referencerenderer/rrRenderer.js
@@ -386,7 +386,7 @@ void FragmentProcessor::render (const rr::MultisamplePixelBufferAccess& msColorB
     var stencilState = state.stencilStates[fragmentFacing];
     var colorMaskFactor = [state.colorMask[0] ? 1 : 0, state.colorMask[1] ? 1 : 0, state.colorMask[2] ? 1 : 0, state.colorMask[3] ? 1 : 0];
     var colorMaskNegationFactor = [state.colorMask[0] ? false : true, state.colorMask[1] ? false : true, state.colorMask[2] ? false : true, state.colorMask[3] ? false : true];
-    var sRGBTarget = false;
+    var sRGBTarget = state.sRGBEnabled && colorBuffer.getFormat().isSRGB();
 
     // Scissor test.
 


### PR DESCRIPTION
The failure is a little deep, the variables and the shaders feed to real renderer and renference renderer are exactly the same. However, the generated reference image looks much sharper than the real result, I guess that either the msaa is not applied to the reference image, or the reference image doesn't change the colos space from srgb8_alhph8 to linear (rgba). After tracing the native code, it turns out the deduction is true. 

Now fboMultisample.html can pass. PTAL. Thanks!