### PR TITLE
Fix PixelStore tests according to the new WebGL2 constraints.

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-pack-parameters.html
+++ b/sdk/tests/conformance2/reading/read-pixels-pack-parameters.html
@@ -115,7 +115,7 @@ function samePixel(array, index, refPixel, row, pixelTag)
     return false;
 }
 
-function runTestIteration(xoffset, yoffset, width, height, packParams, usePixelPackBuffer)
+function runTestIteration(xoffset, yoffset, width, height, packParams, usePixelPackBuffer, packParamsValid)
 {
     if (!("alignment" in packParams))
         packParams.alignment = 4;
@@ -168,7 +168,12 @@ function runTestIteration(xoffset, yoffset, width, height, packParams, usePixelP
         }
         gl.readPixels(xoffset, yoffset, width, height, gl.RGBA, gl.UNSIGNED_BYTE, array);
     }
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "readPixels should succeed");
+    if (packParamsValid) {
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "readPixels should succeed");
+    } else {
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Invalid pack params combination");
+        return;
+    }
 
     if (size == 0)
         return;
@@ -262,83 +267,83 @@ function testPackParameters(usePixelPackBuffer)
     debug("");
     var destText = usePixelPackBuffer ? "PIXEL_PACK buffer" : "array buffer";
     debug("Verify that reading pixels to " + destText + " works fine with various pack alignments.");
-    runTestIteration(0, 0, 1, 3, {alignment:1}, usePixelPackBuffer);
-    runTestIteration(0, 0, 1, 3, {alignment:2}, usePixelPackBuffer);
-    runTestIteration(0, 0, 1, 3, {alignment:4}, usePixelPackBuffer);
-    runTestIteration(0, 0, 1, 3, {alignment:8}, usePixelPackBuffer);
-    runTestIteration(0, 0, 2, 3, {alignment:4}, usePixelPackBuffer);
-    runTestIteration(0, 0, 2, 3, {alignment:8}, usePixelPackBuffer);
-    runTestIteration(0, 0, 3, 3, {alignment:4}, usePixelPackBuffer);
-    runTestIteration(0, 0, 3, 3, {alignment:8}, usePixelPackBuffer);
-    runTestIteration(0, 0, 0, 0, {alignment:1}, usePixelPackBuffer);
-    runTestIteration(0, 0, 1, 3, {alignment:4}, usePixelPackBuffer);
-    runTestIteration(0, 0, 1, 3, {alignment:8}, usePixelPackBuffer);
+    runTestIteration(0, 0, 1, 3, {alignment:1}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 1, 3, {alignment:2}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 1, 3, {alignment:4}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 1, 3, {alignment:8}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 2, 3, {alignment:4}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 2, 3, {alignment:8}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 3, 3, {alignment:4}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 3, 3, {alignment:8}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 0, 0, {alignment:1}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 1, 3, {alignment:4}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 1, 3, {alignment:8}, usePixelPackBuffer, true);
 
     debug("");
-    debug("Verify that reading pixels to " + destText + " works fine with PACK_ROW_LENGTH < width.");
-    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer);
-    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:1}, usePixelPackBuffer);
+    debug("Verify that reading pixels to " + destText + " is disallowed when PACK_ROW_LENGTH < width.");
+    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:2}, usePixelPackBuffer, false);
+    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:1}, usePixelPackBuffer, false);
 
     debug("");
     debug("Verify that reading pixels to " + destText + " works fine with PACK_ROW_LENGTH == width.");
-    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
-    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer);
+    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
+    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:3}, usePixelPackBuffer, true);
 
     debug("");
     debug("Verify that reading pixels to " + destText + " works fine with PACK_ROW_LENGTH > width and with no padding");
-    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
-    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer);
+    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
+    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:4}, usePixelPackBuffer, true);
 
     debug("");
     debug("Verify that reading pixels to " + destText + " works fine with PACK_ROW_LENGTH > width and with padding");
