### PR TITLE
Fixed tests uploading canvases to textures via texSubImage3D.

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-canvas.js
@@ -129,7 +129,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         // Initialize the texture to black first
         gl.texImage3D(bindingTarget, 0, gl[internalFormat], canvas.width, canvas.height, 1 /* depth */, 0,
                       gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], canvas);
+        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, canvas.width, canvas.height, 1 /* depth */,
+                         gl[pixelFormat], gl[pixelType], canvas);
 
         var width = gl.canvas.width;
         var height = gl.canvas.height;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-webgl-canvas.js
@@ -113,7 +113,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         // Initialize the texture to black first
         gl.texImage3D(bindingTarget, 0, gl[internalFormat], canvas.width, canvas.height, 1 /* depth */, 0,
                       gl[pixelFormat], gl[pixelType], null);
-        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, gl[pixelFormat], gl[pixelType], canvas);
+        gl.texSubImage3D(bindingTarget, 0, 0, 0, 0, canvas.width, canvas.height, 1 /* depth */,
+                         gl[pixelFormat], gl[pixelType], canvas);
 
         var width = gl.canvas.width;
         var height = gl.canvas.height;


### PR DESCRIPTION
These were using an obsolete function signature.