### PR TITLE
Fix the failure of pixelbufferobject.html

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fPixelBufferObjectTest.js
+++ b/sdk/tests/deqp/functional/gles3/es3fPixelBufferObjectTest.js
@@ -403,7 +403,7 @@ var tcuImageCompare = framework.common.tcuImageCompare;
         gl.bufferData(gl.PIXEL_PACK_BUFFER, readReference.getLevel(0).getDataSize(), gl.STREAM_READ);
         gl.readPixels(0, 0, width, height, readPixelsFormat, readPixelsType, 0);
 
-        var bufferData = new UintArray8(readReference.getLevel(0).getDataSize());
+        var bufferData = new Uint8Array(readReference.getLevel(0).getDataSize());
 
         gl.getBufferSubData(gl.PIXEL_PACK_BUFFER, 0, bufferData);
 


### PR DESCRIPTION
Run the webgl2 conformance test on MacOSX and fount the pixelbufferobject.html failed. It turned out to be a typo. 

@kenrussell , @zhenyao , PTAL. Thanks. 