### PR TITLE
Multi-sample floating-point color buffers can be optional supported.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
@@ -79,12 +79,13 @@ var DE_ASSERT = function(x) {
 
     es3fFboMultisampleTests.BasicFboMultisampleCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_colorFormat);
-        this.checkSampleCount(this.m_colorFormat, this.m_numSamples);
+        var sampleCountSupported = this.checkSampleCount(this.m_colorFormat, this.m_numSamples);
 
         if (this.m_depthStencilFormat != gl.NONE) {
             this.checkFormatSupport(this.m_depthStencilFormat);
-            this.checkSampleCount(this.m_depthStencilFormat, this.m_numSamples);
+            sampleCountSupported = this.checkSampleCount(this.m_depthStencilFormat, this.m_numSamples);
         }
+        return sampleCountSupported;
     };
 
     /**
@@ -305,14 +306,14 @@ var DE_ASSERT = function(x) {
             gl.R8,
 
             // gl.EXT_color_buffer_float
-            // Multi-sample floating-point color buffers are not supported, see https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
-            // gl.RGBA32F,
-            // gl.RGBA16F,
-            // gl.R11F_G11F_B10F,
-            // gl.RG32F,
-            // gl.RG16F,
-            // gl.R32F,
-            // gl.R16F
+            // Multi-sample floating-point color buffers can be optional supported, see https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
+            gl.RGBA32F,
+            gl.RGBA16F,
+            gl.R11F_G11F_B10F,
+            gl.RG32F,
+            gl.RG16F,
+            gl.R32F,
+            gl.R16F
         ];
 
         /** @const {Array<number>} */ var depthStencilFormats = [

--- a/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
@@ -134,9 +134,17 @@ var DE_ASSERT = function(x) {
             // Exceeds spec-mandated minimum - need to check.
             /** @const @type {goog.NumberArray} */ var supportedSampleCounts = es3fFboTestCase.querySampleCounts(sizedFormat);
             var supported = Array.prototype.slice.call(supportedSampleCounts);
-            if (supported.indexOf(numSamples) == -1)
-                throw new Error('Sample count not supported');
+            if (supported.indexOf(numSamples) == -1) {
+                if (numSamples >= 2) {
+                    testPassed("Sample count not supported, but it is allowed.");
+                    return false;
+                } else {
+                    throw new Error('Sample count not supported');
+                }
+            }
+            return true;
         }
+        return true;
     };
 
     /**
@@ -202,8 +210,11 @@ var DE_ASSERT = function(x) {
         /** @type {tcuSurface.Surface} */ var result = new tcuSurface.Surface(width, height);
 
         // Call preCheck() that can throw exception if some requirement is not met.
-        if (this.preCheck)
-            this.preCheck();
+        if (this.preCheck) {
+            var sampleCountSupported = this.preCheck();
+            if (!sampleCountSupported)
+                return tcuTestCase.IterateResult.STOP;
+        }
 
         // Render using GLES3.
         try {


### PR DESCRIPTION
Enable the tests and move related files to 2.0.1