### PR TITLE
Test 3d texture sub-source uploads from ImageData

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
@@ -99,9 +99,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultiplyAlpha);
         // Upload the image into the texture
         // Initialize the texture to black first
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], imageData.width, imageData.height, 1 /* depth */, 0,
-                      gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], imageData);
+        var uploadWidth = imageData.width;
+        var uploadHeight = imageData.height;
+        var depth = 1;
+        gl.texImage3D(bindingTarget, 0, gl[internalFormat], uploadWidth, uploadHeight, depth, 0, gl[pixelFormat], gl[pixelType], null);
+        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, uploadWidth, uploadHeight, depth, gl[pixelFormat], gl[pixelType], imageData);
 
         var width = gl.canvas.width;
         var halfWidth = Math.floor(width / 2);

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
@@ -117,7 +117,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             }
 
             // Initialize the texture to black first
-            gl.texImage3D(bindingTarget, 0, gl[internalFormat], uploadWidth, uploadHeight, depth, 0,
+            gl.texImage3D(bindingTarget, 0, gl[internalFormat], uploadWidth, allocatedHeight, depth, 0,
                           gl[pixelFormat], gl[pixelType], null);
             gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, uploadWidth, uploadHeight, depth,
                              gl[pixelFormat], gl[pixelType], imageData);
@@ -185,8 +185,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     }
 
     function simulate(flipY, premultiplyAlpha, depth, sourceSubRectangle, rTexCoord, unpackImageHeight) {
-        // NOTE: depth and unpackImageHeight are not actually simulated, so
-        // new test cases with different values may not actually work.
         var ro = [255, 0, 0];   var rt = premultiplyAlpha ? [0, 0, 0] : [255, 0, 0];
         var go = [0, 255, 0];   var gt = premultiplyAlpha ? [0, 0, 0] : [0, 255, 0];
         var bo = [0, 0, 255];   var bt = premultiplyAlpha ? [0, 0, 0] : [0, 0, 255];
@@ -241,17 +239,16 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             [0, 0, 2, 4],
             [2, 0, 2, 4],
         ];
