### PR TITLE
skip the integer cube_map texture related tests

### DIFF
--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
@@ -179,6 +179,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         if (skipCorner && sourceSubRectangle &&
                 sourceSubRectangle[2] == 1 && sourceSubRectangle[3] == 1) {
             debug("Test skipped, see WebGL#1819");
+            return;
         }
 
         // Initialize the contents of the source canvas.

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
@@ -179,6 +179,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         if (skipCorner && sourceSubRectangle &&
                 sourceSubRectangle[2] == 1 && sourceSubRectangle[3] == 1) {
             debug("Test skipped, see WebGL#1819");
+            return;
         }
 
         // Initialize the contents of the source canvas.


### PR DESCRIPTION
Fix a small bug. I suppose that the original code want to skip these tests. 

PTAL. Thanks a lot!