### PR TITLE
Fix ambiguous test cases in tex-sub-image-2d-bad-args.html

### DIFF
--- a/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
+++ b/sdk/tests/conformance/textures/misc/tex-sub-image-2d-bad-args.html
@@ -100,15 +100,15 @@ if (contextVersion < 2) {
     gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGB, gl.UNSIGNED_SHORT_5_6_5, c);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "type not same as original RGB");
 }
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, c);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "make texture RGBA 4_4_4_4");
-gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, c);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "format same as original RGBA 4_4_4_4");
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, c);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "make texture RGBA UNSIGNED_BYTE");
+gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "format same as original");
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGB, gl.UNSIGNED_BYTE, c);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "format not same as original RGBA 4_4_4_4");
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "format not same as original");
 if (contextVersion < 2) {
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "type not same as original RGBA 4_4_4_4");
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, c);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "type not same as original");
 }
 
 // Large canvas will trigger GPU-to-GPU fast path in chrome,
@@ -117,23 +117,23 @@ var largeCanvas = document.createElement("canvas");
 largeCanvas.width = 257;
 largeCanvas.height = 257;
 var largeCanvasContext = largeCanvas.getContext("2d");
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, largeCanvas);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "make texture RGBA 4_4_4_4");
-gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, c);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "format same as original RGBA 4_4_4_4");
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, largeCanvas);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "make texture RGBA UNSIGNED_BYTE");
+gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "format same as original");
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGB, gl.UNSIGNED_BYTE, c);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "format not same as original RGBA 4_4_4_4");
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "format not same as original");
 if (contextVersion < 2) {
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, c);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "type not same as original RGBA 4_4_4_4");
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, c);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "type not same as original");
 }
-gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, largeCanvas);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "format same as original RGBA 4_4_4_4");
+gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, largeCanvas);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "format same as original");
 gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGB, gl.UNSIGNED_BYTE, largeCanvas);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "format not same as original RGBA 4_4_4_4");
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "format not same as original");
 if (contextVersion < 2) {
-    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, largeCanvas);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "type not same as original RGBA 4_4_4_4");
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_SHORT_4_4_4_4, largeCanvas);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "type not same as original");
 }
 
 var maxCubeMapTextureSize = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);


### PR DESCRIPTION
When we test against the argument 'format', we should keep the argument 'type' correct. 

PTAL. Thanks a lot!