### PR TITLE
Add missing LUMINANCE format to the tex format table in WebGL2 spec.

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1549,6 +1549,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <tr><td>RGB</td><td>RGB</td><td>UNSIGNED_BYTE<br>UNSIGNED_SHORT_5_6_5</td></tr>
         <tr><td>RGBA</td><td>RGBA</td><td>UNSIGNED_BYTE,<br>UNSIGNED_SHORT_4_4_4_4<br>UNSIGNED_SHORT_5_5_5_1</td></tr>
         <tr><td>LUMINANCE_ALPHA</td><td>LUMINANCE_ALPHA</td><td>UNSIGNED_BYTE</td></tr>
+        <tr><td>LUMINANCE</td><td>LUMINANCE</td><td>UNSIGNED_BYTE</td></tr>
         <tr><td>ALPHA</td><td>ALPHA</td><td>UNSIGNED_BYTE</td></tr>
         <tr><td>R8</td><td>RED</td><td>UNSIGNED_BYTE</td></tr>
         <tr><td>R16F</td><td>RED</td><td>HALF_FLOAT<br>FLOAT</td></tr>


### PR DESCRIPTION
This is reported on https://github.com/KhronosGroup/WebGL/issues/1997

@kenrussell PTAL