### PR TITLE
Add test for TexImage with different data source

### DIFF
--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -7,6 +7,7 @@ gl-get-tex-parameter.html
 mipmap-fbo.html
 tex-3d-size-limit.html
 tex-image-and-sub-image-with-array-buffer-view-sub-source.html
+tex-image-with-different-data-source.html
 tex-input-validation.html
 tex-mipmap-levels.html
 tex-new-formats.html

--- a/sdk/tests/conformance2/textures/misc/tex-image-with-different-data-source.html
+++ b/sdk/tests/conformance2/textures/misc/tex-image-with-different-data-source.html
@@ -1,0 +1,72 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="canvas1" width="16" height="16"></canvas>
+<canvas id="canvas2" width="16" height="16"></canvas>
+<canvas id="c" width="16" height="16"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description('Tests texImage2D with different data source');
+
+var wtu = WebGLTestUtils;
+var c = document.getElementById("c");
+var gl = wtu.create3DContext("canvas1", undefined, 2);
+var tex = gl.createTexture();
+
+// Do TexImage2D taking a canvas source first.
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, gl.RGBA, gl.UNSIGNED_BYTE, c);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "TexImage2D taking a canvas source should succeed");
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, 16, 16, 0, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, null);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Teximage2D taking a null array buffer should succeed");
+gl.deleteTexture(tex);
+
+// Do TexImage2D taking an array buffer first.
+gl = wtu.create3DContext("canvas2", undefined, 2);
+tex = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, tex);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, 16, 16, 0, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, null);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Teximage2D taking a null array buffer should succeed");
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, c);
+wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "TexImage2D taking RGB10_A2 internalformat and a canvas source should fail");
+gl.deleteTexture(tex);
+
+var successfullyParsed = true;
+</script>
+<script src="../../../js/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
@kenrussell PTAL. More tests will be added to conformance2/textures/[canvas|video|image|image_data...] for invalid internalformat/format/type combinations.