-    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
-    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer);
+    runTestIteration(0, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(-1, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(0, -1, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(-1, -1, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(-5, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(0, -5, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(2, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(0, 2, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(2, 2, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(5, 0, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
+    runTestIteration(0, 5, 3, 3, {alignment:8, rowLength:5}, usePixelPackBuffer, true);
 
     debug("");
     debug("Verify that reading pixels to " + destText + " works fine with pack skip parameters.");
-    runTestIteration(0, 0, 3, 3, {alignment:8, skipPixels:2}, usePixelPackBuffer);
-    runTestIteration(0, 0, 3, 3, {alignment:8, skipPixels:1, skipRows:3}, usePixelPackBuffer);
-    runTestIteration(0, 0, 3, 3, {alignment:8, skipRows:3}, usePixelPackBuffer);
-    runTestIteration(0, 0, 2, 3, {alignment:8, skipPixels:2}, usePixelPackBuffer);
-    runTestIteration(0, 0, 2, 3, {alignment:8, skipPixels:1, skipRows:3}, usePixelPackBuffer);
-    runTestIteration(0, 0, 2, 3, {alignment:8, skipRows:3}, usePixelPackBuffer);
+    runTestIteration(0, 0, 3, 3, {alignment:8, skipPixels:2}, usePixelPackBuffer, false);
+    runTestIteration(0, 0, 3, 3, {alignment:8, skipPixels:1, skipRows:3}, usePixelPackBuffer, false);
+    runTestIteration(0, 0, 3, 3, {alignment:8, skipRows:3}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 2, 3, {alignment:8, skipPixels:2}, usePixelPackBuffer, false);
+    runTestIteration(0, 0, 2, 3, {alignment:8, skipPixels:1, skipRows:3}, usePixelPackBuffer, false);
+    runTestIteration(0, 0, 2, 3, {alignment:8, skipRows:3}, usePixelPackBuffer, true);
 }
 
 debug("");

--- a/sdk/tests/conformance2/textures/misc/tex-unpack-params.html
+++ b/sdk/tests/conformance2/textures/misc/tex-unpack-params.html
@@ -268,7 +268,12 @@ function runTestIteration2D(gl, testCase, useUnpackBuffer) {
   }
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB8, testCase.width, testCase.height, 0,
                 gl.RGB, gl.UNSIGNED_BYTE, useUnpackBuffer ? 0 : array);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage2D with correct buffer size should succeed");
+  if (testCase.validUnpackParams2D) {
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage2D with correct buffer size should succeed");
+  } else {
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid unpack params combination");
+    return;
+  }
 
   var buffer1 = unpackPixels(array, testCase.width, testCase.height, 1, imageSizes);
   var buffer2 = getPixelsFromTexture2D(gl, tex, 0, 0, testCase.width, testCase.height);
@@ -300,7 +305,12 @@ function runTestIteration2D(gl, testCase, useUnpackBuffer) {
   }
   gl.texSubImage2D(gl.TEXTURE_2D, 0, testCase.xoffset, testCase.yoffset, subWidth, subHeight,
                    gl.RGB, gl.UNSIGNED_BYTE, useUnpackBuffer ? 0 : array);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texSubImage2D with correct buffer size should succeed");
+  if (testCase.validUnpackParamsForSub2D) {
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texSubImage2D with correct buffer size should succeed");
+  } else {
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid unpack params combination");
+    return;
+  }
 
   var buffer1 = unpackPixels(array, subWidth, subHeight, 1, imageSizes);
   var buffer2 = getPixelsFromTexture2D(
@@ -361,7 +371,12 @@ function runTestIteration3D(gl, testCase, useUnpackBuffer) {
   }
   gl.texImage3D(gl.TEXTURE_3D, 0, gl.RGB8, testCase.width, testCase.height, testCase.depth, 0,
                 gl.RGB, gl.UNSIGNED_BYTE, useUnpackBuffer ? 0 : array);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D with correct buffer size should succeed");
+  if (testCase.validUnpackParams3D) {
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D with correct buffer size should succeed");
+  } else {
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid unpack params combination");
+    return;
+  }
 
   var buffer1 = unpackPixels(array, testCase.width, testCase.height, testCase.depth, imageSizes);
   var buffer2 = getPixelsFromTexture3D(
@@ -396,7 +411,12 @@ function runTestIteration3D(gl, testCase, useUnpackBuffer) {
   gl.texSubImage3D(gl.TEXTURE_3D, 0, testCase.xoffset, testCase.yoffset, testCase.zoffset,
                    subWidth, subHeight, subDepth,
                    gl.RGB, gl.UNSIGNED_BYTE, useUnpackBuffer ? 0 : array);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texSubImage3D with correct buffer size should succeed");
+  if (testCase.validUnpackParamsForSub3D) {
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texSubImage3D with correct buffer size should succeed");
+  } else {
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid unpack params combination");
+    return;
+  }
 
   buffer1 = unpackPixels(array, subWidth, subHeight, subDepth, imageSizes);
   buffer2 = getPixelsFromTexture3D(gl, tex, testCase.xoffset, testCase.yoffset, testCase.zoffset,
@@ -422,85 +442,137 @@ function runTests() {
   // For 2D cases, depth, zoffset, imageHeight, skipImages are ignored.
   var testCases = [
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 1, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 1, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 5, height: 7, depth: 4, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 2, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 2, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 6, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 4, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 4, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 5, height: 8, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 8, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 8, rowLength: 0, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
 
     // ROW_LENGTH == width
     { width: 10, height: 9, depth: 2, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 4, rowLength: 10, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 4, rowLength: 10, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
 
     // ROW_LENGTH < width
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 1, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 1, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 2, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 2, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 4, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 4, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 8, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 8, rowLength: 4, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: false, validUnpackParams3D: false },
 
     // ROW_LENGTH > width
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 1, rowLength: 6, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 1, rowLength: 6, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 2, rowLength: 7, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 2, rowLength: 7, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 4, rowLength: 8, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 4, rowLength: 8, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 5, height: 7, depth: 5, xoffset: 2, yoffset: 3, zoffset: 2,
-      alignment: 8, rowLength: 9, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 8, rowLength: 9, imageHeight: 0, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
 
     // IMAGE_HEIGHT == height
     { width: 6, height: 7, depth: 4, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 8, rowLength: 0, imageHeight: 7, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 8, rowLength: 0, imageHeight: 7, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
 
     // IMAGE_HEIGHT < height
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 1, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 1, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 2, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 2, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 4, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 4, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 8, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 8, rowLength: 0, imageHeight: 6, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: false },
 
     // IMAGE_HEIGHT > height
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 1, rowLength: 0, imageHeight: 8, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 1, rowLength: 0, imageHeight: 8, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 6, height: 7, depth: 3, xoffset: 2, yoffset: 2, zoffset: 1,
-      alignment: 2, rowLength: 0, imageHeight: 9, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 2, rowLength: 0, imageHeight: 9, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 7, height: 7, depth: 3, xoffset: 2, yoffset: 4, zoffset: 1,
-      alignment: 4, rowLength: 0, imageHeight: 10, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 4, rowLength: 0, imageHeight: 10, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
     { width: 8, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 8, rowLength: 0, imageHeight: 11, skipPixels: 0, skipRows: 0, skipImages: 0 },
+      alignment: 8, rowLength: 0, imageHeight: 11, skipPixels: 0, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: true, validUnpackParamsForSub3D: true },
 
     // SKIP parameters
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 1, rowLength: 0, imageHeight: 0, skipPixels: 10, skipRows: 0, skipImages: 0 },
+      alignment: 1, rowLength: 0, imageHeight: 0, skipPixels: 10, skipRows: 0, skipImages: 0,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 2, rowLength: 0, imageHeight: 0, skipPixels: 2, skipRows: 8, skipImages: 0 },
+      alignment: 2, rowLength: 0, imageHeight: 0, skipPixels: 2, skipRows: 8, skipImages: 0,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 4, rowLength: 0, imageHeight: 0, skipPixels: 3, skipRows: 5, skipImages: 1 },
+      alignment: 4, rowLength: 0, imageHeight: 0, skipPixels: 3, skipRows: 5, skipImages: 1,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 8, rowLength: 0, imageHeight: 0, skipPixels: 7, skipRows: 0, skipImages: 2 },
+      alignment: 8, rowLength: 0, imageHeight: 0, skipPixels: 7, skipRows: 0, skipImages: 2,
+      validUnpackParams2D: false, validUnpackParams3D: false },
 
     // all mixed.
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 1, rowLength: 6, imageHeight: 6, skipPixels: 3, skipRows: 5, skipImages: 1 },
+      alignment: 1, rowLength: 6, imageHeight: 6, skipPixels: 3, skipRows: 5, skipImages: 1,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 2, rowLength: 4, imageHeight: 8, skipPixels: 7, skipRows: 2, skipImages: 2 },
+      alignment: 2, rowLength: 4, imageHeight: 8, skipPixels: 7, skipRows: 2, skipImages: 2,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 5, height: 7, depth: 3, xoffset: 2, yoffset: 3, zoffset: 1,
-      alignment: 4, rowLength: 10, imageHeight: 2, skipPixels: 0, skipRows: 3, skipImages: 1 },
+      alignment: 4, rowLength: 10, imageHeight: 2, skipPixels: 0, skipRows: 3, skipImages: 1,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: false },
     { width: 1, height: 1, depth: 1, xoffset: 0, yoffset: 0, zoffset: 0,
-      alignment: 2, rowLength: 3, imageHeight: 2, skipPixels: 3, skipRows: 5, skipImages: 1 },
+      alignment: 2, rowLength: 3, imageHeight: 2, skipPixels: 3, skipRows: 5, skipImages: 1,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 17, height: 6, depth: 4, xoffset: 12, yoffset: 3, zoffset: 2,
-      alignment: 2, rowLength: 4, imageHeight: 8, skipPixels: 1, skipRows: 4, skipImages: 2 },
+      alignment: 2, rowLength: 4, imageHeight: 8, skipPixels: 1, skipRows: 4, skipImages: 2,
+      validUnpackParams2D: false, validUnpackParams3D: false },
     { width: 8, height: 17, depth: 3, xoffset: 2, yoffset: 13, zoffset: 1,
-      alignment: 4, rowLength: 9, imageHeight: 2, skipPixels: 0, skipRows: 3, skipImages: 1 },
+      alignment: 4, rowLength: 9, imageHeight: 2, skipPixels: 0, skipRows: 3, skipImages: 1,
+      validUnpackParams2D: true, validUnpackParamsForSub2D: true,
+      validUnpackParams3D: false },
   ];
 
   // Upload textures from client data

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1400,6 +1400,10 @@ match the <em>type</em> according to the following table; otherwise, generates a
           <tr><td>Uint16Array</td><td>HALF_FLOAT</td></tr>
           <tr><td>Float32Array</td><td>FLOAT</td></tr>
         </table>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS">pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
       </dd>
 
       <dt class="idl-code">void texImage2D(GLenum target, GLint level, GLint internalformat, GLenum format, GLenum type, TexImageSource? source) /* May throw DOMException */
