### PR TITLE
Revise ESSL 1.0 invariance tests for WebGL 1.0 and 2.0.

### DIFF
--- a/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
+++ b/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
@@ -328,45 +328,23 @@ var cases = [
     linkSuccess: false,
     passMsg: "fragment shader with invariant gl_FrontFacing must fail compilation",
   },
+  {
+    vShaderId: "vertexShaderVariant",
+    vShaderSuccess: true,
+    fShaderId: "fragmentShaderGlobalInvariant",
+    fShaderSuccess: true,
+    linkSuccess: false,
+    passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
+  },
+  {
+    vShaderId: "vertexShaderInvariant",
+    vShaderSuccess: true,
+    fShaderId: "fragmentShaderGlobalInvariant",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must succeed",
+  }
 ];
-
-var contextVersion = WebGLTestUtils.getDefault3DContextVersion();
-if (contextVersion < 2)
-    cases.push(
-    {
-      vShaderId: "vertexShaderVariant",
-      vShaderSuccess: true,
-      fShaderId: "fragmentShaderGlobalInvariant",
-      fShaderSuccess: true,
-      linkSuccess: false,
-      passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
-    },
-    {
-      vShaderId: "vertexShaderInvariant",
-      vShaderSuccess: true,
-      fShaderId: "fragmentShaderGlobalInvariant",
-      fShaderSuccess: true,
-      linkSuccess: true,
-      passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must succeed",
-    });
-else 
-    cases.push(
-    {
-      vShaderId: "vertexShaderVariant",
-      vShaderSuccess: true,
-      fShaderId: "fragmentShaderGlobalInvariant",
-      fShaderSuccess: false,
-      linkSuccess: false,
-      passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
-    },
-    {
-      vShaderId: "vertexShaderInvariant",
-      vShaderSuccess: true,
-      fShaderId: "fragmentShaderGlobalInvariant",
-      fShaderSuccess: false,
-      linkSuccess: false,
-      passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must fail",
-    });
 
 GLSLConformanceTester.runTests(cases);
 var successfullyParsed = true;


### PR DESCRIPTION
After studying the specifications, the rules are as follows:

 - ESSL 1.0 allows "#pragma STDGL invariant(all)" in both vertex and
   fragment shaders, no matter whether the context is WebGL 1.0 or 2.0.
   When linking ESSL 1.0 shaders in either context type, the invariant
   qualifier must match on varyings shared between vertex and fragment
   shaders.

 - ESSL 3.00 allows the invariant #pragma only in vertex shaders. The
   invariant qualifier is allowed only on output variables. (The
   specification isn't clear on whether it is allowed on output
   variables of fragment shaders, or just vertex shaders.) Because the
   invariant qualifier is not allowed on input variables, it is not
   required to match on varyings shared between vertex and fragment
   shaders.

These tests, which all use ESSL 1.0, must apply equally to both WebGL
1.0 and 2.0 contexts. Therefore, undo the most recent change which
applied different tests to different context versions.

Additional confusion arises because of differing invariance rules
between desktop GLSL versions.
https://bugs.chromium.org/p/angleproject/issues/detail?id=1293#c3
describes the rules. The shader translator will have to take care of
adjusting the output based on the desktop GLSL version.