### PR TITLE
Check TexSubImage3D works with pixel buffer

### DIFF
--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -18,6 +18,7 @@ tex-new-formats.html
 tex-storage-2d.html
 tex-storage-and-subimage-3d.html
 tex-storage-compressed-formats.html
+--min-version 2.0.1 tex-subimage3d-pixel-buffer-bug.html
 tex-unpack-params.html
 texel-fetch-undefined.html
 texture-npot.html

--- a/sdk/tests/conformance2/textures/misc/tex-subimage3d-pixel-buffer-bug.html
+++ b/sdk/tests/conformance2/textures/misc/tex-subimage3d-pixel-buffer-bug.html
@@ -1,0 +1,111 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test bug of TexSubImage3D with pixel buffer</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="2" height="2" style="width: 2px; height: 2px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader_texsize" type="x-shader/x-vertex">#version 300 es
+in vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+
+<script id="fshader_texsize_3d" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform highp sampler3D tex;
+uniform int lod;
+uniform ivec3 texSize;
+out vec4 fragColor;
+void main()
+{
+    fragColor = (textureSize(tex, lod) == texSize ? vec4(1.0, 0.0, 0.0, 1.0) : vec4(0.0, 0.0, 0.0, 1.0));
+}
+</script>
+
+
+<script>
+"use strict";
+description(document.title);
+debug("This is a regression test for <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=666384'>Chromium Issue 666384</a>");
+debug("");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example", undefined, 2);
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
+
+function runTest() {
+  wtu.setupUnitQuad(gl, 0, 1);
+
+  var program = wtu.setupProgram(
+      gl, ['vshader_texsize', 'fshader_texsize_3d'], ['vPosition'], [0]);
+
+  var width = 32;
+  var height = 16;
+  var depth = 8;
+  gl.uniform1i(gl.getUniformLocation(program, "tex"), 0);
+  gl.uniform1i(gl.getUniformLocation(program, "lod"), 2);
+  gl.uniform3i(gl.getUniformLocation(program, "texSize"), 8, 4, 2);
+  var tex3d = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_3D, tex3d);
+  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MIN_FILTER) should succeed");
+  gl.texStorage3D(gl.TEXTURE_3D, 4, gl.RGBA8, width, height, depth);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage3D should succeed");
+  var buffer = gl.createBuffer();
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, buffer);
+  gl.bufferData(gl.PIXEL_UNPACK_BUFFER, new Uint8Array(width * height * depth * 4), gl.DYNAMIC_DRAW);
+  gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, width, height, depth, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Update texture data with texSubImage3D from pixel buffer should succeed");
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
+  gl.deleteTexture(tex3d);
+  gl.deleteBuffer(buffer);
+}
+
+runTest();
+var successfullyParsed = true;
+
+</script>
+<script src="../../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
TexSubImage3D is buggy when update texture data from pixel buffer on
Linux Mesa. Add this test to track the bug.