### PR TITLE
Lower quality threshold for some deqp/filtering.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fTextureFilteringTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fTextureFilteringTests.js
@@ -835,8 +835,8 @@ goog.scope(function() {
 
             if (!isHighQuality) {
                 // Evaluate against lower precision requirements.
-                lodPrecision.lodBits = 4;
-                lookupPrecision.uvwBits = [4, 4, 0];
+                lodPrecision.lodBits = 2;
+                lookupPrecision.uvwBits = [3, 3, 0];
 
                 bufferedLogToConsole('Warning: Verification against high ' +
                  'precision requirements failed, trying with lower ' +
@@ -1233,8 +1233,8 @@ goog.scope(function() {
 
         if (!isHighQuality) {
             // Evaluate against lower precision requirements.
-            lodPrecision.lodBits = 4;
-            lookupPrecision.uvwBits = [4, 4, 0];
+            lodPrecision.lodBits = 3;
+            lookupPrecision.uvwBits = [3, 3, 0];
 
             bufferedLogToConsole(
                 'Warning: Verification against high ' +


### PR DESCRIPTION
AMD is having trouble passing the quality bar for some cube and
2D array texture formats (RGB5A1, RGBA4, RGBA16F, RGB10A2, RGB5E9).

The low-quality thresholds are arbitrary in dEQP and were chosen
to make certain drivers pass - lowering the thresholds from 4 bits
to 3 (or in one case, 2) makes all tests pass.

I spoke to Pyry  (phaulos@google) from the dEQP team about this. He
told me the GL spec isn't very clear about filtering precision, and it's quite
possible that GL drivers themselves aren't perfectly conformant. They chose
these numbers by experimentation. I'd like to report this issue to AMD so
they can investigate, but it might not be possible to fix in the short time frame.
