### PR TITLE
Add a test to verify type mismatch

### DIFF
--- a/sdk/tests/conformance2/rendering/00_test_list.txt
+++ b/sdk/tests/conformance2/rendering/00_test_list.txt
@@ -15,6 +15,7 @@ draw-buffers.html
 element-index-uint.html
 framebuffer-completeness-unaffected.html
 framebuffer-unsupported.html
+--min-version 2.0.1 fs-color-type-mismatch-color-buffer-type.html
 instanced-arrays.html
 --min-version 2.0.1 instanced-rendering-bug.html
 out-of-bounds-index-buffers-after-copying.html

--- a/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
+++ b/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>The Color Type of Fragment Shader's Output Should Match The Type of Color Buffers</title>
+<title>The Color Types of Fragment Shader's Outputs Should Match The Data Types of Color Buffers</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
@@ -75,7 +75,7 @@ void main() {
 "use strict";
 
 var wtu = WebGLTestUtils;
-description("This test verifies that the color type of fragment shader's output should match color buffers' type.");
+description("This test verifies that the color types of fragment shader's outputs should match color buffers' types.");
 
 var gl = wtu.create3DContext("example", undefined, 2);
 
@@ -97,8 +97,8 @@ if (!gl) {
 
     init();
 
-    // COLOR_ATTACHMENT0 is fixed-point data, which can be convert to float.
-    // COLOR_ATTACHMENT1 is integer data. The fragment output data is float.
+    // COLOR_ATTACHMENT0 is fixed-point data, which can be converted to float.
+    // COLOR_ATTACHMENT1 is integer data. The fragment outputs are all float.
     allocate_textures();
     check_type_match();
     allocate_renderbuffers();
@@ -124,10 +124,10 @@ function init() {
     program1 = wtu.setupProgram(gl, ['vshader', 'fshaderMRT'], ['aPosition'], [0]);
     program2 = wtu.setupProgram(gl, ['vshader', 'fshaderRealMRT'], ['aPosition'], [0]);
     if (!program0 || !program1 || !program2) {
-        testFailed("Set up program failed");
+        testFailed("Failed to set up program");
         return;
     }
-    testPassed("Set up program succeeded");
+    testPassed("Succeed to set up program");
 
     wtu.setupUnitQuad(gl, 0, 1);
     gl.viewport(0, 0, width, height);
@@ -166,7 +166,7 @@ function rendering(draw_buffers, error) {
     }
 
     wtu.drawUnitQuad(gl);
-    wtu.glErrorShouldBe(gl, error, "If color buffers' type mismatch the type of fragment shader's output, geneate INVALID_OPERATION. Otherwise, it should be NO_ERROR");
+    wtu.glErrorShouldBe(gl, error, "If color buffers' type mismatch the type of fragment shader's outputs, geneate INVALID_OPERATION. Otherwise, it should be NO_ERROR");
 }
 
 gl.bindTexture(gl.TEXTURE_2D, null);

--- a/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
+++ b/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
@@ -83,7 +83,9 @@ var width = 8;
 var height = 8;
 var tex0;
 var tex1;
-var fbo;
+var rb0;
+var rb1;
+var fbo = gl.createFramebuffer();
 var program0;
 var program1;
 var program2;
@@ -97,19 +99,24 @@ if (!gl) {
 
     // COLOR_ATTACHMENT0 is fixed-point data, which can be convert to float.
     // COLOR_ATTACHMENT1 is integer data. The fragment output data is float.
-    allocate_resource();
+    allocate_textures();
+    check_type_match();
+    allocate_renderbuffers();
+    check_type_match();
+}
 
+function check_type_match() {
     gl.useProgram(program0);
-    check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
-    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.NO_ERROR);
+    rendering([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
+    rendering([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.NO_ERROR);
 
     gl.useProgram(program1);
-    check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
-    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
+    rendering([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
+    rendering([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
 
     gl.useProgram(program2);
-    check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
-    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
+    rendering([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
+    rendering([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
 }
 
 function init() {
@@ -126,10 +133,9 @@ function init() {
     gl.viewport(0, 0, width, height);
 }
 
-function allocate_resource() {
+function allocate_textures() {
     tex0 = gl.createTexture();
     tex1 = gl.createTexture();
-    fbo = gl.createFramebuffer();
     wtu.fillTexture(gl, tex0, width, height, [0xff, 0x0, 0x0, 0xff], 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.RGBA);
     wtu.fillTexture(gl, tex1, width, height, [0x0, 0xff, 0x0, 0xff], 0, gl.RGBA_INTEGER, gl.UNSIGNED_BYTE, gl.RGBA8UI);
 
@@ -138,7 +144,20 @@ function allocate_resource() {
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, tex1, 0);
 }
 
-function check_type_match(draw_buffers, error) {
+function allocate_renderbuffers() {
+    rb0 = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, rb0);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, width, height);
+    rb1 = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, rb1);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8UI, width, height);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rb0);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.RENDERBUFFER, rb1);
+}
+
+function rendering(draw_buffers, error) {
     gl.drawBuffers(draw_buffers);
 
     if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
@@ -151,10 +170,13 @@ function check_type_match(draw_buffers, error) {
 }
 
 gl.bindTexture(gl.TEXTURE_2D, null);
+gl.bindRenderbuffer(gl.RENDERBUFFER, null);
 gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 gl.useProgram(null);
 gl.deleteTexture(tex0);
 gl.deleteTexture(tex1);
+gl.deleteRenderbuffer(rb0);
+gl.deleteRenderbuffer(rb1);
 gl.deleteFramebuffer(fbo);
 gl.deleteProgram(program0);
 gl.deleteProgram(program1);

--- a/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
+++ b/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
@@ -1,0 +1,168 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>The Color Type of Fragment Shader's Output Should Match The Type of Color Buffers</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="8" height="8"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in highp vec4 aPosition;
+void main() {
+    gl_Position = aPosition;
+}
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 oColor;
+void main() {
+    oColor = vec4(1.0, 0.0, 0.0, 0.0);
+}
+</script>
+
+<script id="fshaderMRT" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 oColor[2];
+void main() {
+    oColor[0] = vec4(1.0, 0.0, 0.0, 0.0);
+}
+</script>
+
+<script id="fshaderRealMRT" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 oColor[2];
+void main() {
+    oColor[0] = vec4(1.0, 0.0, 0.0, 0.0);
+    oColor[1] = vec4(0.0, 1.0, 0.0, 0.0);
+}
+</script>
+
+<script>
+"use strict";
+
+var wtu = WebGLTestUtils;
+description("This test verifies that the color type of fragment shader's output should match color buffers' type.");
+
+var gl = wtu.create3DContext("example", undefined, 2);
+
+var width = 8;
+var height = 8;
+var tex0;
+var tex1;
+var fbo;
+var program0;
+var program1;
+var program2;
+
+if (!gl) {
+    testFailed("WebGL context does not exist");
+} else {
+    testPassed("WebGL context exists");
+
+    init();
+
+    // The sampling texture is bound to COLOR_ATTACHMENT1 during resource allocation
+    allocate_resource();
+
+    gl.useProgram(program0);
+    check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
+    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.NO_ERROR);
+    
+    gl.useProgram(program1);
+    check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
+    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.NO_ERROR);
+    
+    gl.useProgram(program2);
+    check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
+    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
+}
+
+function init() {
+    program0 = wtu.setupProgram(gl, ['vshader', 'fshader'], ['aPosition'], [0]);
+    program1 = wtu.setupProgram(gl, ['vshader', 'fshaderMRT'], ['aPosition'], [0]);
+    program2 = wtu.setupProgram(gl, ['vshader', 'fshaderRealMRT'], ['aPosition'], [0]);
+    if (!program0 || !program1 || !program2) {
+        testFailed("Set up program failed");
+        return;
+    }
+    testPassed("Set up program succeeded");
+
+    wtu.setupUnitQuad(gl, 0, 1);
+    gl.viewport(0, 0, width, height);
+}
+
+function allocate_resource() {
+    tex0 = gl.createTexture();
+    tex1 = gl.createTexture();
+    fbo = gl.createFramebuffer();
+    wtu.fillTexture(gl, tex0, width, height, [0xff, 0x0, 0x0, 0xff], 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.RGBA);
+    wtu.fillTexture(gl, tex1, width, height, [0x0, 0xff, 0x0, 0xff], 0, gl.RGBA_INTEGER, gl.UNSIGNED_BYTE, gl.RGBA8UI);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex0, 0);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, tex1, 0);
+}
+
+function check_type_match(draw_buffers, error) {
+    gl.drawBuffers(draw_buffers);
+
+    // Make sure framebuffer is complete before feedback loop detection
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer incomplete.");
+        return;
+    }
+
+    wtu.drawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, error, "If color buffers' type mismatch the type of fragment shader's output, geneate INVALID_OPERATION. Otherwise, it should be NO_ERROR");
+}
+
+gl.bindTexture(gl.TEXTURE_2D, null);
+gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+gl.useProgram(null);
+gl.deleteTexture(tex0);
+gl.deleteTexture(tex1);
+gl.deleteFramebuffer(fbo);
+gl.deleteProgram(program0);
+gl.deleteProgram(program1);
+gl.deleteProgram(program2);
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
+++ b/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
@@ -95,17 +95,18 @@ if (!gl) {
 
     init();
 
-    // The sampling texture is bound to COLOR_ATTACHMENT1 during resource allocation
+    // COLOR_ATTACHMENT0 is fixed-point data, which can be convert to float.
+    // COLOR_ATTACHMENT1 is integer data. The fragment output data is float.
     allocate_resource();
 
     gl.useProgram(program0);
     check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
     check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.NO_ERROR);
-    
+
     gl.useProgram(program1);
     check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
-    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.NO_ERROR);
-    
+    check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
+
     gl.useProgram(program2);
     check_type_match([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
     check_type_match([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
@@ -140,7 +141,6 @@ function allocate_resource() {
 function check_type_match(draw_buffers, error) {
     gl.drawBuffers(draw_buffers);
 
-    // Make sure framebuffer is complete before feedback loop detection
     if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
         testFailed("Framebuffer incomplete.");
         return;


### PR DESCRIPTION
@kenrussell and @zhenyao , PTAL. Thanks a lot! 

One more test case for undefined behavior in GLES3 spec, but we should generate INVALID_OPERATION in WebGL 2. 

Zhenyao has landed a patch to handle this issue at https://codereview.chromium.org/2142353002. But I didn't find a conformance test to cover this feature. So I wrote this one.