### PR TITLE
Fix more bugs in blitframebuffer-outside-readbuffer.html

### DIFF
--- a/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
@@ -49,7 +49,7 @@ description("This test verifies the functionality of blitFramebuffer.");
 var gl = wtu.create3DContext("example", undefined, 2);
 
 function checkPixel(color, expectedColor) {
-  var tolerance = 7;
+  var tolerance = 3;
   return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
           Math.abs(color[1] - expectedColor[1]) <= tolerance &&
           Math.abs(color[2] - expectedColor[2]) <= tolerance &&
@@ -58,7 +58,7 @@ function checkPixel(color, expectedColor) {
 
 function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) {
     debug("");
-    debug("bliting outside of read framebuffer, read buffer format is: " + wtu.glEnumToString(gl, readbufferFormat) + ", draw buffer format is: " + wtu.glEnumToString(gl, drawbufferFormat));
+    debug("blitting outside of read framebuffer, read buffer format is: " + wtu.glEnumToString(gl, readbufferFormat) + ", draw buffer format is: " + wtu.glEnumToString(gl, drawbufferFormat));
 
     // Initiate data to read framebuffer
     var size_read = 3;
@@ -114,24 +114,24 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
             [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
 
             // The reference pixels of the 2nd line: (0, 1) ~ (6, 1)
-            [0x10, 0x10, 0x10, 0xff], [0x20, 0x20, 0x20, 0xff], [0x20, 0x20, 0x20, 0xff], [0x30, 0x30, 0x30, 0xff],
-            [0x40, 0x40, 0x40, 0xff], [0x40, 0x40, 0x40, 0xff], [0x10, 0x10, 0x10, 0xff],
+            [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
+            [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
 
             // The reference pixels of the 3rd line: (0, 2) ~ (6, 2)
-            [0x10, 0x10, 0x10, 0xff], [0x20, 0x20, 0x20, 0xff], [0x20, 0x20, 0x20, 0xff], [0x30, 0x30, 0x30, 0xff],
-            [0x40, 0x40, 0x40, 0xff], [0x40, 0x40, 0x40, 0xff], [0x10, 0x10, 0x10, 0xff],
+            [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x20, 0x20, 0x20, 0xff], [0x30, 0x30, 0x30, 0xff],
+            [0x40, 0x40, 0x40, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
 
             // The reference pixels of the 4th line: (0, 3) ~ (6, 3)
-            [0x10, 0x10, 0x10, 0xff], [0x50, 0x50, 0x50, 0xff], [0x50, 0x50, 0x50, 0xff], [0x60, 0x60, 0x60, 0xff],
-            [0x70, 0x70, 0x70, 0xff], [0x70, 0x70, 0x70, 0xff], [0x10, 0x10, 0x10, 0xff],
+            [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x50, 0x50, 0x50, 0xff], [0x60, 0x60, 0x60, 0xff],
+            [0x70, 0x70, 0x70, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
 
             // The reference pixels of the 5th line: (0, 4) ~ (6, 4)
-            [0x10, 0x10, 0x10, 0xff], [0x80, 0x80, 0x80, 0xff], [0x80, 0x80, 0x80, 0xff], [0x90, 0x90, 0x90, 0xff],
-            [0xa0, 0xa0, 0xa0, 0xff], [0xa0, 0xa0, 0xa0, 0xff], [0x10, 0x10, 0x10, 0xff],
+            [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x80, 0x80, 0x80, 0xff], [0x90, 0x90, 0x90, 0xff],
+            [0xa0, 0xa0, 0xa0, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
 
             // The reference pixels of the 6th line: (0, 5) ~ (6, 5)
-            [0x10, 0x10, 0x10, 0xff], [0x80, 0x80, 0x80, 0xff], [0x80, 0x80, 0x80, 0xff], [0x90, 0x90, 0x90, 0xff],
-            [0xa0, 0xa0, 0xa0, 0xff], [0xa0, 0xa0, 0xa0, 0xff], [0x10, 0x10, 0x10, 0xff],
+            [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
+            [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
 
             // The reference pixels of the 7th line: (0, 6) ~ (6, 6)
             [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff], [0x10, 0x10, 0x10, 0xff],
@@ -140,7 +140,7 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
 
         // The 1st round test: blit read framebuffer to the image in draw framebuffer
         // All directions of the read region have pixels outside of the read buffer
-        // The src region and/or dst region may be reversed during bliting.
+        // The src region and/or dst region may be reversed during blitting.
         var test1 = [
              [-1, 4, 1, 6], // reverse neither src nor dst
              [4, -1, 1, 6], // reverse src only
@@ -163,6 +163,8 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
             var srcEnd = test1[i][1];
             var dstStart = test1[i][2];
             var dstEnd = test1[i][3];
+            var realBlittedDstStart = 2;
+            var realBlittedDstEnd = 5;
             gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo_read);
             gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fbo_draw);
             gl.blitFramebuffer(srcStart, srcStart, srcEnd, srcEnd, dstStart, dstStart, dstEnd, dstEnd, gl.COLOR_BUFFER_BIT, gl.LINEAR);
@@ -189,7 +191,7 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
 
                     // We may need to covert the color space for pixels in blit region
                     if ((readbufferHasSRGBImage ^ drawbufferHasSRGBImage) &&
-                        (ii >= dstStart && ii < dstEnd && jj >= dstStart && jj < dstEnd)) {
+                        (ii >= realBlittedDstStart && ii < realBlittedDstEnd && jj >= realBlittedDstStart && jj < realBlittedDstEnd)) {
                         if (drawbufferHasSRGBImage) {
                             expectedColor = wtu.linearToSRGB(expectedColor);
                         } else {
@@ -208,18 +210,18 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
         // The 2nd round test: blit read framebuffer to the image in draw framebuffer
         // Only one direction of the read region have pixels outside of the read buffer
         var tests = [
-             [-1, 0], // clamp to the left edge of the read buffer
-             [0, -1], // clamp to the bottom edge of the read buffer
-             [1, 0],  // clamp to the right edge of the read buffer
-             [0, 1]   // clamp to the top edge of the read buffer
+             [-1, 0], // pixels are outside the left edge of the read buffer
+             [0, -1], // pixels are outside the bottom edge of the read buffer
+             [1, 0],  // pixels are outside the right edge of the read buffer
+             [0, 1]   // pixels are outside the top edge of the read buffer
         ];
         for (var i = 0; i < 4; ++i) {
             debug("");
             switch (i) {
-                case 0: debug("clamp to the left edge of the read buffer"); break;
-                case 1: debug("clamp to the bottom edge of the read buffer"); break;
-                case 2: debug("clamp to the right edge of the read buffer"); break;
-                case 3: debug("clamp to the top edge of the read buffer"); break;
+                case 0: debug("verify that pixels lying outside the left edge of the read buffer should remain untouched"); break;
+                case 1: debug("verify that pixels lying outside the bottom edge of the read buffer should remain untouched"); break;
+                case 2: debug("verify that pixels lying outside the right edge of the read buffer should remain untouched"); break;
+                case 3: debug("verify that pixels lying outside the top edge of the read buffer should remain untouched"); break;
             }
             gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo_read);
             gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fbo_draw);
@@ -240,7 +242,8 @@ function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) 
                     var color = [pixels[loc * 4], pixels[loc * 4 + 1], pixels[loc * 4 + 2], pixels[loc * 4 + 3]];
                     var expectedColor = ref[loc];
                     // We may need to covert the color space for pixels in blit region
-                    if ((readbufferHasSRGBImage ^ drawbufferHasSRGBImage)) {
+                    if ((readbufferHasSRGBImage ^ drawbufferHasSRGBImage) &&
+                        (ii >= realBlittedDstStart && ii < realBlittedDstEnd && jj >= realBlittedDstStart && jj < realBlittedDstEnd)) {
                         if (drawbufferHasSRGBImage) {
                             expectedColor = wtu.linearToSRGB(expectedColor);
                         } else {

--- a/sdk/tests/conformance2/rendering/blitframebuffer-scissor-enabled.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-scissor-enabled.html
@@ -62,7 +62,7 @@ if (!gl) {
         [0, 0, 2, 2], // No intersection with blitFramebuffer's dst region
     ];
 
-    // We can compute the real drawing area by intersecting the scissor bound with dst region of bliting.
+    // We can compute the real drawing area by intersecting the scissor bound with dst region of blitting.
     var intersections = [
         [2, 2, 4, 4],
         [0, 0, 0, 0],


### PR DESCRIPTION
Update the test cases. Any pixel lying outside of the read buffer, the corresponding dst pixel should remain untouched, instead of clamp_to_edge. 

I will merge this one with blitframebuffer-filter-outofbounds.html later (Or just remove this file if deqp has thoroughly tested the feature). This one test out-of-bounds too, but have tests to reversed src/dst, and pixels outside every edge the readbuffer, and so forth. 

PTAL. @zhenyao and @kenrussell . 

It turns out that this test can pass in Linux now, but fail in MacOSX. 