### PR TITLE
Add a lint tool for catching common mistakes in test files

### DIFF
--- a/sdk/tests/py/lint/LICENSE
+++ b/sdk/tests/py/lint/LICENSE
@@ -1,0 +1,30 @@
+W3C 3-clause BSD License
+
+http://www.w3.org/Consortium/Legal/2008/03-bsd-license.html
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of works must retain the original copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the original copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of the W3C nor the names of its contributors may be
+  used to endorse or promote products derived from this work without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/sdk/tests/py/lint/README.md
+++ b/sdk/tests/py/lint/README.md
@@ -1,0 +1,115 @@
+## Introduction
+
+We have a lint tool for catching common mistakes in test files. The tool comes from
+[W3C/wpt-tools](https://github.com/w3c/wpt-tools/) with modification for catching
+common mistakes in submitted pull request, all WebGL/sdk/tests and specified folder.
+
+The copyright of this tool is belong to W3C and/or the author listed in the test
+file. The tool is dual-licensed under the
+[W3C Test Suite License](http://www.w3.org/Consortium/Legal/2008/04-testsuite-license)
+and [BSD 3-clause License](http://www.w3.org/Consortium/Legal/2008/03-bsd-license),
+which are introduced in
+[W3C's test suite licensing policy](http://www.w3.org/Consortium/Legal/2008/04-testsuite-copyright).
+
+Now the tool can check html, htm, xhtml, xhtm, js, frag and vert files.
+- You can run it manually by starting the `lint.py` executable from the root of your local
+WebGL/sdk/tests working directory like this:
+
+```
+./py/lint/lint.py
+```
+
+You can use the lint tool to check submitted pull request and fix the errors reported by the tool.
+Reviewers will not merge branches with tests that have lint errors, so you must either
+[fix all lint errors](#fixing-lint-errors) or update
+[white-list test files] (#updating-the-whitelist) to suppress the errors.
+
+## Usage of lint tool
+
+1. Check other repos, specify the repo name with `-r`, default
+is WebGL/sdk/tests:</br>
+<code>
+./py/lint/lint.py -r demo-express
+</code>
+1. Check submitted pull request:</br>
+<code>
+./py/lint/lint.py -p
+</code>
+1. Check specified folder, the specified folder must be relative path of
+WebGL/sdk/tests:</br>
+<code>
+./py/lint/lint.py -d conformance/attribs
+</code>
+
+## Fixing lint errors
+
+You must fix any errors the lint tool reports, unless an error is for
+something essential to a certain test or that for some other exceptional
+reason shouldn't prevent the test from being merged. In those cases you can
+update [white-list test files](#updating-the-whiteslist) to suppress the errors.
+Otherwise, use the details in this section to fix all errors reported.
+
+* **CR AT EOL**: Test-file line ends with CR (U+000D) character; **fix**:
+  reformat file so each line just has LF (U+000A) line ending (standard,
+  cross-platform "Unix" line endings instead of, e.g., DOS line endings).
+
+* **INDENT TABS**: Test-file line starts with one or more tab characters;
+  **fix**: use spaces to replace any tab characters at beginning of lines.
+
+* **TRAILING WHITESPACE**: Test-file line has trailing whitespace; **fix**:
+  remove trailing whitespace from all lines in the file.
+
+* **UNNECESSARY EXECUTABLE PERMISSION**: Test file contains unnecessary executable permission; **fix**:
+  remove unnecessary executable permission of the file.
+
+* **FILENAME WHITESPACE**: Test file name contains white space; **fix**:
+  remove white space from test file name.
+
+## Updating the whitelist
+
+Normally you must [fix all lint errors](#fixing-lint-errors). But in the
+unusual case of error reports for things essential to certain tests or that
+for other exceptional reasons shouldn't prevent a merge of a test, you can
+update and commit the `lint.whitelist` file in the WebGL/sdk/tests/py/lint/
+directory to suppress errors the lint tool would report for a test file.
+
+To add a test file or directory to the whitelist, use the following format:
+
+```
+ERROR TYPE:file/name/pattern
+```
+
+For example, to whitelist the file `example/file.html` such that all
+`TRAILING WHITESPACE` errors the lint tool would report for it are
+suppressed, add the following line to the `lint.whitelist` file.
+
+```
+TRAILING WHITESPACE:example/file.html
+```
+
+To whitelist an entire directory rather than just one file, use the `*`
+wildcard. For example, to whitelist the `example` directory such that all
+`TRAILING WHITESPACE` errors the lint tool would report for any files in it
+are suppressed, add the following line to the `lint.whitelist` file.
+
+```
+TRAILING WHITESPACE:example/*
+```
+
+If needed, you can also use the `*` wildcard to express other filename
+patterns or directory-name patterns (just as you would when, e.g.,
+executing shell commands from the command line).
+
+Finally, to whitelist just one line in a file, use the following format:
+
+```
+ERROR TYPE:file/name/pattern:line_number
+```
+
+For example, to whitelist just line 128 of the file `example/file.html`
+such that any `TRAILING WHITESPACE` error the lint tool would report for
+that line is suppressed, add the following to the `lint.whitelist` file.
+
+```
+TRAILING WHITESPACE:example/file.html:128
+```

--- a/sdk/tests/py/lint/lint.py
+++ b/sdk/tests/py/lint/lint.py
@@ -1,0 +1,223 @@
+#! /usr/bin/env python
+import os
+import subprocess
+import re
+import sys
+import fnmatch
+import commands
+
+from collections import defaultdict
+from optparse import OptionParser
+
+lint_root = os.path.dirname(os.path.abspath(__file__))
+repo_root = os.path.dirname(os.path.dirname(lint_root))
+
+
+def git(command, *args):
+    args = list(args)
+    proc_kwargs = {"cwd": repo_root}
+    command_line = ["git", command] + args
+
+    try:
+        return subprocess.check_output(command_line, **proc_kwargs)
+    except subprocess.CalledProcessError:
+        raise
+
+
+def iter_files(flag=False, floder=""):
+    if floder != "" and floder != None:
+        os.chdir(repo_root)
+        for pardir, subdir, files in os.walk(floder):
+            for item in subdir + files:
+                if not os.path.isdir(os.path.join(pardir, item)):
+                    yield os.path.join(pardir, item)
+        os.chdir(lint_root)
+    else:
+        if not flag:
+            os.chdir(repo_root)
+            for pardir, subdir, files in os.walk(repo_root):
+                for item in subdir + files:
+                    if not os.path.isdir(os.path.join(pardir, item)):
+                        yield os.path.join(pardir, item).split(repo_root + "/")[1]
+            os.chdir(lint_root)
+        else:
+            for item in git("diff", "--name-status", "HEAD~1").strip().split("\n"):
+                status = item.split("\t")
+                if status[0].strip() != "D":
+                    yield status[1]
+
+
+def check_filename_space(path):
+    bname = os.path.basename(path)
+    if re.compile(" ").search(bname):
+        return [("FILENAME WHITESPACE", "Filename of %s contains white space" % path, None)]
+    return []
+
+
+def check_permission(path):
+    bname = os.path.basename(path)
+    if not re.compile('\.py$|\.sh$').search(bname):
+        if os.access(os.path.join(repo_root, path), os.X_OK):
+            return [("UNNECESSARY EXECUTABLE PERMISSION", "%s contains unnecessary executable permission" % path, None)]
+    return []
+
+
+def parse_whitelist_file(filename):
+    data = defaultdict(lambda:defaultdict(set))
+
+    with open(filename) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            parts = [item.strip() for item in line.split(":")]
+            if len(parts) == 2:
+                parts.append(None)
+            else:
+                parts[-1] = int(parts[-1])
+
+            error_type, file_match, line_number = parts
+            data[file_match][error_type].add(line_number)
+
+    def inner(path, errors):
+        whitelisted = [False for item in xrange(len(errors))]
+
+        for file_match, whitelist_errors in data.iteritems():
+            if fnmatch.fnmatch(path, file_match):
+                for i, (error_type, msg, line) in enumerate(errors):
+                    if "*" in whitelist_errors:
+                        whitelisted[i] = True
+                    elif error_type in whitelist_errors:
+                        allowed_lines = whitelist_errors[error_type]
+                        if None in allowed_lines or line in allowed_lines:
+                            whitelisted[i] = True
+
+        return [item for i, item in enumerate(errors) if not whitelisted[i]]
+    return inner
+
+
+_whitelist_fn = None
+def whitelist_errors(path, errors):
+    global _whitelist_fn
+
+    if _whitelist_fn is None:
+        _whitelist_fn = parse_whitelist_file(os.path.join(lint_root, "lint.whitelist"))
+    return _whitelist_fn(path, errors)
+
+
+class Regexp(object):
+    pattern = None
+    file_extensions = None
+    error = None
+    _re = None
+
+    def __init__(self):
+        self._re = re.compile(self.pattern)
+
+    def applies(self, path):
+        return (self.file_extensions is None or
+                os.path.splitext(path)[1] in self.file_extensions)
+
+    def search(self, line):
+        return self._re.search(line)
+
+
+class TrailingWhitespaceRegexp(Regexp):
+    pattern = " $"
+    error = "TRAILING WHITESPACE"
+
+
+class TabsRegexp(Regexp):
+    pattern = "^\t"
+    error = "INDENT TABS"
+
+
+class CRRegexp(Regexp):
+    pattern = "\r$"
+    error = "CR AT EOL"
+
+regexps = [item() for item in
+           [TrailingWhitespaceRegexp,
+            TabsRegexp,
+            CRRegexp]]
+
+
+def check_regexp_line(path, f):
+    errors = []
+
+    applicable_regexps = [regexp for regexp in regexps if regexp.applies(path)]
+
+    for i, line in enumerate(f):
+        for regexp in applicable_regexps:
+            if regexp.search(line):
+                errors.append((regexp.error, "%s line %i" % (path, i+1), i+1))
+
+    return errors
+
+
+def output_errors(errors):
+    for error_type, error, line_number in errors:
+        print "%s: %s" % (error_type, error)
+
+
+def output_error_count(error_count):
+    if not error_count:
+        return
+
+    by_type = " ".join("%s: %d" % item for item in error_count.iteritems())
+    count = sum(error_count.values())
+    if count == 1:
+        print "There was 1 error (%s)" % (by_type,)
+    else:
+        print "There were %d errors (%s)" % (count, by_type)
+
+
+def main():
+    global repo_root
+    error_count = defaultdict(int)
+
+    parser = OptionParser()
+    parser.add_option('-p', '--pull', dest="pull_request", action='store_true', default=False)
+    parser.add_option("-d", '--dir', dest="dir", help="specify the checking dir, e.g. tools")
+    parser.add_option("-r", '--repo', dest="repo", help="specify the repo, e.g. WebGL")
+    options, args = parser.parse_args()
+    if options.pull_request == True:
+        options.pull_request = "WebGL"
+        repo_root = repo_root.replace("WebGL/sdk/tests", options.pull_request)
+    if options.repo == "" or options.repo == None:
+        options.repo = "WebGL/sdk/tests"
+    repo_root = repo_root.replace("WebGL/sdk/tests", options.repo)
+
+    def run_lint(path, fn, *args):
+        errors = whitelist_errors(path, fn(path, *args))
+        output_errors(errors)
+        for error_type, error, line in errors:
+            error_count[error_type] += 1
+
+    for path in iter_files(options.pull_request, options.dir):
+        abs_path = os.path.join(repo_root, path)
+        if not os.path.exists(abs_path):
+            continue
+        for path_fn in file_path_lints:
+            run_lint(path, path_fn)
+        for state_fn in file_state_lints:
+            run_lint(path, state_fn)
+
+        if not os.path.isdir(abs_path):
+            if re.compile('\.html$|\.htm$|\.xhtml$|\.xhtm$|\.frag$|\.vert$|\.js$').search(abs_path):
+                with open(abs_path) as f:
+                    for file_fn in file_content_lints:
+                        run_lint(path, file_fn, f)
+                        f.seek(0)
+
+    output_error_count(error_count)
+    return sum(error_count.itervalues())
+
+file_path_lints = [check_filename_space]
+file_content_lints = [check_regexp_line]
+file_state_lints = [check_permission]
+
+if __name__ == "__main__":
+    error_count = main()
+    if error_count > 0:
+        sys.exit(1)

--- a/sdk/tests/py/lint/lint.whitelist
+++ b/sdk/tests/py/lint/lint.whitelist
@@ -1,0 +1,46 @@
+# File containing whiteslist for lint errors
+# Format is:
+# ERROR TYPE:file/name/pattern[:line number]
+# e.g.
+# TRAILING WHITESPACE:example/file.html:128
+# to allow trailing whitespace on example/file.html line 128
+
+## Whitespace rules that we can't enforce yet ##
+
+TRAILING WHITESPACE:*.md
+TRAILING WHITESPACE:*.txt
+TRAILING WHITESPACE:*.frag
+TRAILING WHITESPACE:*.vert
+
+## Accept executable permission ##
+
+UNNECESSARY EXECUTABLE PERMISSION:*.cgi
+UNNECESSARY EXECUTABLE PERMISSION:.git/*
+
+## Ignore INDENT TABS ##
+ 
+INDENT TABS:*.frag
+INDENT TABS:*.vert
+#The original dEQP tests used tabs throughout.
+INDENT TABS:deqp/functional/gles3/*.js
+
+## File types that should never be checked ##
+
+*:*.pdf
+*:*.jpg
+*:*.png
+*:*.gif
+*:*.pdf
+*:*.wav
+*:*.mp3
+*:*.m4a
+*:*.oga
+*:*.ogv
+*:*.webm
+*:*.mp4
+*:*.m4v
+*:*.ttf
+*:*.woff
+*:*.eot
+*:*.sfd
+*:*.swf


### PR DESCRIPTION
@kenrussell @zhenyao @Honry I modified the lint tool to make it more suitable for WebGL. In WebGL conformance tests, most of lint errors are TRAILING WHITESPACE, INDENT TABS and CR AT EOL. So we removed non-existent lint error scansion and ran the tool without installing libraries. Since there are many \*.js, \*.frag and \*.vert files in WebGL tests, we also scanned this three file formats in our new tool. You can try the tool from the root of your local WebGL/sdk/tests working directory as follow:
**If you want to check your pull request:**
`./py/lint/lint.py -p`
**If check specified folder, the specified folder must be relative path of WebGL/sdk/tests:**
`./py/lint/lint.py -d conformance/attribs`
**If check other repos, you can specify the repo name with `-r`, default is WebGL/sdk/tests:**
`./py/lint/lint.py -r demo-express`
Looking forward to your suggestion, thanks a lot!