### PR TITLE
Check the result from AA in a general way in versions from 1.0.0 to 1…

### DIFF
--- a/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
@@ -39,8 +39,7 @@ var successfullyParsed = false;
 var webGL = null;
 var contextAttribs = null;
 var pixel = [0, 0, 0, 1];
-var pixel_1 = [0, 0, 0, 1];
-var pixel_2 = [0, 0, 0, 1];
+var redChannels = [0, 0, 0];
 var correctColor = null;
 
 function init()
@@ -198,17 +197,18 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(webGL, vertices, colors, 0, 0);
-    var buf_1 = new Uint8Array(1 * 1 * 4);
-    var buf_2 = new Uint8Array(1 * 1 * 4);
-    webGL.readPixels(0, 0, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_1);
-    webGL.readPixels(0, 1, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_2);
-    pixel_1[0] = buf_1[0];
-    pixel_2[0] = buf_2[0];
-    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
-    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
-    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
-    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
-        "contextAttribs.antialias");
+
+    shouldBeTrue("webGL.canvas.width == webGL.canvas.height");
+    // Both the width and height of canvas are N.
+    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
+    var N = webGL.canvas.width;
+    var buf = new Uint8Array(N * N * 4);
+    webGL.readPixels(0, 0, N, N, webGL.RGBA, webGL.UNSIGNED_BYTE, buf);
+    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
+    redChannels[1] = buf[4 * N * (N - 1)]; // left top
+    redChannels[2] = buf[4 * (N - 1)]; // right bottom
+    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
+    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
 }
 
 function runTest()
@@ -235,8 +235,8 @@ function runTest()
 <canvas id="depthOff" width="1px" height="1px"></canvas>
 <canvas id="stencilOn" width="1px" height="1px"></canvas>
 <canvas id="stencilOff" width="1px" height="1px"></canvas>
-<canvas id="antialiasOn" width="2px" height="2px"></canvas>
-<canvas id="antialiasOff" width="2px" height="2px"></canvas>
+<canvas id="antialiasOn" width="3px" height="3px"></canvas>
+<canvas id="antialiasOff" width="3px" height="3px"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 </body>

--- a/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -40,8 +40,7 @@ var successfullyParsed = false;
 var webGL = null;
 var contextAttribs = null;
 var pixel = [0, 0, 0, 1];
-var pixel_1 = [0, 0, 0, 1];
-var pixel_2 = [0, 0, 0, 1];
+var redChannels = [0, 0, 0];
 var correctColor = null;
 var value;
 
@@ -204,10 +203,13 @@ function testStencil(stencil)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
+    // Both the width and height of canvas are N.
+    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
+    var N = 3;
     if (antialias)
-        shouldBeNonNull("webGL = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("webGL = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("webGL = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("webGL = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = webGL.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -219,17 +221,13 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(webGL, vertices, colors, 0, 0);
-    var buf_1 = new Uint8Array(1 * 1 * 4);
-    var buf_2 = new Uint8Array(1 * 1 * 4);
-    webGL.readPixels(0, 0, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_1);
-    webGL.readPixels(0, 1, 1, 1, webGL.RGBA, webGL.UNSIGNED_BYTE, buf_2);
-    pixel_1[0] = buf_1[0];
-    pixel_2[0] = buf_2[0];
-    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
-    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
-    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
-    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
-        "contextAttribs.antialias");
+    var buf = new Uint8Array(N * N * 4);
+    webGL.readPixels(0, 0, N, N, webGL.RGBA, webGL.UNSIGNED_BYTE, buf);
+    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
+    redChannels[1] = buf[4 * N * (N - 1)]; // left top
+    redChannels[2] = buf[4 * (N - 1)]; // right bottom
+    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
+    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -63,8 +63,7 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var pixel_1 = [0, 0, 0, 1];
-var pixel_2 = [0, 0, 0, 1];
+var redChannels = [0, 0, 0];
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -297,10 +296,13 @@ function testStencilAndDepth(stencil, depth)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
+    // Both the width and height of canvas are N.
+    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
+    var N = 3;
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -312,17 +314,13 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf_1 = new Uint8Array(1 * 1 * 4);
-    var buf_2 = new Uint8Array(1 * 1 * 4);
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_1);
-    gl.readPixels(0, 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_2);
-    pixel_1[0] = buf_1[0];
-    pixel_2[0] = buf_2[0];
-    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
-    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
-    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
-    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
-        "contextAttribs.antialias");
+    var buf = new Uint8Array(N * N * 4);
+    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
+    redChannels[1] = buf[4 * N * (N - 1)]; // left top
+    redChannels[2] = buf[4 * (N - 1)]; // right bottom
+    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
+    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -62,8 +62,7 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var pixel_1 = [0, 0, 0, 1];
-var pixel_2 = [0, 0, 0, 1];
+var redChannels = [0, 0, 0];
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -302,10 +301,13 @@ function testStencilAndDepth(stencil, depth)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
+    // Both the width and height of canvas are N.
+    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
+    var N = 3;
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(2, 2, { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -317,17 +319,13 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf_1 = new Uint8Array(1 * 1 * 4);
-    var buf_2 = new Uint8Array(1 * 1 * 4);
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_1);
-    gl.readPixels(0, 1, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf_2);
-    pixel_1[0] = buf_1[0];
-    pixel_2[0] = buf_2[0];
-    // For some anti-alias algorithms, effects may be not on diagonal line pixels, so that either:
-    //    - The red channel of the pixel at (0, 0) is not 0 and not 255, or,
-    //    - If it is 0, expect that the red channel of the pixel at (0, 1) is not 0 and not 255.
-    shouldBe("pixel_1[0] != 255 && pixel_1[0] != 0 || pixel_1[0] == 0 && pixel_2[0] != 255 && pixel_2[0] != 0",
-        "contextAttribs.antialias");
+    var buf = new Uint8Array(N * N * 4);
+    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
+    redChannels[1] = buf[4 * N * (N - 1)]; // left top
+    redChannels[2] = buf[4 * (N - 1)]; // right bottom
+    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
+    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
 }
 
 function runTest()


### PR DESCRIPTION
….0.4

When drawing a square with 2 different color triangles, some AA may
affect all the pixels on diagonal, while some others, such as CMAA, may
keep the pixels on the egde intact. Given this, (1, 1) can be always a
good candidate for the check.

This is a follow-up of https://github.com/KhronosGroup/WebGL/pull/1988,
to apply same rule to versions from 1.0.0 to 1.0.4.