### PR TITLE
Fix regression on preCheck

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fFboColorbufferTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboColorbufferTests.js
@@ -172,6 +172,7 @@ setParentClass(es3fFboColorbufferTests.FboColorClearCase, es3fFboColorbufferTest
 
 es3fFboColorbufferTests.FboColorClearCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
 es3fFboColorbufferTests.FboColorClearCase.prototype.render = function(dst) {
@@ -275,6 +276,7 @@ setParentClass(es3fFboColorbufferTests.FboColorMultiTex2DCase, es3fFboColorbuffe
 es3fFboColorbufferTests.FboColorMultiTex2DCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_tex0Fmt);
         this.checkFormatSupport(this.m_tex1Fmt);
+        return true; // No exception thrown
     };
 
 es3fFboColorbufferTests.FboColorMultiTex2DCase.prototype.render = function(dst) {
@@ -396,6 +398,7 @@ setParentClass(es3fFboColorbufferTests.FboColorTexCubeCase, es3fFboColorbufferTe
 
 es3fFboColorbufferTests.FboColorTexCubeCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
 es3fFboColorbufferTests.FboColorTexCubeCase.prototype.render = function(dst) {
@@ -542,6 +545,7 @@ setParentClass(es3fFboColorbufferTests.FboColorTex2DArrayCase, es3fFboColorbuffe
 
 es3fFboColorbufferTests.FboColorTex2DArrayCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
     es3fFboColorbufferTests.FboColorTex2DArrayCase.prototype.render = function(dst) {
@@ -667,6 +671,7 @@ setParentClass(es3fFboColorbufferTests.FboColorTex3DCase, es3fFboColorbufferTest
 
 es3fFboColorbufferTests.FboColorTex3DCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
     es3fFboColorbufferTests.FboColorTex3DCase.prototype.render = function(dst) {
@@ -803,6 +808,7 @@ setParentClass(es3fFboColorbufferTests.FboBlendCase, es3fFboColorbufferTests.Fbo
 
 es3fFboColorbufferTests.FboBlendCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     }
 
     es3fFboColorbufferTests.FboBlendCase.prototype.render = function(dst) {

--- a/sdk/tests/deqp/functional/gles3/es3fFboDepthbufferTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboDepthbufferTests.js
@@ -77,6 +77,7 @@ setParentClass(es3fFboDepthbufferTests.BasicFboDepthCase, es3fFboTestCase.FboTes
 
 es3fFboDepthbufferTests.BasicFboDepthCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
 es3fFboDepthbufferTests.BasicFboDepthCase.prototype.render = function(dst) {
@@ -169,6 +170,7 @@ setParentClass(es3fFboDepthbufferTests.DepthWriteClampCase, es3fFboTestCase.FboT
 
 es3fFboDepthbufferTests.DepthWriteClampCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
 es3fFboDepthbufferTests.DepthWriteClampCase.prototype.render = function(dst) {
@@ -253,6 +255,7 @@ setParentClass(es3fFboDepthbufferTests.DepthTestClampCase, es3fFboTestCase.FboTe
 
 es3fFboDepthbufferTests.DepthTestClampCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
 es3fFboDepthbufferTests.DepthTestClampCase.prototype.render = function(dst) {

--- a/sdk/tests/deqp/functional/gles3/es3fFboInvalidateTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboInvalidateTests.js
@@ -453,6 +453,7 @@ setParentClass(es3fFboInvalidateTests.InvalidateFboRenderCase, es3fFboTestCase.F
 es3fFboInvalidateTests.InvalidateFboRenderCase.prototype.preCheck = function() {
     if (this.m_colorFmt != gl.NONE) this.checkFormatSupport(this.m_colorFmt);
     if (this.m_depthStencilFmt != gl.NONE) this.checkFormatSupport(this.m_depthStencilFmt);
+    return true; // No exception thrown
 };
 
 es3fFboInvalidateTests.InvalidateFboRenderCase.prototype.render = function(dst) {
@@ -557,6 +558,7 @@ setParentClass(es3fFboInvalidateTests.InvalidateFboUnbindReadCase, es3fFboTestCa
 es3fFboInvalidateTests.InvalidateFboUnbindReadCase.prototype.preCheck = function() {
     if (this.m_colorFmt != gl.NONE) this.checkFormatSupport(this.m_colorFmt);
     if (this.m_depthStencilFmt != gl.NONE) this.checkFormatSupport(this.m_depthStencilFmt);
+    return true; // No exception thrown
 };
 
 es3fFboInvalidateTests.InvalidateFboUnbindReadCase.prototype.render = function(dst) {
@@ -667,6 +669,7 @@ setParentClass(es3fFboInvalidateTests.InvalidateFboUnbindBlitCase, es3fFboTestCa
 es3fFboInvalidateTests.InvalidateFboUnbindBlitCase.prototype.preCheck = function() {
     if (this.m_colorFmt != gl.NONE) this.checkFormatSupport(this.m_colorFmt);
     if (this.m_depthStencilFmt != gl.NONE) this.checkFormatSupport(this.m_depthStencilFmt);
+    return true; // No exception thrown
 };
 
 es3fFboInvalidateTests.InvalidateFboUnbindBlitCase.prototype.render = function(dst) {
@@ -787,6 +790,7 @@ setParentClass(es3fFboInvalidateTests.InvalidateSubFboUnbindReadCase, es3fFboTes
 es3fFboInvalidateTests.InvalidateSubFboUnbindReadCase.prototype.preCheck = function() {
     if (this.m_colorFmt != gl.NONE) this.checkFormatSupport(this.m_colorFmt);
     if (this.m_depthStencilFmt != gl.NONE) this.checkFormatSupport(this.m_depthStencilFmt);
+    return true; // No exception thrown
 };
 
 es3fFboInvalidateTests.InvalidateSubFboUnbindReadCase.prototype.compare = function(reference, result) {
@@ -915,6 +919,7 @@ setParentClass(es3fFboInvalidateTests.InvalidateSubFboRenderCase, es3fFboTestCas
 es3fFboInvalidateTests.InvalidateSubFboRenderCase.prototype.preCheck = function() {
     if (this.m_colorFmt != gl.NONE) this.checkFormatSupport(this.m_colorFmt);
     if (this.m_depthStencilFmt != gl.NONE) this.checkFormatSupport(this.m_depthStencilFmt);
+    return true; // No exception thrown
 };
 
 es3fFboInvalidateTests.InvalidateSubFboRenderCase.prototype.render = function(dst) {
@@ -1014,6 +1019,7 @@ setParentClass(es3fFboInvalidateTests.InvalidateSubFboUnbindBlitCase, es3fFboTes
 es3fFboInvalidateTests.InvalidateSubFboUnbindBlitCase.prototype.preCheck = function() {
     if (this.m_colorFmt != gl.NONE) this.checkFormatSupport(this.m_colorFmt);
     if (this.m_depthStencilFmt != gl.NONE) this.checkFormatSupport(this.m_depthStencilFmt);
+    return true; // No exception thrown
 };
 
 es3fFboInvalidateTests.InvalidateSubFboUnbindBlitCase.prototype.render = function(dst) {

--- a/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboMultisampleTests.js
@@ -79,13 +79,15 @@ var DE_ASSERT = function(x) {
 
     es3fFboMultisampleTests.BasicFboMultisampleCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_colorFormat);
-        var sampleCountSupported = this.checkSampleCount(this.m_colorFormat, this.m_numSamples);
+        if (!this.checkSampleCount(this.m_colorFormat, this.m_numSamples))
+            return false;
 
         if (this.m_depthStencilFormat != gl.NONE) {
             this.checkFormatSupport(this.m_depthStencilFormat);
-            sampleCountSupported = this.checkSampleCount(this.m_depthStencilFormat, this.m_numSamples);
+            if (!this.checkSampleCount(this.m_depthStencilFormat, this.m_numSamples))
+                return false;
         }
-        return sampleCountSupported;
+        return true; // No exception thrown
     };
 
     /**

--- a/sdk/tests/deqp/functional/gles3/es3fFboStencilbufferTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboStencilbufferTests.js
@@ -68,6 +68,7 @@ goog.scope(function() {
 
     es3fFboStencilbufferTests.BasicFboStencilCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
     /**

--- a/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFboTestCase.js
@@ -136,7 +136,7 @@ var DE_ASSERT = function(x) {
             var supported = Array.prototype.slice.call(supportedSampleCounts);
             if (supported.indexOf(numSamples) == -1) {
                 if (minSampleCount == 0 || numSamples > gl.getParameter(gl.MAX_SAMPLES)) {
-                    testPassed("Sample count not supported, but it is allowed.");
+                    checkMessage(false, "Sample count not supported, but it is allowed.");
                     return false;
                 } else {
                     throw new Error('Sample count not supported');
@@ -210,11 +210,8 @@ var DE_ASSERT = function(x) {
         /** @type {tcuSurface.Surface} */ var result = new tcuSurface.Surface(width, height);
 
         // Call preCheck() that can throw exception if some requirement is not met.
-        if (this.preCheck) {
-            var sampleCountSupported = this.preCheck();
-            if (!sampleCountSupported)
-                return tcuTestCase.IterateResult.STOP;
-        }
+        if (this.preCheck && !this.preCheck())
+            return tcuTestCase.IterateResult.STOP;
 
         // Render using GLES3.
         try {

--- a/sdk/tests/deqp/functional/gles3/es3fFramebufferBlitTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fFramebufferBlitTests.js
@@ -649,6 +649,7 @@ goog.scope(function() {
     es3fFramebufferBlitTests.BlitColorConversionCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_srcFormat);
         this.checkFormatSupport(this.m_dstFormat);
+        return true; // No exception thrown
     };
 
     /**
@@ -805,6 +806,7 @@ goog.scope(function() {
      */
     es3fFramebufferBlitTests.BlitDepthStencilCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
     /**
@@ -972,6 +974,7 @@ goog.scope(function() {
      */
     es3fFramebufferBlitTests.BlitDefaultFramebufferCase.prototype.preCheck = function() {
         this.checkFormatSupport(this.m_format);
+        return true; // No exception thrown
     };
 
     /**


### PR DESCRIPTION
In https://github.com/KhronosGroup/WebGL/pull/1946, preCheck's behavior
is only changed for fbomultisample case. This breaks behavior of
preCheck for other cases. This patch makes all the appeared preChecks
return true if no exception or early return.

This also changes test status from pass to a warning for tests which
returns early.