### PR TITLE
Fixes to ported dEQP multisample test.

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
@@ -469,8 +469,6 @@ goog.scope(function() {
             '    o_color = v_color;\n' +
             '}\n';
 
-
-
         var numSamples = /** @type {number} */  (gl.getParameter(gl.SAMPLES));
         if (!this.m_fboParams.useFbo && numSamples <= 1) {
             var msg = 'No multisample buffers';
@@ -563,6 +561,7 @@ goog.scope(function() {
 
         this.m_viewportSize = Math.min(this.m_desiredViewportSize, this.m_renderWidth, this.m_renderHeight);
         this.randomizeViewport();
+        return true;
     };
 
     /**
@@ -598,7 +597,6 @@ goog.scope(function() {
      * @return {tcuTestCase.IterateResult}
      */
     es3fMultisampleTests.NumSamplesCase.prototype.iterate = function() {
-        /** @type {tcuSurface.Surface} */ var renderedImg = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
         this.randomizeViewport();
 
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
@@ -608,7 +606,7 @@ goog.scope(function() {
 
         // Read and log rendered image.
 
-        renderedImg = this.readImage();
+        /** @type {tcuSurface.Surface} */ var renderedImg = this.readImage();
         tcuLogImage.logImage('RenderedImage', 'Rendered image', renderedImg.getAccess());
 
         // Detect new, previously unseen colors from image.
@@ -795,7 +793,6 @@ goog.scope(function() {
      * @return {tcuTestCase.IterateResult}
      */
     es3fMultisampleTests.CommonEdgeCase.prototype.iterate = function() {
-        /** @type {tcuSurface.Surface} */ var renderedImg = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
         /** @type {tcuSurface.Surface} */ var errorImg = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
 
         this.randomizeViewport();
@@ -988,7 +985,7 @@ goog.scope(function() {
 
         // Read pixels and check unicolored regions.
 
-        renderedImg = this.readImage();
+        /** @type {tcuSurface.Surface} */ var renderedImg = this.readImage();
 
         errorImg.getAccess().clear([0.0, 1.0, 0.0, 1.0]);
         tcuLogImage.logImage('RenderedImage', 'Rendered image', renderedImg.getAccess());
@@ -1116,9 +1113,6 @@ goog.scope(function() {
      * @return {tcuTestCase.IterateResult}
      */
     es3fMultisampleTests.SampleStencilCase.prototype.iterate = function() {
-        /** @type {tcuSurface.Surface} */ var renderedImgFirst = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
-        /** @type {tcuSurface.Surface} */ var renderedImgSecond = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
-
         this.randomizeViewport();
 
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
@@ -1142,7 +1136,7 @@ goog.scope(function() {
                 [1.0, 1.0, 1.0, 1.0]);
         }
 
-        renderedImgFirst = this.readImage();
+        /** @type {tcuSurface.Surface} */ var renderedImgFirst = this.readImage();
         tcuLogImage.logImage('RenderedImgFirst', 'First image rendered', renderedImgFirst.getAccess());
         bufferedLogToConsole('Clearing color buffer to black');
 
@@ -1152,8 +1146,7 @@ goog.scope(function() {
 
         bufferedLogToConsole('Checking that color buffer was actually cleared to black');
 
-        /** @type {tcuSurface.Surface} */ var clearedImg = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
-        clearedImg = this.readImage();
+        /** @type {tcuSurface.Surface} */ var clearedImg = this.readImage();
 
         for (var y = 0; y < clearedImg.getHeight(); y++)
         for (var x = 0; x < clearedImg.getWidth(); x++) {
@@ -1175,7 +1168,7 @@ goog.scope(function() {
             [1.0, 1.0],
             [1.0, 1.0, 1.0, 1.0]);
 
-        renderedImgSecond = this.readImage();
+        /** @type {tcuSurface.Surface} */ var renderedImgSecond = this.readImage();
         tcuLogImage.logImage('RenderedImgSecond', 'Second image rendered', renderedImgSecond.getAccess());
         /** @type {boolean} */
         var passed = tcuImageCompare.pixelThresholdCompare(
@@ -1265,9 +1258,6 @@ goog.scope(function() {
      * @return {tcuTestCase.IterateResult}
      */
     es3fMultisampleTests.MaskProportionalityCase.prototype.iterate = function() {
-        /** @type {tcuSurface.Surface} */ var renderedImg = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
-        /** @type {number} */ var numPixels = renderedImg.getWidth() * renderedImg.getHeight();
-
         bufferedLogToConsole('Clearing color to black');
         gl.colorMask(true, true, true, true);
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
@@ -1305,9 +1295,9 @@ goog.scope(function() {
 
         this.renderQuad_WithColor(pt0, pt1, pt2, pt3, quadColor);
 
-        // Read ang log image.
-
-        renderedImg = this.readImage();
+        // Read and log image.
+        /** @type {tcuSurface.Surface} */ var renderedImg = this.readImage();
+        /** @type {number} */ var numPixels = renderedImg.getWidth() * renderedImg.getHeight();
 
         tcuLogImage.logImage('RenderedImage', 'Rendered image', renderedImg.getAccess());
         // Compute average red component in rendered image.
@@ -1411,8 +1401,6 @@ goog.scope(function() {
      * @return {tcuTestCase.IterateResult}
      */
     es3fMultisampleTests.MaskConstancyCase.prototype.iterate = function() {
-        /** @type {tcuSurface.Surface} */ var renderedImg = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
-
         this.randomizeViewport();
 
         bufferedLogToConsole('Clearing color to black');
@@ -1465,7 +1453,7 @@ goog.scope(function() {
             }
         }
 
-        renderedImg = this.readImage();
+        /** @type {tcuSurface.Surface} */ var renderedImg = this.readImage();
 
         tcuLogImage.logImage('RenderedImage', 'Rendered image', renderedImg.getAccess());
         for (var y = 0; y < renderedImg.getHeight(); y++)
@@ -1541,9 +1529,6 @@ goog.scope(function() {
     * @return {tcuTestCase.IterateResult}
     */
     es3fMultisampleTests.CoverageMaskInvertCase.prototype.iterate = function() {
-        /** @type {tcuSurface.Surface} */ var renderedImgNoSampleCoverage = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
-        /** @type {tcuSurface.Surface} */ var renderedImgSampleCoverage = new tcuSurface.Surface(this.m_viewportSize, this.m_viewportSize);
-
         this.randomizeViewport();
 
         gl.enable(gl.BLEND);
@@ -1556,7 +1541,7 @@ goog.scope(function() {
         gl.clear(gl.COLOR_BUFFER_BIT);
         bufferedLogToConsole('Drawing the pattern with gl.SAMPLE_COVERAGE disabled');
         this.drawPattern(false);
-        renderedImgNoSampleCoverage = this.readImage();
+        /** @type {tcuSurface.Surface} */ var renderedImgNoSampleCoverage = this.readImage();
 
         tcuLogImage.logImage('RenderedImageNoSampleCoverage', 'Rendered image with gl.SAMPLE_COVERAGE disabled', renderedImgNoSampleCoverage.getAccess());
         bufferedLogToConsole('Clearing color to all-zeros');
@@ -1566,7 +1551,7 @@ goog.scope(function() {
         this.drawPattern(false);
         bufferedLogToConsole('Drawing the pattern with gl.SAMPLE_COVERAGE enabled, using same sample coverage values but inverted masks');
         this.drawPattern(true);
-        renderedImgSampleCoverage = this.readImage();
+        /** @type {tcuSurface.Surface} */ var renderedImgSampleCoverage = this.readImage();
 
         tcuLogImage.logImage('RenderedImageSampleCoverage', 'Rendered image with gl.SAMPLE_COVERAGE enabled', renderedImgSampleCoverage.getAccess());
         /** @type {boolean} */ var passed = tcuImageCompare.pixelThresholdCompare(


### PR DESCRIPTION
- Fixed bug in MultisampleCase.init where it was not returning a
  return value. Callers were only executing if it returned true. I'm
  not sure how any of these tests were ever running since it should
  have been implicitly returning "undefined" which should evaluate to
  false. Fixing this bug caused several more tests to start to run.

- Eliminated unnecessary typed array allocations for rendered images.
  Roughly twice the needed memory was being allocated.