### PR TITLE
Remove R11_G11_B10 entries from skip list

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuSkipList.js
+++ b/sdk/tests/deqp/framework/common/tcuSkipList.js
@@ -141,31 +141,6 @@ goog.scope(function() {
         _skip("blit.rect.nearest_consistency_out_of_bounds_min_reverse_dst_y");
         _skip("blit.rect.nearest_consistency_out_of_bounds_min_reverse_src_dst_y");
 
-        _setReason("Mac OSX drivers handle R11F_G11F_B10F format incorrectly");
-        // https://github.com/KhronosGroup/WebGL/issues/1832
-        // deqp/functional/gles3/fragmentoutput/basic.float.html
-        _skip("fragment_outputs.basic.float.r11f_g11f_b10f_mediump*");
-        _skip("fragment_outputs.basic.float.r11f_g11f_b10f_highp*");
-        // deqp/functional/gles3/fragmentoutput/array.float.html
-        _skip("fragment_outputs.array.float.r11f_g11f_b10f_mediump*");
-        _skip("fragment_outputs.array.float.r11f_g11f_b10f_highp*");
-        // deqp/functional/gles3/fragmentoutput/random_00.html
-        _skip("fragment_outputs.random.57");
-        // deqp/functional/gles3/fragmentoutput/random_02.html
-        _skip("fragment_outputs.random.11");
-        // deqp/functional/gles3/fborender/resize_01.html
-        _skip("render.resize.rbo_r11f_g11f_b10f");
-        // deqp/functional/gles3/fborender/recreate_color_02.html
-        _skip("render.recreate_color.rbo_r11f_g11f_b10f_depth_stencil_rbo_depth24_stencil8");
-        // deqp/functional/gles3/fbocolorbuffer/clear.html
-        _skip("color.clear.r11f_g11f_b10f");
-        // deqp/functional/gles3/fbomultisample.2_samples.html
-        _skip("msaa.2_samples.r11f_g11f_b10f");
-        // deqp/functional/gles3/fbomultisample.4_samples.html
-        _skip("msaa.4_samples.r11f_g11f_b10f");
-        // deqp/functional/gles3/fbomultisample.8_samples.html
-        _skip("msaa.8_samples.r11f_g11f_b10f");
-
         _setReason("Missing shadow sampler functions in D3D11");
         // https://github.com/KhronosGroup/WebGL/issues/1870
         // deqp/functional/gles3/shadertexturefunction/texture.html


### PR DESCRIPTION
Since the MacOSX driver bug is fixed in 10.12.2 release