### PR TITLE
Override mimetype for wtu.readFile to text/plain.

### DIFF
--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -1773,6 +1773,7 @@ var getFileListAsync = function(url, callback) {
 var readFile = function(file) {
   var xhr = new XMLHttpRequest();
   xhr.open("GET", file, false);
+  xhr.overrideMimeType("text/plain");
   xhr.send();
   return xhr.responseText.replace(/\r/g, "");
 };

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -1789,6 +1789,7 @@ var getFileListAsync = function(url, callback) {
 var readFile = function(file) {
   var xhr = new XMLHttpRequest();
   xhr.open("GET", file, false);
+  xhr.overrideMimeType("text/plain");
   xhr.send();
   return xhr.responseText.replace(/\r/g, "");
 };


### PR DESCRIPTION
This avoids spurious warnings like:
  "XML Parsing Error: syntax error
   Location: file:///c:/dev/webgl-repo/conformance-suites/2.0.0/resources/uniformBlockShader.vert
   Line Number 1, Column 1:"