### PR TITLE
Address unspecified behavior in the WEBGL_multiview spec

### DIFF
--- a/extensions/proposals/WEBGL_multiview/extension.xml
+++ b/extensions/proposals/WEBGL_multiview/extension.xml
@@ -185,6 +185,12 @@
       <addendum>
         Attempting to enable both <code>GL_OVR_multiview</code> and <code>GL_OVR_multiview2</code> in the same shader results in a compile error.
       </addendum>
+      <addendum>
+        Attempting to draw when the number of views in the draw framebuffer does not match the number of views specified in the active program generates an <code>INVALID_OPERATION</code> error.
+      </addendum>
+      <addendum>
+        When the number of views specified in the active program is one, <code>gl_ViewID_OVR</code> will always evaluate to zero.
+      </addendum>
     </mirrors>
     <features>
       <feature>
@@ -223,6 +229,10 @@ interface WEBGL_multiview {
   <history>
     <revision date="2016/11/11">
       <change>Initial revision.</change>
+    </revision>
+
+    <revision date="2016/11/25">
+      <change>Specified what happens when the number of views doesn't match or if the number of views is one.</change>
     </revision>
   </history>
 </proposal>


### PR DESCRIPTION
The native extension spec recommends an error in case the number of
views doesn't match between the framebuffer and the shader. This
should be required behavior in the WebGL version of the extension.

When the number of views specified in the active program is one,
it needs to be specified what happens with gl_ViewID_OVR. The simplest
option is to specify that it always evaluates to zero in this case.
Another alternative would be to forbid statically using gl_ViewID_OVR
in this case, but this could only be validated at link time.