### PR TITLE
Error for querying FB-dependent limit should error as if asking to re…

### DIFF
--- a/conformance-suites/2.0.0/conformance/extensions/oes-texture-half-float.html
+++ b/conformance-suites/2.0.0/conformance/extensions/oes-texture-half-float.html
@@ -415,10 +415,10 @@ function runFramebufferTest() {
         shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
 
         shouldBeNull("gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT)");
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "IMPLEMENTATION_COLOR_READ_FORMAT should fail for incomplete framebuffers.");
+        wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_FRAMEBUFFER_OPERATION], "IMPLEMENTATION_COLOR_READ_FORMAT should fail for incomplete framebuffers.");
 
         shouldBeNull("gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE)");
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "IMPLEMENTATION_COLOR_READ_TYPE should fail for incomplete framebuffers.");
+        wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_FRAMEBUFFER_OPERATION], "IMPLEMENTATION_COLOR_READ_TYPE should fail for incomplete framebuffers.");
 
         gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, arrayBufferFloatOutput);
         wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION , "readPixels should fail on incomplete framebuffers.");

--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -415,10 +415,10 @@ function runFramebufferTest() {
         shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
 
         shouldBeNull("gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT)");
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "IMPLEMENTATION_COLOR_READ_FORMAT should fail for incomplete framebuffers.");
+        wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_FRAMEBUFFER_OPERATION], "IMPLEMENTATION_COLOR_READ_FORMAT should fail for incomplete framebuffers.");
 
         shouldBeNull("gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE)");
-        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "IMPLEMENTATION_COLOR_READ_TYPE should fail for incomplete framebuffers.");
+        wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_FRAMEBUFFER_OPERATION], "IMPLEMENTATION_COLOR_READ_TYPE should fail for incomplete framebuffers.");
 
         gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.FLOAT, arrayBufferFloatOutput);
         wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION , "readPixels should fail on incomplete framebuffers.");

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -2050,7 +2050,7 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             <p>If <em>pname</em> is not in the table above, generates an <code>INVALID_ENUM</code> error and returns null.</p>
             <p>If <em>pname</em> is <code>IMPLEMENTATION_COLOR_READ_FORMAT</code>
             or <code>IMPLEMENTATION_COLOR_READ_TYPE</code>, and the currently bound framebuffer is
-            not <em>framebuffer complete</em>, generates an <code>INVALID_OPERATION</code> error and
+            not <em>framebuffer complete</em>, generates an <code>INVALID_FRAMEBUFFER_OPERATION</code> error and
             returns null.
             <p>The following <em>pname</em> arguments return a string describing some aspect of the current WebGL implementation:</p>
             <table>


### PR DESCRIPTION
…ad. (that is, INVALID_FRAMEBUFFER_OPERATION)

@kenrussell @zhenyao @RafaelCintron @grorg 

This behavior is specified in the spec as INVALID_OPERATION instead of GLES2's "returns undefined values".
However this behavior differs in its error code from trying to read from or draw to an incomplete framebuffer.

Firefox's implementation returns INVALID_FRAMEBUFFER_OPERATION, because it shares validation code with the other entrypoints. Instead of special-casing this, I propose we change the error code for 1.0.4/2.0.1+.