### PR TITLE
Fixed nullability of getUniform's arguments in WebGL 2.0.

### DIFF
--- a/specs/2.0.0/index.html
+++ b/specs/2.0.0/index.html
@@ -2096,7 +2096,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <dl class="methods">
       <dt class="idl-code">
-        any getUniform(WebGLProgram? program, WebGLUniformLocation? location)
+        any getUniform(WebGLProgram program, WebGLUniformLocation location)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.12">OpenGL ES 3.0.4 &sect;6.1.12</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetUniform.xhtml" class="nonnormative">man page</a>)

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -2116,7 +2116,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <dl class="methods">
       <dt class="idl-code">
-        any getUniform(WebGLProgram? program, WebGLUniformLocation? location)
+        any getUniform(WebGLProgram program, WebGLUniformLocation location)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.12">OpenGL ES 3.0.4 &sect;6.1.12</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetUniform.xhtml" class="nonnormative">man page</a>)


### PR DESCRIPTION
The arguments were made non-nullable in WebGL 1.0. Updating this
detail documentation was overlooked.