### PR TITLE
Update more extension tests to account for removal of ETC2/EAC

### DIFF
--- a/conformance-suites/2.0.0/conformance/extensions/webgl-compressed-texture-atc.html
+++ b/conformance-suites/2.0.0/conformance/extensions/webgl-compressed-texture-atc.html
@@ -204,12 +204,8 @@ function runTestExtension() {
     }
 
     supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 3 formats for WebGL 1.0 and 13 formats for WebGL 2.0.
-    if (contextVersion < 2) {
-        shouldBe("supportedFormats.length", "3");
-    } else {
-        shouldBe("supportedFormats.length", "13");
-    }
+    // There should be exactly 3 formats for both WebGL 1.0 and WebGL 2.0.
+    shouldBe("supportedFormats.length", "3");
 
     // check that all 3 formats exist
     for (var name in validFormats.length) {

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-atc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-atc.html
@@ -204,12 +204,8 @@ function runTestExtension() {
     }
 
     supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 3 formats for WebGL 1.0 and 13 formats for WebGL 2.0.
-    if (contextVersion < 2) {
-        shouldBe("supportedFormats.length", "3");
-    } else {
-        shouldBe("supportedFormats.length", "13");
-    }
+    // There should be exactly 3 formats for both WebGL 1.0 and WebGL 2.0.
+    shouldBe("supportedFormats.length", "3");
 
     // check that all 3 formats exist
     for (var name in validFormats.length) {


### PR DESCRIPTION
This is fallout from #2053, in which I forgot to update the ATC tests.

This wasn't noticed because it runs only on limited configurations (as ATC is an AMD extension). I found it while debugging test failures on Google Pixel (Qualcomm Adreno 530), which supports it.

This corrects a failure on this device on both Chrome and Firefox.