### PR TITLE
Increase the error tolerance in certain readPixels test cases

### DIFF
--- a/conformance-suites/2.0.0/conformance2/reading/read-pixels-from-fbo-test.html
+++ b/conformance-suites/2.0.0/conformance2/reading/read-pixels-from-fbo-test.html
@@ -191,6 +191,7 @@ function denormalizeColor(srcInternalFormat, destType, color) {
       result[2] = result[2] * 0x1F;
       break;
     case gl.UNSIGNED_INT_2_10_10_10_REV:
+      tol = 25;
       result[0] = result[0] * 0x3FF;
       result[1] = result[1] * 0x3FF;
       result[2] = result[2] * 0x3FF;
@@ -656,4 +657,3 @@ var successfullyParsed = true;
 <script src="../../js/js-test-post.js"></script>
 </body>
 </html>
-

--- a/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
+++ b/sdk/tests/conformance2/reading/read-pixels-from-fbo-test.html
@@ -191,6 +191,7 @@ function denormalizeColor(srcInternalFormat, destType, color) {
       result[2] = result[2] * 0x1F;
       break;
     case gl.UNSIGNED_INT_2_10_10_10_REV:
+      tol = 25;
       result[0] = result[0] * 0x3FF;
       result[1] = result[1] * 0x3FF;
       result[2] = result[2] * 0x3FF;
@@ -656,4 +657,3 @@ var successfullyParsed = true;
 <script src="../../js/js-test-post.js"></script>
 </body>
 </html>
-


### PR DESCRIPTION
They are exposed by https://codereview.chromium.org/2577293002/

Verified on Mac/Linux that the tolerance increase is necessary.