### PR TITLE
Let WebGL2RenderingContext implement WebGLRenderingContextBase

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -968,11 +968,11 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   [WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
-WebGL2RenderingContextBase implements WebGLRenderingContextBase;
 
 interface <dfn id="WebGL2RenderingContext">WebGL2RenderingContext</dfn>
 {
 };
+WebGL2RenderingContext implements WebGLRenderingContextBase;
 WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
 </pre>


### PR DESCRIPTION
To have one mixin implement another is unusual, and does not match how
this is implement in Chromium:
https://cs.chromium.org/chromium/src/third_party/WebKit/Source/modules/webgl/WebGL2RenderingContext.idl