### PR TITLE
Skip some tests on which the HLSL compiler generates invalid code.

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuSkipList.js
+++ b/sdk/tests/deqp/framework/common/tcuSkipList.js
@@ -149,6 +149,25 @@ goog.scope(function() {
         // deqp/functional/gles3/fbocolorbuffer/clear.html
         _skip("color.clear.r11f_g11f_b10f");
 
+        _setReason("HLSL compiler bugs");
+        // deqp/functional/gles3/shaderloop_for.html
+        _skip("loops.for.constant_iterations.nested_sequence_vertex");
+        _skip("loops.for.constant_iterations.nested_sequence_fragment");
+        _skip("loops.for.constant_iterations.nested_tricky_dataflow_1_vertex");
+        _skip("loops.for.constant_iterations.nested_tricky_dataflow_1_fragment");
+        _skip("loops.for.constant_iterations.nested_tricky_dataflow_2_vertex");
+        _skip("loops.for.constant_iterations.nested_tricky_dataflow_2_fragment");
+        // deqp/functional/gles3/shaderloop_while.html
+        _skip("loops.while.constant_iterations.nested_tricky_dataflow_1_vertex");
+        _skip("loops.while.constant_iterations.nested_tricky_dataflow_1_fragment");
+        _skip("loops.while.constant_iterations.nested_tricky_dataflow_2_vertex");
+        _skip("loops.while.constant_iterations.nested_tricky_dataflow_2_fragment");
+        // deqp/functional/gles3/shaderloop_do_while.html
+        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_1_vertex");
+        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_1_fragment");
+        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_2_vertex");
+        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_2_fragment");
+
         _setReason("Missing shadow sampler functions in D3D11");
         // https://github.com/KhronosGroup/WebGL/issues/1870
         // deqp/functional/gles3/shadertexturefunction/texturelod.html


### PR DESCRIPTION
Corentin (@Kangz) diagnosed these failures in ANGLE and determined that they are due to the HLSL compiler generating invalid bytecode.

His findings, along with a shader that reproduces them, can be found here: https://gist.github.com/Kangz/a0624ca46fb1da5e7804ee80900bf291