### PR TITLE
Large image requests can always receive OOM.

### DIFF
--- a/conformance-suites/1.0.3/conformance/textures/texture-size-limit.html
+++ b/conformance-suites/1.0.3/conformance/textures/texture-size-limit.html
@@ -155,9 +155,9 @@ function testFormatType(t, test) {
       var badOtherDimension = t.target == gl.TEXTURE_2D ? 1 : badSize;
       var pixels = new test.dataType(badSize * badOtherDimension * test.size);
       gl.texImage2D(target, level, test.format, size, otherDimension, 0, test.format, test.type, pixels);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no error for level: " + level + " " + size + "x" + otherDimension);
+      wtu.glErrorShouldBe(gl, [gl.NO_ERROR, gl.OUT_OF_MEMORY], "there should be no error for level: " + level + " " + size + "x" + otherDimension);
       gl.texImage2D(target, level, test.format, otherDimension, size, 0, test.format, test.type, pixels);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no error for level: " + level + " " + otherDimension + "x" + size);
+      wtu.glErrorShouldBe(gl, [gl.NO_ERROR, gl.OUT_OF_MEMORY], "there should be no error for level: " + level + " " + otherDimension + "x" + size);
       gl.texImage2D(target, level, test.format, badSize, badOtherDimension, 0, test.format, test.type, pixels);
       wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "should generate INVALID_VALUE for level: " + level + " " + badSize + "x" + badOtherDimension);
       gl.texImage2D(target, level, test.format, badOtherDimension, badSize, 0, test.format, test.type, pixels);

--- a/sdk/tests/conformance/textures/misc/texture-size-limit.html
+++ b/sdk/tests/conformance/textures/misc/texture-size-limit.html
@@ -155,9 +155,9 @@ function testFormatType(t, test) {
       var badOtherDimension = t.target == gl.TEXTURE_2D ? 1 : badSize;
       var pixels = new test.dataType(badSize * badOtherDimension * test.size);
       gl.texImage2D(target, level, test.format, size, otherDimension, 0, test.format, test.type, pixels);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no error for level: " + level + " " + size + "x" + otherDimension);
+      wtu.glErrorShouldBe(gl, [gl.NO_ERROR, gl.OUT_OF_MEMORY], "there should be no error for level: " + level + " " + size + "x" + otherDimension);
       gl.texImage2D(target, level, test.format, otherDimension, size, 0, test.format, test.type, pixels);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no error for level: " + level + " " + otherDimension + "x" + size);
+      wtu.glErrorShouldBe(gl, [gl.NO_ERROR, gl.OUT_OF_MEMORY], "there should be no error for level: " + level + " " + otherDimension + "x" + size);
       gl.texImage2D(target, level, test.format, badSize, badOtherDimension, 0, test.format, test.type, pixels);
       wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "should generate INVALID_VALUE for level: " + level + " " + badSize + "x" + badOtherDimension);
       gl.texImage2D(target, level, test.format, badOtherDimension, badSize, 0, test.format, test.type, pixels);

--- a/sdk/tests/conformance2/textures/misc/tex-3d-size-limit.html
+++ b/sdk/tests/conformance2/textures/misc/tex-3d-size-limit.html
@@ -88,11 +88,11 @@ function test3DTextureDimensions() {
         var badSize = size * 2;
 
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, size, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed.");
+        wtu.glErrorShouldBe(gl, [gl.NO_ERROR, gl.OUT_OF_MEMORY], "texImage3D should succeed.");
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 1, size, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed.");
+        wtu.glErrorShouldBe(gl, [gl.NO_ERROR, gl.OUT_OF_MEMORY], "texImage3D should succeed.");
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 1, 1, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed.");
+        wtu.glErrorShouldBe(gl, [gl.NO_ERROR, gl.OUT_OF_MEMORY], "texImage3D should succeed.");
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, badSize, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
         wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "texImage3D should fail for dimension out of range.");
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 2, badSize, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);


### PR DESCRIPTION
For sizes <MAX_SIZE, they must not generate INVALID_VALUE, but OOM is fine. (and reasonable in many cases)
