### PR TITLE
ETC2/EAC not supported "by default" in WebGL 2

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3698,7 +3698,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
        COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2, COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2,
        COMPRESSED_RGBA8_ETC2_EAC, and COMPRESSED_SRGB8_ALPHA8_ETC2_EAC.
 
-    <p>These texture formats are not supported in WebGL 2.0.
+    <p>These texture formats are not supported by default in WebGL 2.0.
 
     <div class="note rationale">
         <p>These formats are not natively supported by most desktop GPU hardware.


### PR DESCRIPTION
@kenrussell 