### PR TITLE
VertexAttribIPointer with no array buffer is bound and offset is zero

### DIFF
--- a/conformance-suites/2.0.0/conformance2/attribs/gl-vertexattribipointer.html
+++ b/conformance-suites/2.0.0/conformance2/attribs/gl-vertexattribipointer.html
@@ -55,9 +55,13 @@ if (!gl) {
   debug("");
   debug("Checking gl.vertexAttribIPointer.");
 
+  // gl.vertexAttribIPointer(0, 3, gl.INT, 0, 0);
+  // wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+  //     "vertexAttribIPointer should succeed if no buffer is bound and offset is zero");
+
   gl.vertexAttribIPointer(0, 3, gl.INT, 0, 12);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
-      "vertexAttribIPointer should fail if no buffer is bound");
+      "vertexAttribIPointer should fail if no buffer is bound and offset is non-zero");
 
   var vertexObject = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);

--- a/sdk/tests/conformance2/attribs/gl-vertexattribipointer.html
+++ b/sdk/tests/conformance2/attribs/gl-vertexattribipointer.html
@@ -55,9 +55,13 @@ if (!gl) {
   debug("");
   debug("Checking gl.vertexAttribIPointer.");
 
+  gl.vertexAttribIPointer(0, 3, gl.INT, 0, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+      "vertexAttribIPointer should succeed if no buffer is bound and offset is zero");
+
   gl.vertexAttribIPointer(0, 3, gl.INT, 0, 12);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
-      "vertexAttribIPointer should fail if no buffer is bound");
+      "vertexAttribIPointer should fail if no buffer is bound and offset is non-zero");
 
   var vertexObject = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);


### PR DESCRIPTION
@kenrussell, @zhenyao and @jdashg , PTAL. 

Apply https://github.com/KhronosGroup/WebGL/pull/2228 to VertexAttribIPointer too.