### PR TITLE
Skip OffscreenCanvas test if it's not supported

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/context-creation-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-creation-worker.html
@@ -39,21 +39,22 @@
 <script>
 description("This test ensures that the WebGL context can be created on an OffscreenCanvas.");
 
-if (!window.OffscreenCanvas)
+if (!window.OffscreenCanvas) {
+  testSkipped("OffscreenCanvas is not supported.");
   finishTest();
-
-var worker = new Worker('context-creation-worker.js');
-worker.postMessage("Start worker");
-worker.onmessage = function(e) {
-  if (e.data == "Test passed") {
-    testPassed("All tests have passed");
-  } else {
-    testFailed("Some tests failed");
+} else {
+  var worker = new Worker('context-creation-worker.js');
+  worker.postMessage("Start worker");
+  worker.onmessage = function(e) {
+    if (e.data == "Test passed") {
+      testPassed("All tests have passed");
+    } else {
+      testFailed("Some tests failed");
+    }
+    finishTest();
   }
-  finishTest();
 }
-var successfullyParsed = true;
-</script>
 
+</script>
 </body>
 </html>

--- a/sdk/tests/conformance/offscreencanvas/context-creation-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-creation-worker.html
@@ -40,7 +40,7 @@
 description("This test ensures that the WebGL context can be created on an OffscreenCanvas.");
 
 if (!window.OffscreenCanvas) {
-  testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
   finishTest();
 } else {
   var worker = new Worker('context-creation-worker.js');

--- a/sdk/tests/conformance/offscreencanvas/context-creation.html
+++ b/sdk/tests/conformance/offscreencanvas/context-creation.html
@@ -42,17 +42,17 @@
 description("This test ensures that the WebGL context can be created on an OffscreenCanvas.");
 
 if (!window.OffscreenCanvas) {
-  finishTest();
-}
-
-if (contextCreation('webgl')) {
-  testPassed("WebGL context created correctly.");
+  testSkipped("OffscreenCanvas is not supported.");
 } else {
-  testFailed("WebGL context creation failed");
+  if (contextCreation('webgl')) {
+    testPassed("WebGL context created correctly.");
+  } else {
+    testFailed("WebGL context creation failed");
+  }
 }
 
 var successfullyParsed = true;
-finishTest();
 </script>
+<script src="../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance/offscreencanvas/context-creation.html
+++ b/sdk/tests/conformance/offscreencanvas/context-creation.html
@@ -42,7 +42,7 @@
 description("This test ensures that the WebGL context can be created on an OffscreenCanvas.");
 
 if (!window.OffscreenCanvas) {
-  testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
 } else {
   if (contextCreation('webgl')) {
     testPassed("WebGL context created correctly.");

--- a/sdk/tests/conformance/offscreencanvas/context-lost-restored-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-restored-worker.html
@@ -37,7 +37,9 @@ function init()
   description("Tests behavior under a restored context for OffscreenCanvas in a worker.");
 
   if (!window.OffscreenCanvas) {
+    testSkipped("OffscreenCanvas is not supported.");
     finishTest();
+    return;
   }
 
   var worker = new Worker('context-lost-restored-worker.js');
@@ -49,10 +51,10 @@ function init()
       testFailed("Some test failed");
     }
     finishTest();
+    return;
   }
 }
 
-var successfullyParsed = true;
 </script>
 </head>
 <body onload="init()">

--- a/sdk/tests/conformance/offscreencanvas/context-lost-restored-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-restored-worker.html
@@ -37,7 +37,7 @@ function init()
   description("Tests behavior under a restored context for OffscreenCanvas in a worker.");
 
   if (!window.OffscreenCanvas) {
-    testSkipped("OffscreenCanvas is not supported.");
+    testPassed("No OffscreenCanvas support");
     finishTest();
     return;
   }

--- a/sdk/tests/conformance/offscreencanvas/context-lost-restored.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-restored.html
@@ -39,7 +39,7 @@ function init()
     description("Tests behavior under a restored context for OffscreenCanvas.");
 
     if (!window.OffscreenCanvas) {
-      testSkipped("OffscreenCanvas is not supported.");
+      testPassed("No OffscreenCanvas support");
       finishTest();
       return;
     }

--- a/sdk/tests/conformance/offscreencanvas/context-lost-restored.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-restored.html
@@ -39,18 +39,22 @@ function init()
     description("Tests behavior under a restored context for OffscreenCanvas.");
 
     if (!window.OffscreenCanvas) {
+      testSkipped("OffscreenCanvas is not supported.");
       finishTest();
+      return;
     }
 
     if (!setupTest()) {
         testFailed("Cannot initialize test");
         finishTest();
+        return;
     }
 
     canvas.addEventListener("webglcontextlost", function(e) {
         if (!testLostContext(e)) {
             testFailed("Some test failed");
             finishTest();
+            return;
         }
         // restore the context after this event has exited.
         setTimeout(function() {
@@ -58,19 +62,23 @@ function init()
             if (!compareGLError(gl.INVALID_OPERATION, "WEBGL_lose_context.restoreContext()")) {
                 testFailed("Some test failed");
                 finishTest();
+                return;
             }
             testLosingAndRestoringContext().then(function() {
                 testPassed("Test passed");
                 finishTest();
+                return;
             }, function() {
                 testFailed("Some test failed");
                 finishTest();
+                return;
             });
        }, 0);
     });
     canvas.addEventListener("webglcontextrestored", function() {
         testFailed("Some test failed");
         finishTest();
+        return;
     });
     allowRestore = false;
     contextLostEventFired = false;
@@ -79,6 +87,7 @@ function init()
     if (!testOriginalContext()) {
         testFailed("Some test failed");
         finishTest();
+        return;
     }
     WEBGL_lose_context.loseContext();
     // The context should be lost immediately.
@@ -91,7 +100,6 @@ function init()
     shouldBeFalse("contextLostEventFired");
 }
 
-var successfullyParsed = true;
 </script>
 </head>
 <body onload="init()">

--- a/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
@@ -37,7 +37,7 @@ function init()
   description("Tests behavior under a lost context for OffscreenCanvas in a worker");
 
   if (!window.OffscreenCanvas) {
-    testSkipped("OffscreenCanvas is not supported.");
+    testPassed("No OffscreenCanvas support");
     finishTest();
     return;
   }

--- a/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
@@ -37,7 +37,9 @@ function init()
   description("Tests behavior under a lost context for OffscreenCanvas in a worker");
 
   if (!window.OffscreenCanvas) {
+    testSkipped("OffscreenCanvas is not supported.");
     finishTest();
+    return;
   }
 
   var worker = new Worker('context-lost-worker.js');
@@ -49,9 +51,10 @@ function init()
       testFailed("Some tests failed");
     }
     finishTest();
