### PR TITLE
Fix typo: indx -> index

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1795,15 +1795,15 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void useProgram(WebGLProgram? program);
     void validateProgram(WebGLProgram? program);
 
-    void vertexAttrib1f(GLuint indx, GLfloat x);
-    void vertexAttrib1fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
-    void vertexAttrib2fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
-    void vertexAttrib3fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
-    void vertexAttrib4fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttribPointer(GLuint indx, GLint size, GLenum type,
+    void vertexAttrib1f(GLuint index, GLfloat x);
+    void vertexAttrib1fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttrib2f(GLuint index, GLfloat x, GLfloat y);
+    void vertexAttrib2fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttrib3f(GLuint index, GLfloat x, GLfloat y, GLfloat z);
+    void vertexAttrib3fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttrib4f(GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+    void vertexAttrib4fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttribPointer(GLuint index, GLint size, GLenum type,
                              GLboolean normalized, GLsizei stride, GLintptr offset);
 
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
@@ -2917,15 +2917,15 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             If the array passed to any of the vector forms (those ending in <code>v</code>) has an
             invalid length, an <code>INVALID_VALUE</code> error will be generated. The length is
             invalid if it is too short for or is not an integer multiple of the assigned type.
-        <dt><p class="idl-code">void vertexAttrib[1234]f(GLuint indx, ...)</p>
-            <p class="idl-code">void vertexAttrib[1234]fv(GLuint indx, ...)
+        <dt><p class="idl-code">void vertexAttrib[1234]f(GLuint index, ...)</p>
+            <p class="idl-code">void vertexAttrib[1234]fv(GLuint index, ...)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.7">OpenGL ES 2.0 &sect;2.7</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glVertexAttrib.xml">man page</a>)</span></p>
        <dd>
            Sets the vertex attribute at the passed index to the given constant value. Values set via the
            <code>vertexAttrib</code> are guaranteed to be returned from the <code>getVertexAttrib</code> function
            with the <code>CURRENT_VERTEX_ATTRIB</code> param, even if there have been intervening calls to
            <code>drawArrays</code> or <code>drawElements</code>.
-       <dt class="idl-code">void vertexAttribPointer(GLuint indx, GLint size, GLenum type,
+       <dt class="idl-code">void vertexAttribPointer(GLuint index, GLint size, GLenum type,
                             GLboolean normalized, GLsizei stride, GLintptr offset)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.8">OpenGL ES 2.0 &sect;2.8</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glVertexAttribPointer.xml">man page</a>)</span>
         <dd>

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -707,15 +707,15 @@ interface WebGLRenderingContextBase
     void useProgram(WebGLProgram? program);
     void validateProgram(WebGLProgram? program);
 
-    void vertexAttrib1f(GLuint indx, GLfloat x);
-    void vertexAttrib1fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttrib2f(GLuint indx, GLfloat x, GLfloat y);
-    void vertexAttrib2fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttrib3f(GLuint indx, GLfloat x, GLfloat y, GLfloat z);
-    void vertexAttrib3fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttrib4f(GLuint indx, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
-    void vertexAttrib4fv(GLuint indx, VertexAttribFVSource values);
-    void vertexAttribPointer(GLuint indx, GLint size, GLenum type,
+    void vertexAttrib1f(GLuint index, GLfloat x);
+    void vertexAttrib1fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttrib2f(GLuint index, GLfloat x, GLfloat y);
+    void vertexAttrib2fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttrib3f(GLuint index, GLfloat x, GLfloat y, GLfloat z);
+    void vertexAttrib3fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttrib4f(GLuint index, GLfloat x, GLfloat y, GLfloat z, GLfloat w);
+    void vertexAttrib4fv(GLuint index, VertexAttribFVSource values);
+    void vertexAttribPointer(GLuint index, GLint size, GLenum type,
                              GLboolean normalized, GLsizei stride, GLintptr offset);
 
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1746,8 +1746,8 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         invalid length, an <code>INVALID_VALUE</code> error will be generated. The length is invalid
         if it is too short for or is not an integer multiple of the assigned type.
       </dd>
-      <dt><p class="idl-code">void vertexAttribI4[u]i(GLuint indx, ...)</p>
-          <p class="idl-code">void vertexAttribI4[u]iv(GLuint indx, ...)
+      <dt><p class="idl-code">void vertexAttribI4[u]i(GLuint index, ...)</p>
+          <p class="idl-code">void vertexAttribI4[u]iv(GLuint index, ...)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.7">OpenGL ES 3.0.4 &sect;2.7</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glVertexAttrib.xhtml" class="nonnormative">man page</a>)


### PR DESCRIPTION
This keeps unified words in other parts of spec.