### PR TITLE
Fix a small bug in call sites to clearBuffer

### DIFF
--- a/sdk/tests/conformance2/reading/format-r11f-g11f-b10f.html
+++ b/sdk/tests/conformance2/reading/format-r11f-g11f-b10f.html
@@ -127,7 +127,7 @@ function setTolerance (testR, testG, testB, value) {
 function clearAndVerifyColor(width, height, testR, testG, testB, value) {
   var data = setupColor(testR, testG, testB, value);
   var tol = setTolerance(testR, testG, testB, value);
-  gl.clearBufferfv(gl.COLOR, gl.DRAWBUFFER0, data);
+  gl.clearBufferfv(gl.COLOR, 0, data);
   var buffer = new Float32Array(width * height * 4);
   gl.readPixels(0, 0, width, height, gl.RGBA, gl.FLOAT, buffer);
   for (var ii = 0; ii < width * height; ++ii) {
@@ -149,7 +149,7 @@ function clearDrawAndVerifyColor(fbo, program, testR, testG, testB, value) {
   debug("Testing : [" + data + "] with tolerance = [" + tol + "]");
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-  gl.clearBufferfv(gl.COLOR, gl.DRAWBUFFER0, data);
+  gl.clearBufferfv(gl.COLOR, 0, data);
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   gl.clearColor(0, 0, 0,1);


### PR DESCRIPTION
This is a typo: gl.DRAWBUFFER0 is meant to be gl.DRAW_BUFFER0. But we should use i, instead of DRAW_BUFFERi according to the spec. If we use the latter, it will report INVALID_ENUM. 

I felt weird why the original test can pass. So I dig a little into the code. It turned out that gl.DRAWBUFFER0 was undefined. So it was 0xNaN, which was thought to be 0 too... So it can pass by chance!

PTAL. Thanks a lot!