### PR TITLE
Add WebGL 2 conformance test canvas-resizing-with-pbo-bound

### DIFF
--- a/sdk/tests/conformance2/rendering/00_test_list.txt
+++ b/sdk/tests/conformance2/rendering/00_test_list.txt
@@ -1,6 +1,7 @@
 attrib-type-match.html
 blitframebuffer-outside-readbuffer.html
 blitframebuffer-test.html
+canvas-resizing-with-pbo-bound.html
 clear-func-buffer-type-match.html
 --min-version 2.0.1 clipping-wide-points.html
 draw-buffers.html

--- a/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
+++ b/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
@@ -1,7 +1,7 @@
 <!--
 
 /*
-** Copyright (c) 2013 The Khronos Group Inc.
+** Copyright (c) 2016 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the
@@ -56,7 +56,7 @@ void main()
 <script>
 "use strict";
 
-description("Verifies that resizing the canvas (recreating the ) works correctly while a PBO is bound.");
+description("Verifies that resizing the canvas (recreating the backing framebuffer) works correctly while a PBO is bound.");
 
 debug("");
 debug("Regression test for Chromium <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=644572'>Issue 644572</a>");
@@ -128,7 +128,7 @@ function render() {
   wtu.checkCanvasRect(gl, largeSize - inset, inset, 1, 1, green, "lower right should be green", 1);
   wtu.checkCanvasRect(gl, inset, currentSize - inset, 1, 1, green, "upper left should be green", 1);
   wtu.checkCanvasRect(gl, largeSize - inset, currentSize - inset, 1, 1, green, "upper right should be green", 1);
-  
+
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No GL error");
   if (gl.getParameter(gl.PIXEL_UNPACK_BUFFER_BINDING) != pbo) {
     testFailed("Pixel unpack buffer binding was lost");

--- a/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
+++ b/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
@@ -108,7 +108,7 @@ function nextTest() {
 }
 
 function render() {
-  if (++numFrames < 30) {
+  if (++numFrames < 4) {
     if (currentSize == largeSize) {
       canvas.height = smallSize;
       currentSize = smallSize;
@@ -134,7 +134,7 @@ function render() {
     testFailed("Pixel unpack buffer binding was lost");
   }
 
-  if (numFrames < 60) {
+  if (numFrames < 4) {
     wtu.requestAnimFrame(render);
   } else {
     wtu.requestAnimFrame(nextTest);

--- a/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
+++ b/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
@@ -1,0 +1,149 @@
+<!--
+
+/*
+** Copyright (c) 2013 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL 2 Resizing With PBO Bound Test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<canvas id="canvas1" style="width: 256px; height: 256px;"> </canvas>
+<canvas id="canvas2" style="width: 256px; height: 256px;"> </canvas>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">
+attribute vec2 position;
+void main()
+{
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">
+void main()
+{
+  gl_FragColor = vec4(0.0,1.0,0.0,1.0);
+}
+</script>
+<script>
+"use strict";
+
+description("Verifies that resizing the canvas (recreating the ) works correctly while a PBO is bound.");
+
+debug("");
+debug("Regression test for Chromium <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=644572'>Issue 644572</a>");
+debug("");
+
+var err;
+var wtu = WebGLTestUtils;
+var canvas;
+var largeSize = 256;
+var smallSize = 128;
+var currentSize;
+var gl;
+var program;
+var numFrames = 0;
+var testNumber = 0;
+var pbo;
+
+function nextTest() {
+  ++testNumber;
+  numFrames = 0;
+  currentSize = largeSize;
+  if (testNumber > 2) {
+    finishTest();
+    return;
+  }
+
+  canvas = document.getElementById("canvas" + testNumber);
+  canvas.width = currentSize;
+  canvas.height = currentSize;
+  var usePreserveDrawingBuffer = (testNumber == 1) ? true : false;
+  debug("Testing preserveDrawingBuffer = " + usePreserveDrawingBuffer);
+  gl = wtu.create3DContext(canvas, { preserveDrawingBuffer: usePreserveDrawingBuffer }, 2);
+
+  if (!gl) {
+    testFailed("context does not exist");
+  } else {
+    testPassed("context exists");
+
+    gl.clearColor(0, 1, 0, 1);
+
+    program = wtu.setupProgram(gl, ["vshader", "fshader"], ["position"]);
+    shouldBeNonNull("program");
+
+    pbo = gl.createBuffer();
+    gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pbo);
+
+    wtu.requestAnimFrame(render);
+  }
+}
+
+function render() {
+  if (++numFrames < 30) {
+    if (currentSize == largeSize) {
+      canvas.height = smallSize;
+      currentSize = smallSize;
+    } else {
+      canvas.height = largeSize;
+      currentSize = largeSize;
+    }
+  }
+
+  gl.viewport(0, 0, largeSize, currentSize);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  // Check the four corners
+  var green = [ 0, 255, 0, 255 ];
+  var inset = 3;
+  wtu.checkCanvasRect(gl, inset, inset, 1, 1, green, "lower left should be green", 1);
+  wtu.checkCanvasRect(gl, largeSize - inset, inset, 1, 1, green, "lower right should be green", 1);
+  wtu.checkCanvasRect(gl, inset, currentSize - inset, 1, 1, green, "upper left should be green", 1);
+  wtu.checkCanvasRect(gl, largeSize - inset, currentSize - inset, 1, 1, green, "upper right should be green", 1);
+  
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No GL error");
+  if (gl.getParameter(gl.PIXEL_UNPACK_BUFFER_BINDING) != pbo) {
+    testFailed("Pixel unpack buffer binding was lost");
+  }
+
+  if (numFrames < 60) {
+    wtu.requestAnimFrame(render);
+  } else {
+    wtu.requestAnimFrame(nextTest);
+  }
+}
+
+wtu.requestAnimFrame(nextTest);
+
+</script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
+++ b/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
@@ -81,8 +81,6 @@ function nextTest() {
 
     gl.clearColor(0, 1, 0, 1);
 
-    shouldBeNonNull("program");
-
     pbo = gl.createBuffer();
     gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pbo);
 

--- a/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
+++ b/sdk/tests/conformance2/rendering/canvas-resizing-with-pbo-bound.html
@@ -39,20 +39,6 @@
 <canvas id="canvas1" style="width: 256px; height: 256px;"> </canvas>
 <canvas id="canvas2" style="width: 256px; height: 256px;"> </canvas>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec2 position;
-void main()
-{
-  gl_Position = vec4(position, 0.0, 1.0);
-}
-</script>
-
-<script id="fshader" type="x-shader/x-fragment">
-void main()
-{
-  gl_FragColor = vec4(0.0,1.0,0.0,1.0);
-}
-</script>
 <script>
 "use strict";
 
@@ -62,14 +48,12 @@ debug("");
 debug("Regression test for Chromium <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=644572'>Issue 644572</a>");
 debug("");
 
-var err;
 var wtu = WebGLTestUtils;
 var canvas;
 var largeSize = 256;
 var smallSize = 128;
 var currentSize;
 var gl;
-var program;
 var numFrames = 0;
 var testNumber = 0;
 var pbo;
@@ -97,7 +81,6 @@ function nextTest() {
 
     gl.clearColor(0, 1, 0, 1);
 
-    program = wtu.setupProgram(gl, ["vshader", "fshader"], ["position"]);
     shouldBeNonNull("program");
 
     pbo = gl.createBuffer();


### PR DESCRIPTION
Tests rapid resizing of the canvas while a pixel unpack buffer is bound.

Regression test for Chromium bug 644572
https://bugs.chromium.org/p/chromium/issues/detail?id=644572