### PR TITLE
Add DEPTH_STENCIL to depth-renderable list.

### DIFF
--- a/sdk/tests/js/tests/gl-object-get-calls.js
+++ b/sdk/tests/js/tests/gl-object-get-calls.js
@@ -772,7 +772,7 @@ if (contextVersion > 1) {
         gl.RG32UI, gl.RGB8I, gl.RGB8UI, gl.RGB16I,
         gl.RGB16UI, gl.RGB32I, gl.RGB32UI, gl.RGBA8I,
         gl.RGBA8UI, gl.RGBA16I, gl.RGBA16UI, gl.RGBA32I,
-        gl.RGBA32UI, gl.RGB, gl.RGBA, gl.DEPTH_COMPONENT16,
+        gl.RGBA32UI, gl.RGB, gl.RGBA, gl.DEPTH_STENCIL, gl.DEPTH_COMPONENT16,
         gl.DEPTH_COMPONENT24, gl.DEPTH_COMPONENT32F, gl.DEPTH24_STENCIL8,
         gl.DEPTH32F_STENCIL8, gl.STENCIL_INDEX8
     );


### PR DESCRIPTION
In webgl2 3.7.5 Renderbuffer objects:
To be backward compatible with WebGL 1, also accepts internal format
DEPTH_STENCIL, which should be mapped to DEPTH24_STENCIL8 by implementations.