### PR TITLE
deqp/gles3/fragmentoutput: for ints, the threshold is UINT_MAX

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFragmentOutputTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFragmentOutputTests.js
@@ -900,9 +900,11 @@ var tcuImageCompare = framework.common.tcuImageCompare;
 
                 case tcuTexture.TextureChannelClass.SIGNED_INTEGER:
                 case tcuTexture.TextureChannelClass.UNSIGNED_INTEGER: {
+                    // The C++ dEQP code uses ~0u but ~0 is -1 in Javascript
+                    var UINT_MAX = Math.pow(2.0, 32.0) - 1;
                     threshold = tcuTextureUtil.select(
                                     [0, 0, 0, 0],
-                                    [1, 1, 1, 1],
+                                    [UINT_MAX, UINT_MAX, UINT_MAX, UINT_MAX],
                                     cmpMask
                                     ); // UVec4
                     isOk = tcuImageCompare.intThresholdCompare(name, desc, reference, rendered, threshold/*, tcu::COMPARE_LOG_RESULT*/);


### PR DESCRIPTION
Image comparison was done with a threshold of 1 for unwritten integer
channels, which forced them to be in the [-1, 1] range, This was not
correct because the integer formats are not normalized, use UINT_MAX
instead.

This makes the code match the C++ version of dEQP.