### PR TITLE
Add clear test that vertexAttribPointer with null buffer and zero off…

### DIFF
--- a/conformance-suites/2.0.0/conformance/attribs/gl-vertexattribpointer.html
+++ b/conformance-suites/2.0.0/conformance/attribs/gl-vertexattribpointer.html
@@ -73,10 +73,10 @@ if (!gl) {
   gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
-  gl.bindBuffer(gl.ARRAY_BUFFER, null);
-  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-      "vertexAttribPointer should succeed if no buffer is bound and `offset` is zero.");
+  //gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  //gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+  //wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+  //    "vertexAttribPointer should succeed if no buffer is bound and `offset` is zero.");
 
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
 

--- a/conformance-suites/2.0.0/conformance/attribs/gl-vertexattribpointer.html
+++ b/conformance-suites/2.0.0/conformance/attribs/gl-vertexattribpointer.html
@@ -59,13 +59,27 @@ if (!gl) {
     gl.FIXED = 0x140C;
   }
 
-  gl.vertexAttribPointer(0, 3, gl.FLOAT, 0, 0, 12);
-  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
-      "vertexAttribPointer should fail if no buffer is bound");
-
   var vertexObject = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(0), gl.STATIC_DRAW);
+
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 4);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+      "vertexAttribPointer should fail if no buffer is bound and `offset` is non-zero.");
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
+  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+      "vertexAttribPointer should succeed if no buffer is bound and `offset` is zero.");
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
+
 
   if (wtu.getDefault3DContextVersion() < 2) {
     gl.vertexAttribPointer(0, 1, gl.INT, 0, 0, 0);

--- a/conformance-suites/2.0.0/conformance/more/functions/vertexAttribPointerBadArgs.html
+++ b/conformance-suites/2.0.0/conformance/more/functions/vertexAttribPointerBadArgs.html
@@ -33,57 +33,42 @@
 <script type="application/javascript" src="../util.js"></script>
 <script type="application/javascript">
 
-var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
-var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];
-var texcoords = [0.0,0.0,  1.0,0.0,  0.0,1.0];
-
 Tests.startUnit = function () {
-  var canvas = document.getElementById('gl');
+  var canvas = document.createElement('canvas');
   var gl = wrapGLContext(getGLContext(canvas));
-  var prog = new Shader(gl, 'vert', 'frag');
-  prog.use();
-  var sh = prog.shader.program;
-//   log(gl.getShaderInfoLog(prog.shaders[1]));
-  var v = gl.getAttribLocation(sh, 'Vertex');
-  var n = gl.getAttribLocation(sh, 'Normal');
-  var t = gl.getAttribLocation(sh, 'Tex');
-  return [gl,prog,v,n,t];
+  return [gl];
 }
 
-Tests.setup = function(gl, prog, v,n,t) {
+Tests.setup = function(gl) {
   assert(0 == gl.getError());
-  return [gl, prog, v,n,t];
-}
-Tests.teardown = function(gl, prog, v,n,t) {
-  gl.disableVertexAttribArray(v);
-  gl.disableVertexAttribArray(n);
-  gl.disableVertexAttribArray(t);
+  return [gl];
 }
 
-Tests.endUnit = function(gl, prog, v,n,t) {
-  prog.destroy();
+Tests.teardown = function(gl) {
 }
 
-Tests.testVertexAttribPointerVBO = function(gl, prog, v,n,t) {
+Tests.endUnit = function(gl) {
+}
+
+Tests.testVertexAttribPointerVBO = function(gl) {
   var vbo = gl.createBuffer();
-  var vertsArr = new Float32Array(verts);
   gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
-  gl.bufferData(gl.ARRAY_BUFFER, vertsArr, gl.STATIC_DRAW);
-  gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(4), gl.STATIC_DRAW);
+  gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
   assertFail("negative offset",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, -4);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, -4);});
   assertOk("out of range offset (OK because we can change the buffer later)",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 1200);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 1200);});
   assertFail("Offset that is incompatible with type",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 3);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 3);});
   assertFail("negative stride",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, -1, 0);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, -1, 0);});
   assertFail("bad size",
-      function(){gl.vertexAttribPointer(v, 5, gl.FLOAT, false, 0, 0);});
+      function(){gl.vertexAttribPointer(0, 5, gl.FLOAT, false, 0, 0);});
   assertFail("stride that doesn't match type",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 1, 0);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 1, 0);});
   assertFail("bad type",
-      function(){gl.vertexAttribPointer(v, 3, gl.TEXTURE_2D, false, 0, 0);});
+      function(){gl.vertexAttribPointer(0, 3, gl.TEXTURE_2D, false, 0, 0);});
   assertFail("bad index",
       function(){gl.vertexAttribPointer(-1, 3, gl.FLOAT, false, 0, 0);});
   assertFail("bad index (big negative)",
@@ -91,41 +76,17 @@ Tests.testVertexAttribPointerVBO = function(gl, prog, v,n,t) {
   assertFail("bad index (big positive)",
       function(){gl.vertexAttribPointer(8693948, 3, gl.FLOAT, false, 0, 0);});
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
-  assertFail("binding to null buffer",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);});
+  //assertOk("binding to null buffer with offset=0",
+  //    function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);});
+  assertFail("binding to null buffer with offset!=0",
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 16);});
   gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
