### PR TITLE
Move srgb converter related apis into wtu

### DIFF
--- a/sdk/tests/conformance2/rendering/blitframebuffer-filter-srgb.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-filter-srgb.html
@@ -56,43 +56,6 @@ function checkPixel(color, expectedColor) {
           Math.abs(color[3] - expectedColor[3]) <= tolerance);;
 }
 
-function sRGBToLinear(color) {
-    return [sRGBChannelToLinear(color[0]),
-            sRGBChannelToLinear(color[1]),
-            sRGBChannelToLinear(color[2]),
-            color[3]]
-}
-
-function linearToSRGB(color) {
-    return [linearChannelToSRGB(color[0]),
-            linearChannelToSRGB(color[1]),
-            linearChannelToSRGB(color[2]),
-            color[3]]
-}
-
-function sRGBChannelToLinear(value) {
-    value = value / 255;
-    if (value <= 0.04045)
-        value = value / 12.92;
-    else
-        value = Math.pow((value + 0.055) / 1.055, 2.4);
-    return Math.trunc(value * 255 + 0.5);
-}
-
-function linearChannelToSRGB(color) {
-    color = color / 255;
-    if (color <= 0.0) {
-        color = 0.0;
-    } else if (color < 0.0031308) {
-        color = color * 12.92;
-    } else if (color < 1) {
-        color = Math.pow(color, 0.41666) * 1.055 - 0.055;
-    } else {
-        color = 1.0;
-    }
-    return Math.trunc(color * 255 + 0.5);
-}
-
 var tex_read = gl.createTexture();
 var tex_draw = gl.createTexture();
 var fbo_read = gl.createFramebuffer();
@@ -145,7 +108,7 @@ function blitframebuffer_filter_srgb(readbufferFormat, drawbufferFormat, filter,
         var color = [src_buffer[ii], src_buffer[ii + 1], src_buffer[ii + 2], src_buffer[ii + 3]];
         var ref_color;
         if (readbufferFormat == gl.SRGB8_ALPHA8) {
-            ref_color = sRGBToLinear(color);
+            ref_color = wtu.sRGBToLinear(color);
         } else {
             ref_color = color;
         }
@@ -165,7 +128,7 @@ function blitframebuffer_filter_srgb(readbufferFormat, drawbufferFormat, filter,
         var color = [temp[ii], temp[ii + 1], temp[ii + 2], temp[ii + 3]];
         var ref_color;
         if (drawbufferFormat == gl.SRGB8_ALPHA8) {
-            ref_color = linearToSRGB(color);
+            ref_color = wtu.linearToSRGB(color);
         } else {
             ref_color = color;
         }

--- a/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
@@ -56,43 +56,6 @@ function checkPixel(color, expectedColor) {
           Math.abs(color[3] - expectedColor[3]) <= tolerance);;
 }
 
-function sRGBToLinear(color) {
-    return [sRGBChannelToLinear(color[0]),
-            sRGBChannelToLinear(color[1]),
-            sRGBChannelToLinear(color[2]),
-            color[3]]
-}
-
-function linearToSRGB(color) {
-    return [linearChannelToSRGB(color[0]),
-            linearChannelToSRGB(color[1]),
-            linearChannelToSRGB(color[2]),
-            color[3]]
-}
-
-function sRGBChannelToLinear(value) {
-    value = value / 255;
-    if (value <= 0.04045)
-        value = value / 12.92;
-    else
-        value = Math.pow((value + 0.055) / 1.055, 2.4);
-    return Math.trunc(value * 255 + 0.5);
-}
-
-function linearChannelToSRGB(color) {
-    color = color / 255;
-    if (color <= 0.0) {
-        color = 0.0;
-    } else if (color < 0.0031308) {
-        color = color * 12.92;
-    } else if (color < 1) {
-        color = Math.pow(color, 0.41666) * 1.055 - 0.055;
-    } else {
-        color = 1.0;
-    }
-    return Math.trunc(color * 255 + 0.5);
-}
-
 function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) {
     debug("");
     debug("bliting outside of read framebuffer, read buffer format is: " + wtu.glEnumToString(gl, readbufferFormat) + ", draw buffer format is: " + wtu.glEnumToString(gl, drawbufferFormat));
@@ -228,9 +191,9 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
                     if ((readbufferHasSRGBImage ^ drawbufferHasSRGBImage) &&
                         (ii >= dstStart && ii < dstEnd && jj >= dstStart && jj < dstEnd)) {
                         if (drawbufferHasSRGBImage) {
-                            expectedColor = linearToSRGB(expectedColor);
+                            expectedColor = wtu.linearToSRGB(expectedColor);
                         } else {
-                            expectedColor = sRGBToLinear(expectedColor);
+                            expectedColor = wtu.sRGBToLinear(expectedColor);
                         }
                     }
                     if (checkPixel(color, expectedColor) == true) {
@@ -279,9 +242,9 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
                     // We may need to covert the color space for pixels in blit region
                     if ((readbufferHasSRGBImage ^ drawbufferHasSRGBImage)) {
                         if (drawbufferHasSRGBImage) {
-                            expectedColor = linearToSRGB(expectedColor);
+                            expectedColor = wtu.linearToSRGB(expectedColor);
                         } else {
-                            expectedColor = sRGBToLinear(expectedColor);
+                            expectedColor = wtu.sRGBToLinear(expectedColor);
                         }
                     }
                     if (checkPixel(color, expectedColor) == true) {

--- a/sdk/tests/conformance2/textures/misc/tex-srgb-mipmap.html
+++ b/sdk/tests/conformance2/textures/misc/tex-srgb-mipmap.html
@@ -117,7 +117,7 @@ function generateMipmap()
     // Decode the srgba texture to a linear texture which will be used as reference.
     var linearTex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, linearTex);
-    wtu.fillTexture(gl, linearTex, width, height, sRGBToLinear(colors['srgba']), 0, gl.RGBA, gl.UNSIGNED_BYTE);
+    wtu.fillTexture(gl, linearTex, width, height, wtu.sRGBToLinear(colors['srgba']), 0, gl.RGBA, gl.UNSIGNED_BYTE);
     // Set up-left region of the texture as red color.
     // In order to make sure bi-linear interpolation operates on different colors, red region
     // is 1 pixel smaller than a quarter of the full texture on each side.
@@ -214,22 +214,6 @@ function generateMipmap()
         ctx.putImageData(imgData, 0, 0);
         var img = wtu.makeImageFromCanvas(canvas);
         return img;
-    }
-
-    function sRGBToLinear(color) {
-        return [sRGBChannelToLinear(color[0]),
-                sRGBChannelToLinear(color[1]),
-                sRGBChannelToLinear(color[2]),
-                color[3]]
-    }
-
-    function sRGBChannelToLinear(value) {
-        value = value / 255;
-        if (value <= 0.04045)
-            value = value / 12.92;
-        else
-            value = Math.pow((value + 0.055) / 1.055, 2.4);
-        return Math.trunc(value * 255 + 0.5);
     }
 }
 

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -2930,6 +2930,60 @@ var setupImageForCrossOriginTest = function(img, imgUrl, localUrl, callback) {
   }, false);
 }
 
