### PR TITLE
Allow only std140 layout in tests and make it the default

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -32,6 +32,7 @@ texture-offset-out-of-range.html
 --min-version 2.0.1 texture-offset-uniform-texture-coordinate.html
 --min-version 2.0.1 tricky-loop-conditions.html
 --min-version 2.0.1 unary-minus-operator-in-dynamic-loop.html
+uniform-block-layouts.html
 uniform-location-length-limits.html
 vector-dynamic-indexing.html
 --min-version 2.0.1 vector-dynamic-indexing-nv-driver-bug.html

--- a/sdk/tests/conformance2/glsl3/uniform-block-layouts.html
+++ b/sdk/tests/conformance2/glsl3/uniform-block-layouts.html
@@ -1,0 +1,84 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Disallowed uniform block layouts</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderPackedUniformBlock" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+layout(packed) uniform foo {
+    vec4 bar;
+};
+
+void main() {
+    my_FragColor = bar;
+}
+</script>
+<script id="fshaderSharedUniformBlock" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+layout(shared) uniform foo {
+    vec4 bar;
+};
+
+void main() {
+    my_FragColor = bar;
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description("WebGL does not allow interface blocks with shared or packed layouts.");
+
+GLSLConformanceTester.runTests([
+{
+  fShaderId: 'fshaderPackedUniformBlock',
+  fShaderSuccess: false,
+  passMsg: 'Packed uniform buffers are disallowed'
+},
+{
+  fShaderId: 'fshaderSharedUniformBlock',
+  fShaderSuccess: false,
+  passMsg: 'Shared uniform buffers are disallowed'
+}
+], 2);
+</script>
+</body>
+</html>
+

--- a/sdk/tests/deqp/data/gles3/shaders/linkage.test
+++ b/sdk/tests/deqp/data/gles3/shaders/linkage.test
@@ -3682,46 +3682,9 @@ group uniform "Uniform linkage"
 			""
 		end
 
-		case layout_qualifier_mismatch_1
-			version 300 es
-			expect link_fail
-			vertex ""
-				#version 300 es
-
-				layout(std140) uniform Block
-				{
-					highp vec4 val;
-				};
-
-				${VERTEX_DECLARATIONS}
-				out mediump float res;
-				void main()
-				{
-					res = val.x;
-					${VERTEX_OUTPUT}
-				}
-			""
-			fragment ""
-				#version 300 es
-
-				uniform Block
-				{
-					highp vec4 val;
-				};
-
-				precision mediump float;
-				${FRAGMENT_DECLARATIONS}
-				in mediump float res;
-				void main()
-				{
-					dEQP_FragColor = vec4(val);
-				}
-			""
-		end
-
 		case layout_qualifier_mismatch_2
 			version 300 es
-			expect link_fail
+			expect compile_fail
 			vertex ""
 				#version 300 es
 

--- a/sdk/tests/deqp/functional/gles3/es3fUniformBlockTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fUniformBlockTests.js
@@ -710,8 +710,9 @@ goog.scope(function() {
          es3fUniformBlockTests.createRandomCaseGroup(randomGroup, 'nested_structs_instance_arrays', 'Nested structs, instance arrays, per-block buffers', glsUniformBlockCase.BufferMode.BUFFERMODE_PER_BLOCK, allShaders | allLayouts | unused | allBasicTypes | matFlags | glsRandomUniformBlockCase.FeatureBits.FEATURE_STRUCTS | glsRandomUniformBlockCase.FeatureBits.FEATURE_INSTANCE_ARRAYS, 25, 125);
          es3fUniformBlockTests.createRandomCaseGroup(randomGroup, 'nested_structs_arrays_instance_arrays', 'Nested structs, instance arrays, per-block buffers', glsUniformBlockCase.BufferMode.BUFFERMODE_PER_BLOCK, allShaders | allLayouts | unused | allBasicTypes | matFlags | glsRandomUniformBlockCase.FeatureBits.FEATURE_STRUCTS | glsRandomUniformBlockCase.FeatureBits.FEATURE_ARRAYS | glsRandomUniformBlockCase.FeatureBits.FEATURE_INSTANCE_ARRAYS, 25, 175);
 
-         es3fUniformBlockTests.createRandomCaseGroup(randomGroup, 'all_per_block_buffers', 'All random features, per-block buffers', glsUniformBlockCase.BufferMode.BUFFERMODE_PER_BLOCK, allFeatures, 50, 200);
-         es3fUniformBlockTests.createRandomCaseGroup(randomGroup, 'all_shared_buffer', 'All random features, shared buffer', glsUniformBlockCase.BufferMode.BUFFERMODE_SINGLE, allFeatures, 50, 250);
+         // Disabled: WebGL does not support shared or packed uniform buffers.
+         //es3fUniformBlockTests.createRandomCaseGroup(randomGroup, 'all_per_block_buffers', 'All random features, per-block buffers', glsUniformBlockCase.BufferMode.BUFFERMODE_PER_BLOCK, allFeatures, 50, 200);
+         //es3fUniformBlockTests.createRandomCaseGroup(randomGroup, 'all_shared_buffer', 'All random features, shared buffer', glsUniformBlockCase.BufferMode.BUFFERMODE_SINGLE, allFeatures, 50, 250);
          bufferedLogToConsole('ubo.random: Tests created');
     };
 

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3481,6 +3481,14 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         qualifiers will fail either the compilation or linking stages.
     </p>
 
+    <p>
+        The initial state of compilation is as if the following were declared:
+    </p>
+
+    <p><code>
+        layout(std140) uniform;
+    </p><code>
+
     <div class="note rationale">
         This restriction is enforced to improve portability by avoiding exposing uniform block
         layouts that are specific to one vendor's GPUs.


### PR DESCRIPTION
The spec is updated to mention that std140 layout is the initial
default for uniform blocks.

The tests are updated to expect compilation to fail when uniform block
layout is shared or packed. Some deqp tests that covered shared and
packed uniform buffers are removed from the suite. One linkage test
used to assume that the default layout would be shared, that one is
also removed.