### PR TITLE
Add more logging to ImageBitmap test

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -50,6 +50,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var image = new Image();
         image.onload = function() {
+            console.log("Source image has been loaded");
             runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
             finishTest();
         }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
@@ -53,10 +53,10 @@ function runOneIterationImageBitmapTest(useTexSubImage2D, bindingTarget, program
     }
 
     if (optionsVal.is3D)
-        debug('Testing texSubImage3D' + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
+        console.log('Testing texSubImage3D' + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
                 ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
     else
-        debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
+        console.log('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
               ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
               ', bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP'));
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -80,6 +80,8 @@ function runOneIterationImageBitmapTest(useTexSubImage2D, bindingTarget, program
                    gl.TEXTURE_CUBE_MAP_POSITIVE_Z,
                    gl.TEXTURE_CUBE_MAP_NEGATIVE_Z];
     }
+
+    console.log("Starts uploading the image into texture");
     // Upload the image into the texture
     for (var tt = 0; tt < targets.length; ++tt) {
         if (optionsVal.is3D) {
@@ -97,6 +99,7 @@ function runOneIterationImageBitmapTest(useTexSubImage2D, bindingTarget, program
             }
         }
     }
+    console.log("Uploading texture completed");
 
     var width = gl.canvas.width;
     var halfWidth = Math.floor(width / 2);
@@ -128,10 +131,10 @@ function runOneIterationImageBitmapTest(useTexSubImage2D, bindingTarget, program
 
         // Check the top pixel and bottom pixel and make sure they have
         // the right color.
-        debug("Checking " + (flipY ? "top" : "bottom"));
+        console.log("Checking " + (flipY ? "top" : "bottom"));
         wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
         wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-        debug("Checking " + (flipY ? "bottom" : "top"));
+        console.log("Checking " + (flipY ? "bottom" : "top"));
         wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
         wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
     }
@@ -195,6 +198,7 @@ function runImageBitmapTest(source, alphaVal, internalFormat, pixelFormat, pixel
     var p3 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
     var p4 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
     Promise.all([p1, p2, p3, p4]).then(function() {
+        console.log("All createImageBitmap promises are resolved");
         runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D);
     }, function() {
         // createImageBitmap with options could be rejected if it is not supported


### PR DESCRIPTION
A WebGL conformance test for ImageBitmap seems to time out some times:
https://bugs.chromium.org/p/chromium/issues/detail?id=596622

Here we add more logs to that test so that next time when it timed out, we will have enough info to know which point it timed out.

Please review. @kenrussell @zhenyao @toji 