+    return;
   }
 }
-var successfullyParsed = false;
+
 </script>
 </head>
 <body onload="init()">

--- a/sdk/tests/conformance/offscreencanvas/context-lost.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost.html
@@ -38,7 +38,9 @@ function init()
     description("Tests behavior under a lost context for OffscreenCanvas");
 
     if (!window.OffscreenCanvas) {
+      testSkipped("OffscreenCanvas is not supported.");
       finishTest();
+      return;
     }
 
     canvas = new OffscreenCanvas(10, 10);
@@ -49,6 +51,7 @@ function init()
     if (!testValidContext()) {
         testFailed("Some tests failed");
         finishTest();
+        return;
     }
 
     extension = gl.getExtension("WEBGL_lose_context");
@@ -57,6 +60,7 @@ function init()
     if (extension == null || OES_vertex_array_object == null) {
         testFailed("Some tests failed");
         finishTest();
+        return;
     }
 
     // We need to initialize |uniformLocation| before losing context.
@@ -68,14 +72,15 @@ function init()
         if (testLostContextWithoutRestore()) {
             testPassed("All tests passed");
             finishTest();
+            return;
         } else {
             testFailed("Some tests failed");
             finishTest();
+            return;
         }
     }, false);
 }
 
-var successfullyParsed = true;
 </script>
 </head>
 <body onload="init()">

--- a/sdk/tests/conformance/offscreencanvas/context-lost.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost.html
@@ -38,7 +38,7 @@ function init()
     description("Tests behavior under a lost context for OffscreenCanvas");
 
     if (!window.OffscreenCanvas) {
-      testSkipped("OffscreenCanvas is not supported.");
+      testPassed("No OffscreenCanvas support");
       finishTest();
       return;
     }

