### PR TITLE
Finally

### DIFF
--- a/sdk/tests/deqp/framework/referencerenderer/rrFragmentOperations.js
+++ b/sdk/tests/deqp/framework/referencerenderer/rrFragmentOperations.js
@@ -196,7 +196,18 @@ rrFragmentOperations.executeDepthCompare = function(inputFragments, depthFunc, d
                 var fragSampleNdx = 0;
                 var depthBufferValue = depthBuffer.getPixDepth(fragSampleNdx, frag.pixelCoord[0], frag.pixelCoord[1]);
                 var sampleDepthFloat = frag.sampleDepths[fragSampleNdx];
-                var sampleDepth = deMath.clamp(sampleDepthFloat, 0.0, 1.0);
+
+                /* convert input float to target buffer format for comparison */
+                var access = new tcuTexture.PixelBufferAccess({
+                    format: depthBuffer.getFormat(),
+                    width: 1,
+                    height: 1,
+                    depth: 1,
+                    data: new ArrayBuffer(8)
+                });
+                access.setPixDepth(sampleDepthFloat, 0, 0, 0);
+                var sampleDepth = access.getPixDepth(0, 0, 0);
+
                 frag.depthPassed = expression(sampleDepth, depthBufferValue);
             }
         }

--- a/sdk/tests/deqp/framework/referencerenderer/rrUtil.js
+++ b/sdk/tests/deqp/framework/referencerenderer/rrUtil.js
@@ -42,18 +42,15 @@ goog.scope(function() {
         p0[0], p0[1], p0[2], 1.0,
         p0[0], p1[1], hz, 1.0,
         p1[0], p0[1], hz, 1.0,
-        p1[0], p0[1], hz, 1.0,
-        p0[0], p1[1], hz, 1.0,
         p1[0], p1[1], p1[2], 1.0
         ];
         /** @type {Array<number>} */ var coord = [
         0.0, 0.0,
         0.0, 1.0,
         1.0, 0.0,
-        1.0, 0.0,
-        0.0, 1.0,
         1.0, 1.0
         ];
+        /** @type {Array<number>} */ var indices = [0, 1, 2, 2, 1, 3];
 
         var posLoc = ctx.getAttribLocation(program, 'a_position');
         if (posLoc == -1)
@@ -91,7 +88,17 @@ goog.scope(function() {
             ctx.bindBuffer(gl.ARRAY_BUFFER, null);
         }
 
-        ctx.drawQuads(gl.TRIANGLES, 0, 6);
+        {
+            var ndxID = ctx.createBuffer();
+
+            ctx.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ndxID);
+            ctx.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(indices), gl.STATIC_DRAW);
+
+            ctx.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0);
+
+            ctx.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);
+            ctx.deleteBuffer(ndxID);
+        }
 
         ctx.bindVertexArray(null);
         ctx.deleteBuffer(bufIDs[0]);


### PR DESCRIPTION
PTAL, this is the actual fix for fbodepthbuffer and framebufferblit.depth_stencil.

Basically when doing a depth compare of 0.5 and 0.5 in the tests, what was actually happening was that we were comparing a depth of 0.5 for the fragment and 0.5 + epsilon for the depth buffer because it was quantized.

To fix this we convert the incoming fragment buffer depth to the depthbuffer format and back, making it incur the same loss of precision.

The rrUtil change is a noop cleanup I did thinking it might have been the root cause of this bug.