### PR TITLE
Allow gl.NO_ERROR when attempting to bind a deleted object in old test suites.

### DIFF
--- a/conformance-suites/1.0.0/conformance/object-deletion-behaviour.html
+++ b/conformance-suites/1.0.0/conformance/object-deletion-behaviour.html
@@ -67,7 +67,7 @@ shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(tex)");
 shouldBeNull("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isTexture(tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_2D, tex)");
+shouldGenerateGLError(gl, [gl.INVALID_OPERATION, gl.NO_ERROR], "gl.bindTexture(gl.TEXTURE_2D, tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
 
 var texCubeMap = gl.createTexture();
@@ -76,7 +76,7 @@ shouldBe("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)", "texCubeMap");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(texCubeMap)");
 shouldBeFalse("gl.isTexture(texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
+shouldGenerateGLError(gl, [gl.INVALID_OPERATION, gl.NO_ERROR], "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
 
 debug("");
@@ -93,7 +93,7 @@ shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteRenderbuffer(rbo)");
 shouldBeNull("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isRenderbuffer(rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
+shouldGenerateGLError(gl, [gl.INVALID_OPERATION, gl.NO_ERROR], "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
 
 debug("");
@@ -105,7 +105,7 @@ shouldBe("gl.getParameter(gl.ARRAY_BUFFER_BINDING)", "buffer");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(buffer)");
 shouldBeFalse("gl.isBuffer(buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
+shouldGenerateGLError(gl, [gl.INVALID_OPERATION, gl.NO_ERROR], "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 
 var bufferElement = gl.createBuffer();
@@ -114,7 +114,7 @@ shouldBe("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)", "bufferElement");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(bufferElement)");
 shouldBeFalse("gl.isBuffer(bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
+shouldGenerateGLError(gl, [gl.INVALID_OPERATION, gl.NO_ERROR], "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
 
 debug("");
@@ -125,7 +125,7 @@ shouldBe("gl.getParameter(gl.FRAMEBUFFER_BINDING)", "fbo");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteFramebuffer(fbo)");
 shouldBeFalse("gl.isFramebuffer(fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
+shouldGenerateGLError(gl, [gl.INVALID_OPERATION, gl.NO_ERROR], "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
 
 successfullyParsed = true;

--- a/conformance-suites/1.0.1/conformance/misc/object-deletion-behaviour.html
+++ b/conformance-suites/1.0.1/conformance/misc/object-deletion-behaviour.html
@@ -79,7 +79,7 @@ shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHME
 shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isTexture(tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_2D, tex)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_2D, tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
 
 var texCubeMap = gl.createTexture();
@@ -89,7 +89,7 @@ shouldBe("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)", "texCubeMap");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(texCubeMap)");
 shouldBeFalse("gl.isTexture(texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
 
 var t = gl.createTexture();
@@ -97,7 +97,7 @@ shouldBeNonNull("t");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindTexture(gl.TEXTURE_2D, t)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(t)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_2D, t)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_2D, t)");
 shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)");
 
 var t2 = gl.createTexture();
@@ -131,7 +131,7 @@ shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHME
 shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isRenderbuffer(rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo2)");
 shouldBe("gl.getParameter(gl.RENDERBUFFER_BINDING)", "rbo2");
@@ -316,7 +316,7 @@ shouldBe("gl.getParameter(gl.ARRAY_BUFFER_BINDING)", "buffer");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(buffer)");
 shouldBeFalse("gl.isBuffer(buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 
 var buffer2 = gl.createBuffer();
@@ -327,7 +327,7 @@ shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindBuffer(gl.ARRAY_BUFFER, null)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(buffer2)");
 shouldBeFalse("gl.isBuffer(buffer2)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, buffer2)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, buffer2)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 
 var bufferElement = gl.createBuffer();
@@ -337,7 +337,7 @@ shouldBe("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)", "bufferElement");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(bufferElement)");
 shouldBeFalse("gl.isBuffer(bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
 
 var b = gl.createBuffer();
@@ -345,7 +345,7 @@ shouldBeNonNull("b");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(b)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
 shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW)");
 
 var b1 = gl.createBuffer();
@@ -378,7 +378,7 @@ shouldBe("gl.getParameter(gl.FRAMEBUFFER_BINDING)", "fbo");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteFramebuffer(fbo)");
 shouldBeFalse("gl.isFramebuffer(fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo2)");
 shouldBe("gl.getParameter(gl.FRAMEBUFFER_BINDING)", "fbo2");

--- a/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
@@ -630,11 +630,11 @@ function create3DContextWithWrapperThatThrowsOnGLError(canvas) {
 
 /**
  * Tests that an evaluated expression generates a specific GL error.
- * @param {!WebGLContext} gl The WebGLContext to use.
- * @param {number} glError The expected gl error.
- * @param {string} evalSTr The string to evaluate.
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
+ * @param {string} evalStr The string to evaluate.
  */
-var shouldGenerateGLError = function(gl, glError, evalStr) {
+var shouldGenerateGLError = function(gl, glErrors, evalStr) {
   var exception;
   try {
     eval(evalStr);
@@ -644,30 +644,34 @@ var shouldGenerateGLError = function(gl, glError, evalStr) {
   if (exception) {
     testFailed(evalStr + " threw exception " + exception);
   } else {
-    var err = gl.getError();
-    if (err != glError) {
-      testFailed(evalStr + " expected: " + getGLErrorAsString(gl, glError) + ". Was " + getGLErrorAsString(gl, err) + ".");
-    } else {
-      testPassed(evalStr + " was expected value: " + getGLErrorAsString(gl, glError) + ".");
-    }
+    glErrorShouldBe(gl, glErrors, "after evaluating: " + evalStr);
   }
 };
 
 /**
  * Tests that the first error GL returns is the specified error.
- * @param {!WebGLContext} gl The WebGLContext to use.
- * @param {number} glError The expected gl error.
- * @param {string} opt_msg
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
+ * @param {string} opt_msg Optional additional message.
  */
-var glErrorShouldBe = function(gl, glError, opt_msg) {
+var glErrorShouldBe = function(gl, glErrors, opt_msg) {
+  if (!glErrors.length) {
+    glErrors = [glErrors];
+  }
   opt_msg = opt_msg || "";
   var err = gl.getError();
-  if (err != glError) {
-    testFailed("getError expected: " + getGLErrorAsString(gl, glError) +
-               ". Was " + getGLErrorAsString(gl, err) + " : " + opt_msg);
+  var ndx = glErrors.indexOf(err);
+  var errStrs = [];
+  for (var ii = 0; ii < glErrors.length; ++ii) {
+    errStrs.push(glEnumToString(gl, glErrors[ii]));
+  }
+  var expected = errStrs.join(" or ");
+  if (ndx < 0) {
+    var msg = "getError expected" + ((glErrors.length > 1) ? " one of: " : ": ");
+    testFailed(msg + expected +  ". Was " + glEnumToString(gl, err) + " : " + opt_msg);
   } else {
-    testPassed("getError was expected value: " +
-                getGLErrorAsString(gl, glError) + " : " + opt_msg);
+    var msg = "getError was " + ((glErrors.length > 1) ? "one of: " : "expected value: ");
+    testPassed(msg + expected + " : " + opt_msg);
   }
 };
 

--- a/conformance-suites/1.0.2/conformance/misc/object-deletion-behaviour.html
+++ b/conformance-suites/1.0.2/conformance/misc/object-deletion-behaviour.html
@@ -99,7 +99,7 @@ shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHME
 shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isTexture(tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_2D, tex)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_2D, tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
 
 var texCubeMap = gl.createTexture();
@@ -109,7 +109,7 @@ shouldBe("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)", "texCubeMap");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(texCubeMap)");
 shouldBeFalse("gl.isTexture(texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
 
 var t = gl.createTexture();
@@ -117,7 +117,7 @@ shouldBeNonNull("t");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindTexture(gl.TEXTURE_2D, t)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(t)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_2D, t)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_2D, t)");
 shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)");
 
 var t2 = gl.createTexture();
@@ -151,7 +151,7 @@ shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHME
 shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isRenderbuffer(rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo2)");
 shouldBe("gl.getParameter(gl.RENDERBUFFER_BINDING)", "rbo2");
@@ -336,7 +336,7 @@ shouldBe("gl.getParameter(gl.ARRAY_BUFFER_BINDING)", "buffer");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(buffer)");
 shouldBeFalse("gl.isBuffer(buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 
 var buffer2 = gl.createBuffer();
@@ -347,7 +347,7 @@ shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindBuffer(gl.ARRAY_BUFFER, null)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(buffer2)");
 shouldBeFalse("gl.isBuffer(buffer2)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, buffer2)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, buffer2)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 
 var bufferElement = gl.createBuffer();
@@ -357,7 +357,7 @@ shouldBe("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)", "bufferElement");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(bufferElement)");
 shouldBeFalse("gl.isBuffer(bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
 
 var b = gl.createBuffer();
@@ -365,7 +365,7 @@ shouldBeNonNull("b");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(b)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
 shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW)");
 
 var b1 = gl.createBuffer();
@@ -398,7 +398,7 @@ shouldBe("gl.getParameter(gl.FRAMEBUFFER_BINDING)", "fbo");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteFramebuffer(fbo)");
 shouldBeFalse("gl.isFramebuffer(fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo2)");
 shouldBe("gl.getParameter(gl.FRAMEBUFFER_BINDING)", "fbo2");

--- a/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
@@ -1106,11 +1106,11 @@ function create3DContextWithWrapperThatThrowsOnGLError(canvas) {
 
 /**
  * Tests that an evaluated expression generates a specific GL error.
- * @param {!WebGLContext} gl The WebGLContext to use.
- * @param {number} glError The expected gl error.
- * @param {string} evalSTr The string to evaluate.
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
+ * @param {string} evalStr The string to evaluate.
  */
-var shouldGenerateGLError = function(gl, glError, evalStr) {
+var shouldGenerateGLError = function(gl, glErrors, evalStr) {
   var exception;
   try {
     eval(evalStr);
@@ -1120,30 +1120,34 @@ var shouldGenerateGLError = function(gl, glError, evalStr) {
   if (exception) {
     testFailed(evalStr + " threw exception " + exception);
   } else {
-    var err = gl.getError();
-    if (err != glError) {
-      testFailed(evalStr + " expected: " + getGLErrorAsString(gl, glError) + ". Was " + getGLErrorAsString(gl, err) + ".");
-    } else {
-      testPassed(evalStr + " was expected value: " + getGLErrorAsString(gl, glError) + ".");
-    }
+    glErrorShouldBe(gl, glErrors, "after evaluating: " + evalStr);
   }
 };
 
 /**
  * Tests that the first error GL returns is the specified error.
- * @param {!WebGLContext} gl The WebGLContext to use.
- * @param {number} glError The expected gl error.
- * @param {string} opt_msg
+ * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {number|Array.<number>} glErrors The expected gl error or an array of expected errors.
+ * @param {string} opt_msg Optional additional message.
  */
-var glErrorShouldBe = function(gl, glError, opt_msg) {
+var glErrorShouldBe = function(gl, glErrors, opt_msg) {
+  if (!glErrors.length) {
+    glErrors = [glErrors];
+  }
   opt_msg = opt_msg || "";
   var err = gl.getError();
-  if (err != glError) {
-    testFailed("getError expected: " + getGLErrorAsString(gl, glError) +
-               ". Was " + getGLErrorAsString(gl, err) + " : " + opt_msg);
+  var ndx = glErrors.indexOf(err);
+  var errStrs = [];
+  for (var ii = 0; ii < glErrors.length; ++ii) {
+    errStrs.push(glEnumToString(gl, glErrors[ii]));
+  }
+  var expected = errStrs.join(" or ");
+  if (ndx < 0) {
+    var msg = "getError expected" + ((glErrors.length > 1) ? " one of: " : ": ");
+    testFailed(msg + expected +  ". Was " + glEnumToString(gl, err) + " : " + opt_msg);
   } else {
-    testPassed("getError was expected value: " +
-                getGLErrorAsString(gl, glError) + " : " + opt_msg);
+    var msg = "getError was " + ((glErrors.length > 1) ? "one of: " : "expected value: ");
+    testPassed(msg + expected + " : " + opt_msg);
   }
 };
 

--- a/conformance-suites/1.0.3/conformance/misc/object-deletion-behaviour.html
+++ b/conformance-suites/1.0.3/conformance/misc/object-deletion-behaviour.html
@@ -98,7 +98,7 @@ shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHME
 shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isTexture(tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_2D, tex)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_2D, tex)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
 
 var texCubeMap = gl.createTexture();
@@ -108,7 +108,7 @@ shouldBe("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)", "texCubeMap");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(texCubeMap)");
 shouldBeFalse("gl.isTexture(texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_CUBE_MAP, texCubeMap)");
 shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP)");
 
 var t = gl.createTexture();
@@ -116,7 +116,7 @@ shouldBeNonNull("t");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindTexture(gl.TEXTURE_2D, t)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteTexture(t)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindTexture(gl.TEXTURE_2D, t)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindTexture(gl.TEXTURE_2D, t)");
 shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)");
 
 var t2 = gl.createTexture();
@@ -150,7 +150,7 @@ shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHME
 shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
 shouldBeFalse("gl.isRenderbuffer(rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo)");
 shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindRenderbuffer(gl.RENDERBUFFER, rbo2)");
 shouldBe("gl.getParameter(gl.RENDERBUFFER_BINDING)", "rbo2");
@@ -335,7 +335,7 @@ shouldBe("gl.getParameter(gl.ARRAY_BUFFER_BINDING)", "buffer");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(buffer)");
 shouldBeFalse("gl.isBuffer(buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, buffer)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 
 var buffer2 = gl.createBuffer();
@@ -346,7 +346,7 @@ shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindBuffer(gl.ARRAY_BUFFER, null)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(buffer2)");
 shouldBeFalse("gl.isBuffer(buffer2)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, buffer2)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, buffer2)");
 shouldBeNull("gl.getParameter(gl.ARRAY_BUFFER_BINDING)");
 
 var bufferElement = gl.createBuffer();
@@ -356,7 +356,7 @@ shouldBe("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)", "bufferElement");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(bufferElement)");
 shouldBeFalse("gl.isBuffer(bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufferElement)");
 shouldBeNull("gl.getParameter(gl.ELEMENT_ARRAY_BUFFER_BINDING)");
 
 var b = gl.createBuffer();
@@ -364,7 +364,7 @@ shouldBeNonNull("b");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteBuffer(b)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindBuffer(gl.ARRAY_BUFFER, b)");
 shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bufferData(gl.ARRAY_BUFFER, 1, gl.STATIC_DRAW)");
 
 var b1 = gl.createBuffer();
@@ -397,7 +397,7 @@ shouldBe("gl.getParameter(gl.FRAMEBUFFER_BINDING)", "fbo");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.deleteFramebuffer(fbo)");
 shouldBeFalse("gl.isFramebuffer(fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
-shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
+shouldGenerateGLError(gl, [gl.NO_ERROR, gl.INVALID_OPERATION], "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo)");
 shouldBeNull("gl.getParameter(gl.FRAMEBUFFER_BINDING)");
 shouldGenerateGLError(gl, gl.NO_ERROR, "gl.bindFramebuffer(gl.FRAMEBUFFER, fbo2)");
 shouldBe("gl.getParameter(gl.FRAMEBUFFER_BINDING)", "fbo2");


### PR DESCRIPTION
Too bad I started fixing from 1.0.0 to 1.0.3 and not in the opposite order, because otherwise I would have just copy-pasted the version of `shouldGenerateGLError` that accepts an array instead of re-implementing it myself.

If it's not too much of a churn I'd like to leave it as is, but I can also take more time to do that.

r? @kenrussell 