### PR TITLE
Add tests to verify that srgb conversion is done when it clears a srgb color buffer

### DIFF
--- a/sdk/tests/conformance2/rendering/00_test_list.txt
+++ b/sdk/tests/conformance2/rendering/00_test_list.txt
@@ -10,6 +10,7 @@ blitframebuffer-size-overflow.html
 blitframebuffer-test.html
 canvas-resizing-with-pbo-bound.html
 clear-func-buffer-type-match.html
+--min-version 2.0.1 clear-srgb-color-buffer.html
 --min-version 2.0.1 clipping-wide-points.html
 draw-buffers.html
 element-index-uint.html

--- a/sdk/tests/conformance2/rendering/clear-srgb-color-buffer.html
+++ b/sdk/tests/conformance2/rendering/clear-srgb-color-buffer.html
@@ -1,0 +1,131 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Clear sRGB Color Buffer</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<canvas id="example" width="8" height="8"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+"use strict";
+
+var wtu = WebGLTestUtils;
+description("This test verifies the functionality of clearing srgb color buffer.");
+
+var gl = wtu.create3DContext("example", undefined, 2);
+
+var tex = gl.createTexture();
+var fbo = gl.createFramebuffer();
+var size = 8;
+
+if (!gl) {
+    testFailed("WebGL context does not exist");
+} else {
+    testPassed("WebGL context exists");
+
+    // Create a srgb color buffer
+    init();
+
+    clear_srgb_color_buffer(0);
+    clear_srgb_color_buffer(1);
+}
+
+function checkPixel(color, expectedColor) {
+    var tolerance = 3;
+    return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
+            Math.abs(color[1] - expectedColor[1]) <= tolerance &&
+            Math.abs(color[2] - expectedColor[2]) <= tolerance &&
+            Math.abs(color[3] - expectedColor[3]) <= tolerance);
+}
+
+function init() {
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.SRGB8_ALPHA8, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer incomplete.");
+        return;
+    } else {
+        testPassed("framebuffer complete!");
+    }
+}
+
+function clear_srgb_color_buffer(iter) {
+    debug("");
+    debug("Clear sRGB color buffer through glClear or glClearBufferfv");
+
+    var color = [0x33, 0x88, 0xbb, 0xff];
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+
+    if (iter == 0) {
+        gl.clearColor(color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+    } else {
+        var data = new Float32Array([color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255]);
+        gl.clearBufferfv(gl.COLOR, 0, data);
+    }
+
+    // Read pixels and compare
+    var pixels = new Uint8Array(size * size * 4);
+    gl.readPixels(0, 0, size, size, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+    var color_ref = wtu.linearToSRGB(color);
+    for (var ii = 0; ii < size; ++ii) {
+        for (var jj = 0; jj < size; ++jj) {
+            var index = (ii * size + jj ) * 4;
+            var pix = [pixels[index], pixels[index + 1], pixels[index + 2], pixels[index + 3]];
+            if (checkPixel(pix, color_ref) == true) {
+                testPassed("pixel at [" + jj + ", " + ii + "] is (" + pix + "). It is correct!");
+            } else {
+                testFailed("pixel at [" + jj + ", " + ii + "] should be (" + color_ref + "), but the actual color is (" + pix + ")");
+            }
+        }
+    }
+}
+
+gl.bindTexture(gl.TEXTURE_2D, null);
+gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+gl.deleteTexture(tex);
+gl.deleteFramebuffer(fbo);
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
In GLES 3 spec, it explicitly says that the implementation should do srgb conversion when clear a srgb color buffer, see page 189 at section 4.2.3 <Clearing the Buffers>: https://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.2.3. 

However, the OGL spec may not. For example, in OGL 4.1 spec, the srgb conversion is not included by the per-fragment operations for clear buffer. See page 276 at section 4.2.3 <Clearing the Buffers>  : https://www.opengl.org/registry/doc/glspec41.core.20100725.pdf 

This behavior is consistent to other similar behaviors in OGL spec. For example, blitFramebuffer and generateMipmap against srgb color buffer may not do srgb conversion on OGL 4.3 profile or prior to OGL 4.3 profile.

I didn't find any test case covered this feature, so I wrote this test. 

However, the new test can pass on MacOS Intel (OGL 4.1). That's interesting...

PTAL. Thanks a lot!