### PR TITLE
Interpolation qualifier in all linked shaders must match

### DIFF
--- a/sdk/tests/deqp/data/gles3/shaders/linkage.test
+++ b/sdk/tests/deqp/data/gles3/shaders/linkage.test
@@ -495,8 +495,12 @@ group varying "Varying linkage"
 
 		# different interpolation
 		case differing_interpolation_2
+			# This deviates from C++ dEQP here. GLSL ES 3.00.4 specifies interpolation
+			# qualifier of variables with the same name declared in all linked shaders
+			# must match, in Section 4.3.9 Interpolation.
 			version 300 es
 			desc "varying interpolation different (smooth vs. centroid)"
+			expect link_fail
 			values
 			{
 				input float in0		= [ -1.25 | -25.0 | 1.0 | 2.25 | 3.4 | 16.0 ];


### PR DESCRIPTION
GLSL ES 3.00.4 specifies that "The type and presence of the
interpolation qualifiers and storage qualifiers and invariant qualifiers
of variables with the same name declared in all linked shaders must
match, otherwise the link command will fail." in Section 4.3.9 Interpolation.

The restriction for interpolation qualifier is relaxed to "It is a
link-time error if, within the same stage, the interpolation qualifiers
of variables of the same name do not match." in Section 4.5
Interpolation Qualifiers, GLSLangSpec 4.40.