### PR TITLE
Remove checkSourceCanvasImageData for texImage2D tests

### DIFF
--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -1,4 +1,5 @@
 --min-version 2.0.1 active-3d-texture-bug.html
+canvas-remains-unchanged-after-used-in-webgl-texture.html
 copy-texture-image.html
 copy-texture-image-luma-format.html
 copy-texture-image-webgl-specific.html

--- a/sdk/tests/conformance2/textures/misc/canvas-remains-unchanged-after-used-in-webgl-texture.html
+++ b/sdk/tests/conformance2/textures/misc/canvas-remains-unchanged-after-used-in-webgl-texture.html
@@ -1,0 +1,94 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="c" width="16" height="16"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description('Tests canvas remains unchanged after it is used in webgl texutre');
+
+debug("This is a regression test for <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=446380'>Chromium Issue 446380</a>");
+debug("");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("c", undefined, 2);
+
+function checkSourceCanvasImageData(imageDataBefore, imageDataAfter) {
+  if (imageDataBefore.length != imageDataAfter.length) {
+    testFailed("The size of image data in source canvas become different after it is used in webgl texture.");
+    return;
+  }
+  for (var i = 0; i < imageDataAfter.length; i++) {
+    if (imageDataBefore[i] != imageDataAfter[i]) {
+      testFailed("Pixel values in source canvas have changed after canvas used in webgl texture.");
+      return;
+    }
+  }
+  testPassed("Pixel values in source canvas remain unchanged after canvas used in webgl texture.");
+}
+
+function runTest(width, height) {
+  var canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  var ctx = canvas.getContext("2d");
+  ctx.fillStyle = "rgba(1, 63, 127, 1)";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  var refCanvas = document.createElement("canvas");
+  refCanvas.width = width;
+  refCanvas.height = height;
+  var refCtx = refCanvas.getContext("2d");
+  refCtx.fillStyle = "rgba(1, 63, 127, 1)";
+  refCtx.fillRect(0, 0, canvas.width, canvas.height);
+  // A refCanvas with same data as canvas is used to get original image data, since
+  // getImageData may change hardware accelerated status of canvas and we don't want to
+  // omit testing for hardware accelerated canvas.
+  var imageDataBefore = refCtx.getImageData(0, 0, refCanvas.width, refCanvas.height);
+  var tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, canvas);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "TexImage2D should succeed");
+  checkSourceCanvasImageData(imageDataBefore, ctx.getImageData(0, 0, canvas.width, canvas.height));
+  gl.deleteTexture(tex);
+}
+
+runTest(2, 2);
+runTest(257, 257);
+
+finishTest();
+</script>
+</body>
+</html>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
@@ -104,20 +104,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       setCanvasToRedGreen(ctx);
     }
 
-    function checkSourceCanvasImageData(imageDataBefore, imageDataAfter) {
-      if (imageDataBefore.length != imageDataAfter.length) {
-        testFailed("The size of image data in source canvas become different after it is used in webgl texture.");
-        return;
-      }
-      for (var i = 0; i < imageDataAfter.length; i++) {
-        if (imageDataBefore[i] != imageDataAfter[i]) {
-          testFailed("Pixel values in source canvas have changed after canvas used in webgl texture.");
-          return;
-        }
-      }
-      testPassed("Pixel values in source canvas remain unchanged after canvas used in webgl texture.");
-    }
-
     function runOneIteration(canvas, useTexSubImage2D, flipY, program, bindingTarget, opt_texture, opt_fontTest)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
@@ -281,13 +267,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                     var imageDataBefore = null;
                     if (c.init) {
                       c.init(ctx, bindingTarget);
-                      imageDataBefore = ctx.getImageData(0, 0, canvas.width, canvas.height);
                     }
                     texture = runOneIteration(canvas, c.sub, c.flipY, program, bindingTarget, texture, c.font);
-                    if (c.init) {
-                        debug("Checking if pixel values in source canvas change after canvas used as webgl texture");
-                        checkSourceCanvasImageData(imageDataBefore, ctx.getImageData(0, 0, canvas.width, canvas.height));
-                    }
                     // for the first 2 iterations always make a new texture.
                     if (count > 2) {
                       gl.deleteTexture(texture);


### PR DESCRIPTION
getImageData() will disable hardware acceleration for canvas2d in chrome.
So, we cannot tests GPU-to-GPU path for texImage2D taking a canvas as source.
If we need to check if pixel values in source canvas change after canvas
used as webgl texture, we can add a standalone test for it.

See GetImageDataForcesNoAcceleration flag in blink:
https://cs.chromium.org/chromium/src/third_party/WebKit/Source/platform/graphics/ExpensiveCanvasHeuristicParameters.h?rcl=0&l=68.