### PR TITLE
update attrib type in shader to match with attrib type set by vertexAttribI4{u}i{v}

### DIFF
--- a/sdk/tests/conformance2/attribs/gl-vertex-attrib-i-render.html
+++ b/sdk/tests/conformance2/attribs/gl-vertex-attrib-i-render.html
@@ -40,6 +40,14 @@ void main()
     gl_Position = vec4(p.x + a.x + a.y + a.z + a.w, p.y, 0.0, 10.0);
 }
 </script>
+<script id='vshader_unsigned' type='x-shader/x-vertex'>#version 300 es
+layout(location=0) in ivec2 p;
+layout(location=1) in uvec4 a;
+void main()
+{
+    gl_Position = vec4(p.x + int(a.x + a.y + a.z + a.w), p.y, 0.0, 10.0);
+}
+</script>
 <script id='fshader' type='x-shader/x-fragment'>#version 300 es
 precision mediump float;
 layout(location=0) out vec4 oColor;
@@ -69,7 +77,8 @@ function runTest() {
         testFailed('could not create context');
         return;
     }
-    var program = wtu.setupProgram(gl, ['vshader', 'fshader'])
+    var program = wtu.setupProgram(gl, ['vshader', 'fshader']);
+    var program_unsigned = wtu.setupProgram(gl, ['vshader_unsigned', 'fshader']);
 
     gl.enableVertexAttribArray(0);
     var pos = gl.createBuffer();
@@ -83,6 +92,11 @@ function runTest() {
     var tests = ['vertexAttribI4i', 'vertexAttribI4ui', 'vertexAttribI4iv', 'vertexAttribI4uiv'];
 
     for (var ii = 0; ii < 4; ++ii) {
+        if (ii % 2 == 0) {
+            gl.useProgram(program);
+        } else {
+            gl.useProgram(program_unsigned);
+        }
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         if (ii < 2) {
             gl[tests[ii]](1, vals[ii][0], vals[ii][1], vals[ii][2], vals[ii][3]);

--- a/sdk/tests/conformance2/attribs/gl-vertexattribipointer-offsets.html
+++ b/sdk/tests/conformance2/attribs/gl-vertexattribipointer-offsets.html
@@ -51,6 +51,17 @@ void main()
 }
 </script>
 
+<script id="vshader_unsigned" type="x-shader/x-vertex">#version 300 es
+layout(location=0) in uvec4 aPosition;
+layout(location=1) in vec4 aColor;
+out vec4 vColor;
+void main()
+{
+    gl_Position = vec4(aPosition);
+    vColor = aColor;
+}
+
+</script>
 <script id="fshader" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 in vec4 vColor;
@@ -70,6 +81,7 @@ function init()
     var wtu = WebGLTestUtils;
     var gl = wtu.create3DContext("example", undefined, 2);
     var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
+    var program_unsigned = wtu.setupProgram(gl, ["vshader_unsigned", "fshader"], ["vPosition"]);
 
     var tests = [
       { data: new Int32Array([ 0, 1, 0, 1, 0, 0, 0, 0, 0 ]),
@@ -116,6 +128,11 @@ function init()
                 var stride = test.componentSize * kNumComponents + test.componentSize * ss;
                 debug("");
                 debug("check with " + wtu.glEnumToString(gl, test.type) + " at offset: " + offset + " with stride:" + stride);
+                if (test.type == gl.INT || test.type == gl.SHORT || test.type == gl.BYTE) {
+                    gl.useProgram(program);
+                } else {
+                    gl.useProgram(program_unsigned);
+                }
                 gl.vertexAttrib4fv(1, color);
                 var data = new Uint8Array(test.componentSize * kNumVerts * kNumComponents + stride * (kNumVerts - 1));
                 var view = new Uint8Array(test.data.buffer);


### PR DESCRIPTION
update the test cases, in order to make them conform to the spec: vertex attrib function must match shader attrib type: https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.31

I'd like to submit this pr to fix a couple of test cases at first. Then merge more cases in one pr later. 