### PR TITLE
Disable WebGL 2.0.0 snapshot tests failing due to Mac AMD/Intel drivers

### DIFF
--- a/conformance-suites/2.0.0/conformance2/rendering/framebuffer-completeness-unaffected.html
+++ b/conformance-suites/2.0.0/conformance2/rendering/framebuffer-completeness-unaffected.html
@@ -77,9 +77,12 @@ if (!gl) {
   gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.RENDERBUFFER, null);
   shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
 
-  debug("set read buffer to ATTACHMENT1, fbo should be complete");
-  gl.readBuffer(gl.COLOR_ATTACHMENT1);
-  shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+  // Setting of GL_READ_BUFFER and GL_DRAW_BUFFERs affects framebuffer completeness on Mac Intel.
+  // Chromium bug: crbug.com/630800
+  // Apple Radar: 28236629
+  //debug("set read buffer to ATTACHMENT1, fbo should be complete");
+  //gl.readBuffer(gl.COLOR_ATTACHMENT1);
+  //shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
 
   debug("drawBuffers selects ATTACHMENT0, fbo should be complete");
   gl.drawBuffers([gl.COLOR_ATTACHMENT0]);

--- a/conformance-suites/2.0.0/conformance2/textures/canvas/00_test_list.txt
+++ b/conformance-suites/2.0.0/conformance2/textures/canvas/00_test_list.txt
@@ -15,8 +15,8 @@ tex-2d-rgb565-rgb-unsigned_short_5_6_5.html
 tex-2d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
 tex-2d-r11f_g11f_b10f-rgb-half_float.html
 tex-2d-r11f_g11f_b10f-rgb-float.html
-tex-2d-rgb9_e5-rgb-half_float.html
-tex-2d-rgb9_e5-rgb-float.html
+//tex-2d-rgb9_e5-rgb-half_float.html  // crbug.com/663188 , Apple Radar 29259244
+//tex-2d-rgb9_e5-rgb-float.html       // crbug.com/663188 , Apple Radar 29259244
 tex-2d-rgb16f-rgb-half_float.html
 tex-2d-rgb16f-rgb-float.html
 tex-2d-rgb32f-rgb-float.html
@@ -48,8 +48,8 @@ tex-3d-rgb565-rgb-unsigned_short_5_6_5.html
 tex-3d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
 tex-3d-r11f_g11f_b10f-rgb-half_float.html
 tex-3d-r11f_g11f_b10f-rgb-float.html
-tex-3d-rgb9_e5-rgb-half_float.html
-tex-3d-rgb9_e5-rgb-float.html
+//tex-3d-rgb9_e5-rgb-half_float.html  // crbug.com/663188 , Apple Radar 29259244
+//tex-3d-rgb9_e5-rgb-float.html       // crbug.com/663188 , Apple Radar 29259244
 tex-3d-rgb16f-rgb-half_float.html
 tex-3d-rgb16f-rgb-float.html
 tex-3d-rgb32f-rgb-float.html

--- a/conformance-suites/2.0.0/conformance2/textures/webgl_canvas/00_test_list.txt
+++ b/conformance-suites/2.0.0/conformance2/textures/webgl_canvas/00_test_list.txt
@@ -15,8 +15,8 @@ tex-2d-rgb565-rgb-unsigned_short_5_6_5.html
 tex-2d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
 tex-2d-r11f_g11f_b10f-rgb-half_float.html
 tex-2d-r11f_g11f_b10f-rgb-float.html
-tex-2d-rgb9_e5-rgb-half_float.html
-tex-2d-rgb9_e5-rgb-float.html
+//tex-2d-rgb9_e5-rgb-half_float.html  // crbug.com/663188 , Apple Radar 29259244
+//tex-2d-rgb9_e5-rgb-float.html       // crbug.com/663188 , Apple Radar 29259244
 tex-2d-rgb16f-rgb-half_float.html
 tex-2d-rgb16f-rgb-float.html
 tex-2d-rgb32f-rgb-float.html
@@ -48,8 +48,8 @@ tex-3d-rgb565-rgb-unsigned_short_5_6_5.html
 tex-3d-r11f_g11f_b10f-rgb-unsigned_int_10f_11f_11f_rev.html
 tex-3d-r11f_g11f_b10f-rgb-half_float.html
 tex-3d-r11f_g11f_b10f-rgb-float.html
