### PR TITLE
Skip WebGL 2 blit tests mark as having issues in GLES3.

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuSkipList.js
+++ b/sdk/tests/deqp/framework/common/tcuSkipList.js
@@ -92,6 +92,44 @@ goog.scope(function() {
         // Please see https://android.googlesource.com/platform/external/deqp/+/master/android/cts/master/src/gles3-driver-issues.txt
         _skip("texture_functions.texturegrad.samplercubeshadow*");
 
+        // https://android.googlesource.com/platform/external/deqp/+/0c1f83aee4709eef7ef2a3edd384f9c192f476fd/android/cts/master/src/gles3-hw-issues.txt#801
+        _setReason("Tricky blit rects can result in imperfect copies on some HW.");
+        _skip("fbo.blit.rect.nearest_consistency_mag");
+        _skip("fbo.blit.rect.nearest_consistency_mag_reverse_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_mag_reverse_src_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_mag_reverse_src_x");
+        _skip("fbo.blit.rect.nearest_consistency_mag_reverse_src_y");
+        _skip("fbo.blit.rect.nearest_consistency_min");
+        _skip("fbo.blit.rect.nearest_consistency_min_reverse_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_min_reverse_src_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_min_reverse_src_x");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_mag");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_mag_reverse_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_mag_reverse_src_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_mag_reverse_src_x");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_mag_reverse_src_y");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_min");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_min_reverse_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_min_reverse_src_dst_x");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_min_reverse_src_x");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_min_reverse_src_y");
+
+        // https://android.googlesource.com/platform/external/deqp/+/0c1f83aee4709eef7ef2a3edd384f9c192f476fd/android/cts/master/src/gles3-driver-issues.txt#381
+        _setReason("Tricky blit rects can result in imperfect copies on some drivers.");
+        _skip("fbo.blit.rect.out_of_bounds_linear");
+        _skip("fbo.blit.rect.out_of_bounds_reverse_src_x_linear");
+        _skip("fbo.blit.rect.out_of_bounds_reverse_src_y_linear");
+        _skip("fbo.blit.rect.out_of_bounds_reverse_dst_x_linear");
+        _skip("fbo.blit.rect.out_of_bounds_reverse_dst_y_linear");
+        _skip("fbo.blit.rect.out_of_bounds_reverse_src_dst_x_linear");
+        _skip("fbo.blit.rect.out_of_bounds_reverse_src_dst_y_linear");
+
+        // https://android.googlesource.com/platform/external/deqp/+/0c1f83aee4709eef7ef2a3edd384f9c192f476fd/android/cts/master/src/gles3-driver-issues.txt#368
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_mag_reverse_dst_y");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_mag_reverse_src_dst_y");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_min_reverse_dst_y");
+        _skip("fbo.blit.rect.nearest_consistency_out_of_bounds_min_reverse_src_dst_y");
+
         _setReason("Mac OSX drivers handle R11F_G11F_B10F format incorrectly");
         // https://github.com/KhronosGroup/WebGL/issues/1832
         // deqp/functional/gles3/fragmentoutput/basic.float.html


### PR DESCRIPTION
Some of these tricky tests were failing on various drivers and Hw,
so they were removed from the Android CTS. The tests themselves
might not be buggy, but they are not required to pass on Android.

PTAL, this should fix some failures on Windows, probably on other platforms.