### PR TITLE
fix an error from pull #1795

### DIFF
--- a/sdk/tests/deqp/data/gles2/shaders/shader-lib-test.html
+++ b/sdk/tests/deqp/data/gles2/shaders/shader-lib-test.html
@@ -158,7 +158,7 @@
                         test_result(
                                 "Checking string parser. Passing \"\"hello world\"extra\". Expecting \"hello world\"",
                                 result == "hello world", result
-ts/deqp/data/gles2/shaders/qualification_order.html                       );
+                        );
                         return true;
                 },
                 function() {


### PR DESCRIPTION
@zhenyao When I cleaned the lint errors in sdk folders, I modified shader-lib-test.html by mistake. I'm so sorry, PTAL. 
BTW: There are still 14576 lint errors in sdk folders. Most of them are in *.frag and *.vert files. Wheather it need help?