### PR TITLE
Depth stencil feedback loop

### DIFF
--- a/sdk/tests/conformance2/rendering/00_test_list.txt
+++ b/sdk/tests/conformance2/rendering/00_test_list.txt
@@ -12,6 +12,7 @@ canvas-resizing-with-pbo-bound.html
 clear-func-buffer-type-match.html
 --min-version 2.0.1 clear-srgb-color-buffer.html
 --min-version 2.0.1 clipping-wide-points.html
+--min-version 2.0.1 depth-stencil-feedback-loop.html
 draw-buffers.html
 element-index-uint.html
 framebuffer-completeness-unaffected.html

--- a/sdk/tests/conformance2/rendering/depth-stencil-feedback-loop.html
+++ b/sdk/tests/conformance2/rendering/depth-stencil-feedback-loop.html
@@ -1,0 +1,179 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Rendering and Sampling Feedback Loop Tests for Depth/Stencil Buffer</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="8" height="8"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in highp vec4 aPosition;
+in vec2 aTexCoord;
+out vec2 texCoord;
+void main() {
+    gl_Position = aPosition;
+    texCoord = aTexCoord;
+}
+</script>
+
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform sampler2D tex;
+in vec2 texCoord;
+out vec4 oColor;
+void main() {
+    oColor = texture(tex, texCoord);
+}
+</script>
+
+<script>
+"use strict";
+
+var wtu = WebGLTestUtils;
+description("This test verifies the functionality of rendering to the same texture where it samples from.");
+
+var gl = wtu.create3DContext("example", undefined, 2);
+
+var width = 8;
+var height = 8;
+var tex0;
+var tex1;
+var tex2;
+var fbo;
+var program;
+var positionLoc;
+var texCoordLoc;
+
+if (!gl) {
+    testFailed("WebGL context does not exist");
+} else {
+    testPassed("WebGL context exists");
+
+    init();
+    detect_depth_stencil_feedback_loop();
+    deinit();
+}
+
+function init() {
+    // Setup program
+    program = wtu.setupProgram(gl, ['vshader', 'fshader'], ['aPosition', 'aTexCoord'], [0, 1]);
+    positionLoc = gl.getAttribLocation(program, "aPosition");
+    texCoordLoc = gl.getAttribLocation(program, "aTexCoord");
+    if (!program || positionLoc < 0 || texCoordLoc < 0) {
+        testFailed("Set up program failed");
+        return;
+    }
+    testPassed("Set up program succeeded");
+
+    wtu.setupUnitQuad(gl, 0, 1);
+    gl.viewport(0, 0, width, height);
+
+    var texLoc = gl.getUniformLocation(program, "tex");
+    gl.uniform1i(texLoc, 0);
+
+    // Create textures and allocate storage
+    tex0 = gl.createTexture();
+    tex1 = gl.createTexture();
+    tex2 = gl.createTexture();
+    wtu.fillTexture(gl, tex0, width, height, [0x0, 0xff, 0x0, 0xff], 0, gl.RGBA, gl.UNSIGNED_BYTE, gl.RGBA);
+    wtu.fillTexture(gl, tex1, width, height, [0x80], 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_INT, gl.DEPTH_COMPONENT16);
+    wtu.fillTexture(gl, tex2, width, height, [0x40], 0, gl.DEPTH_STENCIL, gl.UNSIGNED_INT_24_8, gl.DEPTH24_STENCIL8);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Succeed to create textures.");
+
+    fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex0, 0);
+}
+
+function detect_depth_stencil_feedback_loop() {
+    // Test rendering and sampling feedback loop for depth buffer
+    gl.bindTexture(gl.TEXTURE_2D, tex1);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, tex1, 0);
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer incomplete.");
+        return;
+    }
+
+    gl.enable(gl.DEPTH_TEST);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "The test samples from a image. The same image is used as depth buffer during rendering.");
+
+    gl.depthMask(gl.FALSE);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test sampls from a image. The same image is used as depth buffer. But depth mask is false.");
+
+    gl.depthMask(gl.TRUE);
+    gl.disable(gl.DEPTH_TEST);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test samples from a image. The same image is used as depth buffer. But depth test is not enabled during rendering.");
+
+    // Test rendering and sampling feedback loop for stencil buffer
+    gl.bindTexture(gl.TEXTURE_2D, tex2);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, tex2, 0);
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer incomplete.");
+        return;
+    }
+
+    gl.enable(gl.STENCIL_TEST);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "The test samples from a image. The same image is used as stencil buffer during rendering.");
+
+    gl.stencilMask(0x0);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test sampls from a image. The same image is used as stencil buffer. But stencil mask is zero.");
+
+    gl.stencilMask(0xffff);
+    gl.disable(gl.STENCIL_TEST);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test samples from a image. The same image is used as stencil buffer. But stencil test is not enabled during rendering.");
+}
+
+function deinit() {
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.deleteTexture(tex0);
+    gl.deleteTexture(tex1);
+    gl.deleteTexture(tex2);
+    gl.deleteFramebuffer(fbo);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
piman pointed out that there should be feedback loop detection for depth/stencil buffer, see https://codereview.chromium.org/2461973002/diff/40001/gpu/command_buffer/service/gles2_cmd_decoder.cc. 
Add test case to expose this feature.
Also see the comments at #2160. 

PTAL. @zhenyao 