### PR TITLE
Another test case skipped due to R11F_G11F_B10F bug on Mac OSX.

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuSkipList.js
+++ b/sdk/tests/deqp/framework/common/tcuSkipList.js
@@ -115,6 +115,8 @@ goog.scope(function() {
         _skip("render.resize.rbo_r11f_g11f_b10f");
         // deqp/functional/gles3/fborender/recreate_color_02.html
         _skip("render.recreate_color.rbo_r11f_g11f_b10f_depth_stencil_rbo_depth24_stencil8");
+        // deqp/functional/gles3/fbocolorbuffer/clear.html
+        _skip("color.clear.r11f_g11f_b10f");
     } // if (!runSkippedTests)
 
     /*


### PR DESCRIPTION
See https://github.com/KhronosGroup/WebGL/issues/1832