### PR TITLE
Revert https://github.com/KhronosGroup/WebGL/pull/1908

### DIFF
--- a/sdk/tests/js/tests/tex-input-validation.js
+++ b/sdk/tests/js/tests/tex-input-validation.js
@@ -439,14 +439,10 @@ debug("");
 debug("Checking CopyTexSubImage2D: a set of inputs that are valid in GL but invalid in WebGL");
 
 testCases = [
-  // Section 3.8.5 of the GLES 3.0.4 spec, pg 140, requires that, if the
-  // destination format is sized, any component size of the source and
-  // destination formats must exactly match if the component exists in
-  // destination format.
   { target: gl.TEXTURE_2D,
     colorBufferFormat: gl.RGB5_A1,
     internalFormat: gl.RGBA,
-    expectedError: gl.INVALID_OPERATION },
+    expectedError: gl.NO_ERROR },
   { target: gl.TEXTURE_2D,
     colorBufferFormat: gl.RGB565,
     internalFormat: gl.RGBA,


### PR DESCRIPTION
Sorry for the mistake, but if the destination format is unsized,
then we don't require component size to match, just that requiured
components are available.