### PR TITLE
Move failed tests on Intel Mesa to 2.0.1

### DIFF
--- a/conformance-suites/2.0.0/conformance2/textures/misc/tex-mipmap-levels.html
+++ b/conformance-suites/2.0.0/conformance2/textures/misc/tex-mipmap-levels.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL2 Non-Power of 2 texture conformance test.</title>
+<title>WebGL2 texture mipmap level conformance test.</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
@@ -74,18 +74,6 @@ precision mediump float;
 uniform sampler2D tex;
 uniform int lod;
 uniform ivec2 texSize;
-out vec4 fragColor;
-void main()
-{
-    fragColor = (textureSize(tex, lod) == texSize ? vec4(255, 0, 0, 255) : vec4(0, 0, 0, 255));
-}
-</script>
-
-<script id="fshader_texsize_3d" type="x-shader/x-fragment">#version 300 es
-precision mediump float;
-uniform highp sampler3D tex;
-uniform int lod;
-uniform ivec3 texSize;
 out vec4 fragColor;
 void main()
 {
@@ -246,28 +234,6 @@ wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
   wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
   gl.deleteTexture(tex);
-
-  // Test textureSize should work correctly with non-zero base level for texStorage3D
-  var program = wtu.setupProgram(
-      gl, ['vshader_texsize', 'fshader_texsize_3d'], ['vPosition'], [0]);
-
-  gl.uniform1i(gl.getUniformLocation(program, "tex"), 0);
-  gl.uniform1i(gl.getUniformLocation(program, "lod"), 1);
-  gl.uniform3i(gl.getUniformLocation(program, "texSize"), 8, 4, 2);
-  tex3d = gl.createTexture();
-  gl.bindTexture(gl.TEXTURE_3D, tex3d);
-  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAG_FILTER) should succeed");
-  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MIN_FILTER) should succeed");
-  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_BASE_LEVEL, 1);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_BASE_LEVEL) should succeed");
-  gl.texStorage3D(gl.TEXTURE_3D, 4, gl.RGBA8, 32, 16, 8);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage3D should succeed");
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
-  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
-  gl.deleteTexture(tex3d);
 
 })();
 