@@ -1450,6 +1454,10 @@ match the <em>type</em> according to the following table; otherwise, generates a
         <p>The combination of <em>format</em>, <em>type</em>, and WebGLTexture's internal format must be listed in Table 1 or 2 from <span class="gl-spec"><a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a></span>.</p>
         <p>If an attempt is made to call the function with no WebGLTexture bound, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If no WebGLBuffer is bound to the <code>PIXEL_UNPACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS">pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
       </dd>
 
       <dt class="idl-code"><a name="TEXSUBIMAGE2D">void texSubImage2D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, ArrayBufferView? pixels)
@@ -1463,6 +1471,10 @@ match the <em>type</em> according to the following table; otherwise, generates a
         <p>If <em>pixels</em> is non-null, the type of <em>pixels</em> must
 match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">above table</a>; otherwise, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>See <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific pixel storage parameters that affect the behavior of this function.</p>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS"> pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
       </dd>
 
 
@@ -1483,6 +1495,10 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         <p><em>offset</em> is the byte offset into the WebGLBuffer's data store; generates an <code>INVALID_VALUE</code> error if it's less than 0.</p>
         <p>If an attempt is made to call the function with no WebGLTexture bound, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If no WebGLBuffer is bound to the <code>PIXEL_UNPACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS"> pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
       </dd>
 
       <dt class="idl-code">void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, ArrayBufferView? pixels)
