### PR TITLE
Update tests for recent ECMAScript changes

### DIFF
--- a/conformance-suites/1.0.1/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.1/conformance/typedarrays/array-unit-tests.html
@@ -544,21 +544,27 @@ function testConstructionWithNullBuffer(type, name) {
     var array;
     try {
         array = new type(null);
-        testFailed("Construction of " + name + " with null buffer should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with null buffer threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with null threw exception");
+    }
+    try {
+        array = new type(null, 0);
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
+    } catch (e) {
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0) threw exception");
     }
     try {
         array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0) should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0) threw exception");
-    }
-    try {
-        array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0, 0) should throw exception");
-    } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0, 0) threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0, 0) threw exception");
     }
 }
 

--- a/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
@@ -610,21 +610,27 @@ function testConstructionWithNullBuffer(type, name) {
     var array;
     try {
         array = new type(null);
-        testFailed("Construction of " + name + " with null buffer should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with null buffer threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with null threw exception");
+    }
+    try {
+        array = new type(null, 0);
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
+    } catch (e) {
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0) threw exception");
     }
     try {
         array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0) should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0) threw exception");
-    }
-    try {
-        array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0, 0) should throw exception");
-    } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0, 0) threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0, 0) threw exception");
     }
 }
 

--- a/conformance-suites/1.0.2/conformance/typedarrays/data-view-test.html
+++ b/conformance-suites/1.0.2/conformance/typedarrays/data-view-test.html
@@ -99,6 +99,88 @@ function checkSet(func, index, value, littleEndian)
         shouldThrow(expr);
 }
 
+function checkGetWithoutArgument(func, expected)
+{
+    var threw = false;
+    var value;
+    try {
+        value = view["get" + func]();
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.get" + func + " with no arguments throws.");
+    } else {
+        if (value === expected) {
+            testPassed("view.get" + func + " treats missing argument as 0.");
+        } else {
+            testFailed("view.get" + func + " accepts a missing argument but does not cast it to 0.");
+        }
+    }
+}
+
+function checkSetWithoutSecondArgument(func, index, isFloat)
+{
+    var expected = isFloat ? NaN : 0;
+    var threw = false;
+    var value;
+    try {
+        value = view["set" + func](index);
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.set" + func + " with missing second argument throws.");
+    } else {
+        var stored = view["get" + func](index);
+        if (value === undefined && isFloat ? isNaN(stored) : stored === expected) {
+            testPassed("view.set" + func + " treats missing second argument as " + expected + ".");
+        } else {
+            testFailed("view.set" + func + " accepts a missing second argument but does not cast it to " + expected + ".");
+        }
+    }
+}
+
+function checkSetWithoutArguments(func, isFloat)
+{
+    var expected = isFloat ? NaN : 0;
+    var threw = false;
+    var value;
+    try {
+        value = view["set" + func]();
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.set" + func + " with no arguments throws.");
+    } else {
+        var stored = view["get" + func](0);
+        if (value === undefined && isFloat ? isNaN(stored) : stored === expected) {
+            testPassed("view.set" + func + " treats missing first argument as 0.");
+        } else {
+            testFailed("view.set" + func + " accepts a missing first argument but does not cast it to 0.");
+        }
+    }
+}
+
+function testMissingArguments(func, constructor, isFloat)
+{
+    view = new DataView((new constructor(3)).buffer);
+    view["set" + func](0, 1);
+    view["set" + func](getElementSize(func), 2);
+    checkGetWithoutArgument(func, 1);
+    checkSetWithoutSecondArgument(func, getElementSize(func), isFloat);
+    view = new DataView((new constructor(3)).buffer);
+    view["set" + func](0, 1);
+    checkSetWithoutArguments(func, isFloat);
+}
+
 function test(isTestingGet, func, index, value, littleEndian)
 {
     if (isTestingGet)
@@ -315,18 +397,6 @@ function runGetTests()
     debug("");
     debug("Test for get methods that read from negative index");
     runNegativeIndexTests(true);
-
-    debug("");
-    debug("Test for wrong arguments passed to get methods");
-    view = new DataView((new Uint8Array([1, 2])).buffer);
-    shouldThrow("view.getInt8()");
-    shouldThrow("view.getUint8()");
-    shouldThrow("view.getInt16()");
-    shouldThrow("view.getUint16()");
-    shouldThrow("view.getInt32()");
-    shouldThrow("view.getUint32()");
-    shouldThrow("view.getFloat32()");
-    shouldThrow("view.getFloat64()");
 }
 
 function runSetTests()
@@ -344,26 +414,20 @@ function runSetTests()
     debug("");
     debug("Test for set methods that write to negative index");
     runNegativeIndexTests(false);
+}
 
