### PR TITLE
Fix reference color in framebufferblit test

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuImageCompare.js
+++ b/sdk/tests/deqp/framework/common/tcuImageCompare.js
@@ -141,7 +141,7 @@ tcuImageCompare.intThresholdCompare = function(imageSetName, imageSetDesc, refer
     for (var z = 0; z < depth; z++) {
         for (var y = 0; y < height; y++) {
             for (var x = 0; x < width; x++) {
-            var refPix = reference.getPixelInt(x, y, z);
+                var refPix = reference.getPixelInt(x, y, z);
                 var cmpPix = result.getPixelInt(x, y, z);
 
                 var diff = deMath.absDiff(refPix, cmpPix);

--- a/sdk/tests/deqp/framework/common/tcuTexture.js
+++ b/sdk/tests/deqp/framework/common/tcuTexture.js
@@ -1365,6 +1365,7 @@ tcuTexture.ConstPixelBufferAccess.prototype._getPixelInternal = function(x, y, z
             color[0] /= 255;
             color[1] /= 255;
             color[2] /= 255;
+            color[3] = 1;
             return color;
         }
     }

--- a/sdk/tests/deqp/framework/referencerenderer/rrUtil.js
+++ b/sdk/tests/deqp/framework/referencerenderer/rrUtil.js
@@ -70,13 +70,16 @@ goog.scope(function() {
         bufIDs[1] = ctx.createBuffer();
 
         ctx.useProgram(program);
-        ctx.bindBuffer(gl.ARRAY_BUFFER, bufIDs[0]);
-        ctx.bufferData(gl.ARRAY_BUFFER, new Float32Array(position), gl.STATIC_DRAW);
 
-        ctx.enableVertexAttribArray(posLoc);
-        ctx.vertexAttribPointer(posLoc, 4, gl.FLOAT, false, 0, 0);
+        if (posLoc >= 0) {
+            ctx.bindBuffer(gl.ARRAY_BUFFER, bufIDs[0]);
+            ctx.bufferData(gl.ARRAY_BUFFER, new Float32Array(position), gl.STATIC_DRAW);
 
-        ctx.bindBuffer(gl.ARRAY_BUFFER, null);
+            ctx.enableVertexAttribArray(posLoc);
+            ctx.vertexAttribPointer(posLoc, 4, gl.FLOAT, false, 0, 0);
+
+            ctx.bindBuffer(gl.ARRAY_BUFFER, null);
+        }
 
         if (coordLoc >= 0) {
             ctx.bindBuffer(gl.ARRAY_BUFFER, bufIDs[1]);
@@ -94,6 +97,12 @@ goog.scope(function() {
         ctx.deleteBuffer(bufIDs[0]);
         ctx.deleteBuffer(bufIDs[1]);
         ctx.deleteVertexArray(vaoID);
+
+        if (posLoc >= 0)
+          ctx.disableVertexAttribArray(posLoc);
+
+        if (coordLoc >= 0)
+          ctx.disableVertexAttribArray(coordLoc);
     };
 
 });

--- a/sdk/tests/deqp/functional/gles3/es3fFboTestUtil.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestUtil.js
@@ -283,7 +283,7 @@ es3fFboTestUtil.FboIncompleteException.prototype.getReason = function() {return 
             /** @const {number} */ var f1 = 0.5 + (x - y) * 0.5;
             /** @const {Array<number>} */ var fv = [f0, f1, 1.0 - f0, 1.0 - f1];
 
-            /** @const {Array<number>} */ var color = deMath.clampVector(deMath.add(gradientMin, deMath.multiply(deMath.subtract(gradientMax, gradientMin), fv)), 0, 1);
+            /** @const {Array<number>} */ var color = deMath.add(gradientMin, deMath.multiply(deMath.subtract(gradientMax, gradientMin), fv));
             /** @const {Array<number>} */ var icolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deInt32);
             /** @const {Array<number>} */ var uicolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deUint32);
 
@@ -673,7 +673,7 @@ es3fFboTestUtil.FboIncompleteException.prototype.getReason = function() {return 
 
             colors = tex.sample(texCoords, lod);
 
-            var color = deMath.clampVector(deMath.add(deMath.multiply(colors, texScale), texBias), 0, 1);
+            var color = deMath.add(deMath.multiply(colors, texScale), texBias);
             var icolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deInt32);
             var uicolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deUint32);
 
@@ -801,7 +801,7 @@ es3fFboTestUtil.FboIncompleteException.prototype.getReason = function() {return 
 
             colors = tex.sample(texCoords, lod);
 
-            /** @const {Array<number>} */ var color = deMath.clampVector(deMath.add(deMath.multiply(colors, texScale), texBias), 0, 1);
+            /** @const {Array<number>} */ var color = deMath.add(deMath.multiply(colors, texScale), texBias);
             /** @const {Array<number>} */ var icolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deInt32);
             /** @const {Array<number>} */ var uicolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deUint32);
 
@@ -931,7 +931,7 @@ es3fFboTestUtil.FboIncompleteException.prototype.getReason = function() {return 
 
             colors = tex.sample(texCoords, lod);
 
-            /** @const {Array<number>} */ var color = deMath.clampVector(deMath.add(deMath.multiply(colors, texScale), texBias), 0, 1);
+            /** @const {Array<number>} */ var color = deMath.add(deMath.multiply(colors, texScale), texBias);
             /** @const {Array<number>} */ var icolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deInt32);
             /** @const {Array<number>} */ var uicolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deUint32);
 
@@ -1031,7 +1031,7 @@ es3fFboTestUtil.FboIncompleteException.prototype.getReason = function() {return 
         var numPackets = packet.length;
         /** @const {number} */ var gradientMin = this.u_minGradient.value[0];
         /** @const {number} */ var gradientMax = this.u_maxGradient.value[0];
-        /** @type {Array<number>} */ var color = deMath.clampVector(this.u_color.value, 0, 1);
+        /** @type {Array<number>} */ var color = this.u_color.value;
         /** @type {Array<number>} */ var icolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deInt32);
         /** @type {Array<number>} */ var uicolor = es3fFboTestUtil.castVectorSaturate(color, tcuTexture.deTypes.deUint32);
 

--- a/sdk/tests/deqp/functional/gles3/es3fFramebufferBlitTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFramebufferBlitTests.js
@@ -722,14 +722,16 @@ goog.scope(function() {
         ctx.viewport(0, 0, this.m_size[0], this.m_size[1]);
 
         // Render gradients.
-        ctx.bindFramebuffer(gl.FRAMEBUFFER, srcFbo);
-        gradientToDstShader.setGradient(ctx, gradShaderDstID, dstRangeInfo.valueMin, dstRangeInfo.valueMax);
-
-        rrUtil.drawQuad(ctx, gradShaderDstID, [-1, -1, 0], [1, 1, 0]);
-
-        ctx.bindFramebuffer(gl.FRAMEBUFFER, dstFbo);
-        gradientToSrcShader.setGradient(ctx, gradShaderSrcID, srcRangeInfo.valueMin, dstRangeInfo.valueMax);
-        rrUtil.drawQuad(ctx, gradShaderSrcID, [-1, -1, 0], [1, 1, 0]);
+        for (var ndx = 0; ndx < 2; ndx++) {
+            ctx.bindFramebuffer(gl.FRAMEBUFFER, ndx ? dstFbo : srcFbo);
+            if (ndx) {
+                gradientToDstShader.setGradient(ctx, gradShaderDstID, dstRangeInfo.valueMax, dstRangeInfo.valueMin);
+                rrUtil.drawQuad(ctx, gradShaderDstID, [-1, -1, 0], [1, 1, 0]);
+            } else {
+                gradientToSrcShader.setGradient(ctx, gradShaderSrcID, srcRangeInfo.valueMin, srcRangeInfo.valueMax);
+                rrUtil.drawQuad(ctx, gradShaderSrcID, [-1, -1, 0], [1, 1, 0]);
+            }
+        }
 
         // Execute copy.
         ctx.bindFramebuffer(gl.READ_FRAMEBUFFER, srcFbo);


### PR DESCRIPTION
Fix two main problems in current code:
1. Set alpha channel as 1 instead of 255 for RGB format.
2. Don not need to clamp float format color to [0, 1]. The value is
always in [valueMin, valueMax].