### PR TITLE
Rename preferLowPowerToHighPerformance to powerPreference.

### DIFF
--- a/extensions/WEBGL_lose_context/extension.xml
+++ b/extensions/WEBGL_lose_context/extension.xml
@@ -37,13 +37,19 @@ interface WEBGL_lose_context {
   </idl>
   <newfun>
     <function name="loseContext" type="void">
-      When this function is called and the context is not lost, simulate
+      <p>When this function is called and the context is not lost, simulate
       losing the context so as to trigger the steps described in the WebGL
       spec for handling context lost. The context will remain in the lost
       state according to the WebGL specification until
       <code>restoreContext()</code> is called.  If the context is already
       lost when this function is called, generate an
-      <code>INVALID_OPERATION</code> error.
+      <code>INVALID_OPERATION</code> error.</p>
+
+      <p>Implementations should destroy the underlying graphics context and
+      all graphics resources when this method is called. This is the
+      recommended mechanism for applications to programmatically halt their
+      use of the WebGL API.</p>
+
     </function>
     <function name="restoreContext" type="void">
       When this function is called while the context is lost, and the conditions
@@ -99,6 +105,10 @@ interface WEBGL_lose_context {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2017/02/03">
+      <change>Per discussion in working group, document that this extension
+      should destroy the underlying context and all graphics resources.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_lose_context/extension.xml
+++ b/extensions/WEBGL_lose_context/extension.xml
@@ -37,19 +37,13 @@ interface WEBGL_lose_context {
   </idl>
   <newfun>
     <function name="loseContext" type="void">
-      <p>When this function is called and the context is not lost, simulate
+      When this function is called and the context is not lost, simulate
       losing the context so as to trigger the steps described in the WebGL
       spec for handling context lost. The context will remain in the lost
       state according to the WebGL specification until
       <code>restoreContext()</code> is called.  If the context is already
       lost when this function is called, generate an
-      <code>INVALID_OPERATION</code> error.</p>
-
-      <p>Implementations should destroy the underlying graphics context and
-      all graphics resources when this method is called. This is the
-      recommended mechanism for applications to programmatically halt their
-      use of the WebGL API.</p>
-
+      <code>INVALID_OPERATION</code> error.
     </function>
     <function name="restoreContext" type="void">
       When this function is called while the context is lost, and the conditions
@@ -105,10 +99,6 @@ interface WEBGL_lose_context {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
-    </revision>
-    <revision date="2017/02/03">
-      <change>Per discussion in working group, document that this extension
-      should destroy the underlying context and all graphics resources.</change>
     </revision>
   </history>
 </ratified>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -807,7 +807,6 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
                 only a hint and a WebGL implementation may choose to ignore it.
               </p>
               <p>
-
                 WebGL implementations use context lost and restored events to regulate power and
                 memory consumption, <em>regardless</em> of the value of this attribute. <em>At
                 WebGLRenderingContext creation time, this attribute will be ignored if no event

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -807,12 +807,12 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
                 only a hint and a WebGL implementation may choose to ignore it.
               </p>
               <p>
+
                 WebGL implementations use context lost and restored events to regulate power and
-                memory consumption, <em>even if</em> this attribute is not specified. <em>The
-                application must have registered an event listener which would handle the
-                <code>"webglcontextlost"</code> and <code>"webglcontextrestored"</code> events if
-                they were dispatched to the canvas element before fetching a WebGLRenderingContext
-                specifying this attribute, or "default" will be used.</em>
+                memory consumption, <em>regardless</em> of the value of this attribute. <em>At
+                WebGLRenderingContext creation time, this attribute will be ignored if no event
+                listeners exist which would handle both <code>"webglcontextlost"</code>
+                and <code>"webglcontextrestored"</code> events dispatched to the canvas element.</em>
               </p>
               <p>
                 The allowed values are:

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -829,7 +829,7 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
                     <em>high-performance</em>
                   </p>
                   <p>
-                    Indicates a request for a GPU configuration that values high rendering
+                    Indicates a request for a GPU configuration that prioritizes high rendering
                     performance over power consumption.  Any content that chooses this value should
                     be aware that it is more likely that the user agent will force a lost context at
                     any time. Implementations may decide to initially respect this request and,

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -809,10 +809,10 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
               <p>
                 WebGL implementations use context lost and restored events to regulate power and
                 memory consumption, <em>even if</em> this attribute is not specified. <em>The
-                application must have registered
-                <code>"webglcontextlost"</code> and <code>"webglcontextrestored"</code> event
-                listeners on the canvas element before fetching a WebGLRenderingContext specifying
-                this attribute, or "default" will be used.</em>
+                application must have registered an event listener which would handle the
+                <code>"webglcontextlost"</code> and <code>"webglcontextrestored"</code> events if
+                they were dispatched to the canvas element before fetching a WebGLRenderingContext
+                specifying this attribute, or "default" will be used.</em>
               </p>
               <p>
                 The allowed values are:
@@ -829,7 +829,7 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
                     <em>high-performance</em>
                   </p>
                   <p>
-                    Indicates a request for a GPU configuration that prioritizes high rendering
+                    Indicates a request for a GPU configuration that prioritizes rendering
                     performance over power consumption.  Any content that chooses this value should
                     be aware that it is more likely that the user agent will force a lost context at
                     any time. Implementations may decide to initially respect this request and,
@@ -846,8 +846,8 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
                     rendering performance. Generally, content should use this if it is unlikely to
                     be constrained by drawing performance; for example, if it renders only one frame
                     per second, draws only relatively simple geometry with simple shaders, or uses a
-                    small HTML canvas element. Developers are encouraged to specify this value if
-                    their content allows, since it may significantly improve battery life on mobile
+                    small HTML canvas element. Developers are encouraged to use this value if their
+                    content allows, since it may significantly improve battery life on mobile
                     devices.
                   </p>
               </dd></dl>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -713,6 +713,10 @@ typedef unsigned short GLushort;
 typedef unsigned long  GLuint;
 typedef unrestricted float GLfloat;
 typedef unrestricted float GLclampf;
+
+// The power preference settings are documented in the WebGLContextAttributes
+// section of the specification.
+enum WebGLPowerPreference { "default", "low-power", "high-performance" };
 </pre>
 
 <!-- ======================================================================================================= -->
@@ -726,16 +730,14 @@ typedef unrestricted float GLclampf;
     <!-- The capitalization rules here match those of the crossOrigin
     attribute, which was added to HTMLMediaElement on behalf of
     WebGL. -->
-    <pre class="idl">enum PowerPreference { "default", "low-power", "high-performance" };
-
-dictionary <dfn id="WebGLContextAttributes">WebGLContextAttributes</dfn> {
+    <pre class="idl">dictionary <dfn id="WebGLContextAttributes">WebGLContextAttributes</dfn> {
     GLboolean alpha = true;
     GLboolean depth = true;
     GLboolean stencil = false;
     GLboolean antialias = true;
     GLboolean premultipliedAlpha = true;
     GLboolean preserveDrawingBuffer = false;
-    PowerPreference powerPreference = "default";
+    WebGLPowerPreference powerPreference = "default";
     GLboolean failIfMajorPerformanceCaveat = false;
 };</pre>
 
@@ -797,12 +799,58 @@ dictionary <dfn id="WebGLContextAttributes">WebGLContextAttributes</dfn> {
             </dd>
         <dt><span class=prop-value>powerPreference</span></dt>
             <dd>
-              Provides a hint to the implementation suggesting that, if possible, it
-              creates a context that optimizes for power consumption over
-              performance. For example, on hardware that has more than one
-              GPU, it may be the case that one of them is less powerful
-              but also uses less power. An implementation may choose to, and may
-              have to, ignore this hint.
+              <p>
+                Provides a hint to the user agent indicating what configuration of GPU is suitable
+                for this WebGL context. This may influence which GPU is used in a system with
+                multiple GPUs. For example, a dual-GPU system might have one GPU that consumes
+                less power at the expense of rendering performance. Note that this property is
+                only a hint and a WebGL implementation may choose to ignore it.
+              </p>
+              <p>
+                WebGL implementations use context lost and restored events to regulate power and
+                memory consumption, <em>even if</em> this attribute is not specified. <em>The
+                application must have registered
+                <code>"webglcontextlost"</code> and <code>"webglcontextrestored"</code> event
+                listeners on the canvas element before fetching a WebGLRenderingContext specifying
+                this attribute, or "default" will be used.</em>
+              </p>
+              <p>
+                The allowed values are:
+              </p>
+              <dl><dd>
+                  <p>
+                    <em>default</em>
+                  </p>
+                  <p>
+                    Let the user agent decide which GPU configuration is most suitable. This is the
+                    default value.
+                  </p>
+                  <p>
+                    <em>high-performance</em>
+                  </p>
+                  <p>
+                    Indicates a request for a GPU configuration that values high rendering
+                    performance over power consumption.  Any content that chooses this value should
+                    be aware that it is more likely that the user agent will force a lost context at
+                    any time. Implementations may decide to initially respect this request and,
+                    after some time, lose the context and restore a new context ignoring the
+                    request. Developers are encouraged to only specify this value if they believe it
+                    is absolutely necessary, since it may significantly decrease battery life on
+                    mobile devices.
+                  </p>
+                  <p>
+                    <em>low-power</em>
+                  </p>
+                  <p>
+                    Indicates a request for a GPU configuration that prioritizes power saving over
+                    rendering performance. Generally, content should use this if it is unlikely to
+                    be constrained by drawing performance; for example, if it renders only one frame
+                    per second, draws only relatively simple geometry with simple shaders, or uses a
+                    small HTML canvas element. Developers are encouraged to specify this value if
+                    their content allows, since it may significantly improve battery life on mobile
+                    devices.
+                  </p>
+              </dd></dl>
             </dd>
         <dt> <span class=prop-value>failIfMajorPerformanceCaveat</span></dt>
             <dd>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -723,14 +723,19 @@ typedef unrestricted float GLclampf;
         The <code>WebGLContextAttributes</code> dictionary contains drawing surface attributes and
         is passed as the second parameter to <code>getContext</code>.
     </p>
-    <pre class="idl">dictionary <dfn id="WebGLContextAttributes">WebGLContextAttributes</dfn> {
+    <!-- The capitalization rules here match those of the crossOrigin
+    attribute, which was added to HTMLMediaElement on behalf of
+    WebGL. -->
+    <pre class="idl">enum PowerPreference { "default", "low-power", "high-performance" };
+
+dictionary <dfn id="WebGLContextAttributes">WebGLContextAttributes</dfn> {
     GLboolean alpha = true;
     GLboolean depth = true;
     GLboolean stencil = false;
     GLboolean antialias = true;
     GLboolean premultipliedAlpha = true;
     GLboolean preserveDrawingBuffer = false;
-    GLboolean preferLowPowerToHighPerformance = false;
+    PowerPreference powerPreference = "default";
     GLboolean failIfMajorPerformanceCaveat = false;
 };</pre>
 
@@ -790,7 +795,7 @@ typedef unrestricted float GLclampf;
                 </em>
                 </blockquote>
             </dd>
-        <dt><span class=prop-value>preferLowPowerToHighPerformance</span></dt>
+        <dt><span class=prop-value>powerPreference</span></dt>
             <dd>
               Provides a hint to the implementation suggesting that, if possible, it
               creates a context that optimizes for power consumption over

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -22,6 +22,10 @@ typedef unsigned long  GLuint;
 typedef unrestricted float GLfloat;
 typedef unrestricted float GLclampf;
 
+// The power preference settings are documented in the WebGLContextAttributes
+// section of the specification.
+enum WebGLPowerPreference { "default", "low-power", "high-performance" };
+
 
 dictionary WebGLContextAttributes {
     GLboolean alpha = true;
@@ -30,7 +34,7 @@ dictionary WebGLContextAttributes {
     GLboolean antialias = true;
     GLboolean premultipliedAlpha = true;
     GLboolean preserveDrawingBuffer = false;
-    GLboolean preferLowPowerToHighPerformance = false;
+    WebGLPowerPreference powerPreference = "default";
     GLboolean failIfMajorPerformanceCaveat = false;
 };
 


### PR DESCRIPTION
Document that WEBGL_lose_context extension should destroy graphics
resources.