--- a/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
+++ b/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
@@ -287,6 +287,13 @@ goog.scope(function() {
         _skip("multisample.fbo_4_samples.constancy_alpha_to_coverage");
         _skip("multisample.fbo_8_samples.constancy_alpha_to_coverage");
         _skip("multisample.fbo_max_samples.constancy_alpha_to_coverage");
+
+        _setReason("Intel Mesa driver bug on updating texture with TexSubImage3D from pixel buffer.");
+        // crbug.com/666384
+        _skip("texture_functions.texturesize.sampler3d*");
+        _skip("texture_functions.texturesize.isampler3d*");
+        _skip("texture_functions.texturesize.sampler2darray*");
+        _skip("texture_functions.texturesize.isampler2darray*");
     } // if (!runSkippedTests)
 
     /*

--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -9,6 +9,7 @@ gl-get-tex-parameter.html
 --min-version 2.0.1 integer-cubemap-specification-order-bug.html
 mipmap-fbo.html
 --min-version 2.0.1 npot-video-sizing.html
+--min-version 2.0.1 tex-3d-mipmap-levels-intel-bug.html
 tex-3d-size-limit.html
 tex-image-and-sub-image-with-array-buffer-view-sub-source.html
 tex-image-with-bad-args.html

--- a/sdk/tests/conformance2/textures/misc/tex-3d-mipmap-levels-intel-bug.html
+++ b/sdk/tests/conformance2/textures/misc/tex-3d-mipmap-levels-intel-bug.html
@@ -1,0 +1,103 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 3D texture mipmap level conformance test.</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="2" height="2" style="width: 2px; height: 2px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader_texsize" type="x-shader/x-vertex">#version 300 es
+in vec4 vPosition;
+void main()
+{
+    gl_Position = vPosition;
+}
+</script>
+
+<script id="fshader_texsize_3d" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform highp sampler3D tex;
+uniform int lod;
+uniform ivec3 texSize;
+out vec4 fragColor;
+void main()
+{
+    fragColor = (textureSize(tex, lod) == texSize ? vec4(255, 0, 0, 255) : vec4(0, 0, 0, 255));
+}
+</script>
+
+
+<script>
+"use strict";
+description(document.title);
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example", undefined, 2);
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
+
+// This test fails on Intel Mesa, see crbug.com/666384.
+(function() {
+  debug("");
+  debug("Test textureSize should work correctly with non-zero base level for texStorage3D");
+  var program = wtu.setupProgram(
+      gl, ['vshader_texsize', 'fshader_texsize_3d'], ['vPosition'], [0]);
+  wtu.setupUnitQuad(gl, 0, 1);
+
+  gl.uniform1i(gl.getUniformLocation(program, "tex"), 0);
+  gl.uniform1i(gl.getUniformLocation(program, "lod"), 1);
+  gl.uniform3i(gl.getUniformLocation(program, "texSize"), 8, 4, 2);
+  var tex3d = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_3D, tex3d);
+  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAG_FILTER) should succeed");
+  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MIN_FILTER) should succeed");
+  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_BASE_LEVEL, 1);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_BASE_LEVEL) should succeed");
+  gl.texStorage3D(gl.TEXTURE_3D, 4, gl.RGBA8, 32, 16, 8);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage3D should succeed");
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
+  gl.deleteTexture(tex3d);
+})();
+
+var successfullyParsed = true;
+
+</script>
+<script src="../../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/misc/tex-mipmap-levels.html
+++ b/sdk/tests/conformance2/textures/misc/tex-mipmap-levels.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL2 Non-Power of 2 texture conformance test.</title>
+<title>WebGL2 texture mipmap level conformance test.</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
@@ -74,18 +74,6 @@ precision mediump float;
 uniform sampler2D tex;
 uniform int lod;
 uniform ivec2 texSize;
-out vec4 fragColor;
-void main()
-{
-    fragColor = (textureSize(tex, lod) == texSize ? vec4(255, 0, 0, 255) : vec4(0, 0, 0, 255));
-}
-</script>
-
-<script id="fshader_texsize_3d" type="x-shader/x-fragment">#version 300 es
-precision mediump float;
-uniform highp sampler3D tex;
-uniform int lod;
-uniform ivec3 texSize;
 out vec4 fragColor;
 void main()
 {
@@ -246,28 +234,6 @@ wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
   wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
   gl.deleteTexture(tex);
-
-  // Test textureSize should work correctly with non-zero base level for texStorage3D
-  var program = wtu.setupProgram(
-      gl, ['vshader_texsize', 'fshader_texsize_3d'], ['vPosition'], [0]);
-
-  gl.uniform1i(gl.getUniformLocation(program, "tex"), 0);
-  gl.uniform1i(gl.getUniformLocation(program, "lod"), 1);
-  gl.uniform3i(gl.getUniformLocation(program, "texSize"), 8, 4, 2);
-  tex3d = gl.createTexture();
-  gl.bindTexture(gl.TEXTURE_3D, tex3d);
-  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MAG_FILTER) should succeed");
-  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_MIN_FILTER) should succeed");
-  gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_BASE_LEVEL, 1);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texParameter(TEXTURE_BASE_LEVEL) should succeed");
-  gl.texStorage3D(gl.TEXTURE_3D, 4, gl.RGBA8, 32, 16, 8);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texStorage3D should succeed");
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
-  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
-  gl.deleteTexture(tex3d);
 
 })();
 


### PR DESCRIPTION
Make WebGL 2.0.0 100% pass with Chrome on Linux Intel HD530 with Mesa
driver 13.0.3.