### PR TITLE
Fix timeout in 3D image-bitmap-from-video tests and backport 2D fixup to 2.0.0 snapshot

### DIFF
--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -27,6 +27,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var gl = null;
     var successfullyParsed = false;
 
+    var videos = [
+        { src: resourcePath + "red-green.mp4"           , type: 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', },
+        { src: resourcePath + "red-green.webmvp8.webm"  , type: 'video/webm; codecs="vp8, vorbis"',           },
+        { src: resourcePath + "red-green.bt601.vp9.webm", type: 'video/webm; codecs="vp9"',                   },
+        { src: resourcePath + "red-green.theora.ogv"    , type: 'video/ogg; codecs="theora, vorbis"',         },
+    ];
+
     function init()
     {
         description('Verify texImage2D and texSubImage2D code paths taking ImageBitmap created from an HTMLVideoElement (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
@@ -48,15 +55,44 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
-        var video = document.createElement("video");
-        video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
-            .then(() => {
+        var videoNdx = 0;
+        var video;
+        function runNextVideo() {
+            if (video) {
+                video.pause();
+            }
+
+            if (videoNdx == videos.length) {
                 finishTest();
+                return;
+            }
+
+            var info = videos[videoNdx++];
+            debug("");
+            debug("testing: " + info.type);
+            video = document.createElement("video");
+            var canPlay = true;
+            if (!video.canPlayType) {
+                testFailed("video.canPlayType required method missing");
+                runNextVideo();
+                return;
+            }
+
+            if(!video.canPlayType(info.type).replace(/no/, '')) {
+                debug(info.type + " unsupported");
+                runNextVideo();
+                return;
+            };
+
+            document.body.appendChild(video);
+            video.type = info.type;
+            video.src = info.src;
+            wtu.startPlayingAndWaitForVideo(video, function() {
+                runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+                runNextVideo();
             });
         }
-        video.src = resourcePath + "red-green.theora.ogv";
-        document.body.appendChild(video);
+        runNextVideo();
     }
 
     return init;

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -27,6 +27,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var gl = null;
     var successfullyParsed = false;
 
+    var videos = [
+        { src: resourcePath + "red-green.mp4"           , type: 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', },
+        { src: resourcePath + "red-green.webmvp8.webm"  , type: 'video/webm; codecs="vp8, vorbis"',           },
+        { src: resourcePath + "red-green.bt601.vp9.webm", type: 'video/webm; codecs="vp9"',                   },
+        { src: resourcePath + "red-green.theora.ogv"    , type: 'video/ogg; codecs="theora, vorbis"',         },
+    ];
+
     function init()
     {
         description('Verify texImage3D and texSubImage3D code paths taking ImageBitmap created from an HTMLVideoElement (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
@@ -48,15 +55,44 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
-        video = document.createElement("video");
-        video.oncanplaythrough = function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
-            .then(() => {
+        var videoNdx = 0;
+        var video;
+        function runNextVideo() {
+            if (video) {
+                video.pause();
+            }
+
+            if (videoNdx == videos.length) {
                 finishTest();
+                return;
+            }
+
+            var info = videos[videoNdx++];
+            debug("");
+            debug("testing: " + info.type);
+            video = document.createElement("video");
+            var canPlay = true;
+            if (!video.canPlayType) {
+                testFailed("video.canPlayType required method missing");
+                runNextVideo();
+                return;
+            }
+
+            if(!video.canPlayType(info.type).replace(/no/, '')) {
+                debug(info.type + " unsupported");
+                runNextVideo();
+                return;
+            };
+
+            document.body.appendChild(video);
+            video.type = info.type;
+            video.src = info.src;
+            wtu.startPlayingAndWaitForVideo(video, function() {
+                runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+                runNextVideo();
             });
         }
-        video.src = resourcePath + "red-green.theora.ogv";
-        document.body.appendChild(video);
+        runNextVideo();
     }
 
     return init;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js
@@ -27,6 +27,13 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var gl = null;
     var successfullyParsed = false;
 
+    var videos = [
+        { src: resourcePath + "red-green.mp4"           , type: 'video/mp4; codecs="avc1.42E01E, mp4a.40.2"', },
+        { src: resourcePath + "red-green.webmvp8.webm"  , type: 'video/webm; codecs="vp8, vorbis"',           },
+        { src: resourcePath + "red-green.bt601.vp9.webm", type: 'video/webm; codecs="vp9"',                   },
+        { src: resourcePath + "red-green.theora.ogv"    , type: 'video/ogg; codecs="theora, vorbis"',         },
+    ];
+
     function init()
     {
         description('Verify texImage3D and texSubImage3D code paths taking ImageBitmap created from an HTMLVideoElement (' + internalFormat + '/' + pixelFormat + '/' + pixelType + ')');
@@ -48,15 +55,44 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         gl.clearColor(0,0,0,1);
         gl.clearDepth(1);
 
-        video = document.createElement("video");
-        video.src = resourcePath + "red-green.theora.ogv";
-        document.body.appendChild(video);
-        wtu.startPlayingAndWaitForVideo(video, function() {
-            runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true)
-            .then(() => {
+        var videoNdx = 0;
+        var video;
+        function runNextVideo() {
+            if (video) {
+                video.pause();
+            }
+
+            if (videoNdx == videos.length) {
                 finishTest();
+                return;
+            }
+
+            var info = videos[videoNdx++];
+            debug("");
+            debug("testing: " + info.type);
+            video = document.createElement("video");
+            var canPlay = true;
+            if (!video.canPlayType) {
+                testFailed("video.canPlayType required method missing");
+                runNextVideo();
+                return;
+            }
+
+            if(!video.canPlayType(info.type).replace(/no/, '')) {
+                debug(info.type + " unsupported");
+                runNextVideo();
+                return;
+            };
+
+            document.body.appendChild(video);
+            video.type = info.type;
+            video.src = info.src;
+            wtu.startPlayingAndWaitForVideo(video, function() {
+                runImageBitmapTest(video, 1, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, true);
+                runNextVideo();
             });
-        });
+        }
+        runNextVideo();
     }
 
     return init;


### PR DESCRIPTION
Fixed 3D image-bitmap-from-video tests and backported following two prs:
1. Fix timeout when video type is unsupported (#2275).
2. Use wtu.startPlayingAndWaitForVideo in image-bitmap-from-video tests.
(#2184).