### PR TITLE
Add more tests for sequence operator corner cases

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/sequence-operator-evaluation-order.html
+++ b/sdk/tests/conformance/glsl/bugs/sequence-operator-evaluation-order.html
@@ -29,28 +29,22 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>GLSL ternary operator should be evaluated after previous operands in a sequence</title>
+<title>GLSL short-circuiting operators should be evaluated after previous operands in a sequence</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="canvas" width="64" height="64"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderSequenceSideEffectsAffectTernary" type="x-shader/x-fragment">
 precision mediump float;
 
 bool correct = true;
 
-uniform float u;
+uniform float u_zero;
 
 float wrong() {
     correct = false;
@@ -62,37 +56,81 @@ void main() {
     // "All expressions are evaluated, in order, from left to right"
     // Also use a ternary operator where the third operand has side effects to make sure
     // only the second operand is evaluated.
-    float a = u; // Expected to be -0.5
+    float a = u_zero - 0.5; // Result should be -0.5.
     float green = (a++, a > 0.0 ? 1.0 : wrong());
     gl_FragColor = vec4(0.0, correct ? green : 0.0, 0.0, 1.0);
 }
 </script>
+<script id="fshaderSequenceSideEffectsAffectAnd" type="x-shader/x-fragment">
+precision mediump float;
+
+uniform bool u_false;
+
+bool sideEffectA = false;
+bool funcA() {
+    sideEffectA = true;
+    return true;
+}
+
+bool sideEffectB = false;
+bool funcB() {
+    sideEffectB = true;
+    return true;
+}
+
+void main() {
+    bool b = (funcA(), u_false == sideEffectA && funcB());
+    gl_FragColor = (!b && sideEffectA && !sideEffectB) ? vec4(0, 1, 0, 1) : vec4(1, 0, 0, 1);
+}
+</script>
+<script id="fshaderSequenceSideEffectsAffectOr" type="x-shader/x-fragment">
+precision mediump float;
+
+uniform bool u_false;
+
+bool sideEffectA = false;
+bool funcA() {
+    sideEffectA = true;
+    return false;
+}
+
+bool sideEffectB = false;
+bool funcB() {
+    sideEffectB = true;
+    return false;
+}
+
+void main() {
+    bool b = (funcA(), (u_false == !sideEffectA) || funcB());
+    gl_FragColor = (b && sideEffectA && !sideEffectB) ? vec4(0, 1, 0, 1) : vec4(1, 0, 0, 1);
+}
+</script>
 <script type="application/javascript">
 "use strict";
-description("Ternary operator should be evaluated after previous operands in a sequence");
+description();
 debug("");
 debug("This test is targeted to stress syntax tree transformations that might need to be done in shader translation to unfold operators.");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas");
-  if (!gl) {
-    testFailed("WebGL context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
 
-  debug("");
-  debug("Expression where first operand of a sequence operator has side effects which affect the second operand that is a ternary operator");
-  var prog = wtu.setupProgram(gl, ["vshader", "fshaderSequenceSideEffectsAffectTernary"], ["aPosition"], undefined, true);
-  var u = gl.getUniformLocation(prog, 'u');
-  gl.uniform1f(u, -0.5);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-};
-
-test();
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderSequenceSideEffectsAffectTernary',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where first operand of a sequence operator has side effects which affect the second operand that is a ternary operator'
+},
+{
+  fShaderId: 'fshaderSequenceSideEffectsAffectAnd',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where first operand of a sequence operator has side effects which affect the second operand that is an and operator'
+},
+{
+  fShaderId: 'fshaderSequenceSideEffectsAffectOr',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Expression where first operand of a sequence operator has side effects which affect the second operand that is an or operator'
+}
+]);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/glsl3/tricky-loop-conditions.html
+++ b/sdk/tests/conformance2/glsl3/tricky-loop-conditions.html
@@ -167,6 +167,22 @@ var testDataList = [
     passCondition: 'c == 6'
 },
 {
+    description: 'indexing an array constructor inside a sequence operator',
+    globalScopePrefix: [
+            'int sideEffectCounter = 0;',
+            'int func() {',
+            '  sideEffectCounter++;',
+            '  return sideEffectCounter;',
+            '}'
+        ].join('\n'),
+    mainPrefix: 'int c = 0;',
+    loopExpression: 'c = (func(), (int[2](c + 1, c + 2))[1])',
+    loopCondition: 'bool(c = (func(), (int[2](c + 1, c + 2))[1]))',
+    loopContents: '',
+    loopIterations: 3,
+    passCondition: 'c == 6 && sideEffectCounter = 3'
+},
+{
     description: 'dynamic indexing of a vector',
     globalScopePrefix: '',
     mainPrefix: [

--- a/sdk/tests/conformance2/glsl3/vector-dynamic-indexing.html
+++ b/sdk/tests/conformance2/glsl3/vector-dynamic-indexing.html
@@ -260,6 +260,24 @@ void main() {
     my_FragColor = vec4(f, 1.0, 0.0, 1.0);
 }
 </script>
+<script id="fshaderSequenceDynamicIndexingVectorLvalue" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+uniform int u_zero;
+
+int sideEffectCounter = 0;
+float func() {
+    ++sideEffectCounter;
+    return -1.0;
+}
+
+void main() {
+    vec4 v = vec4(0.0, 2.0, 4.0, 6.0);
+    float f = (func(), (++v[u_zero + sideEffectCounter]));
+    my_FragColor = (abs(f - 3.0) < 0.01 && abs(v[1] - 3.0) < 0.01 && sideEffectCounter == 1) ? vec4(0, 1, 0, 1) : vec4(1, 0, 0, 1);
+}
+</script>
 <script type="application/javascript">
 "use strict";
 description("Dynamic indexing of vectors and matrices should work.");
@@ -338,6 +356,12 @@ GLSLConformanceTester.runRenderTests([
   fShaderSuccess: true,
   linkSuccess: true,
   passMsg: 'Index a uniform with a uniform'
+},
+{
+  fShaderId: 'fshaderSequenceDynamicIndexingVectorLvalue',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Sequence operator with dynamic indexing of a vector as an l-value inside'
 }
 ], 2);
 </script>


### PR DESCRIPTION
1. Check that all short-circuiting operators work as the second
operand of a sequence operator.

2. Check that a sequence operator with indexing an array constructor
inside works inside a loop condition or loop expression.

3. Check that dynamic indexing of vectors as an l-value works inside
a sequence operator.