### PR TITLE
Add test: getExtension while PBO is bound should not crash

### DIFF
--- a/sdk/tests/conformance2/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/misc/00_test_list.txt
@@ -1,3 +1,4 @@
 expando-loss-2.html
+getextension-while-pbo-bound-stability.html
 instanceof-test.html
 uninitialized-test-2.html

--- a/sdk/tests/conformance2/misc/getextension-while-pbo-bound-stability.html
+++ b/sdk/tests/conformance2/misc/getextension-while-pbo-bound-stability.html
@@ -1,0 +1,78 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 getExtension while PBO bound stability conformance test.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+var wtu = WebGLTestUtils;
+
+function runTest(extension_name) {
+  debug("");
+  debug("getExtension('" + extension_name + "') while PIXEL_UNPACK_BUFFER bound should be stable");
+
+  var gl = wtu.create3DContext(null, undefined, 2);
+  if (!gl) {
+    testFailed("Fail to get a WebGL context");
+    return;
+  }
+
+  var pbo = gl.createBuffer();
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pbo);
+  var ext = gl.getExtension('EXT_color_buffer_float');
+  var gl_texture_float_linear = gl.getExtension(extension_name);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Late-enable of extension should succeed");
+  if (pbo != gl.getParameter(gl.PIXEL_UNPACK_BUFFER_BINDING)) {
+      testFailed("Fail to maintain PIXEL_UNPACK_BUFFER binding when enabling extension " + extension_name);
+  }
+}
+
+function runTests() {
+  debug("This is a regression test for <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=641643'>Chromium Issue 641642</a>");
+  runTest('EXT_color_buffer_float');
+  runTest('OES_texture_float_linear');
+}
+
+runTests();
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../../js/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Regression test for [Chromium Issue 641643](https://bugs.chromium.org/p/chromium/issues/detail?id=641643)