### PR TITLE
Fix bitmaps

### DIFF
--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
@@ -54,8 +54,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-            finishTest();
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+            .then(() => {
+                finishTest();
+            });
         }
     }
 

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
@@ -51,11 +51,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-
-        setCanvasTo257x257(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-        finishTest();
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+        .then(() => {
+            setCanvasTo257x257(ctx);
+            return runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        }).then(() => {
+            finishTest();
+        });
     }
 
     function setCanvasToRedGreen(ctx) {

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
@@ -56,9 +56,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
-            // bitmap is in unpremultiplied form
-            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"})
+        .catch( () => {
+            testPassed("createImageBitmap with options may be rejected if it is not supported. Retrying without options.");
+            return createImageBitmap(imageData);
+        }).then( bitmap => {
+            return runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        }, () => {
+            testFailed("createImageBitmap(imageData) should succeed.");
+        }).then(() => {
             finishTest();
         });
     }

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -56,8 +56,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-        finishTest();
+        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+        .then(() => {
+            finishTest();
+        });
     }
 
     return init;

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -51,8 +51,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var image = new Image();
         image.onload = function() {
             bufferedLogToConsole("Source image has been loaded");
-            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-            finishTest();
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+            .then(() => {
+                finishTest();
+            });
         }
         image.src = resourcePath + "red-green-semi-transparent.png";
     }

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -50,8 +50,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var video = document.createElement("video");
         video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-            finishTest();
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+            .then(() => {
+                finishTest();
+            });
         }
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
@@ -54,8 +54,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-            finishTest();
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+            .then(() => {
+                finishTest();
+            });
         }
     }
 

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -51,11 +51,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-
-        setCanvasTo257x257(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-        finishTest();
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+        .then(() => {
+            setCanvasTo257x257(ctx);
+            return runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+        }).then(() => {
+            finishTest();
+        });
     }
 
     function setCanvasToRedGreen(ctx) {

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
@@ -56,9 +56,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
-            // bitmap is in unpremultiplied form
-            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"})
+        .catch( () => {
+            testPassed("createImageBitmap with options may be rejected if it is not supported. Retrying without options.");
+            return createImageBitmap(imageData);
+        }).then( bitmap => {
+            return runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+        }, () => {
+            testFailed("createImageBitmap(imageData) should succeed.");
+        }).then(() => {
             finishTest();
         });
     }

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
@@ -56,8 +56,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-        finishTest();
+        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+        .then(() => {
+            finishTest();
+        });
     }
 
     return init;

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
@@ -50,8 +50,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var image = new Image();
         image.onload = function() {
-            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-            finishTest();
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+            .then(() => {
+                finishTest();
+            });
         }
         image.src = resourcePath + "red-green-semi-transparent.png";
     }

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -50,8 +50,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         video = document.createElement("video");
         video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-            finishTest();
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+            .then(() => {
+                finishTest();
+            });
         }
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
@@ -333,58 +333,57 @@ function runOneIterationImageBitmapTestSubSource(useTexSubImage, bindingTarget, 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
 }
 