+/**
+ * Convert sRGB color to linear color.
+ * @param {!Array.<number>} color The color to be converted.
+ *        The array has 4 elements, for example [R, G, B, A].
+ *        where each element is in the range 0 to 255.
+ * @return {!Array.<number>} color The color to be converted.
+ *        The array has 4 elements, for example [R, G, B, A].
+ *        where each element is in the range 0 to 255.
+ */
+var sRGBToLinear = function(color) {
+    return [sRGBChannelToLinear(color[0]),
+            sRGBChannelToLinear(color[1]),
+            sRGBChannelToLinear(color[2]),
+            color[3]]
+}
+
+/**
+ * Convert linear color to sRGB color.
+ * @param {!Array.<number>} color The color to be converted.
+ *        The array has 4 elements, for example [R, G, B, A].
+ *        where each element is in the range 0 to 255.
+ * @return {!Array.<number>} color The color to be converted.
+ *        The array has 4 elements, for example [R, G, B, A].
+ *        where each element is in the range 0 to 255.
+ */
+var linearToSRGB = function(color) {
+    return [linearChannelToSRGB(color[0]),
+            linearChannelToSRGB(color[1]),
+            linearChannelToSRGB(color[2]),
+            color[3]]
+}
+
+function sRGBChannelToLinear(value) {
+    value = value / 255;
+    if (value <= 0.04045)
+        value = value / 12.92;
+    else
+        value = Math.pow((value + 0.055) / 1.055, 2.4);
+    return Math.trunc(value * 255 + 0.5);
+}
+
+function linearChannelToSRGB(color) {
+    color = color / 255;
+    if (color <= 0.0) {
+        color = 0.0;
+    } else if (color < 0.0031308) {
+        color = color * 12.92;
+    } else if (color < 1) {
+        color = Math.pow(color, 0.41666) * 1.055 - 0.055;
+    } else {
+        color = 1.0;
+    }
+    return Math.trunc(color * 255 + 0.5);
+}
 var API = {
   addShaderSource: addShaderSource,
   addShaderSources: addShaderSources,
@@ -3035,6 +3089,10 @@ var API = {
 
   // fullscreen api
   setupFullscreen: setupFullscreen,
+
+  // sRGB converter api
+  sRGBToLinear: sRGBToLinear,
+  linearToSRGB: linearToSRGB,
 
   getHost: getHost,
   getBaseDomain: getBaseDomain,


### PR DESCRIPTION
They are common functions, move them to webgl-test-utils to reuse these functions among tests. 

@kenrussell , PTAL. Thanks a lot!