### PR TITLE
Revise WEBGL_draw_buffers behavior.

### DIFF
--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -68,7 +68,10 @@
         Likewise the shading language preprocessor <code>#define GL_EXT_draw_buffers</code>, will be defined to 1 if the extension is supported.
       </addendum>
       <addendum>
-        The value of <code>gl_MaxDrawBuffers</code> should match <code>MAX_DRAW_BUFFERS_WEBGL</code> from the API if the extension is enabled in a WebGL context; otherwise, the value should be 1. Whether or not the extension is enabled with the <code>#extension GL_EXT_draw_buffers</code> directive in a shader does not affect the value of <code>gl_MaxDrawBuffers</code>.
+        The value of <code>gl_MaxDrawBuffers</code> must match <code>MAX_DRAW_BUFFERS_WEBGL</code> from the API if the extension is enabled in a WebGL context; otherwise, the value must be 1. Whether or not the extension is enabled with the <code>#extension GL_EXT_draw_buffers</code> directive in a shader does not affect the value of <code>gl_MaxDrawBuffers</code>. The value of <code>gl_MaxDrawBuffers</code> is a constant in the shader, and is guaranteed to be frozen at program link time. It is implementation-dependent whether it is frozen at shader compile time. (A consequence is that if a program is linked, and later the WEBGL_draw_buffers extension is enabled, the value of <code>gl_MaxDrawBuffers</code> seen by that program will still be 1.)
+      </addendum>
+      <addendum>
+        If the WEBGL_draw_buffers extension is enabled, but the fragment shader does not contain the <code>#extension GL_EXT_draw_buffers</code> directive to enable it, then writes to <code>gl_FragColor</code> are only written to <code>COLOR_ATTACHMENT0_WEBGL</code>, and not broadcast to all color attachments. In this scenario, other color attachments are guaranteed to remain untouched.
       </addendum>
     </mirrors>
     <features>
@@ -153,6 +156,9 @@ interface WEBGL_draw_buffers {
     </revision>
     <revision date="2014/08/08">
       <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
+    <revision date="2016/06/28">
+      <change>Revised behavior of gl_MaxDrawBuffers and gl_FragColor broadcasting, to avoid significant performance impact for WebGL 1.0 implementations running on top of the desktop OpenGL API.</change>
     </revision>
   </history>
 </ratified>

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -60,6 +60,13 @@ void main() {
     gl_FragColor = vec4(1,0,0,1);
 }
 </script>
+<script id="fshaderRedWithExtension" type="x-shader/x-fragment">
+#extension GL_EXT_draw_buffers : require
+precision mediump float;
+void main() {
+    gl_FragColor = vec4(1,0,0,1);
+}
+</script>
 <script id="fshaderMacroDisabled" type="x-shader/x-fragment">
 #ifdef GL_EXT_draw_buffers
   bad code here
@@ -411,6 +418,7 @@ function runDrawTests() {
 
   var checkProgram = wtu.setupTexturedQuad(gl);
   var redProgram = wtu.setupProgram(gl, ["vshader", "fshaderRed"], ["a_position"]);
+  var redProgramWithExtension = wtu.setupProgram(gl, ["vshader", "fshaderRedWithExtension"], ["a_position"]);
   var drawProgram = createExtDrawBuffersProgram("fshader", {numDrawingBuffers: maxDrawingBuffers});
   var width = 64;
   var height = 64;
@@ -549,10 +557,21 @@ function runDrawTests() {
 
   checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
 
-  debug("test that gl_FragColor broadcasts");
+  debug("test that gl_FragColor does not broadcast unless extension is enabled in fragment shader");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   ext.drawBuffersWEBGL(bufs);
   gl.useProgram(redProgram);
+  wtu.drawUnitQuad(gl);
+
+  checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    return (index == 0) ? [255, 0, 0, 255] : [0, 255, 0, 0];
+  });
+
+  debug("test that gl_FragColor broadcasts if extension is enabled in fragment shader");
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  ext.drawBuffersWEBGL(bufs);
+  gl.useProgram(redProgramWithExtension);
   wtu.drawUnitQuad(gl);
 
   checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
@@ -745,6 +764,7 @@ function runDrawTests() {
   });
   gl.deleteProgram(checkProgram);
   gl.deleteProgram(redProgram);
+  gl.deleteProgram(redProgramWithExtension);
   gl.deleteProgram(drawProgram);
 }
 


### PR DESCRIPTION
While upgrading to WebGL 2.0 it has been discovered that some of the behaviors defined by WebGL 1.0 with the WEBGL_draw_buffers extension will impose severe performance penalties as implementations are upgraded. Revise the extension and the conformance test to avoid these penalties.