### PR TITLE
Add sample count check on GL_MAX_SMAPLES

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
@@ -135,7 +135,7 @@ var DE_ASSERT = function(x) {
             /** @const @type {goog.NumberArray} */ var supportedSampleCounts = es3fFboTestCase.querySampleCounts(sizedFormat);
             var supported = Array.prototype.slice.call(supportedSampleCounts);
             if (supported.indexOf(numSamples) == -1) {
-                if (numSamples >= 2) {
+                if (minSampleCount == 0 || numSamples > gl.getParameter(gl.MAX_SAMPLES)) {
                     testPassed("Sample count not supported, but it is allowed.");
                     return false;
                 } else {


### PR DESCRIPTION
GLES3 spec, section 6.1.15
"Since multisampling is not supported for signed and unsigned integer internal formats, the value of
NUM_SAMPLE_COUNTS will be zero for such formats. For every other accepted internalformat, the value of NUM_SAMPLE_COUNTS is guaranteed to be at least one, and the maximum value in SAMPLES is guaranteed to be at least the value of MAX_SAMPLES."

@Richard-Yunchao please have a look, 3x!
