### PR TITLE
Create an RGBA from an array of floats

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuRGBA.js
+++ b/sdk/tests/deqp/framework/common/tcuRGBA.js
@@ -106,6 +106,19 @@ var deMath = framework.delibs.debase.deMath;
     };
 
     /**
+     * @param {Array<number>} v
+     * @return {tcuRGBA.RGBA}
+     */
+    tcuRGBA.newRGBAFromVec = function (v) {
+        var r = deMath.clamp(v[0] * 255.0, 0, 255);
+        var g = deMath.clamp(v[1] * 255.0, 0, 255);
+        var b = deMath.clamp(v[2] * 255.0, 0, 255);
+        var a = deMath.clamp(v[3] * 255.0, 0, 255);
+
+        return new tcuRGBA.RGBA([r, g, b, a]);
+    };
+
+    /**
      * @param {number} v
      */
     tcuRGBA.RGBA.prototype.setRed = function(v) { DE_ASSERT(deMath.deInRange32(v, 0, 255)); this.m_value[tcuRGBA.RGBA.Shift.RED] = v; };

--- a/sdk/tests/deqp/functional/gles3/es3fFramebufferBlitTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFramebufferBlitTests.js
@@ -227,8 +227,8 @@ goog.scope(function() {
         // Image origin must be visible (for baseColor)
         DE_ASSERT(Math.min(this.m_dstRect[0], this.m_dstRect[2]) >= 0);
         DE_ASSERT(Math.min(this.m_dstRect[1], this.m_dstRect[3]) >= 0);
-        /** @const {tcuRGBA.RGBA} */ var cellColorA = tcuRGBA.newRGBAFromArray(this.m_gridCellColorA);
-        /** @const {tcuRGBA.RGBA} */ var cellColorB = tcuRGBA.newRGBAFromArray(this.m_gridCellColorB);
+        /** @const {tcuRGBA.RGBA} */ var cellColorA = tcuRGBA.newRGBAFromVec(this.m_gridCellColorA);
+        /** @const {tcuRGBA.RGBA} */ var cellColorB = tcuRGBA.newRGBAFromVec(this.m_gridCellColorB);
         // TODO: implement
         // const tcu::RGBA threshold = this.m_context.getRenderTarget().getPixelFormat().getColorThreshold() + tcu::RGBA(7,7,7,7);
         /** @type {tcuRGBA.RGBA} */ var threshold = tcuRGBA.newRGBAComponents(7, 7, 7, 7);


### PR DESCRIPTION
- Added a function to convert an array of floats into an RGBA object.
- Used the aforemention function to solve some framebufferblit tests'
  issues.