-  gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
   gl.deleteBuffer(vbo);
   throwError(gl);
 }
 
 </script>
-<script id="vert" type="x-shader/x-vertex">
-  attribute vec3 Vertex;
-  attribute vec3 Normal;
-  attribute vec2 Tex;
-
-  varying vec4 texCoord0;
-  void main()
-  {
-    gl_Position = vec4(Vertex * Normal, 1.0);
-    texCoord0 = vec4(Tex,0.0,0.0) + gl_Position;
-  }
-</script>
-<script id="frag" type="x-shader/x-fragment">
-  precision mediump float;
-
-  varying vec4 texCoord0;
-  void main()
-  {
-    vec4 c = texCoord0;
-    gl_FragColor = c;
-  }
-</script>
-
-
-<style>canvas{ position:absolute; }</style>
 </head><body>
-  <canvas id="gl" width="1" height="1"></canvas>
 </body></html>

--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
@@ -59,13 +59,27 @@ if (!gl) {
     gl.FIXED = 0x140C;
   }
 
-  gl.vertexAttribPointer(0, 3, gl.FLOAT, 0, 0, 12);
-  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
-      "vertexAttribPointer should fail if no buffer is bound");
-
   var vertexObject = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(0), gl.STATIC_DRAW);
+
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 4);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+      "vertexAttribPointer should fail if no buffer is bound and `offset` is non-zero.");
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
+  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+      "vertexAttribPointer should succeed if no buffer is bound and `offset` is zero.");
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
+
 
   if (wtu.getDefault3DContextVersion() < 2) {
     gl.vertexAttribPointer(0, 1, gl.INT, 0, 0, 0);

--- a/sdk/tests/conformance/more/functions/vertexAttribPointerBadArgs.html
+++ b/sdk/tests/conformance/more/functions/vertexAttribPointerBadArgs.html
@@ -33,57 +33,42 @@
 <script type="application/javascript" src="../util.js"></script>
 <script type="application/javascript">
 
-var verts = [0.0, 0.0, 0.0,   1.0, 0.0, 0.0,   0.0, 1.0, 0.0];
-var normals = [0.0, 0.0, 1.0,   0.0, 0.0, 1.0,   0.0, 0.0, 1.0];
-var texcoords = [0.0,0.0,  1.0,0.0,  0.0,1.0];
-
 Tests.startUnit = function () {
-  var canvas = document.getElementById('gl');
+  var canvas = document.createElement('canvas');
   var gl = wrapGLContext(getGLContext(canvas));
-  var prog = new Shader(gl, 'vert', 'frag');
-  prog.use();
-  var sh = prog.shader.program;
-//   log(gl.getShaderInfoLog(prog.shaders[1]));
-  var v = gl.getAttribLocation(sh, 'Vertex');
-  var n = gl.getAttribLocation(sh, 'Normal');
-  var t = gl.getAttribLocation(sh, 'Tex');
-  return [gl,prog,v,n,t];
+  return [gl];
 }
 
-Tests.setup = function(gl, prog, v,n,t) {
+Tests.setup = function(gl) {
   assert(0 == gl.getError());
-  return [gl, prog, v,n,t];
-}
-Tests.teardown = function(gl, prog, v,n,t) {
-  gl.disableVertexAttribArray(v);
-  gl.disableVertexAttribArray(n);
-  gl.disableVertexAttribArray(t);
+  return [gl];
 }
 
-Tests.endUnit = function(gl, prog, v,n,t) {
-  prog.destroy();
+Tests.teardown = function(gl) {
 }
 
-Tests.testVertexAttribPointerVBO = function(gl, prog, v,n,t) {
+Tests.endUnit = function(gl) {
+}
+
+Tests.testVertexAttribPointerVBO = function(gl) {
   var vbo = gl.createBuffer();
-  var vertsArr = new Float32Array(verts);
   gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
-  gl.bufferData(gl.ARRAY_BUFFER, vertsArr, gl.STATIC_DRAW);
-  gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(4), gl.STATIC_DRAW);
+  gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
   assertFail("negative offset",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, -4);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, -4);});
   assertOk("out of range offset (OK because we can change the buffer later)",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 1200);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 1200);});
   assertFail("Offset that is incompatible with type",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 3);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 3);});
   assertFail("negative stride",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, -1, 0);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, -1, 0);});
   assertFail("bad size",
-      function(){gl.vertexAttribPointer(v, 5, gl.FLOAT, false, 0, 0);});
+      function(){gl.vertexAttribPointer(0, 5, gl.FLOAT, false, 0, 0);});
   assertFail("stride that doesn't match type",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 1, 0);});
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 1, 0);});
   assertFail("bad type",
-      function(){gl.vertexAttribPointer(v, 3, gl.TEXTURE_2D, false, 0, 0);});
+      function(){gl.vertexAttribPointer(0, 3, gl.TEXTURE_2D, false, 0, 0);});
   assertFail("bad index",
       function(){gl.vertexAttribPointer(-1, 3, gl.FLOAT, false, 0, 0);});
   assertFail("bad index (big negative)",
@@ -91,41 +76,17 @@ Tests.testVertexAttribPointerVBO = function(gl, prog, v,n,t) {
   assertFail("bad index (big positive)",
       function(){gl.vertexAttribPointer(8693948, 3, gl.FLOAT, false, 0, 0);});
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
-  assertFail("binding to null buffer",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);});
+  assertOk("binding to null buffer with offset=0",
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);});
+  assertFail("binding to null buffer with offset!=0",
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 16);});
   gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