+function runMissingArgumentTests()
+{
     debug("");
-    debug("Test for wrong arguments passed to set methods");
-    view = new DataView((new Uint8Array([1, 2])).buffer);
-    shouldThrow("view.setInt8()");
-    shouldThrow("view.setUint8()");
-    shouldThrow("view.setInt16()");
-    shouldThrow("view.setUint16()");
-    shouldThrow("view.setInt32()");
-    shouldThrow("view.setUint32()");
-    shouldThrow("view.setFloat32()");
-    shouldThrow("view.setFloat64()");
-    shouldThrow("view.setInt8(1)");
-    shouldThrow("view.setUint8(1)");
-    shouldThrow("view.setInt16(1)");
-    shouldThrow("view.setUint16(1)");
-    shouldThrow("view.setInt32(1)");
-    shouldThrow("view.setUint32(1)");
-    shouldThrow("view.setFloat32(1)");
-    shouldThrow("view.setFloat64(1)");
+    debug("Test for get and set methods missing arguments");
+    testMissingArguments("Int8", Int8Array);
+    testMissingArguments("Uint8", Uint8Array);
+    testMissingArguments("Int16", Int16Array);
+    testMissingArguments("Uint16", Uint16Array);
+    testMissingArguments("Int32", Int32Array);
+    testMissingArguments("Uint32", Uint32Array);
+    testMissingArguments("Float32", Float32Array, true);
+    testMissingArguments("Float64", Float64Array, true);
 }
 
 function runIndexingTests()
@@ -379,6 +443,7 @@ function runIndexingTests()
 runConstructorTests();
 runGetTests();
 runSetTests();
+runMissingArgumentTests();
 runIndexingTests();
 var successfullyParsed = true;
 </script>

--- a/conformance-suites/1.0.3/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.3/conformance/typedarrays/array-unit-tests.html
@@ -639,21 +639,27 @@ function testConstructionWithNullBuffer(type, name) {
     var array;
     try {
         array = new type(null);
-        testFailed("Construction of " + name + " with null buffer should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with null buffer threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with null threw exception");
+    }
+    try {
+        array = new type(null, 0);
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
+    } catch (e) {
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0) threw exception");
     }
     try {
         array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0) should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0) threw exception");
-    }
-    try {
-        array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0, 0) should throw exception");
-    } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0, 0) threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0, 0) threw exception");
     }
 }
 

--- a/conformance-suites/1.0.3/conformance/typedarrays/data-view-test.html
+++ b/conformance-suites/1.0.3/conformance/typedarrays/data-view-test.html
@@ -99,6 +99,88 @@ function checkSet(func, index, value, littleEndian)
         shouldThrow(expr);
 }
 
+function checkGetWithoutArgument(func, expected)
+{
+    var threw = false;
+    var value;
+    try {
+        value = view["get" + func]();
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.get" + func + " with no arguments throws.");
+    } else {
+        if (value === expected) {
+            testPassed("view.get" + func + " treats missing argument as 0.");
+        } else {
+            testFailed("view.get" + func + " accepts a missing argument but does not cast it to 0.");
+        }
+    }
+}
+
+function checkSetWithoutSecondArgument(func, index, isFloat)
+{
+    var expected = isFloat ? NaN : 0;
+    var threw = false;
+    var value;
+    try {
+        value = view["set" + func](index);
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.set" + func + " with missing second argument throws.");
+    } else {
+        var stored = view["get" + func](index);
+        if (value === undefined && isFloat ? isNaN(stored) : stored === expected) {
+            testPassed("view.set" + func + " treats missing second argument as " + expected + ".");
+        } else {
+            testFailed("view.set" + func + " accepts a missing second argument but does not cast it to " + expected + ".");
+        }
+    }
+}
+
+function checkSetWithoutArguments(func, isFloat)
+{
+    var expected = isFloat ? NaN : 0;
+    var threw = false;
+    var value;
+    try {
+        value = view["set" + func]();
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.set" + func + " with no arguments throws.");
+    } else {
+        var stored = view["get" + func](0);
+        if (value === undefined && isFloat ? isNaN(stored) : stored === expected) {
+            testPassed("view.set" + func + " treats missing first argument as 0.");
+        } else {
+            testFailed("view.set" + func + " accepts a missing first argument but does not cast it to 0.");
+        }
+    }
+}
+
+function testMissingArguments(func, constructor, isFloat)
+{
+    view = new DataView((new constructor(3)).buffer);
+    view["set" + func](0, 1);
+    view["set" + func](getElementSize(func), 2);
+    checkGetWithoutArgument(func, 1);
+    checkSetWithoutSecondArgument(func, getElementSize(func), isFloat);
+    view = new DataView((new constructor(3)).buffer);
+    view["set" + func](0, 1);
+    checkSetWithoutArguments(func, isFloat);
+}
+
 function test(isTestingGet, func, index, value, littleEndian)
 {
     if (isTestingGet)
@@ -304,18 +386,6 @@ function runGetTests()
     debug("");
     debug("Test for get methods that read from negative index");
     runNegativeIndexTests(true);
-
-    debug("");
-    debug("Test for wrong arguments passed to get methods");
-    view = new DataView((new Uint8Array([1, 2])).buffer);
-    shouldThrow("view.getInt8()");
-    shouldThrow("view.getUint8()");
-    shouldThrow("view.getInt16()");
-    shouldThrow("view.getUint16()");
-    shouldThrow("view.getInt32()");
-    shouldThrow("view.getUint32()");
-    shouldThrow("view.getFloat32()");
-    shouldThrow("view.getFloat64()");
 }
 
 function runSetTests()
