### PR TITLE
Update a broken link to the canvas element

### DIFF
--- a/specs/1.0.0/index.html
+++ b/specs/1.0.0/index.html
@@ -69,7 +69,7 @@
     <p>
         This specification describes an additional rendering context and support
         objects for the
-        <a href="http://www.w3.org/TR/html5/the-canvas-element.html"
+        <a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element"
            title="HTML 5 Canvas Element">
             HTML 5 <span class="prop-name">canvas</span> element <a href="#refsCANVAS">[CANVAS]</a>.
         </a>
@@ -3018,7 +3018,7 @@ extensions.
     <dl>
     
         <dt id="refsCANVAS">[CANVAS]</dt>
-        <dd><cite><a href="http://www.w3.org/TR/html5/the-canvas-element.html">
+        <dd><cite><a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
             HTML5: The Canvas Element</a></cite>,
             World Wide Web Consortium (W3C).
         </dd>

--- a/specs/1.0.1/index.html
+++ b/specs/1.0.1/index.html
@@ -75,7 +75,7 @@
     <p>
         This specification describes an additional rendering context and support
         objects for the
-        <a href="http://www.w3.org/TR/html5/the-canvas-element.html"
+        <a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element"
            title="HTML 5 Canvas Element">
             HTML 5 <span class="prop-name">canvas</span> element <a href="#refsCANVAS">[CANVAS]</a>.
         </a>
@@ -3401,7 +3401,7 @@ extensions.
     <dl>
     
         <dt id="refsCANVAS">[CANVAS]</dt>
-        <dd><cite><a href="http://www.w3.org/TR/html5/the-canvas-element.html">
+        <dd><cite><a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
             HTML5: The Canvas Element</a></cite>,
             World Wide Web Consortium (W3C).
         </dd>

--- a/specs/1.0.2/index.html
+++ b/specs/1.0.2/index.html
@@ -75,7 +75,7 @@
     <p>
         This specification describes an additional rendering context and support
         objects for the
-        <a href="http://www.w3.org/TR/html5/the-canvas-element.html"
+        <a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element"
            title="HTML 5 Canvas Element">
             HTML 5 <span class="prop-name">canvas</span> element <a href="#refsCANVAS">[CANVAS]</a>.
         </a>
@@ -3548,7 +3548,7 @@ extensions.
     <dl>
     
         <dt id="refsCANVAS">[CANVAS]</dt>
-        <dd><cite><a href="http://www.w3.org/TR/html5/the-canvas-element.html">
+        <dd><cite><a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
             HTML5: The Canvas Element</a></cite>,
             World Wide Web Consortium (W3C).
         </dd>

--- a/specs/1.0.3/index.html
+++ b/specs/1.0.3/index.html
@@ -75,7 +75,7 @@
     <p>
         This specification describes an additional rendering context and support
         objects for the
-        <a href="http://www.w3.org/TR/html5/the-canvas-element.html"
+        <a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element"
            title="HTML 5 Canvas Element">
             HTML 5 <span class="prop-name">canvas</span> element <a href="#refsCANVAS">[CANVAS]</a>.
         </a>
@@ -3707,7 +3707,7 @@ extensions.
     <dl>
     
         <dt id="refsCANVAS">[CANVAS]</dt>
-        <dd><cite><a href="http://www.w3.org/TR/html5/the-canvas-element.html">
+        <dd><cite><a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
             HTML5: The Canvas Element</a></cite>,
             World Wide Web Consortium (W3C).
         </dd>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -79,7 +79,7 @@
     <p>
         This specification describes an additional rendering context and support
         objects for the
-        <a href="http://www.w3.org/TR/html5/the-canvas-element.html"
+        <a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element"
            title="HTML 5 Canvas Element">
             HTML 5 <span class="prop-name">canvas</span> element <a href="#refsCANVAS">[CANVAS]</a>.
         </a>
@@ -3994,7 +3994,7 @@ extensions.
     <dl>
 
         <dt id="refsCANVAS">[CANVAS]</dt>
-        <dd><cite><a href="http://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
+        <dd><cite><a href="https://www.w3.org/TR/html5/scripting-1.html#the-canvas-element">
             HTML5: The Canvas Element</a></cite>,
             World Wide Web Consortium (W3C).
         </dd>


### PR DESCRIPTION
Fix this link for the current 1.0 spec and all existing stable versions (no change in functionality).