### PR TITLE
Add program link info for debug purpose

### DIFF
--- a/sdk/tests/deqp/framework/opengl/gluShaderProgram.js
+++ b/sdk/tests/deqp/framework/opengl/gluShaderProgram.js
@@ -229,6 +229,8 @@ gluShaderProgram.Program.prototype.link = function() {
     assertMsgOptions(this.gl.getError() == this.gl.NO_ERROR, 'gl.getProgramParameter()', false, true);
     this.info.linkOk = linkStatus;
     this.info.infoLog = this.gl.getProgramInfoLog(this.program);
+    if (!this.info.linkOk)
+        bufferedLogToConsole("program linking: " + this.info.infoLog);
 };
 
 /**


### PR DESCRIPTION
The log is only printed to console when test fails. This is useful for
debugging failing cases.