### PR TITLE
Turn skipped multisample tests into warnings.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
@@ -474,7 +474,7 @@ goog.scope(function() {
         var numSamples = /** @type {number} */  (gl.getParameter(gl.SAMPLES));
         if (!this.m_fboParams.useFbo && numSamples <= 1) {
             var msg = 'No multisample buffers';
-            testSkippedOptions(msg, true);
+            checkMessage(false, msg);
             return false;
         }
 


### PR DESCRIPTION
This was the only dEQP test using "testSkippedOptions", causing the
pass rate of the conformance suite to be less than 100%.