-function runTestOnBindingTargetImageBitmap(bindingTarget, program, bitmaps, optionsVal,
+function runTestOnBindingTargetImageBitmap(bindingTarget, program, cases, optionsVal,
     internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
 {
-    var cases = [
-        { sub: false, bitmap: bitmaps.noFlipYPremul, flipY: false, premultiply: true },
-        { sub: true, bitmap: bitmaps.noFlipYPremul, flipY: false, premultiply: true },
-        { sub: false, bitmap: bitmaps.noFlipYUnpremul, flipY: false, premultiply: false },
-        { sub: true, bitmap: bitmaps.noFlipYUnpremul, flipY: false, premultiply: false },
-        { sub: false, bitmap: bitmaps.flipYPremul, flipY: true, premultiply: true },
-        { sub: true, bitmap: bitmaps.flipYPremul, flipY: true, premultiply: true },
-        { sub: false, bitmap: bitmaps.flipYUnpremul, flipY: true, premultiply: false },
-        { sub: true, bitmap: bitmaps.flipYUnpremul, flipY: true, premultiply: false },
-    ];
-
-    for (var i in cases) {
-        runOneIterationImageBitmapTest(cases[i].sub, bindingTarget, program, cases[i].bitmap,
-            cases[i].flipY, cases[i].premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
-    }
+    cases.forEach(x => {
+        runOneIterationImageBitmapTest(x.sub, bindingTarget, program, x.bitmap,
+            x.bitmap.flipY, x.bitmap.premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+    });
 
     if (wtu.getDefault3DContextVersion() > 1 &&
-        (bindingTarget == gl.TEXTURE_2D || bindingTarget == gl.TEXTURE_3D)) {
-        // SKip testing source sub region on TEXTURE_CUBE_MAP and TEXTURE_2D_ARRAY to save running time.
-        for (var i in cases) {
-            runOneIterationImageBitmapTestSubSource(cases[i].sub, bindingTarget, program, cases[i].bitmap,
-                cases[i].flipY, cases[i].premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
-        }
+        (bindingTarget == gl.TEXTURE_CUBE_MAP || bindingTarget == gl.TEXTURE_2D_ARRAY))
+    {
+        // Skip testing source sub region on TEXTURE_CUBE_MAP and TEXTURE_2D_ARRAY on WebGL2 to save
+        // running time.
+        return;
     }
+
+    cases.forEach(x => {
+        runOneIterationImageBitmapTestSubSource(x.sub, bindingTarget, program, x.bitmap,
+            x.bitmap.flipY, x.bitmap.premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+    });
 }
 
 function runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D)
 {
+    var cases = [];
+    bitmaps.forEach(bitmap => {
+        cases.push({bitmap: bitmap, sub: false});
+        cases.push({bitmap: bitmap, sub: true});
+    });
+
     var optionsVal = {alpha: alphaVal, is3D: is3D};
     var program;
     if (is3D) {
         program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTargetImageBitmap(gl.TEXTURE_3D, program, bitmaps, optionsVal,
+        runTestOnBindingTargetImageBitmap(gl.TEXTURE_3D, program, cases, optionsVal,
             internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
     } else {
         program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D, program, bitmaps, optionsVal,
+        runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D, program, cases, optionsVal,
             internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
     }
 
     // cube map texture must be square
-    if (bitmaps.noFlipYPremul.width == bitmaps.noFlipYPremul.height) {
+    if (bitmaps[0].width == bitmaps[0].height) {
         if (is3D) {
             program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-            runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D_ARRAY, program, bitmaps, optionsVal,
+            runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D_ARRAY, program, cases, optionsVal,
                 internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         } else {
             program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-            runTestOnBindingTargetImageBitmap(gl.TEXTURE_CUBE_MAP, program, bitmaps, optionsVal,
+            runTestOnBindingTargetImageBitmap(gl.TEXTURE_CUBE_MAP, program, cases, optionsVal,
                 internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         }
     }
@@ -392,17 +391,25 @@ function runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelForm
 
 function runImageBitmapTest(source, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D)
 {
-    var bitmaps = [];
-    var p1 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-    var p2 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-    var p3 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-    var p4 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-    Promise.all([p1, p2, p3, p4]).then(function() {
-        bufferedLogToConsole("All createImageBitmap promises are resolved");
-        runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D);
-    }, function() {
-        // createImageBitmap with options could be rejected if it is not supported
-        finishTest();
-        return;
-    });
+    var p1 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "premultiply"})
+                .then(cur => { cur.flipY = false; cur.premultiply = true; return cur; });
+    var p2 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "none"})
+                .then(cur => { cur.flipY = false; cur.premultiply = false; return cur; });
+    var p3 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"})
+                .then(cur => { cur.flipY = true; cur.premultiply = true; return cur; });
+    var p4 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "none"})
+                .then(cur => { cur.flipY = true; cur.premultiply = false; return cur; });
+    return Promise.all([p1, p2, p3, p4])
+        .catch( () => {
+            testPassed("createImageBitmap with options may be rejected if it is not supported. Retrying without options.");
+            var p = createImageBitmap(source)
+                .then(cur => { cur.flipY = false; cur.premultiply = false; return cur; });
+            return Promise.all([p]);
+        }).then( bitmaps => {
+            bufferedLogToConsole("All createImageBitmap promises are resolved");
+            runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D);
+        }, (e) => {
+            // This will fail here when running from file:// instead of https://.
+            testFailed("createImageBitmap(source) failed: \"" + e.message + "\"");
+        });
 }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js
@@ -54,8 +54,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-            finishTest();
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+            .then(() => {
+                finishTest();
+            });
         }
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js
@@ -51,11 +51,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-
-        setCanvasTo257x257(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-        finishTest();
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+        .then(() => {
+            setCanvasTo257x257(ctx);
+            return runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        }).then(() => {
+            finishTest();
+        });
     }
 
     function setCanvasToRedGreen(ctx) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
@@ -56,9 +56,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
-            // bitmap is in unpremultiplied form
-            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"})
+        .catch( () => {
+            testPassed("createImageBitmap with options may be rejected if it is not supported. Retrying without options.");
+            return createImageBitmap(imageData);
+        }).then( bitmap => {
+            return runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+        }, () => {
+            testFailed("createImageBitmap(imageData) should succeed.");
+        }).then(() => {
             finishTest();
         });
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -56,8 +56,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-        finishTest();
+        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+        .then(() => {
+            finishTest();
+        });
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js
@@ -51,8 +51,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var image = new Image();
         image.onload = function() {
             bufferedLogToConsole("Source image has been loaded");
-            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-            finishTest();
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+            .then(() => {
+                finishTest();
+            });
         }
         image.src = resourcePath + "red-green-semi-transparent.png";
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -52,8 +52,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);
         wtu.startPlayingAndWaitForVideo(video, function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
-            finishTest();
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+            .then(() => {
+                finishTest();
+            });
         });
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js
@@ -54,8 +54,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         xhr.send();
         xhr.onload = function() {
             var blob = xhr.response;
-            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-            finishTest();
+            runImageBitmapTest(blob, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+            .then(() => {
+                finishTest();
+            });
         }
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js
@@ -51,11 +51,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var testCanvas = document.createElement('canvas');
         var ctx = testCanvas.getContext("2d");
         setCanvasToMin(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-
-        setCanvasTo257x257(ctx);
-        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-        finishTest();
+        runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+        .then(() => {
+            setCanvasTo257x257(ctx);
+            return runImageBitmapTest(testCanvas, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+        }).then(() => {
+            finishTest();
+        });
     }
 
     function setCanvasToRedGreen(ctx) {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js
@@ -56,9 +56,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(bitmap) {
-            // bitmap is in unpremultiplied form
-            runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+        createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"})
+        .catch( () => {
+            testPassed("createImageBitmap with options may be rejected if it is not supported. Retrying without options.");
+            return createImageBitmap(imageData);
+        }).then( bitmap => {
+            return runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+        }, () => {
+            testFailed("createImageBitmap(imageData) should succeed.");
+        }).then(() => {
             finishTest();
         });
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js
@@ -56,8 +56,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                                       0, 255, 0, 0]),
                                       2, 2);
 
-        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-        finishTest();
+        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+        .then(() => {
+            finishTest();
+        });
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js
@@ -50,8 +50,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var image = new Image();
         image.onload = function() {
-            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-            finishTest();
+            runImageBitmapTest(image, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+            .then(() => {
+                finishTest();
+            });
         }
         image.src = resourcePath + "red-green-semi-transparent.png";
     }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -52,8 +52,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         video.src = resourcePath + "red-green.theora.ogv";
         document.body.appendChild(video);
         wtu.startPlayingAndWaitForVideo(video, function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
-            finishTest();
+            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
+            .then(() => {
+                finishTest();
+            });
         });
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
@@ -333,58 +333,57 @@ function runOneIterationImageBitmapTestSubSource(useTexSubImage, bindingTarget, 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
 }
 
