### PR TITLE
Add test for TexImage with bad internalformat/format/type combination

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
+++ b/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
@@ -51,6 +51,8 @@ var doTexImage = function(domElement) {
     gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, domElement);
     wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM, gl.INVALID_OPERATION], "TexImage2D taking RGB10_A2/RGBA/UNSIGNED_INT_2_10_10_10_REV should fail");
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG8, gl.RG, gl.FLOAT, domElement);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "TexImage2D taking RG8/RG/FLOAT should fail");
     gl.deleteTexture(tex);
 }
 


### PR DESCRIPTION
Generate INVLID_OPERATION error for test where each separate argument
is valid but their combination is invalid.