### PR TITLE
Remove tcuSkipList entries for shaderloop*

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuSkipList.js
+++ b/sdk/tests/deqp/framework/common/tcuSkipList.js
@@ -159,25 +159,6 @@ goog.scope(function() {
         // deqp/functional/gles3/fbomultisample.8_samples.html
         _skip("msaa.8_samples.r11f_g11f_b10f");
 
-        _setReason("HLSL compiler bugs");
-        // deqp/functional/gles3/shaderloop_for.html
-        _skip("loops.for.constant_iterations.nested_sequence_vertex");
-        _skip("loops.for.constant_iterations.nested_sequence_fragment");
-        _skip("loops.for.constant_iterations.nested_tricky_dataflow_1_vertex");
-        _skip("loops.for.constant_iterations.nested_tricky_dataflow_1_fragment");
-        _skip("loops.for.constant_iterations.nested_tricky_dataflow_2_vertex");
-        _skip("loops.for.constant_iterations.nested_tricky_dataflow_2_fragment");
-        // deqp/functional/gles3/shaderloop_while.html
-        _skip("loops.while.constant_iterations.nested_tricky_dataflow_1_vertex");
-        _skip("loops.while.constant_iterations.nested_tricky_dataflow_1_fragment");
-        _skip("loops.while.constant_iterations.nested_tricky_dataflow_2_vertex");
-        _skip("loops.while.constant_iterations.nested_tricky_dataflow_2_fragment");
-        // deqp/functional/gles3/shaderloop_do_while.html
-        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_1_vertex");
-        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_1_fragment");
-        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_2_vertex");
-        _skip("loops.do_while.constant_iterations.nested_tricky_dataflow_2_fragment");
-
         _setReason("Missing shadow sampler functions in D3D11");
         // https://github.com/KhronosGroup/WebGL/issues/1870
         // deqp/functional/gles3/shadertexturefunction/texture.html


### PR DESCRIPTION
They were caused by a D3D compiler bug that Microsoft diagnosed. It is now worked around in ANGLE's shader translator.

See https://github.com/google/angle/commit/509e4560b3c897311a101d4d41bb27a51a6c439a