### PR TITLE
add test cases for webgl-draw-buffers-ext to detect feedback loop

### DIFF
--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -33,6 +33,7 @@ webgl-debug-shaders.html
 --min-version 1.0.3 webgl-compressed-texture-size-limit.html
 --min-version 1.0.2 --max-version 1.9.9 webgl-depth-texture.html
 --min-version 1.0.3 --max-version 1.9.9 webgl-draw-buffers.html
+--min-version 1.0.3 --max-version 1.9.9 webgl-draw-buffers-feedback-loop.html
 --min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-framebuffer-unsupported.html
 --min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-max-draw-buffers.html
 --min-version 1.0.3 webgl-shared-resources.html

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers-feedback-loop.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers-feedback-loop.html
@@ -1,0 +1,161 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Rendering and Sampling Feedback Loop Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="8" height="8"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script id="vshader" type="x-shader/x-vertex">
+attribute vec4 aPosition;
+attribute vec2 aTexCoord;
+varying vec2 texCoord;
+void main() {
+    gl_Position = aPosition;
+    texCoord = aTexCoord;
+}
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">
+#extension GL_EXT_draw_buffers : require
+precision mediump float;
+uniform sampler2D tex;
+varying vec2 texCoord;
+void main() {
+    gl_FragData[0] = texture2D(tex, texCoord);
+    gl_FragData[1] = texture2D(tex, texCoord);
+}
+</script>
+
+<script>
+"use strict";
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("example");
+description("This test verifies the functionality of rendering to the same texture where it samples from.");
+
+var gl = wtu.create3DContext(canvas);
+
+var width = 8;
+var height = 8;
+var tex0;
+var tex1;
+var fbo;
+var program;
+var positionLoc;
+var texCoordLoc;
+
+if (!gl) {
+    testFailed("WebGL context does not exist");
+} else {
+    testPassed("WebGL context exists");
+  
+    var ext = gl.getExtension("WEBGL_draw_buffers");
+    if (!ext) {
+        testPassed("No WEBGL_draw_buffers support -- this is legal");
+
+        runSupportedTest(false);
+        finishTest();
+    } else {
+        testPassed("Successfully enabled WEBGL_draw_buffers extension");
+
+        init();
+
+        // The sampling texture is bound to COLOR_ATTACHMENT1 during resource allocation
+        allocate_resource();
+
+        rendering_sampling_feedback_loop([gl.NONE, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
+        rendering_sampling_feedback_loop([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
+        rendering_sampling_feedback_loop([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
+    }
+}
+
+function init() {
+    program = wtu.setupProgram(gl, ['vshader', 'fshader'], ['aPosition', 'aTexCoord'], [0, 1]);
+    positionLoc = gl.getAttribLocation(program, "aPosition");
+    texCoordLoc = gl.getAttribLocation(program, "aTexCoord");
+    if (!program || positionLoc < 0 || texCoordLoc < 0) {
+        testFailed("Set up program failed");
+        return;
+    }
+    testPassed("Set up program succeeded");
+
+    wtu.setupUnitQuad(gl, 0, 1);
+    gl.viewport(0, 0, width, height);
+}
+
+function allocate_resource() {
+    tex0 = gl.createTexture();
+    tex1 = gl.createTexture();
+    fbo = gl.createFramebuffer();
+    wtu.fillTexture(gl, tex0, width, height, [0xff, 0x0, 0x0, 0xff], 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.RGBA);
+    wtu.fillTexture(gl, tex1, width, height, [0x0, 0xff, 0x0, 0xff], 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.RGBA);
+
+    gl.bindTexture(gl.TEXTURE_2D, tex1);
+    var texLoc = gl.getUniformLocation(program, "tex");
+    gl.uniform1i(texLoc, 0);
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex0, 0);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, tex1, 0);
+}
+
+function rendering_sampling_feedback_loop(draw_buffers, error) {
+    // gl.drawBuffers(draw_buffers);
+    ext.drawBuffersWEBGL(draw_buffers);
+
+    // Make sure framebuffer is complete before feedback loop detection
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer incomplete.");
+        return;
+    }
+
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, error, "Rendering to a texture where it samples from should geneates INVALID_OPERATION. Otherwise, it should be NO_ERROR");
+}
+
+gl.bindTexture(gl.TEXTURE_2D, null);
+gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+gl.deleteTexture(tex0);
+gl.deleteTexture(tex1);
+gl.deleteFramebuffer(fbo);
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers-feedback-loop.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers-feedback-loop.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL Rendering and Sampling Feedback Loop Tests</title>
+<title>WebGL Rendering and Sampling Feedback Loop Tests For WEBGL_draw_buffers Extension</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
@@ -82,7 +82,7 @@ if (!gl) {
     testFailed("WebGL context does not exist");
 } else {
     testPassed("WebGL context exists");
-  
+
     var ext = gl.getExtension("WEBGL_draw_buffers");
     if (!ext) {
         testPassed("No WEBGL_draw_buffers support -- this is legal");


### PR DESCRIPTION
Copy the rendering_sampling_feedback_loop.html for drawBuffers API in WebGL 2 to WebGL_draw_buffers extension in WebGL 1, for the sake of this issue: https://bugs.chromium.org/p/angleproject/issues/detail?id=1619.

I have a fix for this issue in Chromium, but that fix need to do some optimization. I think I have time to do the optimization soon.   

PTAL when you have time, @zhenyao and @kenrussell . 