@@ -333,26 +403,20 @@ function runSetTests()
     debug("");
     debug("Test for set methods that write to negative index");
     runNegativeIndexTests(false);
+}
 
+function runMissingArgumentTests()
+{
     debug("");
-    debug("Test for wrong arguments passed to set methods");
-    view = new DataView((new Uint8Array([1, 2])).buffer);
-    shouldThrow("view.setInt8()");
-    shouldThrow("view.setUint8()");
-    shouldThrow("view.setInt16()");
-    shouldThrow("view.setUint16()");
-    shouldThrow("view.setInt32()");
-    shouldThrow("view.setUint32()");
-    shouldThrow("view.setFloat32()");
-    shouldThrow("view.setFloat64()");
-    shouldThrow("view.setInt8(1)");
-    shouldThrow("view.setUint8(1)");
-    shouldThrow("view.setInt16(1)");
-    shouldThrow("view.setUint16(1)");
-    shouldThrow("view.setInt32(1)");
-    shouldThrow("view.setUint32(1)");
-    shouldThrow("view.setFloat32(1)");
-    shouldThrow("view.setFloat64(1)");
+    debug("Test for get and set methods missing arguments");
+    testMissingArguments("Int8", Int8Array);
+    testMissingArguments("Uint8", Uint8Array);
+    testMissingArguments("Int16", Int16Array);
+    testMissingArguments("Uint16", Uint16Array);
+    testMissingArguments("Int32", Int32Array);
+    testMissingArguments("Uint32", Uint32Array);
+    testMissingArguments("Float32", Float32Array, true);
+    testMissingArguments("Float64", Float64Array, true);
 }
 
 function runIndexingTests()
@@ -368,6 +432,7 @@ function runIndexingTests()
 runConstructorTests();
 runGetTests();
 runSetTests();
+runMissingArgumentTests();
 runIndexingTests();
 var successfullyParsed = true;
 </script>

--- a/sdk/tests/conformance/typedarrays/array-unit-tests.html
+++ b/sdk/tests/conformance/typedarrays/array-unit-tests.html
@@ -641,21 +641,27 @@ function testConstructionWithNullBuffer(type, name) {
     var array;
     try {
         array = new type(null);
-        testFailed("Construction of " + name + " with null buffer should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with null buffer threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with null threw exception");
+    }
+    try {
+        array = new type(null, 0);
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
+    } catch (e) {
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0) threw exception");
     }
     try {
         array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0) should throw exception");
+        assertEq("Length of " + name + " constructed with null", 0, array.length);
+        testPassed("Construction of " + name + " with null produced a " + name + " of length 0");
     } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0) threw exception");
-    }
-    try {
-        array = new type(null, 0, 0);
-        testFailed("Construction of " + name + " with (null buffer, 0, 0) should throw exception");
-    } catch (e) {
-        testPassed("Construction of " + name + " with (null buffer, 0, 0) threw exception");
+        // This used to be correct, but TC39 has changed the behavior of these constructors.
+        testPassed("Construction of " + name + " with (null, 0, 0) threw exception");
     }
 }
 

--- a/sdk/tests/conformance/typedarrays/data-view-test.html
+++ b/sdk/tests/conformance/typedarrays/data-view-test.html
@@ -99,6 +99,88 @@ function checkSet(func, index, value, littleEndian)
         shouldThrow(expr);
 }
 
