### PR TITLE
Reset active texture at the end of MultiTextureSamplerTest

### DIFF
--- a/sdk/tests/deqp/modules/shared/glsSamplerObjectTest.js
+++ b/sdk/tests/deqp/modules/shared/glsSamplerObjectTest.js
@@ -627,6 +627,10 @@ var deString = framework.delibs.debase.deString;
         }
     };
 
+    glsSamplerObjectTest.MultiTextureSamplerTest.prototype.deinit = function() {
+        gl.activeTexture(gl.TEXTURE0);
+    }
+
     glsSamplerObjectTest.MultiTextureSamplerTest.prototype.iterate = function() {
         //tcu::TestLog& log = m_testCtx.getLog();
 


### PR DESCRIPTION
Multi texture sampler test actives two texture binding points: TEXTURE0
and TEXTURE1. Reset active texture binding point to TEXTURE0 at the end
of each multi textrue sampler test. Otherwise, tests for 3d texture may
crash on Mac OSX.