@@ -1496,9 +1512,13 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         <p>The combination of <em>internalformat</em>, <em>format</em>, and <em>type</em> must be listed in Table 1 or 2 from <span class="gl-spec"><a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a></span>.</p>
         <p>If an attempt is made to call this function with no WebGLTexture bound (see above), generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If <em>type</em> is specified as <code>FLOAT_32_UNSIGNED_INT_24_8_REV</code>, <em>pixels</em> must be null; otherwise, generates an <code>INVALID_OPERATION</code> error.</p>
-        <p>If <em>pixels</em> is non-null, the type of <em>pixels</em> must
+        <p>If <em>pixels</em> is non-null, the type of <etexm>pixels</em> must
 match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">above table</a>; otherwise, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>See <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific pixel storage parameters that affect the behavior of this function. </p>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS"> pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
 
         <div class="note">It is recommended to use <a href="#TEXSTORAGE3D">texStorage3D</a> instead of texImage3D to allocate three-dimensional textures. texImage3D may impose a higher memory cost compared to texStorage3D in some implementations.</div>
       </dd>
@@ -1511,6 +1531,10 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         <p><em>offset</em> is the byte offset into the WebGLBuffer's data store; generates an <code>INVALID_VALUE</code> error if it's less than 0.</p>
         <p>If an attempt is made to call the function with no WebGLTexture bound, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If no WebGLBuffer is bound to the <code>PIXEL_UNPACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS">pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
       </dd>
 
       <dt>
