### PR TITLE
Add COPY_READ_BUFFER and COPY_WRITE_BUFFER to targets for bindBuffer.

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -985,6 +985,8 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           <table>
               <tr><th>target</th></tr>
               <tr><td>ARRAY_BUFFER</td></tr>
+              <tr><td>COPY_READ_BUFFER</td></tr>
+              <tr><td>COPY_WRITE_BUFFER</td></tr>
               <tr><td>ELEMENT_ARRAY_BUFFER</td></tr>
               <tr><td>PIXEL_PACK_BUFFER</td></tr>
               <tr><td>PIXEL_UNPACK_BUFFER</td></tr>


### PR DESCRIPTION
These were added elsewhere in the spec after issues were resolved some
time ago, but were not added to this detail table for this method.