### PR TITLE
Update tests related to binding a deleted object

### DIFF
--- a/sdk/tests/conformance2/buffers/uniform-buffers.html
+++ b/sdk/tests/conformance2/buffers/uniform-buffers.html
@@ -170,8 +170,8 @@ function runBindingTest() {
 
     // Shouldn't be able to bind a deleted buffer.
     gl.bindBuffer(gl.UNIFORM_BUFFER, b2);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "binding a deleted buffer should generate INVALID_OPERATION");
     shouldBeNull("gl.getParameter(gl.UNIFORM_BUFFER_BINDING)");
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
 
 function runDrawTest() {

--- a/sdk/tests/js/tests/gl-object-get-calls.js
+++ b/sdk/tests/js/tests/gl-object-get-calls.js
@@ -729,6 +729,8 @@ debug("Test cases where name == 0");
 gl.deleteTexture(texture);
 shouldBe('gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE)', 'gl.NONE');
 gl.deleteRenderbuffer(renderbuffer);
+gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
 shouldBe('gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE)', 'gl.NONE');
 gl.deleteBuffer(buffer);
 shouldBeNull('gl.getVertexAttrib(1, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING)');
@@ -738,8 +740,6 @@ if (contextVersion > 1) {
     debug("");
     debug("Test getInternalformatParameter")
 
-    gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     shouldBeNonNull('gl.getInternalformatParameter(gl.RENDERBUFFER, gl.R32I, gl.SAMPLES)');
     wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
@@ -859,7 +859,7 @@ if (contextVersion > 1) {
         "pname",
         validArrayForSamplerParameter,
         function(pname) {
-	    return gl.getSamplerParameter(sampler, pname);
+            return gl.getSamplerParameter(sampler, pname);
     });
 
     debug("");
@@ -904,16 +904,16 @@ if (contextVersion > 1) {
     // Queries' results are tested elsewhere in the conformance suite. It's complicated
     // to wait for this query's result to become available and verify it.
     var validArrayForPname = new Array(
-	gl.QUERY_RESULT,
-	gl.QUERY_RESULT_AVAILABLE
+        gl.QUERY_RESULT,
+        gl.QUERY_RESULT_AVAILABLE
     );
     testInvalidArgument(
-	"getQueryParameter",
-	"pname",
-	validArrayForPname,
-	function(pname) {
-	    return gl.getQueryParameter(query, pname);
-	}
+        "getQueryParameter",
+        "pname",
+        validArrayForPname,
+        function(pname) {
+            return gl.getQueryParameter(query, pname);
+        }
     );
 
     debug("");
@@ -1003,11 +1003,11 @@ if (contextVersion > 1) {
         gl.UNIFORM_IS_ROW_MAJOR
     );
     testInvalidArgument(
-	"getActiveUniforms",
-	"pname",
-	validArrayForPname,
-	function(pname) {
-	    return gl.getActiveUniforms(program, uniformIndices, pname);
+        "getActiveUniforms",
+        "pname",
+        validArrayForPname,
+        function(pname) {
+            return gl.getActiveUniforms(program, uniformIndices, pname);
         }
     );
 
@@ -1070,20 +1070,20 @@ if (contextVersion > 1) {
         testFailed("expected value >= 0" + " actual value for UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES for uniform index[" + i + "]:" + indices[i]);
     }
     var validArrayForPname = new Array(
-	gl.UNIFORM_BLOCK_BINDING,
-	gl.UNIFORM_BLOCK_DATA_SIZE,
-	gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS,
-	gl.UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES,
-	gl.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER,
-	gl.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER
+        gl.UNIFORM_BLOCK_BINDING,
+        gl.UNIFORM_BLOCK_DATA_SIZE,
+        gl.UNIFORM_BLOCK_ACTIVE_UNIFORMS,
+        gl.UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES,
+        gl.UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER,
+        gl.UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER
     );
     testInvalidArgument(
-	"getActiveUniformBlockParameter",
-	"pname",
-	validArrayForPname,
-	function(pname) {
-	    return gl.getActiveUniformBlockParameter(program, 0, pname);
-	}
+        "getActiveUniformBlockParameter",
+        "pname",
+        validArrayForPname,
+        function(pname) {
+            return gl.getActiveUniformBlockParameter(program, 0, pname);
+        }
     );
 }
 


### PR DESCRIPTION
WebGL specification was revised to generate an INVALID_OPERATION error when attemping to bind a deleted object. This patch updates related tests to meet new spec.