### PR TITLE
Use existed function in WebGLTestUtil

### DIFF
--- a/sdk/tests/conformance2/rendering/blitframebuffer-filter-outofbounds.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-filter-outofbounds.html
@@ -54,7 +54,7 @@ function checkPixel(color, expectedColor) {
   return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
           Math.abs(color[1] - expectedColor[1]) <= tolerance &&
           Math.abs(color[2] - expectedColor[2]) <= tolerance &&
-          Math.abs(color[3] - expectedColor[3]) <= tolerance);;
+          Math.abs(color[3] - expectedColor[3]) <= tolerance);
 }
 
 function blitframebuffer_filter_outofbounds(readbufferFormat, drawbufferFormat, filter) {

--- a/sdk/tests/conformance2/rendering/blitframebuffer-filter-srgb.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-filter-srgb.html
@@ -53,7 +53,7 @@ function checkPixel(color, expectedColor) {
   return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
           Math.abs(color[1] - expectedColor[1]) <= tolerance &&
           Math.abs(color[2] - expectedColor[2]) <= tolerance &&
-          Math.abs(color[3] - expectedColor[3]) <= tolerance);;
+          Math.abs(color[3] - expectedColor[3]) <= tolerance);
 }
 
 var tex_read = gl.createTexture();

--- a/sdk/tests/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html
@@ -83,21 +83,6 @@ function blitframebuffer_helper(readbufferFormat, drawbufferFormat, filter) {
 
     gl.blitFramebuffer(0, 0, size, size, 0, 0, size, size, gl.COLOR_BUFFER_BIT, filter);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "blitframebuffer should succeed");
-
-    // Read pixels for comparison
-    var pixels = new Uint8Array(size * size * 4);
-    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo_blit);
-    gl.readPixels(0, 0, size, size, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "readpixels should succeed");
-    return pixels;
-}
-
-function checkPixel(color, expectedColor) {
-  var tolerance = 3;
-  return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
-          Math.abs(color[1] - expectedColor[1]) <= tolerance &&
-          Math.abs(color[2] - expectedColor[2]) <= tolerance &&
-          Math.abs(color[3] - expectedColor[3]) <= tolerance);;
 }
 
 function blitframebuffer_multisampled_readbuffer(readbufferFormat, drawbufferFormat, filter) {
@@ -124,24 +109,12 @@ function blitframebuffer_multisampled_readbuffer(readbufferFormat, drawbufferFor
     gl.useProgram(program);
     wtu.drawFloatColorQuad(gl, color);
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fb0);
-    var pixels = blitframebuffer_helper(readbufferFormat, drawbufferFormat, filter);
+    blitframebuffer_helper(readbufferFormat, drawbufferFormat, filter);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Blit from a multi-sampled srgb image to a srgb image should succeed");
 
     // Compare
-    var failed = false;
-    for (var ii = 0; ii < size; ++ii) {
-        for (var jj = 0; jj < size; ++jj) {
-            var index = (ii * size + jj) * 4;
-            var color = [pixels[index], pixels[index + 1], pixels[index + 2], pixels[index + 3]];
-            if (checkPixel(color, expectedColor) == false) {
-                failed = true;
-                debug("pixel at [" + jj + ", " + ii + "] should be (" + expectedColor + "), but the actual color is (" + color + ")");
-            }
-        }
-    }
-    if (failed == false) {
-        testPassed("All pixels comparision can pass!");
-    }
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo_blit);
+    wtu.checkCanvasRect(gl, 0, 0, size, size, expectedColor);
 }
 
 gl.bindTexture(gl.TEXTURE_2D, null);

--- a/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
@@ -53,7 +53,7 @@ function checkPixel(color, expectedColor) {
   return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
           Math.abs(color[1] - expectedColor[1]) <= tolerance &&
           Math.abs(color[2] - expectedColor[2]) <= tolerance &&
-          Math.abs(color[3] - expectedColor[3]) <= tolerance);;
+          Math.abs(color[3] - expectedColor[3]) <= tolerance);
 }
 
 function blitframebuffer_outside_readbuffer(readbufferFormat, drawbufferFormat) {

--- a/sdk/tests/conformance2/rendering/blitframebuffer-scissor-enabled.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-scissor-enabled.html
@@ -81,7 +81,7 @@ function checkPixel(color, expectedColor) {
   return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
           Math.abs(color[1] - expectedColor[1]) <= tolerance &&
           Math.abs(color[2] - expectedColor[2]) <= tolerance &&
-          Math.abs(color[3] - expectedColor[3]) <= tolerance);;
+          Math.abs(color[3] - expectedColor[3]) <= tolerance);
 }
 
 function blitframebuffer_scissor(readbufferFormat, drawbufferFormat, bound, intersection) {

--- a/sdk/tests/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html
@@ -218,7 +218,7 @@ function checkPixel(color, expectedColor) {
   return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
           Math.abs(color[1] - expectedColor[1]) <= tolerance &&
           Math.abs(color[2] - expectedColor[2]) <= tolerance &&
-          Math.abs(color[3] - expectedColor[3]) <= tolerance);;
+          Math.abs(color[3] - expectedColor[3]) <= tolerance);
 }
 
 var successfullyParsed = true;

--- a/sdk/tests/conformance2/rendering/clear-srgb-color-buffer.html
+++ b/sdk/tests/conformance2/rendering/clear-srgb-color-buffer.html
@@ -64,14 +64,6 @@ if (!gl) {
     clear_srgb_color_buffer(1);
 }
 
-function checkPixel(color, expectedColor) {
-    var tolerance = 3;
-    return (Math.abs(color[0] - expectedColor[0]) <= tolerance &&
-            Math.abs(color[1] - expectedColor[1]) <= tolerance &&
-            Math.abs(color[2] - expectedColor[2]) <= tolerance &&
-            Math.abs(color[3] - expectedColor[3]) <= tolerance);
-}
-
 function init() {
     gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.SRGB8_ALPHA8, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
@@ -100,22 +92,8 @@ function clear_srgb_color_buffer(iter) {
         gl.clearBufferfv(gl.COLOR, 0, data);
     }
 
-    // Read pixels and compare
-    var pixels = new Uint8Array(size * size * 4);
-    gl.readPixels(0, 0, size, size, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-
     var color_ref = wtu.linearToSRGB(color);
-    for (var ii = 0; ii < size; ++ii) {
-        for (var jj = 0; jj < size; ++jj) {
-            var index = (ii * size + jj ) * 4;
-            var pix = [pixels[index], pixels[index + 1], pixels[index + 2], pixels[index + 3]];
-            if (checkPixel(pix, color_ref) == true) {
-                testPassed("pixel at [" + jj + ", " + ii + "] is (" + pix + "). It is correct!");
-            } else {
-                testFailed("pixel at [" + jj + ", " + ii + "] should be (" + color_ref + "), but the actual color is (" + pix + ")");
-            }
-        }
-    }
+    wtu.checkCanvasRect(gl, 0, 0, size, size, color_ref);
 }
 
 gl.bindTexture(gl.TEXTURE_2D, null);


### PR DESCRIPTION
@kenrussell and @zhenyao  , per your request at #2127 , this small change use function in WebGLTestUtils (wtu.checkCanvasRect) to simplify the test. 

I also go through the similar usage, and found another one. The others still use a function to do pixels comparison, but they are not solid color, so they are not suitable to be replaced by wtu.checkCanvasRect. 

PTAL. Thanks a lot!