### PR TITLE
Fix deqp/functional/gles3/lifetime.html

### DIFF
--- a/conformance-suites/2.0.0/deqp/functional/gles3/es3fLifetimeTests.js
+++ b/conformance-suites/2.0.0/deqp/functional/gles3/es3fLifetimeTests.js
@@ -100,12 +100,11 @@ es3fLifetimeTests.ScaleProgram.prototype.draw = function(vao, scale, tf, dst) {
 es3fLifetimeTests.ScaleProgram.prototype.setPos = function(buffer, vao) {
     gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
     gl.bindVertexArray(vao);
-    if (buffer) {
-        gl.vertexAttribPointer(this.m_posLoc, NUM_COMPONENTS, gl.FLOAT, false, 0, 0);
-    } else {
+    if (!buffer) {
         var name = gl.getVertexAttrib(this.m_posLoc, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
         gl.deleteBuffer(name);
     }
+    gl.vertexAttribPointer(this.m_posLoc, NUM_COMPONENTS, gl.FLOAT, false, 0, 0);
     gl.bindVertexArray(null);
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
 };
@@ -245,7 +244,6 @@ es3fLifetimeTests.BufferVAOAttacher.prototype.initAttachment = function(seed, ob
 es3fLifetimeTests.BufferVAOAttacher.prototype.attach = function(element, target) {
     var buffer = /** @type {WebGLBuffer} */ (element);
     var vao = /** @type {WebGLVertexArrayObject} */ (target);
-
     this.m_program.setPos(buffer, vao);
     bufferedLogToConsole('Set the `pos` attribute in VAO ' + vao + ' to buffer ' + buffer);
 };

--- a/conformance-suites/2.0.0/deqp/modules/shared/glsLifetimeTests.js
+++ b/conformance-suites/2.0.0/deqp/modules/shared/glsLifetimeTests.js
@@ -869,12 +869,8 @@ glsLifetimeTests.AttachmentTest.testDeletedNames = function() {
     assertMsgOptions(getAttachment(this.m_attacher, container) == element,
                  'Attachment name not returned by query after attachment was deleted.', false, true);
 
-    if (elemType.nameLingers())
-        assertMsgOptions(elemType.exists(element),
-                     'Attached object name no longer valid after deletion.', false, true);
-    else
-        assertMsgOptions(!elemType.exists(element),
-                     'Attached object name still valid after deletion.', false, true);
+    assertMsgOptions(elemType.exists(element),
+                 'Attached object name no longer valid after deletion.', false, true);
 
     this.m_attacher.detach(element, container);
     assertMsgOptions(getAttachment(this.m_attacher, container) == null,

--- a/sdk/tests/deqp/functional/gles3/es3fLifetimeTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fLifetimeTests.js
@@ -100,12 +100,11 @@ es3fLifetimeTests.ScaleProgram.prototype.draw = function(vao, scale, tf, dst) {
 es3fLifetimeTests.ScaleProgram.prototype.setPos = function(buffer, vao) {
     gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
     gl.bindVertexArray(vao);
-    if (buffer) {
-        gl.vertexAttribPointer(this.m_posLoc, NUM_COMPONENTS, gl.FLOAT, false, 0, 0);
-    } else {
+    if (!buffer) {
         var name = gl.getVertexAttrib(this.m_posLoc, gl.VERTEX_ATTRIB_ARRAY_BUFFER_BINDING);
         gl.deleteBuffer(name);
     }
+    gl.vertexAttribPointer(this.m_posLoc, NUM_COMPONENTS, gl.FLOAT, false, 0, 0);
     gl.bindVertexArray(null);
     gl.bindBuffer(gl.ARRAY_BUFFER, null);
 };
@@ -245,7 +244,6 @@ es3fLifetimeTests.BufferVAOAttacher.prototype.initAttachment = function(seed, ob
 es3fLifetimeTests.BufferVAOAttacher.prototype.attach = function(element, target) {
     var buffer = /** @type {WebGLBuffer} */ (element);
     var vao = /** @type {WebGLVertexArrayObject} */ (target);
-
     this.m_program.setPos(buffer, vao);
     bufferedLogToConsole('Set the `pos` attribute in VAO ' + vao + ' to buffer ' + buffer);
 };

--- a/sdk/tests/deqp/modules/shared/glsLifetimeTests.js
+++ b/sdk/tests/deqp/modules/shared/glsLifetimeTests.js
@@ -869,12 +869,8 @@ glsLifetimeTests.AttachmentTest.testDeletedNames = function() {
     assertMsgOptions(getAttachment(this.m_attacher, container) == element,
                  'Attachment name not returned by query after attachment was deleted.', false, true);
 
-    if (elemType.nameLingers())
-        assertMsgOptions(elemType.exists(element),
-                     'Attached object name no longer valid after deletion.', false, true);
-    else
-        assertMsgOptions(!elemType.exists(element),
-                     'Attached object name still valid after deletion.', false, true);
+    assertMsgOptions(elemType.exists(element),
+                 'Attached object name no longer valid after deletion.', false, true);
 
     this.m_attacher.detach(element, container);
     assertMsgOptions(getAttachment(this.m_attacher, container) == null,


### PR DESCRIPTION
* WebGL objects always linger when attached to containers.
* Don't detach from a VAO before querying which buffer to delete.