### PR TITLE
Add commit to ignoredMethods

### DIFF
--- a/sdk/tests/conformance/context/methods.html
+++ b/sdk/tests/conformance/context/methods.html
@@ -183,6 +183,8 @@ var methods = [
 // Properties to be ignored because they were added in versions of the
 // spec that are backward-compatible with this version
 var ignoredMethods = [
+  // There is no official spec for the commit API yet, the proposal link is:
+  // https://wiki.whatwg.org/wiki/OffscreenCanvas
   "commit"
 ];
 

--- a/sdk/tests/conformance/context/methods.html
+++ b/sdk/tests/conformance/context/methods.html
@@ -183,6 +183,7 @@ var methods = [
 // Properties to be ignored because they were added in versions of the
 // spec that are backward-compatible with this version
 var ignoredMethods = [
+  "commit"
 ];
 
 function assertFunction(v, f) {

--- a/sdk/tests/conformance2/context/methods-2.html
+++ b/sdk/tests/conformance2/context/methods-2.html
@@ -273,6 +273,7 @@ var methods = [
 // Properties to be ignored because they were added in versions of the
 // spec that are backward-compatible with this version
 var ignoredMethods = [
+  "commit"
 ];
 
 function assertFunction(v, f) {

--- a/sdk/tests/conformance2/context/methods-2.html
+++ b/sdk/tests/conformance2/context/methods-2.html
@@ -273,6 +273,8 @@ var methods = [
 // Properties to be ignored because they were added in versions of the
 // spec that are backward-compatible with this version
 var ignoredMethods = [
+  // There is no official spec for the commit API yet, the proposal link is:
+  // https://wiki.whatwg.org/wiki/OffscreenCanvas
   "commit"
 ];
 


### PR DESCRIPTION
Right now chromium is implementing WebGL's commit API, to make sure all the conformance tests will be passing, this API has to be added to ignoredMethods first.

PTAL.
@kenrussell 