### PR TITLE
Add a tricky recursive macro expansion test

### DIFF
--- a/sdk/tests/conformance/glsl/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/00_test_list.txt
@@ -5,6 +5,7 @@ implicit/00_test_list.txt
 --min-version 1.0.2 literals/00_test_list.txt
 --min-version 1.0.2 matrices/00_test_list.txt
 misc/00_test_list.txt
+--min-version 1.0.4 preprocessor/00_test_list.txt
 reserved/00_test_list.txt
 --min-version 1.0.2 samplers/00_test_list.txt
 variables/00_test_list.txt

--- a/sdk/tests/conformance/glsl/preprocessor/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/preprocessor/00_test_list.txt
@@ -1,0 +1,1 @@
+--min-version 1.0.4 macro-expansion-tricky.html

--- a/sdk/tests/conformance/glsl/preprocessor/macro-expansion-tricky.html
+++ b/sdk/tests/conformance/glsl/preprocessor/macro-expansion-tricky.html
@@ -1,0 +1,67 @@
+<!--
+
+/*
+** Copyright (c) 2016 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Tricky macro expansion</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderRecursiveMacroNameInsideIncompleteMacroInvocationInMacroExpansion" type="x-shader/x-fragment">
+#define m(a)
+#define a m((a)
+a)
+
+precision mediump float;
+
+void main() {
+    gl_FragColor = vec4(0.0);
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description();
+
+GLSLConformanceTester.runTests([
+{
+  fShaderId: 'fshaderRecursiveMacroNameInsideIncompleteMacroInvocationInMacroExpansion',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Recursive macro name inside incomplete macro invocation in macro expansion should not crash'
+}
+]);
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
The test is crashing in the latest Firefox and the stable branch of
Chrome. It's passing in Edge and in Chrome Canary, which is using the
latest version of ANGLE shader translator.