### PR TITLE
Fix missing entry in WebGL 2.0 test list

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -7,6 +7,7 @@ array-in-complex-expression.html
 array-length-side-effects.html
 attrib-location-length-limits.html
 compare-structs-containing-arrays.html
+compound-assignment-type-combination.html
 const-array-init.html
 forbidden-operators.html
 frag-depth.html


### PR DESCRIPTION
compound-assignment-type-combination test for WebGL 2 was missing from
the test runner test list.