### PR TITLE
Remove incorrect preprocessor.pragmas.pragma_fragment test.

### DIFF
--- a/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
+++ b/sdk/tests/deqp/data/gles2/shaders/preprocessor.test
@@ -2672,35 +2672,12 @@ group pragmas "Pragma Tests"
 		""
 	end
 
-	case pragma_fragment
-		values { output float out0 = 1.0; }
-
-		vertex ""
-			precision mediump float;
-			${VERTEX_DECLARATIONS}
-			varying float v_val;
-			void main()
-			{
-				v_val = 1.0;
-				${VERTEX_OUTPUT}
-			}
-		""
-		fragment ""
-			#pragma
-			#pragma STDGL invariant(all)
-			#pragma debug(off)
-			#pragma optimize(off)
-
-			precision mediump float;
-			${FRAGMENT_DECLARATIONS}
-			varying float v_val;
-			void main()
-			{
-				out0 = v_val;
-				${FRAGMENT_OUTPUT}
-			}
-		""
-	end
+	# Note: pragma_fragment was removed compared to the native dEQP.
+	# This test was buggy; it required that a varying that was not
+	# invariant in the vertex shader, but invariant in the fragment
+	# shader, must link. The test was in the gles2-failures.txt skip
+	# list in the native test suite. To avoid confusion the test was
+	# removed here, rather than adding it to tcuSkipList.js.
 
 	case pragma_macro_exp
 		values { output float out0 = 1.0; }


### PR DESCRIPTION
This test is buggy and is in the skip list for the native dEQP (in
android/cts/master/src/gles2-failures.txt). The test is never going to
be updated (the invariace matching rules are different between ESSL 1.00
and 3.00) so to avoid confusion the test is being removed rather than
added to tcuSkipList.js.

See http://crbug.com/625363 .