### PR TITLE
Relax EXT_color_buffer_float extension to allow multisample renderbuf…

### DIFF
--- a/extensions/EXT_color_buffer_float/extension.xml
+++ b/extensions/EXT_color_buffer_float/extension.xml
@@ -19,7 +19,13 @@
 
   <overview>
     <mirrors href="http://www.khronos.org/registry/gles/extensions/EXT/EXT_color_buffer_float.txt"
-             name="EXT_color_buffer_float"/>
+             name="EXT_color_buffer_float">
+      <addendum>
+        The sized internal format <code>RGB16F</code> is not color-renderable in this
+        extension. This is a difference in functionality compared to the <a
+        href="../EXT_color_buffer_half_float">EXT_color_buffer_half_float</a> extension.
+      </addendum>
+    </mirrors>
 
     <features>
       <feature>
@@ -57,12 +63,12 @@
         <code>UNSIGNED_BYTE</code> cannot be used for reading from a
         floating-point color buffer.</li>
 
-        <li>Multi-sample floating-point color buffers are not supported.</li>
+        <li>Multi-sample floating-point color renderbuffers may optionally be supported.
+        Applications must follow the limitations defined in the <a
+        href="http://www.khronos.org/registry/gles/extensions/EXT/EXT_color_buffer_float.txt">EXT_color_buffer_float</a>
+        extension, and check for framebuffer completeness after attaching such a renderbuffer.</li>
 
-        <li>The sized internal format <code>RGB16F</code> is not
-        color-renderable in this extension. This is a difference in
-        functionality compared to the <a
-        href="../EXT_color_buffer_half_float">EXT_color_buffer_half_float</a>
+        <li>The sized internal format <code>RGB16F</code> is not color-renderable in this
         extension.</li>
       </ul></p>
   </overview>
@@ -92,6 +98,11 @@ interface EXT_color_buffer_float {
 
     <revision date="2016/06/16">
       <change>Added note about RGB16F not being color-renderable.</change>
+    </revision>
+
+    <revision date="2016/07/21">
+      <change>Allowed allocation of multi-sample floating-point color renderbuffers as optional functionality.</change>
+      <change>Changed XML tags to fix incorrect statement that there are no behavioral changes compared to the native extension.</change>
     </revision>
   </history>
 </extension>


### PR DESCRIPTION
…fers.

Per discussion in WebGL working group. Firefox already allows this. The conformance tests need to be updated. An issue will be filed about doing so.