### PR TITLE
Fix the invariant(all) pragma in fragment shader

### DIFF
--- a/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
+++ b/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
@@ -199,7 +199,7 @@ void main()
 // GLSL 1.0.17 4.3.5
 "use strict";
 // See GLSL ES spec 1.0.17 section 4.6.4 "Invariance and linkage".
-GLSLConformanceTester.runTests([
+var cases = [
   {
     vShaderId: "vertexShaderVariant",
     vShaderSuccess: true,
@@ -215,14 +215,6 @@ GLSLConformanceTester.runTests([
     fShaderSuccess: true,
     linkSuccess: false,
     passMsg: "vertex shader with invariant varying and fragment shader with variant varying must fail",
-  },
-  {
-    vShaderId: "vertexShaderVariant",
-    vShaderSuccess: true,
-    fShaderId: "fragmentShaderGlobalInvariant",
-    fShaderSuccess: true,
-    linkSuccess: false,
-    passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
   },
   {
     vShaderId: "vertexShaderGlobalInvariant",
@@ -271,14 +263,6 @@ GLSLConformanceTester.runTests([
     fShaderSuccess: false,
     linkSuccess: false,
     passMsg: "fragment shader with invariant (separately set in wrong order) varying must fail",
-  },
-  {
-    vShaderId: "vertexShaderInvariant",
-    vShaderSuccess: true,
-    fShaderId: "fragmentShaderGlobalInvariant",
-    fShaderSuccess: true,
-    linkSuccess: true,
-    passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must succeed",
   },
   {
     vShaderId: "vertexShaderInvariantGlPosition",
@@ -344,7 +328,47 @@ GLSLConformanceTester.runTests([
     linkSuccess: false,
     passMsg: "fragment shader with invariant gl_FrontFacing must fail compilation",
   },
-]);
+];
+
+var contextVersion = WebGLTestUtils.getDefault3DContextVersion();
+if (contextVersion < 2)
+    cases.push(
+    {
+      vShaderId: "vertexShaderVariant",
+      vShaderSuccess: true,
+      fShaderId: "fragmentShaderGlobalInvariant",
+      fShaderSuccess: true,
+      linkSuccess: false,
+      passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
+    },
+    {
+      vShaderId: "vertexShaderInvariant",
+      vShaderSuccess: true,
+      fShaderId: "fragmentShaderGlobalInvariant",
+      fShaderSuccess: true,
+      linkSuccess: true,
+      passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must succeed",
+    });
+else 
+    cases.push(
+    {
+      vShaderId: "vertexShaderVariant",
+      vShaderSuccess: true,
+      fShaderId: "fragmentShaderGlobalInvariant",
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
+    },
+    {
+      vShaderId: "vertexShaderInvariant",
+      vShaderSuccess: true,
+      fShaderId: "fragmentShaderGlobalInvariant",
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must fail",
+    });
+
+GLSLConformanceTester.runTests(cases);
 var successfullyParsed = true;
 </script>
 </body>


### PR DESCRIPTION
According to the section 4.6.1 of GLSL ES specification 3.00.4 and 4.8.1
of GLSL specification 4.40, the pragma invariant(all) is not allowed to
be used by a fragment shader.