### PR TITLE
Use wtu.startPlayingAndWaitForVideo in image-bitmap-from-video tests.

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -49,12 +49,12 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.clearDepth(1);
 
         var video = document.createElement("video");
-        video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-            finishTest();
-        }
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);
+        wtu.startPlayingAndWaitForVideo(video, function() {
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+            finishTest();
+        });
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -49,12 +49,12 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.clearDepth(1);
 
         video = document.createElement("video");
-        video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-            finishTest();
-        }
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);
+        wtu.startPlayingAndWaitForVideo(video, function() {
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+            finishTest();
+        });
     }
 
     return init;


### PR DESCRIPTION
Attempt to address flakiness reported in http://crbug.com/671209.

Verified this change in both Chrome and Firefox.