+function checkGetWithoutArgument(func, expected)
+{
+    var threw = false;
+    var value;
+    try {
+        value = view["get" + func]();
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.get" + func + " with no arguments throws.");
+    } else {
+        if (value === expected) {
+            testPassed("view.get" + func + " treats missing argument as 0.");
+        } else {
+            testFailed("view.get" + func + " accepts a missing argument but does not cast it to 0.");
+        }
+    }
+}
+
+function checkSetWithoutSecondArgument(func, index, isFloat)
+{
+    var expected = isFloat ? NaN : 0;
+    var threw = false;
+    var value;
+    try {
+        value = view["set" + func](index);
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.set" + func + " with missing second argument throws.");
+    } else {
+        var stored = view["get" + func](index);
+        if (value === undefined && isFloat ? isNaN(stored) : stored === expected) {
+            testPassed("view.set" + func + " treats missing second argument as " + expected + ".");
+        } else {
+            testFailed("view.set" + func + " accepts a missing second argument but does not cast it to " + expected + ".");
+        }
+    }
+}
+
+function checkSetWithoutArguments(func, isFloat)
+{
+    var expected = isFloat ? NaN : 0;
+    var threw = false;
+    var value;
+    try {
+        value = view["set" + func]();
+    } catch (e) {
+        threw = true;
+    }
+
+    if (threw) {
+        // This used to be correct, but TC39 has changed the behavior of these methods.
+        testPassed("view.set" + func + " with no arguments throws.");
+    } else {
+        var stored = view["get" + func](0);
+        if (value === undefined && isFloat ? isNaN(stored) : stored === expected) {
+            testPassed("view.set" + func + " treats missing first argument as 0.");
+        } else {
+            testFailed("view.set" + func + " accepts a missing first argument but does not cast it to 0.");
+        }
+    }
+}
+
+function testMissingArguments(func, constructor, isFloat)
+{
+    view = new DataView((new constructor(3)).buffer);
+    view["set" + func](0, 1);
+    view["set" + func](getElementSize(func), 2);
+    checkGetWithoutArgument(func, 1);
+    checkSetWithoutSecondArgument(func, getElementSize(func), isFloat);
+    view = new DataView((new constructor(3)).buffer);
+    view["set" + func](0, 1);
+    checkSetWithoutArguments(func, isFloat);
+}
+
 function test(isTestingGet, func, index, value, littleEndian)
 {
     if (isTestingGet)
@@ -304,18 +386,6 @@ function runGetTests()
     debug("");
     debug("Test for get methods that read from negative index");
     runNegativeIndexTests(true);
-
-    debug("");
-    debug("Test for wrong arguments passed to get methods");
-    view = new DataView((new Uint8Array([1, 2])).buffer);
-    shouldThrow("view.getInt8()");
-    shouldThrow("view.getUint8()");
-    shouldThrow("view.getInt16()");
-    shouldThrow("view.getUint16()");
-    shouldThrow("view.getInt32()");
-    shouldThrow("view.getUint32()");
-    shouldThrow("view.getFloat32()");
-    shouldThrow("view.getFloat64()");
 }
 
 function runSetTests()
@@ -333,26 +403,20 @@ function runSetTests()
     debug("");
     debug("Test for set methods that write to negative index");
     runNegativeIndexTests(false);
+}
 
+function runMissingArgumentTests()
+{
     debug("");
-    debug("Test for wrong arguments passed to set methods");
-    view = new DataView((new Uint8Array([1, 2])).buffer);
-    shouldThrow("view.setInt8()");
-    shouldThrow("view.setUint8()");
-    shouldThrow("view.setInt16()");
-    shouldThrow("view.setUint16()");
-    shouldThrow("view.setInt32()");
-    shouldThrow("view.setUint32()");
-    shouldThrow("view.setFloat32()");
-    shouldThrow("view.setFloat64()");
-    shouldThrow("view.setInt8(1)");
-    shouldThrow("view.setUint8(1)");
-    shouldThrow("view.setInt16(1)");
-    shouldThrow("view.setUint16(1)");
-    shouldThrow("view.setInt32(1)");
-    shouldThrow("view.setUint32(1)");
-    shouldThrow("view.setFloat32(1)");
-    shouldThrow("view.setFloat64(1)");
+    debug("Test for get and set methods missing arguments");
+    testMissingArguments("Int8", Int8Array);
+    testMissingArguments("Uint8", Uint8Array);
+    testMissingArguments("Int16", Int16Array);
+    testMissingArguments("Uint16", Uint16Array);
+    testMissingArguments("Int32", Int32Array);
+    testMissingArguments("Uint32", Uint32Array);
+    testMissingArguments("Float32", Float32Array, true);
+    testMissingArguments("Float64", Float64Array, true);
 }
 
 function runIndexingTests()
@@ -368,6 +432,7 @@ function runIndexingTests()
 runConstructorTests();
 runGetTests();
 runSetTests();
+runMissingArgumentTests();
 runIndexingTests();
 var successfullyParsed = true;
 </script>


### PR DESCRIPTION
Several tests are making outdated assertions about various TypedArray and DataView related functions. Their behavior was changed by TC39 [recently](https://github.com/tc39/ecma262/pull/410).

This PR amends those tests so that either the old or new behavior is accepted. I'm not sure if there's a way to officially mark one behavior as deprecated. This PR doesn't update the snapshots, just the tests under sdk/.

Ping @kenrussell; we discussed this briefly over email a while ago. @littledan @leobalter