### PR TITLE
Add fbo complete test for fbo attaching base level of a texture

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/framebuffer-test.html
+++ b/sdk/tests/conformance2/renderbuffers/framebuffer-test.html
@@ -292,12 +292,35 @@ function testFramebufferRenderbuffer() {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bind draw framebuffer to default (null) framebuffer.");
 }
 
+function testFramebufferTextureWithNonZeroBaseLevel() {
+  var width = 32;
+  var height = 16;
+  var level = 1;
+  var texture = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, texture);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, level);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texImage2D(gl.TEXTURE_2D, level, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  var fbo = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, level);
+  shouldBe("gl.FRAMEBUFFER_COMPLETE", "gl.checkFramebufferStatus(gl.FRAMEBUFFER)");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setup framebuffer with texture should succeed.");
+
+  gl.deleteTexture(texture);
+  gl.deleteFramebuffer(fbo);
+}
+
 description("This tests framebuffer/renderbuffer-related functions");
 
 var canvas = document.getElementById("canvas");
 shouldBeNonNull("gl = wtu.create3DContext(canvas, undefined, 2)");
 
 testFramebufferRenderbuffer();
+testFramebufferTextureWithNonZeroBaseLevel();
 
 debug("");
 var successfullyParsed = true;


### PR DESCRIPTION
This failed on NVIDIA Linux with ANGLE and Intel Mac OSX. Chrome bug is filed: https://bugs.chromium.org/p/chromium/issues/detail?id=678526. 