### PR TITLE
Make uninitialized-test-2.html create a WebGL 2.0 context by default.

### DIFF
--- a/sdk/tests/conformance2/misc/uninitialized-test-2.html
+++ b/sdk/tests/conformance2/misc/uninitialized-test-2.html
@@ -42,7 +42,7 @@
 description("Tests to check user code cannot access uninitialized data from GL resources.");
 
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
+var gl = wtu.create3DContext("canvas", undefined, 2);
 if (!gl)
   testFailed("Context created.");
 else


### PR DESCRIPTION
This avoids needing the ?webglVersion=2 query arg.

Thanks to jkummerow@ for pointing this out while investigating
https://bugs.chromium.org/p/v8/issues/detail?id=5386 .