### PR TITLE
Fix the qualifiers mismatch error in differing_interpolation_2

### DIFF
--- a/sdk/tests/deqp/data/gles3/shaders/linkage.test
+++ b/sdk/tests/deqp/data/gles3/shaders/linkage.test
@@ -506,7 +506,7 @@ group varying "Varying linkage"
 			vertex ""
 				#version 300 es
 				${VERTEX_DECLARATIONS}
-				smooth out mediump float var;
+				smooth centroid out mediump float var;
 				void main()
 				{
 					var = in0;


### PR DESCRIPTION
The differing_interpolation_2 case fails in my MAC. According to the ELSL 3.0 spec, it seems MAC is right on this. See the below texts at the end of section 4.3.4 and 4.3.9.

4.3.4
"The output of the vertex shader and the input of the fragment shader form an interface.  For this interface, vertex shader output variables and fragment shader input variables of the same name must match in type and qualification (other than out matching to in)."
4.3.9
"The type and presence of the interpolation qualifiers and storage qualifiers and invariant qualifiers of 
variables with the same name declared in all linked shaders must match, otherwise the link command will 
fail."  