-  gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
   gl.deleteBuffer(vbo);
   throwError(gl);
 }
 
 </script>
-<script id="vert" type="x-shader/x-vertex">
-  attribute vec3 Vertex;
-  attribute vec3 Normal;
-  attribute vec2 Tex;
-
-  varying vec4 texCoord0;
-  void main()
-  {
-    gl_Position = vec4(Vertex * Normal, 1.0);
-    texCoord0 = vec4(Tex,0.0,0.0) + gl_Position;
-  }
-</script>
-<script id="frag" type="x-shader/x-fragment">
-  precision mediump float;
-
-  varying vec4 texCoord0;
-  void main()
-  {
-    vec4 c = texCoord0;
-    gl_FragColor = c;
-  }
-</script>
-
-
-<style>canvas{ position:absolute; }</style>
 </head><body>
-  <canvas id="gl" width="1" height="1"></canvas>
 </body></html>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3398,11 +3398,21 @@ the state of the binding point will remain untouched.
 <p>
 
 The WebGL API does not support client-side arrays. If <code>vertexAttribPointer</code> is called
-without a <code>WebGLBuffer</code> bound to the <code>ARRAY_BUFFER</code> binding point,
-an <code>INVALID_OPERATION</code> error is generated. If <code>drawElements</code> is called with
-a <code>count</code> greater than zero, and no <code>WebGLBuffer</code> is bound to
-the <code>ELEMENT_ARRAY_BUFFER</code> binding point, an <code>INVALID_OPERATION</code> error is
-generated.
+without a <code>WebGLBuffer</code> bound to the <code>ARRAY_BUFFER</code> binding point, and
+<code>offset</code> is non-zero, an <code>INVALID_OPERATION</code> error is generated. If
+<code>drawElements</code> is called with a <code>count</code> greater than zero, and no
+<code>WebGLBuffer</code> is bound to the <code>ELEMENT_ARRAY_BUFFER</code> binding point, an
+<code>INVALID_OPERATION</code> error is generated.
+
+<div class="note rationale">
+    <p>
+    Allowing setting VERTEX_ATTRIB_ARRAY_BUFFER_BINDING to null even though client-side arrays
+    are never supported allows for clearing the binding to its original state, which isn't
+    strictly possible otherwise.
+    <p>
+    This also matches the behavior in OpenGL ES 3.0.5 <a href="#refsGLES30">[GLES30]</a> p25 for
+    non-default VAO objects.
+</div>
 
 </p>
 


### PR DESCRIPTION
…set succeeds.

This is de-facto tested in deqp's lifetime.html, but I'm really surprised we don't seem to test it elsewhere.