### PR TITLE
Fix vp9 webm video resource name

### DIFF
--- a/sdk/tests/conformance/textures/misc/texture-upload-size.html
+++ b/sdk/tests/conformance/textures/misc/texture-upload-size.html
@@ -118,7 +118,7 @@ var tests = [
   {type: "img", isSVG: false, src: "../../../resources/red-green.png"},
   {type: "img", isSVG: true, src: "../../../resources/red-green.svg"},
   {type: "video", src: "../../../resources/red-green.mp4", videoType: 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"'},
-  {type: "video", src: "../../../resources/red-green.webmvp9.webm", videoType: 'video/webm; codecs="vp9"'},
+  {type: "video", src: "../../../resources/red-green.bt601.vp9.webm", videoType: 'video/webm; codecs="vp9"'},
   {type: "video", src: "../../../resources/red-green.webmvp8.webm", videoType: 'video/webm; codecs="vp8, vorbis"'},
   {type: "video", src: "../../../resources/red-green.theora.ogv", videoType: 'video/ogg; codecs="theora, vorbis"'},
 ];

--- a/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
+++ b/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
@@ -125,7 +125,7 @@ var tests = [
   { type: "ImageBitmap",width: 64, height: 64, run: testImageBitmap },
   { type: "ImageData", width: 64, height: 64, run: testImageData },
   { type: "video", src: "../../../resources/red-green.mp4", videoType: 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', run: testVideo },
-  { type: "video", src: "../../../resources/red-green.webmvp9.webm", videoType: 'video/webm; codecs="vp9"', run: testVideo },
+  { type: "video", src: "../../../resources/red-green.bt601.vp9.webm", videoType: 'video/webm; codecs="vp9"', run: testVideo },
   { type: "video", src: "../../../resources/red-green.webmvp8.webm", videoType: 'video/webm; codecs="vp8, vorbis"', run: testVideo },
   { type: "video", src: "../../../resources/red-green.theora.ogv", videoType: 'video/ogg; codecs="theora, vorbis"', run: testVideo },
 ];

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-video.js
@@ -44,7 +44,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     // differently. Some might be GPU accelerated, some might not. Etc...
     var videos = [
       { src: resourcePath + "red-green.mp4"         , type: 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', },
-      { src: resourcePath + "red-green.webmvp9.webm", type: 'video/webm; codecs="vp9"',                   },
+      { src: resourcePath + "red-green.bt601.vp9.webm", type: 'video/webm; codecs="vp9"',                   },
       { src: resourcePath + "red-green.webmvp8.webm", type: 'video/webm; codecs="vp8, vorbis"',           },
       { src: resourcePath + "red-green.theora.ogv",   type: 'video/ogg; codecs="theora, vorbis"',         },
     ];


### PR DESCRIPTION
Updated file name according https://github.com/KhronosGroup/WebGL/pull/2240. 
PTAL @kenrussell @zhenyao @jdashg 