### PR TITLE
Check getProgramInfoLog does not return correct empty string

### DIFF
--- a/sdk/tests/conformance/programs/00_test_list.txt
+++ b/sdk/tests/conformance/programs/00_test_list.txt
@@ -6,5 +6,6 @@ gl-get-active-uniform.html
 gl-getshadersource.html
 gl-shader-test.html
 invalid-UTF-16.html
+--min-version 1.0.4 program-infolog.html
 program-test.html
 --min-version 1.0.2 use-program-crash-with-discard-in-fragment-shader.html

--- a/sdk/tests/conformance/programs/program-infolog.html
+++ b/sdk/tests/conformance/programs/program-infolog.html
@@ -1,0 +1,83 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Program Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="2" height="2"> </canvas>
+<script id="vertexShader" language="x-shader/x-vertex">
+void main()
+{
+  gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+}
+</script>
+<script id="fragmentShader" language="x-shader/x-fragment">
+precision mediump float;
+void main()
+{
+  gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+}
+</script>
+<script>
+"use strict";
+description('getProgramInfoLog should not return \\0');
+
+debug("");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+if (!gl) {
+  testFailed("context does not exist");
+} else {
+  testPassed("context exists");
+}
+
+debug("");
+
+var program = wtu.loadProgramFromScript(gl, 'vertexShader', 'fragmentShader');
+var infolog = gl.getProgramInfoLog(program);
+if (infolog === '\0') {
+  testFailed("getProgramInfoLog should not return '\\0'");
+} else {
+  testPassed("getProgramInfoLog didn't return '\\0'");
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Chrome fails this test both on nVidia and Intel. Firefox passes this test.