### PR TITLE
Test WEBGL_depth_texture with both NEAREST and LINEAR filter modes.

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-depth-texture.html
+++ b/sdk/tests/conformance/extensions/webgl-depth-texture.html
@@ -200,133 +200,147 @@ function runTestExtension() {
             wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texImage2D(gl.' + targets[ii] + ', 1, gl.' + typeInfo.format + ', 1, 1, 0, gl.' + typeInfo.format + ', ' + typeStr + ', null)');
         }
 
-        // check 2d textures.
-        tex = gl.createTexture();
-        gl.bindTexture(gl.TEXTURE_2D, tex);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        // The WebGL_depth_texture extension supports both NEAREST and
+        // LINEAR filtering for depth textures, even though LINEAR
+        // doesn't have much meaning, and isn't supported in WebGL
+        // 2.0. Still, test both.
+        var filterModes = [
+          'LINEAR',
+          'NEAREST'
+        ];
 
-        // test level > 0
-        wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texImage2D(gl.TEXTURE_2D, 1, gl.' + typeInfo.format + ', 1, 1, 0, gl.' + typeInfo.format + ', ' + typeStr + ', null)');
+        for (var jj = 0; jj < filterModes.length; ++jj) {
+            debug('testing ' + filterModes[jj] + ' filtering');
+            var filterMode = gl[filterModes[jj]];
 
-        // test with data
-        wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', 1, 1, 0, gl.' + typeInfo.format + ', ' + typeStr + ', ' + typeInfo.data + ')');
-
-        // test with canvas
-        wtu.shouldGenerateGLError(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM, gl.INVALID_OPERATION], 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', gl.' + typeInfo.format + ', ' + typeStr  + ', canvas2)');
-
-        // test copyTexImage2D
-        wtu.shouldGenerateGLError(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], 'gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', 0, 0, 1, 1, 0)');
-
-        // test real thing
-        wtu.shouldGenerateGLError(gl, gl.NO_ERROR, 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', ' + res + ', ' + res + ', 0, gl.' + typeInfo.format + ', ' + typeStr + ', null)');
-
-        // test texSubImage2D
-        wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.' + typeInfo.format + ', ' + typeStr  + ', ' + typeInfo.data + ')');
-
-        // test copyTexSubImage2D
-        wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1)');
-
-        // test generateMipmap
-        wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.generateMipmap(gl.TEXTURE_2D)');
-
-        var fbo = gl.createFramebuffer();
-        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl[typeInfo.attachment], gl.TEXTURE_2D, tex, 0);
-
-        // Ensure DEPTH_BITS returns >= 16 bits for UNSIGNED_SHORT and UNSIGNED_INT, >= 24 UNSIGNED_INT_24_8_WEBGL.
-        // If there is stencil, ensure STENCIL_BITS reports >= 8 for UNSIGNED_INT_24_8_WEBGL.
-        shouldBeGreaterThanOrEqual('gl.getParameter(gl.DEPTH_BITS)', typeInfo.depthBits);
-        if (typeInfo.stencilBits === undefined) {
-            shouldBe('gl.getParameter(gl.STENCIL_BITS)', '0');
-        } else {
-            shouldBeGreaterThanOrEqual('gl.getParameter(gl.STENCIL_BITS)', typeInfo.stencilBits);
-        }
-
-        // TODO: remove this check if the spec is updated to require these combinations to work.
-        if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE)
-        {
-            // try adding a color buffer.
-            var colorTex = gl.createTexture();
-            gl.bindTexture(gl.TEXTURE_2D, colorTex);
+            // check 2d textures.
+            tex = gl.createTexture();
+            gl.bindTexture(gl.TEXTURE_2D, tex);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-            gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, res, res, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, colorTex, 0);
-        }
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filterMode);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filterMode);
 
-        shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+            // test level > 0
+            wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texImage2D(gl.TEXTURE_2D, 1, gl.' + typeInfo.format + ', 1, 1, 0, gl.' + typeInfo.format + ', ' + typeStr + ', null)');
 