--- a/sdk/tests/conformance/offscreencanvas/methods-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/methods-worker.html
@@ -40,21 +40,21 @@
 description("This test ensures that the WebGL context created for an OffscreenCanvas has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
+  testSkipped("OffscreenCanvas is not supported.");
   finishTest();
-}
-
-var worker = new Worker("methods-worker.js");
-worker.postMessage("Start worker");
-worker.onmessage = function(e) {
-  if (e.data == "Test passed") {
-    testPassed("All tests have passed");
-  } else {
-    testFailed("Some tests failed");
+} else {
+  var worker = new Worker("methods-worker.js");
+  worker.postMessage("Start worker");
+  worker.onmessage = function(e) {
+    if (e.data == "Test passed") {
+      testPassed("All tests have passed");
+    } else {
+      testFailed("Some tests failed");
+    }
+    finishTest();
   }
-  finishTest();
 }
-var successfullyParsed = false;
-</script>
 
+</script>
 </body>
 </html>

--- a/sdk/tests/conformance/offscreencanvas/methods-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/methods-worker.html
@@ -40,7 +40,7 @@
 description("This test ensures that the WebGL context created for an OffscreenCanvas has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
-  testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
   finishTest();
 } else {
   var worker = new Worker("methods-worker.js");

--- a/sdk/tests/conformance/offscreencanvas/methods.html
+++ b/sdk/tests/conformance/offscreencanvas/methods.html
@@ -41,18 +41,17 @@
 description("This test ensures that the WebGL context created for an OffscreenCanvas has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
-  finishTest();
-}
-
-if (testAPIs('webgl')) {
-  testPassed("All WebGL methods found");
+  testSkipped("OffscreenCanvas is not supported.");
 } else {
-  testFailed("Some WebGL methods not found");
+  if (testAPIs('webgl')) {
+    testPassed("All WebGL methods found");
+  } else {
+    testFailed("Some WebGL methods not found");
+  }
 }
 
 var successfullyParsed = true;
-finishTest();
 </script>
-
+<script src="../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance/offscreencanvas/methods.html
+++ b/sdk/tests/conformance/offscreencanvas/methods.html
@@ -41,7 +41,7 @@
 description("This test ensures that the WebGL context created for an OffscreenCanvas has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
-  testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
 } else {
   if (testAPIs('webgl')) {
     testPassed("All WebGL methods found");

--- a/sdk/tests/conformance2/offscreencanvas/context-creation-worker.html
+++ b/sdk/tests/conformance2/offscreencanvas/context-creation-worker.html
@@ -40,21 +40,21 @@
 description("This test ensures that the WebGL context can be created on an OffscreenCanvas.");
 
 if (!window.OffscreenCanvas) {
+  testSkipped("OffscreenCanvas is not supported.");
   finishTest();
-}
-
-var worker = new Worker('context-creation-worker.js');
-worker.postMessage("Start worker");
-worker.onmessage = function(e) {
-  if (e.data == "Test passed") {
-    testPassed("All tests have passed");
-  } else {
-    testFailed("Some tests failed");
+} else {
+  var worker = new Worker('context-creation-worker.js');
+  worker.postMessage("Start worker");
+  worker.onmessage = function(e) {
+    if (e.data == "Test passed") {
+      testPassed("All tests have passed");
+    } else {
+      testFailed("Some tests failed");
+    }
+    finishTest();
   }
-  finishTest();
 }
-var successfullyParsed = false;
-</script>
 
+</script>
 </body>
 </html>

--- a/sdk/tests/conformance2/offscreencanvas/context-creation-worker.html
+++ b/sdk/tests/conformance2/offscreencanvas/context-creation-worker.html
@@ -40,7 +40,7 @@
 description("This test ensures that the WebGL context can be created on an OffscreenCanvas.");
 
 if (!window.OffscreenCanvas) {
-  testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
   finishTest();
 } else {
   var worker = new Worker('context-creation-worker.js');

--- a/sdk/tests/conformance2/offscreencanvas/context-creation.html
+++ b/sdk/tests/conformance2/offscreencanvas/context-creation.html
@@ -41,18 +41,17 @@
 description("This test ensures that the WebGL2 context can be created on an OffscreenCanvas.");
 
 if (!window.OffscreenCanvas) {
-  finishTest();
-}
-
-if (contextCreation('webgl2')) {
-  testPassed("WebGL2 context created correctly.");
+  testSkipped("OffscreenCanvas is not supported.");
 } else {
-  testFailed("WebGL2 context creation failed");
+  if (contextCreation('webgl2')) {
+    testPassed("WebGL2 context created correctly.");
+  } else {
+    testFailed("WebGL2 context creation failed");
+  }
 }
 
 var successfullyParsed = true;
-finishTest();
 </script>
-
+<script src="../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance2/offscreencanvas/context-creation.html
+++ b/sdk/tests/conformance2/offscreencanvas/context-creation.html
@@ -41,7 +41,7 @@
 description("This test ensures that the WebGL2 context can be created on an OffscreenCanvas.");
 
 if (!window.OffscreenCanvas) {
-  testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
 } else {
   if (contextCreation('webgl2')) {
     testPassed("WebGL2 context created correctly.");

--- a/sdk/tests/conformance2/offscreencanvas/methods-2-worker.html
+++ b/sdk/tests/conformance2/offscreencanvas/methods-2-worker.html
@@ -40,7 +40,7 @@
 description("This test ensures that the WebGL context created for an OffscreenCanvas has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
-  testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
   finishTest();
 } else {
   var worker = new Worker('methods-2-worker.js');

--- a/sdk/tests/conformance2/offscreencanvas/methods-2-worker.html
+++ b/sdk/tests/conformance2/offscreencanvas/methods-2-worker.html
@@ -40,21 +40,21 @@
 description("This test ensures that the WebGL context created for an OffscreenCanvas has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
+  testSkipped("OffscreenCanvas is not supported.");
   finishTest();
-}
-
-var worker = new Worker('methods-2-worker.js');
-worker.postMessage("Start worker");
-worker.onmessage = function(e) {
-  if (e.data == "Test passed") {
-    testPassed("All test have passed");
-  } else {
-    testFailed("Some tests failed");
+} else {
+  var worker = new Worker('methods-2-worker.js');
+  worker.postMessage("Start worker");
+  worker.onmessage = function(e) {
+    if (e.data == "Test passed") {
+      testPassed("All test have passed");
+    } else {
+      testFailed("Some tests failed");
+    }
+    finishTest();
   }
-  finishTest();
 }
-var successfullyParsed = false;
-</script>
 
+</script>
 </body>
 </html>

--- a/sdk/tests/conformance2/offscreencanvas/methods-2.html
+++ b/sdk/tests/conformance2/offscreencanvas/methods-2.html
@@ -41,18 +41,17 @@
 description("This test ensures that the WebGL context has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
-    finishTest();
-}
-
-if (testAPIs('webgl2')) {
-  testPassed("All WebGL2 methods found");
+    testSkipped("OffscreenCanvas is not supported.");
 } else {
-  testFailed("Some WebGL2 methods not found");
+  if (testAPIs('webgl2')) {
+    testPassed("All WebGL2 methods found");
+  } else {
+    testFailed("Some WebGL2 methods not found");
+  }
 }
 
 var successfullyParsed = true;
-finishTest();
 </script>
-
+<script src="../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance2/offscreencanvas/methods-2.html
+++ b/sdk/tests/conformance2/offscreencanvas/methods-2.html
@@ -41,7 +41,7 @@
 description("This test ensures that the WebGL context has all the methods in the specification.");
 
 if (!window.OffscreenCanvas) {
-    testSkipped("OffscreenCanvas is not supported.");
+  testPassed("No OffscreenCanvas support");
 } else {
   if (testAPIs('webgl2')) {
     testPassed("All WebGL2 methods found");

--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -249,23 +249,6 @@ function testFailed(msg) {
     _flushBufferedLogsToConsole();
 }
 
-/**
- * @param  {string=} msg
- */
-function testSkipped(msg) {
-    msg = msg || 'Skipped';
-    if (_currentTestName)
-      msg = _currentTestName + ': ' + msg;
-
-    reportSkippedTestResultsToHarness(true, msg);
-
-    if (!quietMode())
-      _addSpan('<span><span class="warn">SKIP</span> ' + escapeHTML(msg) + '</span>');
-    if (_jsTestPreVerboseLogging) {
-        _bufferedLogToConsole('SKIP' + msg);
-    }
-}
-
 var _currentTestName;
 
 /**

--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -249,6 +249,23 @@ function testFailed(msg) {
     _flushBufferedLogsToConsole();
 }
 
+/**
+ * @param  {string=} msg
+ */
+function testSkipped(msg) {
+    msg = msg || 'Skipped';
+    if (_currentTestName)
+      msg = _currentTestName + ': ' + msg;
+
+    reportSkippedTestResultsToHarness(true, msg);
+
+    if (!quietMode())
+      _addSpan('<span><span class="warn">SKIP</span> ' + escapeHTML(msg) + '</span>');
+    if (_jsTestPreVerboseLogging) {
+        _bufferedLogToConsole('SKIP' + msg);
+    }
+}
+
 var _currentTestName;
 
 /**


### PR DESCRIPTION
finishTest() doesn't break the execution of left part of a test. We
should explicitly stop doing following test after finishTest().

This fixes some issues introduced in
https://github.com/KhronosGroup/WebGL/pull/2159.