### PR TITLE
fix the bug that caused by difference between webgl and gles

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fInstancedRenderingTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fInstancedRenderingTests.js
@@ -376,7 +376,6 @@ var deMath = framework.delibs.debase.deMath;
         var numVertexAttribArrays = /** @type{number} */ (gl.getParameter(gl.MAX_VERTEX_ATTRIBS));
         for (var idx = 0; idx < numVertexAttribArrays; idx++) {
             gl.disableVertexAttribArray(idx);
-            gl.vertexAttribPointer(idx, 4, gl.FLOAT, gl.FALSE, 0, null);
             gl.vertexAttribDivisor(idx, 0);
         }
     };


### PR DESCRIPTION
This patch delete one line from https://github.com/KhronosGroup/WebGL/pull/1906. 

Calling to vertexAttribPointer for all attribs in native deqp during deinit is valid. However, It is not valid in webgl according to the latest spec: https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.31. 

PTAL. Thanks a lot!