### PR TITLE
Fix error in image-bitmap-from-canvas tex-3d tests

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -51,10 +51,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
 
         setCanvasTo257x257(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
         finishTest();
     }
 


### PR DESCRIPTION
The last parameter of runImageBitmapTest() indicates whether this is a tex-3d test or not. I checked and found that all the other ImageBitmap tests pass "true" for 3d tests except the one from canvas. This is the fix.

Please review. @kenrussell @zhenyao @toji 