### PR TITLE
Add a texture mipmap case

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-mipmap-levels.html
+++ b/sdk/tests/conformance2/textures/misc/tex-mipmap-levels.html
@@ -59,6 +59,41 @@ void main()
     gl_FragColor = texture2D(tex, texCoord);
 }
 </script>
+
+<script id="vshader_texsize" type="x-shader/x-vertex">#version 300 es
+in vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+
+<script id="fshader_texsize_2d" type="x-shader/x-fragment">#version 300 es
+
+precision mediump float;
+uniform sampler2D tex;
+uniform int lod;
+uniform ivec2 texSize;
+out vec4 fragColor;
+void main()
+{
+    fragColor = (textureSize(tex, lod) == texSize ? vec4(255, 0, 0, 255) : vec4(0, 0, 0, 255));
+}
+</script>
+
+<script id="fshader_texsize_3d" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform highp sampler3D tex;
+uniform int lod;
+uniform ivec3 texSize;
+out vec4 fragColor;
+void main()
+{
+    fragColor = (textureSize(tex, lod) == texSize ? vec4(255, 0, 0, 255) : vec4(0, 0, 0, 255));
+}
+</script>
+
+
 <script>
 "use strict";
 description(document.title);
@@ -189,6 +224,51 @@ wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
       wtu.glErrorShouldBe(gl, gl.NO_ERROR, "generateMipmap should succeed");
   }
   gl.deleteTexture(tex);
+
+  // Test textureSize should work correctly with non-zero base level for texStorage2D
+  var program = wtu.setupProgram(
+      gl, ['vshader_texsize', 'fshader_texsize_2d'], ['vPosition'], [0]);
+
+  gl.uniform1i(gl.getUniformLocation(program, "tex"), 0);
+  gl.uniform1i(gl.getUniformLocation(program, "lod"), 1);
+  gl.uniform2i(gl.getUniformLocation(program, "texSize"), 7, 4);
+  tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAG_FILTER) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MIN_FILTER) should succeed");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, 1);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_BASE_LEVEL) should succeed");
+  gl.texStorage2D(gl.TEXTURE_2D, 4, gl.RGBA8, 31, 17);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage2D should succeed");
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
+  gl.deleteTexture(tex);
+
+  // Test textureSize should work correctly with non-zero base level for texStorage3D
+  var program = wtu.setupProgram(
+      gl, ['vshader_texsize', 'fshader_texsize_3d'], ['vPosition'], [0]);
+
+  gl.uniform1i(gl.getUniformLocation(program, "tex"), 0);
+  gl.uniform1i(gl.getUniformLocation(program, "lod"), 1);
+  gl.uniform3i(gl.getUniformLocation(program, "texSize"), 8, 4, 2);
+  tex3d = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_3D, tex3d);
+  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAG_FILTER) should succeed");
+  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MIN_FILTER) should succeed");
+  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_BASE_LEVEL, 1);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_BASE_LEVEL) should succeed");
+  gl.texStorage3D(gl.TEXTURE_3D, 4, gl.RGBA8, 32, 16, 8);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage3D should succeed");
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
+  gl.deleteTexture(tex3d);
+
 })();
 
 var successfullyParsed = true;


### PR DESCRIPTION
To catch a bug on MacOSX. glTexStorage* don't work as expected if
the current GL_TEXTURE_BASE_LEVEL is not 0. As a result, the shader
function textureSize returns wrong size.