-        // use the default texture to render with while we return to the depth texture.
-        gl.bindTexture(gl.TEXTURE_2D, null);
+            // test with data
+            wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', 1, 1, 0, gl.' + typeInfo.format + ', ' + typeStr + ', ' + typeInfo.data + ')');
 
-        // render the z-quad
-        gl.enable(gl.DEPTH_TEST);
-        gl.clearColor(1, 0, 0, 1);
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        gl.drawArrays(gl.TRIANGLES, 0, 6);
+            // test with canvas
+            wtu.shouldGenerateGLError(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM, gl.INVALID_OPERATION], 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', gl.' + typeInfo.format + ', ' + typeStr  + ', canvas2)');
 
-        dumpIt(gl, res, "--first--");
+            // test copyTexImage2D
+            wtu.shouldGenerateGLError(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], 'gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', 0, 0, 1, 1, 0)');
 
-        // render the depth texture.
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-        gl.bindTexture(gl.TEXTURE_2D, tex);
-        gl.clearColor(0, 0, 1, 1);
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-        gl.drawArrays(gl.TRIANGLES, 0, 6);
+            // test real thing
+            wtu.shouldGenerateGLError(gl, gl.NO_ERROR, 'gl.texImage2D(gl.TEXTURE_2D, 0, gl.' + typeInfo.format + ', ' + res + ', ' + res + ', 0, gl.' + typeInfo.format + ', ' + typeStr + ', null)');
 
-        var actualPixels = new Uint8Array(res * res * 4);
-        gl.readPixels(0, 0, res, res, gl.RGBA, gl.UNSIGNED_BYTE, actualPixels);
+            // test texSubImage2D
+            wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.' + typeInfo.format + ', ' + typeStr  + ', ' + typeInfo.data + ')');
 
-        dumpIt(gl, res, "--depth--");
+            // test copyTexSubImage2D
+            wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1)');
 
-        // Check that each pixel's R value is less than that of the previous pixel
-        // in either direction. Basically verify we have a gradient.
-        var success = true;
-        for (var yy = 0; yy < res; ++yy) {
-          for (var xx = 0; xx < res; ++xx) {
-            var actual = (yy * res + xx) * 4;
-            var left = actual - 4;
-            var down = actual - res * 4;
+            // test generateMipmap
+            wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.generateMipmap(gl.TEXTURE_2D)');
 
-            if (xx > 0) {
-              if (actualPixels[actual] <= actualPixels[left]) {
-                  testFailed("actual(" + actualPixels[actual] + ") < left(" + actualPixels[left] + ")");
-                  success = false;
-              }
+            var fbo = gl.createFramebuffer();
+            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl[typeInfo.attachment], gl.TEXTURE_2D, tex, 0);
+
+            // Ensure DEPTH_BITS returns >= 16 bits for UNSIGNED_SHORT and UNSIGNED_INT, >= 24 UNSIGNED_INT_24_8_WEBGL.
+            // If there is stencil, ensure STENCIL_BITS reports >= 8 for UNSIGNED_INT_24_8_WEBGL.
+            shouldBeGreaterThanOrEqual('gl.getParameter(gl.DEPTH_BITS)', typeInfo.depthBits);
+            if (typeInfo.stencilBits === undefined) {
+                shouldBe('gl.getParameter(gl.STENCIL_BITS)', '0');
+            } else {
+                shouldBeGreaterThanOrEqual('gl.getParameter(gl.STENCIL_BITS)', typeInfo.stencilBits);
             }
-            if (yy > 0) {
-                if (actualPixels[actual] <= actualPixels[down]) {
-                    testFailed("actual(" + actualPixels[actual] + ") < down(" + actualPixels[down] + ")");
-                    success = false;
+
+            // TODO: remove this check if the spec is updated to require these combinations to work.
+            if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE)
+            {
+                // try adding a color buffer.
+                var colorTex = gl.createTexture();
+                gl.bindTexture(gl.TEXTURE_2D, colorTex);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+                gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+                gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, res, res, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+                gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, colorTex, 0);
+            }
+
+            shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+
+            // use the default texture to render with while we return to the depth texture.
+            gl.bindTexture(gl.TEXTURE_2D, null);
+
+            // render the z-quad
+            gl.enable(gl.DEPTH_TEST);
+            gl.clearColor(1, 0, 0, 1);
+            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+            dumpIt(gl, res, "--first--");
+
+            // render the depth texture.
+            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            gl.bindTexture(gl.TEXTURE_2D, tex);
+            gl.clearColor(0, 0, 1, 1);
+            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+            var actualPixels = new Uint8Array(res * res * 4);
+            gl.readPixels(0, 0, res, res, gl.RGBA, gl.UNSIGNED_BYTE, actualPixels);
+
+            dumpIt(gl, res, "--depth--");
+
+            // Check that each pixel's R value is less than that of the previous pixel
+            // in either direction. Basically verify we have a gradient.
+            var success = true;
+            for (var yy = 0; yy < res; ++yy) {
+                for (var xx = 0; xx < res; ++xx) {
+                    var actual = (yy * res + xx) * 4;
+                    var left = actual - 4;
+                    var down = actual - res * 4;
+
+                    if (xx > 0) {
+                        if (actualPixels[actual] <= actualPixels[left]) {
+                            testFailed("actual(" + actualPixels[actual] + ") < left(" + actualPixels[left] + ")");
+                            success = false;
+                        }
+                    }
+                    if (yy > 0) {
+                        if (actualPixels[actual] <= actualPixels[down]) {
+                            testFailed("actual(" + actualPixels[actual] + ") < down(" + actualPixels[down] + ")");
+                            success = false;
+                        }
+                    }
                 }
             }
-          }
-        }
 
