### PR TITLE
Update the WebGL 2 top-of-tree conformance version to 2.0.1 (beta).

### DIFF
--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -177,7 +177,7 @@ var OPTIONS = {
 
 var testVersions = [
   "1.0.4 (beta)",
-  "2.0.0 (beta)"
+  "2.0.1 (beta)"
 ];
 
 function start() {


### PR DESCRIPTION
Note that this will enable several new tests, some of which are known
to not yet pass on all browsers and operating systems.