### PR TITLE
Allow 0 and 1 in gles3/f/fbodepthbuffer.depth_write_clamp

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboDepthbufferTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboDepthbufferTests.js
@@ -216,12 +216,12 @@ es3fFboDepthbufferTests.DepthWriteClampCase.prototype.render = function(dst) {
         ctx.depthMask(false);
 
         // Test if any fragment has greater depth than 1; there should be none
-        ctx.depthFunc(gl.LESS); // (1 < depth) ?
+        ctx.depthFunc(gl.LEQUAL); // (1 <= depth) ?
         gradShader.setUniforms(ctx, gradShaderID, 1, 1, red);
         rrUtil.drawQuad(ctx, gradShaderID, [-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]);
 
         // Test if any fragment has smaller depth than 0; there should be none
-        ctx.depthFunc(gl.GREATER); // (0 > depth) ?
+        ctx.depthFunc(gl.GEQUAL); // (0 >= depth) ?
         gradShader.setUniforms(ctx, gradShaderID, 0, 0, red);
         rrUtil.drawQuad(ctx, gradShaderID, [-1.0, -1.0, -1.0], [1.0, 1.0, 1.0]);
 


### PR DESCRIPTION
The test checked that gl_FragDepth is clamped to (0, 1) before it is
written to the depth buffer while the specification says the depth
should be clamped to [0, 1].

This was found while running the corresponding WebGL 2 CTS test on the
NVIDIA OpenGL driver.

Please do not land before the respective dEQP CL is landed in https://android-review.googlesource.com/#/c/245910/