### PR TITLE
Made views-with-offsets.html WebGL 2.0 only and fixed a couple of err…

### DIFF
--- a/sdk/tests/conformance2/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/misc/00_test_list.txt
@@ -3,3 +3,4 @@ getextension-while-pbo-bound-stability.html
 instanceof-test.html
 object-deletion-behaviour-2.html
 uninitialized-test-2.html
+views-with-offsets.html

--- a/sdk/tests/conformance2/misc/views-with-offsets.html
+++ b/sdk/tests/conformance2/misc/views-with-offsets.html
@@ -43,8 +43,7 @@
 description("Tests texture uploads with ArrayBufferView+offsets");
 
 var wtu = WebGLTestUtils;
-var contextVersion = wtu.getDefault3DContextVersion();
-var gl = wtu.create3DContext();
+var gl = wtu.create3DContext(null, undefined, 2);
 console.log(gl.getParameter(gl.VERSION));
 
 ////
@@ -93,12 +92,7 @@ var fb = gl.createFramebuffer();
 function probeWithBadOffset(fnTest, info) {
   fnTest(+(-1|0));
   if (!gl.getError()) {
-    var text = "Does not support " + info + " with offsets into views.";
-    if (contextVersion >= 2) {
-      testFailed(text);
-    } else {
-      testPassed("Warning: " + text);
-    }
+    testFailed("Does not support " + info + " with offsets into views.");
     return false;
   }
   return true;
@@ -135,11 +129,8 @@ do {
         wtu.glErrorShouldBe(gl, gl.NO_ERROR);
         shouldBeWasArr(testView.slice(i, i+4), readPixelView);
 
-      } else if (effectiveViewLen >= 0) {
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
-
       } else {
-        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
       }
     }
 
@@ -169,11 +160,8 @@ do {
         wtu.glErrorShouldBe(gl, gl.NO_ERROR);
         shouldBeWas(arr565[i], rgb888to565(readPixelView));
 
-      } else if (effectiveViewLen >= 0) {
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
-
       } else {
-        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
       }
     }
   }

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -797,7 +797,8 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
                                GLsizei width, GLsizei height, GLenum format, GLintptr offset);
   void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format,
-                               ArrayBufferView srcData, optional GLuint srcOffset = 0,
+                               ArrayBufferView srcData,
+                               optional GLuint srcOffset = 0,
                                optional GLuint srcLengthOverride = 0);
 
   void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
@@ -1833,7 +1834,9 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <p class="idl-code">
           void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                                     GLsizei width, GLsizei height, GLint border,
-                                    ArrayBufferView srcData, optional GLuint srcOffset = 0)
+                                    ArrayBufferView srcData,
+                                    optional GLuint srcOffset = 0,
+                                    optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexImage2D.xhtml" class="nonnormative">man page</a>)
@@ -1841,16 +1844,21 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         </p>
       <dd>
         <p>Reading from <code>srcData</code> begins <code>srcOffset</code> elements into
-           <code>srcData</code>. (Elements are bytes for Uint8Array, int32s for Int32Array, etc.)
-        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>,
-           generate INVALID_OPERATION.
+           <code>srcData</code>. (Elements are bytes for Uint8Array, int32s for Int32Array, etc.)</p>
+        <p>If <code>srcOffset</code> &gt; <code>srcData.length</code>, generates an INVALID_VALUE error.</p>
+        <p><code>srcLengthOverride</code> defaults to <code>srcData.length - srcOffset</code>.</p>
+        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>, or
+           if the amount of data passed in is not consistent with the format, dimensions, and
+           contents of the compressed image, generates an INVALID_VALUE error.</p>
       </dd>
       </dt>
       <dt>
         <p class="idl-code">
           void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                        GLsizei width, GLsizei height, GLenum format,
-                                       ArrayBufferView srcData, optional GLuint srcOffset = 0)
+                                       ArrayBufferView srcData,
+                                       optional GLuint srcOffset = 0,
+                                       optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexSubImage2D.xhtml" class="nonnormative">man page</a>)
@@ -1859,8 +1867,11 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       <dd>
         <p>Reading from <code>srcData</code> begins <code>srcOffset</code> elements into
            <code>srcData</code>. (Elements are bytes for Uint8Array, int32s for Int32Array, etc.)
-        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>,
-           generate INVALID_OPERATION.
+        <p>If <code>srcOffset</code> &gt; <code>srcData.length</code>, generates an INVALID_VALUE error.</p>
+        <p><code>srcLengthOverride</code> defaults to <code>srcData.length - srcOffset</code>.</p>
+        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>, or
+           if the amount of data passed in is not consistent with the format, dimensions, and
+           contents of the compressed image, generates an INVALID_VALUE error.</p>
       </dd>
       </dt>
 
@@ -1868,7 +1879,9 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <p class="idl-code">
           void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat,
                                     GLsizei width, GLsizei height, GLsizei depth, GLint border,
-                                    ArrayBufferView srcData, optional GLuint srcOffset = 0)
+                                    ArrayBufferView srcData,
+                                    optional GLuint srcOffset = 0,
+                                    optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexImage3D.xhtml" class="nonnormative">man page</a>)
@@ -1877,8 +1890,11 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       <dd>
         <p>Reading from <code>srcData</code> begins <code>srcOffset</code> elements into
            <code>srcData</code>. (Elements are bytes for Uint8Array, int32s for Int32Array, etc.)
-        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>,
-           generate INVALID_OPERATION.
+        <p>If <code>srcOffset</code> &gt; <code>srcData.length</code>, generates an INVALID_VALUE error.</p>
+        <p><code>srcLengthOverride</code> defaults to <code>srcData.length - srcOffset</code>.</p>
+        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>, or
+           if the amount of data passed in is not consistent with the format, dimensions, and
+           contents of the compressed image, generates an INVALID_VALUE error.</p>
       </dd>
       </dt>
       <dt>
@@ -1886,7 +1902,8 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
           void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                        GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                                        GLenum format, ArrayBufferView srcData,
-                                       optional GLuint srcOffset = 0)
+                                       optional GLuint srcOffset = 0,
+                                       optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexSubImage3D.xhtml" class="nonnormative">man page</a>)
@@ -1895,8 +1912,11 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       <dd>
         <p>Reading from <code>srcData</code> begins <code>srcOffset</code> elements into
            <code>srcData</code>. (Elements are bytes for Uint8Array, int32s for Int32Array, etc.)
-        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>,
-           generate INVALID_OPERATION.
+        <p>If <code>srcOffset</code> &gt; <code>srcData.length</code>, generates an INVALID_VALUE error.</p>
+        <p><code>srcLengthOverride</code> defaults to <code>srcData.length - srcOffset</code>.</p>
+        <p>If there's not enough data in <code>srcData</code> starting at <code>srcOffset</code>, or
+           if the amount of data passed in is not consistent with the format, dimensions, and
+           contents of the compressed image, generates an INVALID_VALUE error.</p>
       </dd>
       </dt>
       <p><strong>This section applies to the above four entry points.</strong></p>


### PR DESCRIPTION
…ors.

Added documentation for the srcLengthOverride argument to the
compressedTex*Image* entry points.

Follow-up to #2120.