-function runTestOnBindingTargetImageBitmap(bindingTarget, program, bitmaps, optionsVal,
+function runTestOnBindingTargetImageBitmap(bindingTarget, program, cases, optionsVal,
     internalFormat, pixelFormat, pixelType, gl, tiu, wtu)
 {
-    var cases = [
-        { sub: false, bitmap: bitmaps.noFlipYPremul, flipY: false, premultiply: true },
-        { sub: true, bitmap: bitmaps.noFlipYPremul, flipY: false, premultiply: true },
-        { sub: false, bitmap: bitmaps.noFlipYUnpremul, flipY: false, premultiply: false },
-        { sub: true, bitmap: bitmaps.noFlipYUnpremul, flipY: false, premultiply: false },
-        { sub: false, bitmap: bitmaps.flipYPremul, flipY: true, premultiply: true },
-        { sub: true, bitmap: bitmaps.flipYPremul, flipY: true, premultiply: true },
-        { sub: false, bitmap: bitmaps.flipYUnpremul, flipY: true, premultiply: false },
-        { sub: true, bitmap: bitmaps.flipYUnpremul, flipY: true, premultiply: false },
-    ];
-
-    for (var i in cases) {
-        runOneIterationImageBitmapTest(cases[i].sub, bindingTarget, program, cases[i].bitmap,
-            cases[i].flipY, cases[i].premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
-    }
+    cases.forEach(x => {
+        runOneIterationImageBitmapTest(x.sub, bindingTarget, program, x.bitmap,
+            x.bitmap.flipY, x.bitmap.premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+    });
 
     if (wtu.getDefault3DContextVersion() > 1 &&
-        (bindingTarget == gl.TEXTURE_2D || bindingTarget == gl.TEXTURE_3D)) {
-        // SKip testing source sub region on TEXTURE_CUBE_MAP and TEXTURE_2D_ARRAY to save running time.
-        for (var i in cases) {
-            runOneIterationImageBitmapTestSubSource(cases[i].sub, bindingTarget, program, cases[i].bitmap,
-                cases[i].flipY, cases[i].premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
-        }
+        (bindingTarget == gl.TEXTURE_CUBE_MAP || bindingTarget == gl.TEXTURE_2D_ARRAY))
+    {
+        // Skip testing source sub region on TEXTURE_CUBE_MAP and TEXTURE_2D_ARRAY on WebGL2 to save
+        // running time.
+        return;
     }
+
+    cases.forEach(x => {
+        runOneIterationImageBitmapTestSubSource(x.sub, bindingTarget, program, x.bitmap,
+            x.bitmap.flipY, x.bitmap.premultiply, optionsVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
+    });
 }
 
 function runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D)
 {
+    var cases = [];
+    bitmaps.forEach(bitmap => {
+        cases.push({bitmap: bitmap, sub: false});
+        cases.push({bitmap: bitmap, sub: true});
+    });
+
     var optionsVal = {alpha: alphaVal, is3D: is3D};
     var program;
     if (is3D) {
         program = tiu.setupTexturedQuadWith3D(gl, internalFormat);
-        runTestOnBindingTargetImageBitmap(gl.TEXTURE_3D, program, bitmaps, optionsVal,
+        runTestOnBindingTargetImageBitmap(gl.TEXTURE_3D, program, cases, optionsVal,
             internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
     } else {
         program = tiu.setupTexturedQuad(gl, internalFormat);
-        runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D, program, bitmaps, optionsVal,
+        runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D, program, cases, optionsVal,
             internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
     }
 
     // cube map texture must be square
-    if (bitmaps.noFlipYPremul.width == bitmaps.noFlipYPremul.height) {
+    if (bitmaps[0].width == bitmaps[0].height) {
         if (is3D) {
             program = tiu.setupTexturedQuadWith2DArray(gl, internalFormat);
-            runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D_ARRAY, program, bitmaps, optionsVal,
+            runTestOnBindingTargetImageBitmap(gl.TEXTURE_2D_ARRAY, program, cases, optionsVal,
                 internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         } else {
             program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
-            runTestOnBindingTargetImageBitmap(gl.TEXTURE_CUBE_MAP, program, bitmaps, optionsVal,
+            runTestOnBindingTargetImageBitmap(gl.TEXTURE_CUBE_MAP, program, cases, optionsVal,
                 internalFormat, pixelFormat, pixelType, gl, tiu, wtu);
         }
     }
@@ -392,17 +391,25 @@ function runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelForm
 
 function runImageBitmapTest(source, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D)
 {
-    var bitmaps = [];
-    var p1 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.noFlipYPremul = imageBitmap });
-    var p2 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.noFlipYUnpremul = imageBitmap });
-    var p3 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"}).then(function(imageBitmap) { bitmaps.flipYPremul = imageBitmap });
-    var p4 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "none"}).then(function(imageBitmap) { bitmaps.flipYUnpremul = imageBitmap });
-    Promise.all([p1, p2, p3, p4]).then(function() {
-        bufferedLogToConsole("All createImageBitmap promises are resolved");
-        runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D);
-    }, function() {
-        // createImageBitmap with options could be rejected if it is not supported
-        finishTest();
-        return;
-    });
+    var p1 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "premultiply"})
+                .then(cur => { cur.flipY = false; cur.premultiply = true; return cur; });
+    var p2 = createImageBitmap(source, {imageOrientation: "none", premultiplyAlpha: "none"})
+                .then(cur => { cur.flipY = false; cur.premultiply = false; return cur; });
+    var p3 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "premultiply"})
+                .then(cur => { cur.flipY = true; cur.premultiply = true; return cur; });
+    var p4 = createImageBitmap(source, {imageOrientation: "flipY", premultiplyAlpha: "none"})
+                .then(cur => { cur.flipY = true; cur.premultiply = false; return cur; });
+    return Promise.all([p1, p2, p3, p4])
+        .catch( () => {
+            testPassed("createImageBitmap with options may be rejected if it is not supported. Retrying without options.");
+            var p = createImageBitmap(source)
+                .then(cur => { cur.flipY = false; cur.premultiply = false; return cur; });
+            return Promise.all([p]);
+        }).then( bitmaps => {
+            bufferedLogToConsole("All createImageBitmap promises are resolved");
+            runImageBitmapTestInternal(bitmaps, alphaVal, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, is3D);
+        }, (e) => {
+            // This will fail here when running from file:// instead of https://.
+            testFailed("createImageBitmap(source) failed: \"" + e.message + "\"");
+        });
 }


### PR DESCRIPTION
After these changes, Firefox passes these tests.

Firefox does not yet implement support for the options dict in the createImageBitmap function.
The tests seem to want this to be optional, but the test fails to complete instead of failing softly.