### PR TITLE
Add a proposal for WEBGL_multiview extension

### DIFF
--- a/extensions/proposals/WEBGL_multiview/extension.xml
+++ b/extensions/proposals/WEBGL_multiview/extension.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0"?>
+
+<proposal href="proposals/WEBGL_multiview/">
+  <name>WEBGL_multiview</name>
+  <contact>
+    <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)
+  </contact>
+  <contributors>
+    <contributor>Olli Etuaho, NVIDIA</contributor>
+    <contributor>Members of the WebGL working group</contributor>
+  </contributors>
+  <number>NN</number>
+  <depends>
+    <api version="2.0"/>
+  </depends>
+  <overview>
+
+    <h1>Proposed changes to the core WebGL specification</h1>
+
+    <p>These changes are written here in the extension document in order to facilitate discussion of the proposal. They are intended to be merged to the core WebGL specification and removed from here at a later date.</p>
+
+    <h2>The following is added to the WebGLRenderingContextBase interface:</h2>
+
+    <pre>
+    /* Stereo draw buffer selection */
+    const GLenum BACK_LEFT                      = 0x0402;
+    const GLenum BACK_RIGHT                     = 0x0403;
+
+    void drawBuffer(GLenum buf);
+    </pre>
+
+    <h2>The following is added to the WebGLContextAttributes dictionary:</h2>
+
+    <pre>
+    GLboolean stereo = false;
+    </pre>
+
+    <h2>The following is added to the section "Context creation parameters":</h2>
+
+    <dl>
+        <dt><span class="prop-value">stereo</span></dt>
+        <dd>
+          <p>If the value is true, the default framebuffer will consist of two buffers, one
+          intended to be presented to the user's left eye and one intended to be presented
+          to the user's right eye. These are called the left buffer and the right buffer.
+          Each buffer will have its own depth/stencil attachments.</p>
+
+          <p>Operations using the context as a source image only access the left buffer unless
+          explicitly stated otherwise. This includes read operations done by the WebGL API and
+          also operations done by other web APIs.</p>
+
+          <p>Monoscopic contexts display only the left buffer.</p>
+
+          <p>The buffer that is affected by pixel color writes can be set by calling
+          <code>drawBuffer</code>.</p>
+
+          <p>When stereo is true and the default framebuffer is bound, attempting to draw
+          using a shader that contains a static use of <code>gl_FragCoord</code> will generate an
+          <code>INVALID_OPERATION</code> error.</p>
+        </dd>
+    </dl>
+
+    <h2>The following is added to the API documentation under section "The WebGL context":</h2>
+
+    <h4><a name="drawbuffer">Selecting stereo buffers as a target for writes</a></h4>
+
+    <p>
+        Either the left or right buffer of the default stereo framebuffer can be chosen as a target for pixel color writes.
+    </p>
+
+    <dl class="methods">
+        <dt class="idl-code">void drawBuffer(GLenum buf)</dt>
+        <dd>
+            Indicating a buffer using <code>drawBuffer</code> causes subsequent pixel color value
+            writes to affect the indicated buffer of the default framebuffer.
+            <br /><br />
+
+            In the initial state the draw buffer is <code>BACK_LEFT</code>.
+            <br /><br />
+
+            If the actual context parameter <code>stereo</code> is false, an
+            <code>INVALID_OPERATION</code> error is generated.
+            <br /><br />
+
+            If <code>buf</code> is not <code>BACK_LEFT</code> or <code>BACK_RIGHT</code>, an
+            <code>INVALID_VALUE</code> error is generated.
+            <br /><br />
+
+            If a framebuffer object is bound as the draw framebuffer, an
+            <code>INVALID_OPERATION</code> error is generated.
+        </dd>
+    </dl>
+
+    <h2>The following is added to the section "Differences Between WebGL and OpenGL ES 2.0":</h2>
+
+    <h3>Stereo default framebuffer</h3>
+
+    <p>
+        WebGL adds the possibility to use a stereo default framebuffer and choose either the left or
+        the right buffer of the default framebuffer as the target for writes by adding the
+        <code>drawBuffer</code> entry point.
+    </p>
+
+    <div class="note rationale">
+        This enables efficient implementations of a WebVR display pipeline across VR devices, and adds
+        support for use cases where a WebGL canvas will be composited in stereo.
+    </div>
+
+    <h1>WEBGL_multiview extension</h1>
+
+    <mirrors href="https://www.opengl.org/registry/specs/OVR/multiview.txt" name="OVR_multiview">
+      <addendum>
+        Attempting to enable this extension when the <code>EXT_disjoint_timer_query_webgl2</code> extension is enabled generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        Attempting to enable the <code>EXT_disjoint_timer_query_webgl2</code> extension when this extension is enabled generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        When transform feedback is active, calling <code>framebufferTextureMultiviewWEBGL</code> generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        When transform feedback is active, calling <code>drawBuffer</code> with the <code>buf</code> parameter set to <code>BACK_LEFT_AND_RIGHT_MULTIVIEW_WEBGL</code> generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        When transform feedback is active, calling <code>bindFramebuffer</code> with a framebuffer parameter that has multi-view attachments generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        When transform feedback is active, calling <code>bindFramebuffer</code> to bind the default framebuffer when both the left and right buffers of the stereo default framebuffer are chosen for rendering generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        When a framebuffer with multi-view attachments is bound as the draw framebuffer, or the default framebuffer is bound as the draw framebuffer and both left and right buffers of the stereo default framebuffer are chosen for rendering, calling <code>beginTransformFeedback</code> generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        Calling <code>framebufferTextureMultiviewWEBGL</code> with a <code>texture</code> parameter that does not identify a 2D array texture generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        Calling <code>framebufferTextureMultiviewWEBGL</code> with the parameters set so that <code>baseViewIndex</code> + <code>numViews</code> is greater than the value of <code>MAX_ARRAY_TEXTURE_LAYERS</code> generates an <code>INVALID_VALUE</code> error.
+      </addendum>
+      <addendum>
+        If <code>baseViewIndex</code> + <code>numViews</code> is greater than the number of texture array elements in the texture bound to <code>target</code>, the framebuffer is considered incomplete. Calling getFramebufferStatus for a framebuffer in this state returns <code>FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR</code>.
+      </addendum>
+      <addendum>
+        Calling <code>drawBuffer</code> with the <code>buf</code> parameter set to <code>BACK_LEFT_AND_RIGHT_MULTIVIEW_WEBGL</code> chooses both the left and right buffers of the stereo default framebuffer for rendering. When both the left and right buffers are chosen for rendering, framebuffer writes will be done as if the framebuffer had two-layer texture arrays attached by <code>framebufferTextureMultiviewWEBGL</code>. The left buffer corresponds to <code>gl_ViewID_OVR</code> zero, and the right buffer corresponds to <code>gl_ViewID_OVR</code> one. If <code>drawBuffer</code> is called with the <code>buf</code> parameter set to either <code>BACK_LEFT</code> or <code>BACK_RIGHT</code>, only one of the stereo buffers will again be chosen for rendering.
+      </addendum>
+      <addendum>
+        Attempting to bind a framebuffer that has multi-view attachments to <code>READ_FRAMEBUFFER</code> generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        Although the extension name is prefixed with WEBGL the extension must be enabled with the
+        <code>#extension GL_OVR_multiview</code> directive, as shown in the sample code, to use
+        the extension in a shader.
+
+        Likewise the shading language preprocessor <code>#define GL_OVR_multiview</code>, will be defined to 1 if the extension is supported.
+      </addendum>
+      <addendum>
+        The maximum number of views can be queried by calling <code>getParameter</code> with the <code>pname</code> parameter set to <code>MAX_VIEWS_OVR</code>. The implementation must support at least 2 views.
+      </addendum>
+      <addendum>
+        Two levels of acceleration are exposed through alternative extension directives: <code>GL_OVR_multiview</code> and <code>GL_OVR_multiview2</code>. Using <code>GL_OVR_multiview</code> instead of <code>GL_OVR_multiview2</code> restricts what can be done in shaders but may enable the WebGL implementation to accelerate multiview rendering using fixed-function hardware specifically designed for this purpose.
+      </addendum>
+      <addendum>
+        <p>
+        Attempting to compile a vertex shader that enables the <code>GL_OVR_multiview</code> extension where other outputs than <code>gl_Position.x</code> depend on <code>gl_ViewID_OVR</code> must result in a compile error. This must be checked according to the following rules:
+        </p>
+        <ul>
+            <li><code>gl_ViewID_OVR</code> may be used on the right hand side of assignment to <code>gl_Position.x</code>. The right hand side of assignment to <code>gl_Position.x</code> that statically references <code>gl_ViewID_OVR</code> is not allowed to contain any sub-expressions that require an l-value, such as assignment, increment or decrement. Such right-hand side of assignment is also not allowed to call 1) any user-defined functions or 2) built-in functions that may have side effects visible in the shader.</li>
+            <li><code>gl_ViewID_OVR</code> may also be used in if statement conditions, where the condition is an equality comparison between <code>gl_ViewID_OVR</code> and a literal integer. The if or else branch of such an if statement may only contain one assignment to <code>gl_Position.x</code>. The right hand side of this assignment is not allowed to contain any sub-expressions that require an l-value, such as assignment, increment or decrement. Such right-hand side of assignment is also not allowed to call 1) any user-defined functions or 2) built-in functions that may have side effects visible in the shader.</li>
+            <li>Any other static use of <code>gl_ViewID_OVR</code> is disallowed.</li>
+            <li>If <code>gl_ViewID_OVR</code> is used in a vertex shader, it may not statically read <code>gl_Position</code>.</li>
+        </ul>
+        <p>
+        These restrictions exist to make the extension fully compatible with all possible underlying hardware acceleration extensions like <code>GL_NV_stereo_view_rendering</code>.
+        </p>
+      </addendum>
+      <addendum>
+        Attempting to compile a fragment shader that enables the <code>GL_OVR_multiview</code> extension must result in a compile error in the following cases:
+        <ul>
+          <li>The fragment shader references <code>gl_ViewID_OVR</code>.</li>
+          <li>The fragment shader references <code>gl_FragCoord</code> or any other built-in variables whose value depends on the fragment.</li>
+        </ul>
+      </addendum>
+      <addendum>
+        When linking vertex and fragment shaders, <code>GL_OVR_multiview</code> or <code>GL_OVR_multiview2</code> extension directives must match. Otherwise, linking results in a link error.
+      </addendum>
+      <addendum>
+        Attempting to enable both <code>GL_OVR_multiview</code> and <code>GL_OVR_multiview2</code> in the same shader results in a compile error.
+      </addendum>
+    </mirrors>
+    <features>
+      <feature>
+        Adds support for rendering into multiple views simultaneously.
+      </feature>
+    </features>
+  </overview>
+  <idl xml:space="preserve">
+[NoInterfaceObject]
+interface WEBGL_multiview {
+    const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630;
+    const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632;
+    const GLenum MAX_VIEWS_OVR = 0x9631;
+    const GLenum FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633;
+
+    const GLenum BACK_LEFT_AND_RIGHT_MULTIVIEW_WEBGL = 0x0405;  // TODO: This is now the same as GL_BACK in GLES. Should probably be something else.
+
+    void framebufferTextureMultiviewWEBGL(GLenum target, GLenum attachment, GLuint texture, GLint level, GLint baseViewIndex, GLsizei numViews);
+};
+  </idl>
+  <samplecode xml:space="preserve">
+    <pre>
+    #version 300 es
+    #extension GL_OVR_multiview : require
+    precision mediump float;
+    layout (num_views = 2) in;
+    in vec4 inPos;
+    uniform mat4 u_viewMatrix0;
+    uniform mat4 u_viewMatrix1;
+    void main() {
+        gl_Position.x = (gl_ViewID_OVR == 0 ? u_viewMatrix0 * inPos : u_viewMatrix1 * inPos).x;
+        gl_Position.yzw = (u_viewMatrix0 * inPos).yzw;
+    }
+    </pre>
+  </samplecode>
+  <history>
+    <revision date="2016/11/11">
+      <change>Initial revision.</change>
+    </revision>
+  </history>
+</proposal>


### PR DESCRIPTION
The extension document contains a proposal to amend the WebGL 1.0
specification to include optional stereo rendering capability. In case
the actual context parameter "stereo" is set to true, the default
framebuffer will have left and right buffers, and the user may
choose either left or right draw buffer of the default framebuffer as
a target of pixel color writes.

The intent is that the stereo default framebuffer can be used as a
VRLayer source in the WebVR API. The backing for stereo default
framebuffers should be possible to implement so that the framebuffer
may be submitted for display using a VR headset API with zero copies
in between. Since the exact layout of the framebuffer is not exposed
to the WebGL API, the WebGL implementation may choose a layout that
is suitable for the API provided by the connected headset. The case
where there are multiple connected headsets should be rare, but if it
happens, the implementation may also switch the layout of the default
framebuffer behind the scenes depending on which headset the
framebuffer was last displayed on.

The WEBGL_multiview extension itself is built on OVR_multiview to
enable more efficient stereo rendering.

WEBGL_multiview could be implemented either only inside the browser to
reduce overhead in high-level code, or all the way down to hardware
that supports native stereo acceleration.