@@ -1532,6 +1556,10 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
 match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">above table</a>; otherwise, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If <code>pixels</code> is non-null but its size is less than what is required by the specified <em>width</em>, <em>height</em>, <em>depth</em>, <em>format</em>, <em>type</em>, and pixel storage parameters, generates an <code>INVALID_OPERATION</code> error. </p>
         <p>See <a href="../1.0/index.html#PIXEL_STORAGE_PARAMETERS">Pixel Storage Parameters</a> for WebGL-specific pixel storage parameters that affect the behavior of this function.</p>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS"> pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
       </dd>
       <dt>
         <p class="idl-code">void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLenum format, GLenum type, TexImageSource? source) /* May throw DOMException */
@@ -1569,6 +1597,10 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         <p><em>offset</em> is the byte offset into the WebGLBuffer's data store; generates an <code>INVALID_VALUE</code> error if it's less than 0.</p>
         <p>If an attempt is made to call the function with no WebGLTexture bound, generates an <code>INVALID_OPERATION</code> error.</p>
         <p>If no WebGLBuffer is bound to the <code>PIXEL_UNPACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
+        <p>
+            If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS">pixel store parameter constraints</a> are not met,
+            generates an <code>INVALID_OPERATION</code> error.
+        </p>
       </dd>
 
       <dt>
@@ -1951,6 +1983,10 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         </dt>
         <dd>
           <p>If a WebGLBuffer is bound to the <code>PIXEL_PACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
