### PR TITLE
Increase the threshold on the dEQP compressed_cube tests.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureFormatTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureFormatTests.js
@@ -717,7 +717,8 @@ es3fTextureFormatTests.CompressedCubeFormatCase.prototype.testFace = function(fa
     /* TODO: Implement
     // tcu::RGBA threshold = m_renderCtx.getRenderTarget().getPixelFormat().getColorThreshold() + tcu::RGBA(1,1,1,1);
     */
-    var threshold = [3, 3, 3, 3];
+    // Threshold high enough to cover numerical errors in software decoders on Windows and Mac.  Threshold is 17 in native dEQP.
+    var threshold = [6, 6, 6, 6];
     var renderParams = new glsTextureTestUtil.ReferenceParams(glsTextureTestUtil.textureType.TEXTURETYPE_CUBE);
 
     /** @const */ var wrapS = gl.CLAMP_TO_EDGE;


### PR DESCRIPTION
ANGLE passes this test on native dEQP so I looked into the test source and found it uses a threshold of 17!  A threshold of 6 was enough for Chrome to pass the test on Windows and Mac.