### PR TITLE
Add a conformance test that caught a chrome crash.

### DIFF
--- a/sdk/tests/conformance2/context/00_test_list.txt
+++ b/sdk/tests/conformance2/context/00_test_list.txt
@@ -1,4 +1,5 @@
 constants-and-properties-2.html
 context-attributes-depth-stencil-antialias-obeyed.html
 context-type-test-2.html
+--min-version 2.0.1 context-resize-changes-buffer-binding-bug.html
 methods-2.html

--- a/sdk/tests/conformance2/context/context-resize-changes-buffer-binding-bug.html
+++ b/sdk/tests/conformance2/context/context-resize-changes-buffer-binding-bug.html
@@ -1,0 +1,70 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 Context Resize Bug Test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="test"></canvas>
+<script>
+"use strict";
+description("This test verifies canvas resize does not affect PIXEL_UNPACK_BUFFER binding.");
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("test");
+var gl = wtu.create3DContext(canvas, null, 2);
+if (!gl) {
+  testFailed("context does not exist");
+} else {
+  testPassed("context exists");
+  var texture1= gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_3D, texture1);
+  var buffer0= gl.createBuffer();
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, buffer0);
+
+  canvas.width = 682;
+  // Resizing canvas incorrectly cleared the PIXEL_UNPACK_BUFFER binding to 0
+  // and caused a crash from the following line in Chrome. crbug.com/673929.
+  gl.texImage3D(gl.TEXTURE_3D, 1, gl.R8,  225,664 , 143, 0,
+      gl.LUMINANCE_ALPHA, gl.UNSIGNED_SHORT_4_4_4_4, 0x41414141);
+  testPassed("no crash from texImage3D");
+}
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
The bug is, when resizing a canvas, chrome incorrectly set PIXEL_UNPACK_BUFFER
binding to 0 without recovering it.