### PR TITLE
Add tests checking for non-constant infinity

### DIFF
--- a/sdk/tests/conformance2/glsl3/float-parsing.html
+++ b/sdk/tests/conformance2/glsl3/float-parsing.html
@@ -103,6 +103,38 @@ void main()
     my_FragColor = vec4(0.0, correct, 0.0, 1.0);
 }
 </script>
+<script id="fshaderNonConstFloatIsInfinity" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+out vec4 my_FragColor;
+
+uniform float u; // Assumed to have the default value 0.0
+
+void main()
+{
+    // Out-of-range floats should overflow to infinity
+    // GLSL ES 3.00.6 section 4.1.4 Floats:
+    // "If the value of the floating point number is too large (small) to be stored as a single precision value, it is converted to positive (negative) infinity"
+    float f = 1.0e2048 - u;
+    float correct = (isinf(f) && f > 0.0) ? 1.0 : 0.0;
+    my_FragColor = vec4(0.0, correct, 0.0, 1.0);
+}
+</script>
+<script id="fshaderNonConstFloatIsNegativeInfinity" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+out vec4 my_FragColor;
+
+uniform float u; // Assumed to have the default value 0.0
+
+void main()
+{
+    // Out-of-range floats should overflow to infinity
+    // GLSL ES 3.00.6 section 4.1.4 Floats:
+    // "If the value of the floating point number is too large (small) to be stored as a single precision value, it is converted to positive (negative) infinity"
+    float f = -1.0e2048 + u;
+    float correct = (isinf(f) && f < 0.0) ? 1.0 : 0.0;
+    my_FragColor = vec4(0.0, correct, 0.0, 1.0);
+}
+</script>
 <script type="text/javascript">
 "use strict";
 description();
@@ -137,6 +169,18 @@ GLSLConformanceTester.runRenderTests([
   fShaderSuccess: true,
   linkSuccess: true,
   passMsg: "Test that an exponent that slightly overflows signed 32-bit int range works."
+},
+{
+  fShaderId: 'fshaderNonConstFloatIsInfinity',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Test that a non-constant float that has infinity as a value is processed correctly by isinf()."
+},
+{
+  fShaderId: 'fshaderNonConstFloatIsNegativeInfinity',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Test that a non-constant float that has negative infinity as a value is processed correctly by isinf()."
 }
 ], 2);
 </script>


### PR DESCRIPTION
This targets an ANGLE issue where infinity literals are not written
to the shader output as infinity, but rather as max finite float.