### PR TITLE
Skip top right corner pixel comparison in textureformat cubemap test …

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuImageCompare.js
+++ b/sdk/tests/deqp/framework/common/tcuImageCompare.js
@@ -123,9 +123,10 @@ tcuImageCompare.computeScaleAndBias = function(reference, result) {
  * @param {tcuTexture.ConstPixelBufferAccess} result Result image
  * @param {Array<number>} threshold Maximum allowed difference
  * @param {tcuImageCompare.CompareLogMode=} logMode
+ * @param {Array< Array<number> >} skipPixels pixels that are skipped comparison
  * @return {boolean} true if comparison passes, false otherwise
  */
-tcuImageCompare.intThresholdCompare = function(imageSetName, imageSetDesc, reference, result, threshold, logMode) {
+ tcuImageCompare.intThresholdCompare = function(imageSetName, imageSetDesc, reference, result, threshold, logMode, skipPixels) {
     var width = reference.getWidth();
     var height = reference.getHeight();
     var depth = reference.getDepth();
@@ -141,6 +142,18 @@ tcuImageCompare.intThresholdCompare = function(imageSetName, imageSetDesc, refer
     for (var z = 0; z < depth; z++) {
         for (var y = 0; y < height; y++) {
             for (var x = 0; x < width; x++) {
+                if (skipPixels && skipPixels.length > 0) {
+                    var skip = false;
+                    for (var ii = 0; ii < skipPixels.length; ++ii) {
+                        var refZ = (skipPixels[ii].length > 2 ? skipPixels[ii][2] : 0);
+                        if (x == skipPixels[ii][0] && y == skipPixels[ii][1] && z == refZ) {
+                            skip = true;
+                            break;
+                        }
+                    }
+                    if (skip)
+                        continue;
+                }
                 var refPix = reference.getPixelInt(x, y, z);
                 var cmpPix = result.getPixelInt(x, y, z);
 
@@ -418,10 +431,11 @@ tcuImageCompare.floatThresholdCompare = function(imageSetName, imageSetDesc, ref
  * @param {tcuSurface.Surface} result Result image
  * @param {Array<number>} threshold Maximum allowed difference
  * @param {tcuImageCompare.CompareLogMode=} logMode
+ * @param {Array< Array<number> >} skipPixels pixels that are skipped comparison
  * @return {boolean} true if comparison passes, false otherwise
  */
-tcuImageCompare.pixelThresholdCompare = function(imageSetName, imageSetDesc, reference, result, threshold, logMode) {
-    return tcuImageCompare.intThresholdCompare(imageSetName, imageSetDesc, reference.getAccess(), result.getAccess(), threshold, logMode);
+tcuImageCompare.pixelThresholdCompare = function(imageSetName, imageSetDesc, reference, result, threshold, logMode, skipPixels) {
+    return tcuImageCompare.intThresholdCompare(imageSetName, imageSetDesc, reference.getAccess(), result.getAccess(), threshold, logMode, skipPixels);
 };
 
 /**

--- a/sdk/tests/deqp/functional/gles3/es3fTextureFormatTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureFormatTests.js
@@ -307,7 +307,16 @@ es3fTextureFormatTests.TextureCubeFormatCase.prototype.testFace = function(face)
         this.m_texture.getRefTexture(), texCoord, renderParams);
 
     // Compare and log.
-    var isOk = glsTextureTestUtil.compareImages(referenceFrame, renderedFrame, threshold);
+    var skipPixels = null;
+    if (renderParams.samplerType == glsTextureTestUtil.samplerType.SAMPLERTYPE_INT ||
+        renderParams.samplerType == glsTextureTestUtil.samplerType.SAMPLERTYPE_UINT) {
+        // Skip top right pixel due to Mac Intel driver bug.
+        // https://github.com/KhronosGroup/WebGL/issues/1819
+        skipPixels = [
+            [this.m_width - 1, this.m_height - 1]
+        ];
+    }
+    var isOk = glsTextureTestUtil.compareImages(referenceFrame, renderedFrame, threshold, skipPixels);
 
     assertMsgOptions(isOk, 'Face: ' + this.m_curFace + ' ' + es3fTextureFormatTests.testDescription(), true, true);
     return isOk;

--- a/sdk/tests/deqp/modules/shared/glsTextureTestUtil.js
+++ b/sdk/tests/deqp/modules/shared/glsTextureTestUtil.js
@@ -1408,11 +1408,12 @@ glsTextureTestUtil.sampleTexture3D = function(dst, src, texCoord, params) {
  * @param {tcuSurface.Surface} reference
  * @param {tcuSurface.Surface} rendered
  * @param {Array<number>} threshold
+ * @param {Array< Array<number> >} skipPixels
  *
  * @return {boolean}
  */
-glsTextureTestUtil.compareImages = function(reference, rendered, threshold) {
-    return tcuImageCompare.pixelThresholdCompare('Result', 'Image comparison result', reference, rendered, threshold, undefined /*tcu::COMPARE_LOG_RESULT*/);
+glsTextureTestUtil.compareImages = function(reference, rendered, threshold, skipPixels) {
+    return tcuImageCompare.pixelThresholdCompare('Result', 'Image comparison result', reference, rendered, threshold, undefined /*tcu::COMPARE_LOG_RESULT*/, skipPixels);
 };
 
 /**


### PR DESCRIPTION
…cases.

This is to make the test pass with Mac Intel driver bug.

A separate test case has been added to catch the driver bug.