### PR TITLE
Add a test for mis-matching uniform block

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -23,6 +23,7 @@ shader-with-1024-character-identifier.frag.html
 shader-with-1025-character-define.html
 shader-with-1025-character-identifier.frag.html
 shader-with-invalid-characters.html
+shader-with-mis-matching-uniform-block.html
 short-circuiting-in-loop-condition.html
 texture-offset-out-of-range.html
 tricky-loop-conditions.html

--- a/sdk/tests/conformance2/glsl3/shader-with-mis-matching-uniform-block.html
+++ b/sdk/tests/conformance2/glsl3/shader-with-mis-matching-uniform-block.html
@@ -1,0 +1,80 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL mis-matching uniform block</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader-uniform-block-precision" type="text/something-not-javascript">#version 300 es
+uniform Block {
+    mediump vec4 val;
+};
+
+void main()
+{
+    gl_Position = val;
+}
+</script>
+<script id="fshader-uniform-block-precision" type="text/something-not-javascript">#version 300 es
+uniform Block {
+    highp vec4 val;
+};
+
+out highp vec4 out_FragColor;
+void main()
+{
+    out_FragColor = val;
+}
+</script>
+<script>
+"use strict";
+description("Shaders with precision mis-matching uniform blocks should fail");
+
+GLSLConformanceTester.runTests([
+{
+  vShaderId: 'vshader-uniform-block-precision',
+  vShaderSuccess: true,
+  fShaderId: 'fshader-uniform-block-precision',
+  fShaderSuccess: true,
+  linkSuccess: false,
+  passMsg: "Shaders with precision mis-matching uniform blocks should fail"
+},
+], 2);
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
"The same uniform declared in different shaders that are linked together
must have the same precision qualification.". See Section 4.5.3
Precision Qualifiers in GLSL ES 3.00.4 spec.