-        // NOTE: depth and unpackImageHeight are not actually simulated, so
-        // new test cases with different values may not actually work.
-        var dbg = true;
+        var dbg = false;  // Set to true for debug output images
         if (dbg) {
             (function() {
+                debug("");
                 debug("Original ImageData (transparent pixels appear black):");
                 var cvs = document.createElement("canvas");
                 cvs.width = 4;
                 cvs.height = 4;
-                cvs.style.width = "64px";
-                cvs.style.height = "64px";
+                cvs.style.width = "32px";
+                cvs.style.height = "32px";
                 cvs.style.imageRendering = "pixelated";
                 cvs.style.background = "#000";
                 var ctx = cvs.getContext("2d");
@@ -265,8 +262,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                 for (const premul of [false, true]) {
                     for (let irect = 0; irect < rects.length; irect++) {
                         var rect = rects[irect];
-                        for (let rTexCoord = 0; rTexCoord < (rect ? 2 : 1); rTexCoord++) {
-                            let depth = rect ? 2 : 1;
+                        let depth = rect ? 2 : 1;
+                        for (let rTexCoord = 0; rTexCoord < depth; rTexCoord++) {
                             let unpackImageHeight = rect ? 2 : 0;
                             runOneIteration(sub, flipY, premul, bindingTarget,
                                     depth, rect, rTexCoord, unpackImageHeight,

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
@@ -28,8 +28,17 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var successfullyParsed = false;
     var imageData = null;
     var blackColor = [0, 0, 0];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
+    var originalPixels = (function() {
+        // (red|green|blue|cyan)(opaque|transparent)
+        var ro = [255, 0, 0, 255]; var rt = [255, 0, 0, 0];
+        var go = [0, 255, 0, 255]; var gt = [0, 255, 0, 0];
+        var bo = [0, 0, 255, 255]; var bt = [0, 0, 255, 0];
+        var co = [0, 255, 255, 255]; var ct = [0, 255, 255, 0];
+        return [ro, rt, go, gt,
+                ro, rt, go, gt,
+                bo, bt, co, ct,
+                bo, bt, co, ct];
+    })();
 
     function init()
     {
@@ -44,47 +53,34 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
-        switch (gl[pixelFormat]) {
-          case gl.RED:
-          case gl.RED_INTEGER:
-            greenColor = [0, 0, 0];
-            break;
-          default:
-            break;
-        }
-
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
         gl.disable(gl.BLEND);
 
         var canvas2d = document.getElementById("texcanvas");
         var context2d = canvas2d.getContext("2d");
-        imageData = context2d.createImageData(2, 2);
+        imageData = context2d.createImageData(4, 4);
         var data = imageData.data;
-        data[0] = 255;
-        data[1] = 0;
-        data[2] = 0;
-        data[3] = 255;
-        data[4] = 255;
-        data[5] = 0;
-        data[6] = 0;
-        data[7] = 0;
-        data[8] = 0;
-        data[9] = 255;
-        data[10] = 0;
-        data[11] = 255;
-        data[12] = 0;
-        data[13] = 255;
-        data[14] = 0;
-        data[15] = 0;
+        for (var i = 0; i < originalPixels.length; i++) {
+            data.set(originalPixels[i], 4 * i);
+        }
 
         runTest();
     }
 
-    function runOneIteration(flipY, premultiplyAlpha, bindingTarget, program)
+    function runOneIteration(useTexSubImage3D, flipY, premultiplyAlpha, bindingTarget,
+                             depth, sourceSubRectangle, unpackImageHeight, program)
     {
-        debug('Testing ' + ' with flipY=' + flipY + ' and premultiplyAlpha=' + premultiplyAlpha +
-              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY'));
+        var expected = simulate(flipY, premultiplyAlpha, depth, sourceSubRectangle, unpackImageHeight);
+        var sourceSubRectangleString = '';
+        if (sourceSubRectangle) {
+            sourceSubRectangleString = ', sourceSubRectangle=' + sourceSubRectangle;
+        }
+        debug('');
+        debug('Testing ' + (useTexSubImage3D ? 'texSubImage3D' : 'texImage3D') +
+              ' with flipY=' + flipY + ', premultiplyAlpha=' + premultiplyAlpha +
+              ', bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY') +
+              sourceSubRectangleString);
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Enable writes to the RGBA channels
         gl.colorMask(1, 1, 1, 0);
@@ -94,41 +90,74 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         // Set up texture parameters
         gl.texParameteri(bindingTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
         gl.texParameteri(bindingTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(bindingTarget, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE);
         // Set up pixel store parameters
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, flipY);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, premultiplyAlpha);
-        // Upload the image into the texture
-        // Initialize the texture to black first
+        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
         var uploadWidth = imageData.width;
         var uploadHeight = imageData.height;
-        var depth = 1;
-        gl.texImage3D(bindingTarget, 0, gl[internalFormat], uploadWidth, uploadHeight, depth, 0, gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, uploadWidth, uploadHeight, depth, gl[pixelFormat], gl[pixelType], imageData);
+        if (sourceSubRectangle) {
+            gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, sourceSubRectangle[0]);
+            gl.pixelStorei(gl.UNPACK_SKIP_ROWS, sourceSubRectangle[1]);
+            uploadWidth = sourceSubRectangle[2];
+            uploadHeight = sourceSubRectangle[3];
+        }
+        // Upload the image into the texture
+        if (useTexSubImage3D) {
+            var allocatedHeight = uploadHeight;
+            if (unpackImageHeight) {
+                allocatedHeight = unpackImageHeight;
+            }
+
+            // Initialize the texture to black first
+            gl.texImage3D(bindingTarget, 0, gl[internalFormat], uploadWidth, uploadHeight, depth, 0,
+                          gl[pixelFormat], gl[pixelType], null);
+            gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, uploadWidth, uploadHeight, depth,
+                             gl[pixelFormat], gl[pixelType], imageData);
+        } else {
+            gl.texImage3D(bindingTarget, 0, gl[internalFormat], uploadWidth, uploadHeight, depth, 0,
+                          gl[pixelFormat], gl[pixelType], imageData);
+        }
+        gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, 0);
+        gl.pixelStorei(gl.UNPACK_SKIP_ROWS, 0);
+        gl.pixelStorei(gl.UNPACK_IMAGE_HEIGHT, 0);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from texture upload");
+
+        var tl = expected[0][0];
+        var tr = expected[0][1];
+        var bl = expected[1][0];
+        var br = expected[1][1];
+
+        // Draw the triangles
+        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
 
         var width = gl.canvas.width;
         var halfWidth = Math.floor(width / 2);
         var height = gl.canvas.height;
         var halfHeight = Math.floor(height / 2);
 
-        var top = flipY ? 0 : (height - halfHeight);
-        var bottom = flipY ? (height - halfHeight) : 0;
+        var top = 0;
+        var bottom = height - halfHeight;
+        var left = 0;
+        var right = width - halfWidth;
 
-        var tl = redColor;
-        var tr = premultiplyAlpha ? blackColor : redColor;
-        var bl = greenColor;
-        var br = premultiplyAlpha ? blackColor : greenColor;
-
-        // Draw the triangles
-        wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
-
-        // Check the top pixel and bottom pixel and make sure they have
-        // the right color.
-        debug("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, 0, bottom, halfWidth, halfHeight, tl, "shouldBe " + tl);
-        wtu.checkCanvasRect(gl, halfWidth, bottom, width, halfHeight, tr, "shouldBe " + tr);
-        debug("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, 0, top, halfWidth, halfHeight, bl, "shouldBe " + bl);
-        wtu.checkCanvasRect(gl, halfWidth, top, width, halfHeight, br, "shouldBe " + br);
+        debug("Checking pixel values");
+        debug("Expecting: " + expected);
+        var expectedH = expected.length;
+        var expectedW = expected[0].length;
+        var texelH = Math.floor(gl.canvas.height / expectedH);
+        var texelW = Math.floor(gl.canvas.width / expectedW);
+        for (var row = 0; row < expectedH; row++) {
+            var y = row * texelH;
+            for (var col = 0; col < expectedW; col++) {
+                var x = col * texelW;
+                var val = expected[row][col];
+                wtu.checkCanvasRect(gl, x, y, texelW, texelH, val, "should be " + val);
+            }
+        }
     }
 
     function runTest()
@@ -138,21 +167,104 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
         runTestOnBindingTarget(gl.TEXTURE_2D_ARRAY, program);
 
+        debug("");
         wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
         finishTest();
     }
 
-    function runTestOnBindingTarget(bindingTarget, program) {
-        var cases = [
-            { flipY: true, premultiplyAlpha: false },
-            { flipY: false, premultiplyAlpha: false },
-            { flipY: true, premultiplyAlpha: true },
-            { flipY: false, premultiplyAlpha: true },
-        ];
+    function simulate(flipY, premultiplyAlpha, depth, sourceSubRectangle, unpackImageHeight) {
+        var ro = [255, 0, 0];   var rt = premultiplyAlpha ? [0, 0, 0] : [255, 0, 0];
+        var go = [0, 255, 0];   var gt = premultiplyAlpha ? [0, 0, 0] : [0, 255, 0];
+        var bo = [0, 0, 255];   var bt = premultiplyAlpha ? [0, 0, 0] : [0, 0, 255];
+        var co = [0, 255, 255]; var ct = premultiplyAlpha ? [0, 0, 0] : [0, 255, 255];
+        var expected = [[ro, rt, go, gt],
+                        [ro, rt, go, gt],
+                        [bo, bt, co, ct],
+                        [bo, bt, co, ct]];
+        switch (gl[pixelFormat]) {
+          case gl.RED:
+          case gl.RED_INTEGER:
+            for (var row = 0; row < 4; row++) {
+                for (var col = 0; col < 4; col++) {
+                    expected[row][col][1] = 0; // zero the green channel
+                }
+            }
+            // fall-through
+          case gl.RG:
+          case gl.RG_INTEGER:
+            for (var row = 0; row < 4; row++) {
+                for (var col = 0; col < 4; col++) {
+                    expected[row][col][2] = 0; // zero the blue channel
+                }
+            }
+            break;
+          default:
+            break;
+        }
+        var expected2;
+        if (flipY) {
+            expected2 = [];
+            for (var row = 0; row < 4; row++) {
+                expected2[row] = expected[3 - row];
+            }
+        } else {
+            expected2 = expected;
+        }
+        expected = expected2;
+        if (sourceSubRectangle) {
+            expected2 = [];
+            for (var row = 0; row < sourceSubRectangle[3]; row++) {
+                expected2[row] = [];
+                for (var col = 0; col < sourceSubRectangle[2]; col++) {
+                    expected2[row][col] =
+                        expected[sourceSubRectangle[1] + row][sourceSubRectangle[0] + col];
+                }
+            }
+        }
+        expected = expected2;
+        return expected;
+    }
 
-        for (var i in cases) {
-            runOneIteration(cases[i].flipY, cases[i].premultiplyAlpha,
-                            bindingTarget, program);
+    function runTestOnBindingTarget(bindingTarget, program) {
+        var rects = [
+            [0, 0, 2, 4],
+            [2, 0, 2, 4],
+        ];
+        var depth = 2;
+        var unpackImageHeight = 2;
+        var dbg = false;
+        if (dbg) {
+            (function() {
+                debug("Original ImageData:");
+                var cvs = document.createElement("canvas");
+                cvs.width = 4;
+                cvs.height = 4;
+                cvs.style.width = "64px";
+                cvs.style.height = "64px";
+                cvs.style.imageRendering = "pixelated";
+                cvs.style.background = "#000";
+                var ctx = cvs.getContext("2d");
+                ctx.putImageData(imageData, 0, 0);
+                var output = document.getElementById("console");
+                output.appendChild(cvs);
+            })();
+        }
+        for (const sub of [false, true]) {
+            for (const flipY of [false, true]) {
+                for (const premul of [false, true]) {
+                    for (var irect = 0; irect < rects.length; irect++) {
+                        var rect = rects[irect];
+                        runOneIteration(sub, flipY, premul, bindingTarget, depth, rect, unpackImageHeight, program);
+                        if (dbg) {
+                            debug("Actual:");
+                            var img = document.createElement("img");
+                            img.src = gl.canvas.toDataURL("image/png");
+                            var output = document.getElementById("console");
+                            output.appendChild(img);
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-data.js
@@ -150,6 +150,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var expectedW = expected[0].length;
         var texelH = Math.floor(gl.canvas.height / expectedH);
         var texelW = Math.floor(gl.canvas.width / expectedW);
+        // For each entry of the expected[][] array, check the appropriate
+        // canvas rectangle for correctness.
         for (var row = 0; row < expectedH; row++) {
             var y = row * texelH;
             for (var col = 0; col < expectedW; col++) {
@@ -173,6 +175,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     }
 
     function simulate(flipY, premultiplyAlpha, depth, sourceSubRectangle, unpackImageHeight) {
+        // NOTE: depth and unpackImageHeight are not actually simulated, so
+        // new test cases with different values may not actually work.
         var ro = [255, 0, 0];   var rt = premultiplyAlpha ? [0, 0, 0] : [255, 0, 0];
         var go = [0, 255, 0];   var gt = premultiplyAlpha ? [0, 0, 0] : [0, 255, 0];
         var bo = [0, 0, 255];   var bt = premultiplyAlpha ? [0, 0, 0] : [0, 0, 255];
@@ -229,7 +233,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var rects = [
             [0, 0, 2, 4],
             [2, 0, 2, 4],
+            [0, 2, 4, 2],
         ];
+        // NOTE: depth and unpackImageHeight are not actually simulated, so
+        // new test cases with different values may not actually work.
         var depth = 2;
         var unpackImageHeight = 2;
         var dbg = false;
@@ -254,7 +261,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                 for (const premul of [false, true]) {
                     for (var irect = 0; irect < rects.length; irect++) {
                         var rect = rects[irect];
-                        runOneIteration(sub, flipY, premul, bindingTarget, depth, rect, unpackImageHeight, program);
+                        runOneIteration(sub, flipY, premul, bindingTarget,
+                                depth, rect, unpackImageHeight, program);
                         if (dbg) {
                             debug("Actual:");
                             var img = document.createElement("img");


### PR DESCRIPTION
(And replace the tests for obsolete entry points.)

I pretty much rewrote the whole test, sorry for the huge diff. I think it runs reasonably fast despite being pretty thorough.

Verified in Chromium: https://codereview.chromium.org/2500433003