+          <p>
+              If <a href="#PIXEL_STORE_PARAM_CONSTRAINTS">pixel store parameter constraints</a> are not met,
+              generates an <code>INVALID_OPERATION</code> error.
+          </p>
         </dd>
 
         <dt class="idl-code">void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLintptr offset)
@@ -3324,6 +3360,48 @@ match the <em>type</em> according to the <a href="#TEXTURE_PIXELS_TYPE_TABLE">ab
         (see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ff476464.aspx">msdn manual
         page</a>). In order to have consistent WebGL 2 behavior across platforms, it is reasonable to add
         this limitation in WebGL 2 for all platforms.
+    </div>
+
+    <h3><a name="PIXEL_STORE_PARAM_CONSTRAINTS">Pixel store parameter constraints</a></h3>
+
+    <p>
+        Define:
+        <ul>
+          <li>DataStoreWidth := <code>ROW_LENGTH</code> ? <code>ROW_LENGTH</code> : <em>width</em></li>
+          <li>DataStoreHeight := <code>IMAGE_HEIGHT</code> ? <code>IMAGE_HEIGHT</code> : <em>height</em></li>
+        </ul>
+    </p>
+
+    <p>
+        If <code>PACK_SKIP_PIXELS</code> + <em>width</em> > DataStoreWidth, <code>readPixels</code> generates an
+        <code>INVALID_OPERATION</code> error.
+    </p>
+
+    <p>
+        If <code>UNPACK_SKIP_PIXELS</code> + <em>width</em> > DataStoreWidth, <code>texImage2D</code> and
+        <code>texSubImage2D</code> generate an <code>INVALID_OPERATION</code> error. This does not
+        apply to <code>texImage2D</code> if no <code>PIXEL_UNPACK_BUFFER</code> is bound and
+        <em>pixels</em> is null.
+    </p>
+
+    <p>
+        If <code>UNPACK_SKIP_PIXELS</code> + <em>width</em> > DataStoreWidth or
+        <code>UNPACK_SKIP_ROWS</code> + <em>height</em> >  DataStoreHeight, <code>texImage3D</code> and
+        <code>texSubImage3D</code> generate an <code>INVALID_OPERATION</code> error. This does not
+        apply to <code>texImage3D</code> if no <code>PIXEL_UNPACK_BUFFER</code> is bound and
+        <em>pixels</em> is null.
+    </p>
+
+    <div class="note rationale">
+        These constraints normalize the use of these parameters to specify a sub region where pixels are stored.
+        For example, in <code>readPixels</code> cases, if we want to store pixels to a sub area of the entire
+        data store, we can use <code>PACK_ROW_LENGTH</code> to specify the data store width, and <code>
+        PACK_SKIP_PIXELS</code>, <code>PACK_SKIP_ROWS</code>, <em>width</em> and <em>height</em> to specify the sub
+        area's xoffset, yoffset, width, and height</code>.<br><br>
+
+        These contraints also forbid row and image overlap, where the situations are not tested in the OpenGL ES
+        3.0 DEQP test suites, and many drivers behave incorrectly. They also forbid skipping random pixels or rows,
+        but that can be achieved by adjusting the data store offset accordingly.
     </div>
 
 <!-- ======================================================================================================= -->


### PR DESCRIPTION
This is @jdashg 's proposal. @jdashg made two valid points: 1) this is the most strict constraints, and it's always easier to loose constraints than to tighten them in the future; 2) unconstrained skip parameters usage always can be achieved through adjusting the data store offset.

Also, I verified deqp tests are all within this constraints, i.e., anything violating these constraints are not tested, therefore, bug prone.

Let's go with this for now.

@kenrussell @jdashg Please take a look.

All tests are modified according to the bots from this CL (https://codereview.chromium.org/2154153002/)

@Oletus @qkmiao @Richard-Yunchao @Kangz @null77 @vonture @grorg @RafaelCintron FYI