### PR TITLE
Check the result from AA in a general way

### DIFF
--- a/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -301,16 +301,15 @@ function testStencilAndDepth(stencil, depth)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
+    // Both the width and height of canvas are N.
+    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
+    var N = 3;
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(3, 3, { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(3, 3, { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
-    // Draw a triangle on 3x3 canvas.
-    // ----
-    // | /
-    // |/
     var vertices = new Float32Array([
          1.0, 1.0, 0.0,
         -1.0, 1.0, 0.0,
@@ -320,13 +319,13 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(3 * 3 * 4);
-    gl.readPixels(0, 0, 3, 3, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (0 + (2 * 3))]; // left top
-    redChannels[1] = buf[4 * (1 + (1 * 3))]; // middle
-    redChannels[2] = buf[4 * (2 + (0 * 3))]; // right bottom
-    shouldBeTrue("redChannels[0] == 255 && redChannels[2] == 0")
-    shouldBe("redChannels[1] != 255 && redChannels[1] != 0", "contextAttribs.antialias");
+    var buf = new Uint8Array(N * N * 4);
+    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
+    redChannels[1] = buf[4 * N * (N - 1)]; // left top
+    redChannels[2] = buf[4 * (N - 1)]; // right bottom
+    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
+    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
 }
 
 function runTest()


### PR DESCRIPTION
When drawing a square with 2 different color triangles, some AA may
affect all the pixels on diagonal, while some others, such as CMAA, may
keep the pixels on the egde intact. Given this, (1, 1) can be always a
good candidate for the check.