### PR TITLE
Fix a typo in WebGL 2.0 spec

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3314,7 +3314,7 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
 
     <p>
         If an image is attached to more than one color attachment point in a framebuffer,
-        <code>checkFramebufferStatus</code> returns <code>FRAMEBUFFER_UNSOPPORTED</code>.
+        <code>checkFramebufferStatus</code> returns <code>FRAMEBUFFER_UNSUPPORTED</code>.
         An image can be an individual mip level, an array slice (from either 2D array
         or cube map textures), or a 3D texture slice.
     </p>


### PR DESCRIPTION
@zhenyao I will try to add test on same image attach to two different attachment points in the same fbo and fix it for chrome.