### PR TITLE
Fix link in table of contents

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3597,8 +3597,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         this limitation in WebGL 2 for all platforms.
     </div>
 
-    <h3><a name="DOM_UPLOAD_UNPACK_PARAMS">Pixel store parameters for uploads from
-        <code>TexImageSource</code></a></h3>
+    <h3><a name="DOM_UPLOAD_UNPACK_PARAMS">Pixel store parameters for uploads from TexImageSource</a></h3>
     <p><code>UNPACK_ALIGNMENT</code> and <code>UNPACK_ROW_LENGTH</code> are ignored, as they
        determine row-stride-in-bytes, which is implicit and implementation-dependent for
        TexImageSource objects.


### PR DESCRIPTION
&lt;code&gt; in &lt;a&gt; will make the link in tables of contents be unavailable.
Other similar usage doesn't use &lt;code&gt; tag too.

This fixes https://github.com/KhronosGroup/WebGL/issues/1998.