### PR TITLE
Cover ANGLE bug with large UBO readback.

### DIFF
--- a/sdk/tests/conformance2/buffers/one-large-uniform-buffer.html
+++ b/sdk/tests/conformance2/buffers/one-large-uniform-buffer.html
@@ -60,7 +60,7 @@ void main()
 </script>
 <script>
 "use strict";
-description("This test covers an ANGLE bug when using a large uniform block data store. ANGLE would confuse an internal clipped uniform buffer size and produce an assert or error.");
+description("This test covers ANGLE bugs when using a large uniform blocks. ANGLE would confuse an internal clipped uniform buffer size and produce an assert or error. Also there were issues with readback of large UBOs. See http://crbug.com/660670.");
 
 debug("");
 
@@ -77,6 +77,10 @@ if (!gl) {
     debug("");
     debug("Testing uniform block with large data store");
     runTest();
+
+    debug("");
+    debug("Testing readback on uniform block with large data store");
+    runReadbackTest();
 }
 
 function getQuadVerts(depth) {
@@ -141,6 +145,66 @@ function runTest() {
     // Verify the output color
     var color = [127, 191, 64, 255];
     wtu.checkCanvas(gl, color, "canvas should be same as input uniform", 1);
+}
+
+function runReadbackTest() {
+
+    // Create the program
+    var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["position"]);
+    if (!program) {
+        testFailed("Failed to set up the program");
+        return;
+    }
+
+    // Init uniform buffer. To trigger the bug, it's necessary to use the
+    // DYNAMIC_DRAW usage. This makes ANGLE attempt to map the buffer internally
+    // with an incorrect copy size.
+    var ubo = gl.createBuffer();
+    var num_floats = 4096 * 16;
+    var expected_data = new Float32Array(num_floats);
+    for (var index = 0; index < num_floats; ++index) {
+        expected_data[index] = index;
+    }
+
+    expected_data[0] = 0.5;
+    expected_data[1] = 0.75;
+    expected_data[2] = 0.25;
+    expected_data[3] = 1.0;
+
+    gl.bindBuffer(gl.UNIFORM_BUFFER, ubo);
+    gl.bufferData(gl.UNIFORM_BUFFER, expected_data, gl.DYNAMIC_DRAW);
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, expected_data);
+
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, ubo);
+    var buffer_index = gl.getUniformBlockIndex(program, "uni");
+    if (buffer_index == -1) {
+      testFailed("Failed to get uniform block index");
+      return;
+    }
+    gl.uniformBlockBinding(program, buffer_index, 0);
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setting up uniform block should succeed");
+
+    // Draw the quad
+    gl.useProgram(program);
+    drawQuad(0.5);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Draw with uniform block should succeed");
+
+    // Verify the output color
+    var color = [127, 191, 64, 255];
+    wtu.checkCanvas(gl, color, "canvas should be same as input uniform", 1);
+
+    // Verify readback
+    var actual_data = new Float32Array(num_floats);
+    gl.getBufferSubData(gl.UNIFORM_BUFFER, 0, actual_data);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Readback from uniform block should succeed");
+
+    for (var index = 0; index < num_floats; ++index) {
+        if (actual_data[index] != expected_data[index]) {
+            testFailed("Expected and actual buffer data do not match");
+            return;
+        }
+    }
 }
 
 debug("");


### PR DESCRIPTION
ANGLE only stores starting chunks of large UBOs because of Win7
D3D11 limitations. This was causing problems when reading back
from large UBOs in some cases.

See also http://crbug.com/660670

@zhenyao @kenrussell PTAL. Issue was a bit old but was on my action items list to make a test.