-tex-3d-rgb9_e5-rgb-half_float.html
-tex-3d-rgb9_e5-rgb-float.html
+//tex-3d-rgb9_e5-rgb-half_float.html  // crbug.com/663188 , Apple Radar 29259244
+//tex-3d-rgb9_e5-rgb-float.html       // crbug.com/663188 , Apple Radar 29259244
 tex-3d-rgb16f-rgb-half_float.html
 tex-3d-rgb16f-rgb-float.html
 tex-3d-rgb32f-rgb-float.html

--- a/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
+++ b/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
@@ -254,6 +254,39 @@ goog.scope(function() {
         // Also see conformance2/rendering/blitframebuffer-stencil-only.html for 2.0.1 test.
         _skip("blit.depth_stencil.depth24_stencil8_scale");
         _skip("blit.depth_stencil.depth24_stencil8_stencil_only");
+
+        _setReason("Transform feedback does not pass any tests on Mac AMD.");
+        // crbug.com/526748
+        // Apple Radar: 28126946
+        _skip("transform_feedback.*");
+
+        _setReason("Texture minification filtering is buggy for LINEAR mode on Mac Intel.");
+        // crbug.com/656478
+        // Apple Radar: 28902129
+        _skip("filtering.2d_combinations.linear_nearest_*");
+        _skip("filtering.cube_combinations.linear_nearest_*");
+        _skip("filtering.2d_array_combinations.linear_nearest_clamp_repeat");
+        _skip("filtering.2d_array_combinations.linear_nearest_clamp_mirror");
+        _skip("filtering.2d_array_combinations.linear_nearest_repeat_*");
+        _skip("filtering.2d_array_combinations.linear_nearest_mirror_*");
+        _skip("filtering.3d_combinations.linear_nearest_clamp_clamp_repeat");
+        _skip("filtering.3d_combinations.linear_nearest_clamp_clamp_mirror");
+        _skip("filtering.3d_combinations.linear_nearest_clamp_repeat_*");
+        _skip("filtering.3d_combinations.linear_nearest_clamp_mirror_*");
+        _skip("filtering.3d_combinations.linear_nearest_repeat_*");
+        _skip("filtering.3d_combinations.linear_nearest_mirror_*");
+
+        _setReason("Setting of GL_READ_BUFFER and GL_DRAW_BUFFERs affects framebuffer completeness on Mac Intel.");
+        // crbug.com/630800
+        // Apple Radar: 28236629
+        _skip("completeness.attachment_combinations.none_rbo_none_none");
+        _skip("completeness.attachment_combinations.none_tex_none_none");
+
+        _setReason("multisample constancy_alpha_to_coverage tests fail on Mac Intel.");
+        // crbug.com/663184
+        _skip("multisample.fbo_4_samples.constancy_alpha_to_coverage");
+        _skip("multisample.fbo_8_samples.constancy_alpha_to_coverage");
+        _skip("multisample.fbo_max_samples.constancy_alpha_to_coverage");
     } // if (!runSkippedTests)
 
     /*

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
@@ -191,11 +191,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         canvas.height = height;
         canvasSetupFunction(canvas);
 
-        // For Chrome, this works around a driver bug on Mac Intel.
-        // Chromium bug: crbug.com/665656
-        // Apple Radar: 29563996
-        canvas.toDataURL();
-
         // Upload the source canvas to the texture and draw it to a quad.
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Enable writes to the RGBA channels
@@ -319,10 +314,14 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                             canvas, cases[i].size, canvasSetupFunction,
                             cases[i].subRect,
                             cases[i].expected, bindingTarget, program);
-            runOneIteration(sourceDescription, true, cases[i].flipY,
-                            canvas, cases[i].size, canvasSetupFunction,
-                            cases[i].subRect,
-                            cases[i].expected, bindingTarget, program);
+
+            // In Chrome, this hits a bug on Mac with Intel GPU.
+            // Chromium bug: crbug.com/665656
+            // Apple Radar: 29563996
+            //runOneIteration(sourceDescription, true, cases[i].flipY,
+            //                canvas, cases[i].size, canvasSetupFunction,
+            //                cases[i].subRect,
+            //                cases[i].expected, bindingTarget, program);
         }
     }
 

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
@@ -191,6 +191,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         canvas.height = height;
         canvasSetupFunction(canvas);
 
+        // For Chrome, this works around a driver bug on Mac Intel.
+        // Chromium bug: crbug.com/665656
+        // Apple Radar: 29563996
+        canvas.toDataURL();
+
         // Upload the source canvas to the texture and draw it to a quad.
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         // Enable writes to the RGBA channels


### PR DESCRIPTION
Issue #2193