-        // Check that bottom left corner is vastly different thatn top right.
-        if (actualPixels[(res * res - 1) * 4] - actualPixels[0] < 0xC0) {
-            testFailed("corners are not different enough");
-            success = false;
-        }
+            // Check that bottom left corner is vastly different thatn top right.
+            if (actualPixels[(res * res - 1) * 4] - actualPixels[0] < 0xC0) {
+                testFailed("corners are not different enough");
+                success = false;
+            }
 
-        if (success) {
-            testPassed("depth texture rendered correctly.");
-        }
+            if (success) {
+                testPassed("depth texture rendered correctly.");
+            }
 
-        // check limitations
-        gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-        gl.framebufferTexture2D(gl.FRAMEBUFFER, gl[typeInfo.attachment], gl.TEXTURE_2D, null, 0);
-        var badAttachment = typeInfo.attachment == 'DEPTH_ATTACHMENT' ? 'DEPTH_STENCIL_ATTACHMENT' : 'DEPTH_ATTACHMENT';
-        wtu.shouldGenerateGLError(gl, gl.NO_ERROR, 'gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.' + badAttachment + ', gl.TEXTURE_2D, tex, 0)');
-        shouldNotBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
-        wtu.shouldGenerateGLError(gl, gl.INVALID_FRAMEBUFFER_OPERATION, 'gl.clear(gl.DEPTH_BUFFER_BIT)');
-        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-        shouldBe('gl.getError()', 'gl.NO_ERROR');
+            // check limitations
+            gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+            gl.framebufferTexture2D(gl.FRAMEBUFFER, gl[typeInfo.attachment], gl.TEXTURE_2D, null, 0);
+            var badAttachment = typeInfo.attachment == 'DEPTH_ATTACHMENT' ? 'DEPTH_STENCIL_ATTACHMENT' : 'DEPTH_ATTACHMENT';
+            wtu.shouldGenerateGLError(gl, gl.NO_ERROR, 'gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.' + badAttachment + ', gl.TEXTURE_2D, tex, 0)');
+            shouldNotBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+            wtu.shouldGenerateGLError(gl, gl.INVALID_FRAMEBUFFER_OPERATION, 'gl.clear(gl.DEPTH_BUFFER_BIT)');
+            gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+            shouldBe('gl.getError()', 'gl.NO_ERROR');
+        }
     }
 }
 


### PR DESCRIPTION
The core WebGL 2.0 version of this functionality only works with the
NEAREST filter mode. While LINEAR isn't recommended, it is
historically supported, so test it, but add a comment.