### PR TITLE
Fix tolerance issue in WebGL 2.0.0 snapshot

### DIFF
--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
@@ -149,12 +149,12 @@ function runOneIterationImageBitmapTest(useTexSubImage, bindingTarget, program, 
         // Check the top pixel and bottom pixel and make sure they have
         // the right color.
         bufferedLogToConsole("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl);
+        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl, tolerance);
         if (!skipCorner && !flipY) {
             wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
         }
         bufferedLogToConsole("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl);
+        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl, tolerance);
         if (!skipCorner && flipY) {
             wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
         }


### PR DESCRIPTION
Backport "Add tolerance for pixels checking in image_bitmap_from_video
tests (#2281)" to 2.0.0 snapshot.