### PR TITLE
Print failure message to log for debugging

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-srgb-mipmap.html
+++ b/sdk/tests/conformance2/textures/misc/tex-srgb-mipmap.html
@@ -176,9 +176,11 @@ function generateMipmap()
                 Math.abs(cmp[i * 4 + 1] - ref[i * 4 + 1]) > tolerance ||
                 Math.abs(cmp[i * 4 + 2] - ref[i * 4 + 2]) > tolerance ||
                 Math.abs(cmp[i * 4 + 3] - ref[i * 4 + 3]) > tolerance) {
-                debug("Pixel " + i + ": expected (" +
-                    [ref[i * 4], ref[i * 4 + 1], ref[i * 4 + 2], ref[i * 4 + 3]] + "), got (" +
-                    [cmp[i * 4], cmp[i * 4 + 1], cmp[i * 4 + 2], cmp[i * 4 + 3]] + ")");
+                if (count < 10) {
+                    testFailed("Pixel " + i + ": expected (" +
+                        [ref[i * 4], ref[i * 4 + 1], ref[i * 4 + 2], ref[i * 4 + 3]] + "), got (" +
+                        [cmp[i * 4], cmp[i * 4 + 1], cmp[i * 4 + 2], cmp[i * 4 + 3]] + ")");
+                }
                 count++;
                 diff[i * 4] = 255;
                 diff[i * 4 + 1] = 0;


### PR DESCRIPTION
With the log, it's efficient to debug chrome build bots failures.