### PR TITLE
Some anti-alias algorithms may not effect on diagonal line pixels, but must preserve the behavior on the non-edge pixel.

### DIFF
--- a/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -62,8 +62,7 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var pixel_1 = [0, 0, 0, 1];
-var pixel_2 = [0, 0, 0, 1];
+var redChannels = [0, 0, 0];
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -303,11 +302,15 @@ function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(3, 3, { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(3, 3, { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
+    // Draw a triangle on 3x3 canvas.
+    // ----
+    // | /
+    // |/
     var vertices = new Float32Array([
          1.0, 1.0, 0.0,
         -1.0, 1.0, 0.0,
@@ -317,17 +320,13 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf_1 = new Uint8Array(1 * 1 * 4);
-    var buf_2 = new Uint8Array(1 * 1 * 4);
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_1);
-    gl.readPixels(0, 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_2);
-    pixel_1[0] = buf_1[0];
-    pixel_2[0] = buf_2[0];
-    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
-    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
-    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
-    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
-        "contextAttribs.antialias");
+    var buf = new Uint8Array(3 * 3 * 4);
+    gl.readPixels(0, 0, 3, 3, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannels[0] = buf[4 * (0 + (2 * 3))]; // left top
+    redChannels[1] = buf[4 * (1 + (1 * 3))]; // middle
+    redChannels[2] = buf[4 * (2 + (0 * 3))]; // right bottom
+    shouldBeTrue("redChannels[0] == 255 && redChannels[2] == 0")
+    shouldBe("redChannels[1] != 255 && redChannels[1] != 0", "contextAttribs.antialias");
 }
 
 function runTest()


### PR DESCRIPTION
Some anti-alias algorithms may not effect on 2x2 canvas.

A postprocessing AA cannot handle 2x2 canvas because the following example cannot
be interpreted as triangle.
```
    _____
    |X| |
    -----
    | | |
    ¯¯¯¯¯
```
So enlarge the canvas to 3x3, because the following example can be interpreted
as triangle.
```
    _______
    |X|X|X|
    -------
    |X|X| |
    -------
    |X| | |
    ¯¯¯¯¯¯¯
```

Follow-up of PR #1730
BUG=crbug.com/634945
