### PR TITLE
Fix conformance/context/context-lost.html to generate INVALID_OPERATI…

### DIFF
--- a/conformance-suites/1.0.3/conformance/context/context-lost.html
+++ b/conformance-suites/1.0.3/conformance/context/context-lost.html
@@ -138,9 +138,9 @@ function testValidContext()
     }
 }
 
-function testGLNOErrorFunctions(tests) {
+function testErrorFunctions(expectedError, tests) {
   tests.forEach(function(test) {
-      shouldGenerateGLError(gl, gl.NO_ERROR, test);
+      shouldGenerateGLError(gl, expectedError, test);
   });
 }
 
@@ -299,7 +299,7 @@ function testLostContext()
         "gl.vertexAttribPointer(0, 0, gl.FLOAT, false, 0, 0)",
         "gl.viewport(0, 0, 0, 0)",
     ];
-    testGLNOErrorFunctions(voidTests);
+    testErrorFunctions(gl.NO_ERROR, voidTests);
 
     // Functions return nullable values should all return null.
     var nullTests = [
@@ -344,10 +344,16 @@ function testLostContext()
 
     // test extensions
     if (OES_vertex_array_object) {
-      testGLNOErrorFunctions(
+      testErrorFunctions(gl.NO_ERROR,
+        [
+          "OES_vertex_array_object.bindVertexArrayOES(null)",
+          "OES_vertex_array_object.isVertexArrayOES(null)",
+          "OES_vertex_array_object.isVertexArrayOES(vertexArrayObject)",
+          "OES_vertex_array_object.deleteVertexArrayOES(null)",
+        ]);
+      testErrorFunctions(gl.INVALID_OPERATION,
         [
           "OES_vertex_array_object.bindVertexArrayOES(vertexArrayObject)",
-          "OES_vertex_array_object.isVertexArrayOES(vertexArrayObject)",
           "OES_vertex_array_object.deleteVertexArrayOES(vertexArrayObject)",
         ]);
       testFunctionsThatReturnNULL(

--- a/sdk/tests/conformance/context/context-lost.html
+++ b/sdk/tests/conformance/context/context-lost.html
@@ -138,9 +138,9 @@ function testValidContext()
     }
 }
 
-function testGLNOErrorFunctions(tests) {
+function testErrorFunctions(expectedError, tests) {
   tests.forEach(function(test) {
-      shouldGenerateGLError(gl, gl.NO_ERROR, test);
+      shouldGenerateGLError(gl, expectedError, test);
   });
 }
 
@@ -299,7 +299,7 @@ function testLostContext()
         "gl.vertexAttribPointer(0, 0, gl.FLOAT, false, 0, 0)",
         "gl.viewport(0, 0, 0, 0)",
     ];
-    testGLNOErrorFunctions(voidTests);
+    testErrorFunctions(gl.NO_ERROR, voidTests);
 
     // Functions return nullable values should all return null.
     var nullTests = [
@@ -344,10 +344,16 @@ function testLostContext()
 
     // test extensions
     if (OES_vertex_array_object) {
-      testGLNOErrorFunctions(
+      testErrorFunctions(gl.NO_ERROR,
+        [
+          "OES_vertex_array_object.bindVertexArrayOES(null)",
+          "OES_vertex_array_object.isVertexArrayOES(null)",
+          "OES_vertex_array_object.isVertexArrayOES(vertexArrayObject)",
+          "OES_vertex_array_object.deleteVertexArrayOES(null)",
+        ]);
+      testErrorFunctions(gl.INVALID_OPERATION,
         [
           "OES_vertex_array_object.bindVertexArrayOES(vertexArrayObject)",
-          "OES_vertex_array_object.isVertexArrayOES(vertexArrayObject)",
           "OES_vertex_array_object.deleteVertexArrayOES(vertexArrayObject)",
         ]);
       testFunctionsThatReturnNULL(


### PR DESCRIPTION
…ON for lost WebGLObjects.

The spec says that when a method on the context or an extension is called
that doesn't [WebGLHandlesContextLoss], first generate INVALID_OPERATION
if any object args have their 'invalidated flag' set. If either that, or
IsContextLost() is true, return defaults, etc.

The spec language does not appear to address what to do about methods
called on extensions which have been disabled/detached. This is not
covered in this test, though.

There's a couple things that need to be tightened up, really, but this will get the conversation started.