### PR TITLE
Add missing assertOK() in texImage2D.html

### DIFF
--- a/sdk/tests/conformance/more/functions/texImage2D.html
+++ b/sdk/tests/conformance/more/functions/texImage2D.html
@@ -73,7 +73,7 @@ Tests.testTexImage2D = function(gl) {
 }
 
 Tests.testTexImage2DNull = function(gl) {
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1,1,0,gl.RGBA,gl.UNSIGNED_BYTE, null);
+  assertOk(function(){gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1,1,0,gl.RGBA,gl.UNSIGNED_BYTE, null);});
 }
 
 Tests.endUnit = function(gl) {


### PR DESCRIPTION
Function assertOK() should be called in testTexImage2DNull, or the result
of the test will not be displayed on the webpage.