### PR TITLE
Updated links to cross-origin resources to point to get.webgl.org.

### DIFF
--- a/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
+++ b/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
@@ -34,7 +34,7 @@
 <script type="application/javascript" src="../../../js/webgl-test-utils.js"></script>
 <script type="application/javascript">
 var wtu = WebGLTestUtils;
-var defaultImgUrl = "http://www.opengl.org/img/opengl_logo.jpg";
+var defaultImgUrl = "https://get.webgl.org/conformance-resources/opengl_logo.jpg";
 var localImgUrl = "../../../resources/opengl_logo.jpg";
 
 Tests.autoinit = false; // Prevents the test from running until the image is loaded

--- a/sdk/tests/conformance/more/functions/texImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texImage2DHTML.html
@@ -34,7 +34,7 @@
 <script type="application/javascript" src="../../../js/webgl-test-utils.js"></script>
 <script type="application/javascript">
 var wtu = WebGLTestUtils;
-var defaultImgUrl = "http://mashable.com/wp-content/uploads/2008/08/thunderbird-logo-64x64.png";
+var defaultImgUrl = "https://get.webgl.org/conformance-resources/thunderbird-logo-64x64.png";
 var localImgUrl = "../../../resources/thunderbird-logo-64x64.png";
 
 Tests.autoinit = false; // Prevents the test from running until the image is loaded

--- a/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
@@ -34,7 +34,7 @@
 <script type="application/javascript" src="../../../js/webgl-test-utils.js"></script>
 <script type="application/javascript">
 var wtu = WebGLTestUtils;
-var defaultImgUrl = "http://mashable.com/wp-content/uploads/2008/08/thunderbird-logo-64x64.png";
+var defaultImgUrl = "https://get.webgl.org/conformance-resources/thunderbird-logo-64x64.png";
 var localImgUrl = "../../../resources/thunderbird-logo-64x64.png";
 
 Tests.autoinit = false; // Prevents the test from running until the image is loaded

--- a/sdk/tests/conformance/textures/misc/origin-clean-conformance.html
+++ b/sdk/tests/conformance/textures/misc/origin-clean-conformance.html
@@ -48,7 +48,7 @@ function causedException(func) {
   return hadException;
 }
 
-var defaultImgUrl = "http://www.opengl.org/img/opengl_logo.jpg";
+var defaultImgUrl = "https://get.webgl.org/conformance-resources/opengl_logo.jpg";
 var localImgUrl = "../../../resources/opengl_logo.jpg";
 
 var imgDomain;


### PR DESCRIPTION
Will test these live on the khronos.org site and then backport the
changes to the earlier conformance snapshots.

Partially addresses #2273.