### PR TITLE
Update more conformance tests to OffscreenCanvas

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/00_test_list.txt
+++ b/sdk/tests/conformance/offscreencanvas/00_test_list.txt
@@ -1,3 +1,4 @@
+context-attribute-preserve-drawing-buffer.html
 context-creation.html
 context-creation-worker.html
 context-lost.html
@@ -6,3 +7,4 @@ context-lost-restored.html
 context-lost-restored-worker.html
 methods.html
 methods-worker.html
+offscreencanvas-resize.html

--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -1,0 +1,76 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>OffscreenCanavs context attribute preserveDrawingBuffer</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/canvas-tests-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("This test checks whether OffscreenCanvas webgl context honors the preserveDrawingBuffer flag.");
+
+function getPixelsFromOffscreenWebgl(preserveFlag) {
+  var canvas = document.createElement("canvas");
+  var offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
+  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: preserveFlag});
+
+  // Draw some color on gl and commit
+  gl.clearColor(1, 0, 1, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.commit();
+
+  var pixels = new Uint8Array(4);
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+  return pixels;
+}
+
+if (!window.OffscreenCanvas) {
+    testPassed("No OffscreenCanvas support");
+} else {
+    // Test if OffscreenCanvas.webgl retains context if preserveDrawingBuffer is true.
+    var pixelsPreserve = getPixelsFromOffscreenWebgl(true);
+    shouldBe(pixelsPreserve, [255,0,255,255]);
+
+    // Test if OffscreenCanvas.webgl loses context if presereDrawingbuffer is false.
+    var pixelsNoPreserve = getPixelsFromOffscreenWebgl(false);
+    shouldBe(pixelsNoPreserve, [0,0,0,0]);
+}
+
+var successfullyParsed = true;
+
+</script>
+<script src="../../js/js-test-pre.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -71,6 +71,6 @@ if (!window.OffscreenCanvas) {
 var successfullyParsed = true;
 
 </script>
-<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
+++ b/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
@@ -1,0 +1,109 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Resizing Test for OffscreenCanvas</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/canvas-tests-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("This test ensures that the OffscreenCanvas context returns the correct image size after resizing.");
+
+function testResizeOnNewOffscreenCanvas() {
+  var canvas = new OffscreenCanvas(10, 20);
+  canvas.getContext("webgl");
+  canvas.width = 30;
+  canvas.height = 40;
+  assertWidthAndHeight(canvas, "canvas", 30, 40);
+  var imagebitmap = canvas.transferToImageBitmap();
+  assertWidthAndHeight(imagebitmap, "imagebitmap", 30, 40);
+}
+
+function testResizeOnTransferredOffscreenCanvas() {
+  var placeholder = document.createElement("canvas");
+  var offscreencanvas = transferredOffscreenCanvasCreation(placeholder, 10, 20);
+  var ctx = offscreencanvas.getContext("webgl");
+
+  // Verify that setting the size of an OffscreenCanvas that has a placeholder works.
+  offscreencanvas.width = 30;
+  offscreencanvas.height = 40;
+  assertWidthAndHeight(offscreencanvas, "resized offscreencanvas", 30, 40);
+  var imagebitmap = offscreencanvas.transferToImageBitmap();
+  assertWidthAndHeight(imagebitmap, "imagebitmap transferred from resized offscreencanvas" , 30, 40);
+
+  // Verify that setting the size of an OffscreenCanvas does not directly update the size of its placeholder canvas.
+  assertWidthAndHeight(placeholder, "placeholder canvas", 10, 20);
+
+  var asyncStepsCompleted = 0;
+  ctx.commit();
+  createImageBitmap(placeholder).then(image => {
+    // Verify that the placeholder was not updated synchronously.
+    assertWidthAndHeight(image, "imagebitmap from placeholder canvas", 10, 20);
+    asyncStepsCompleted++;
+    if (asyncStepsCompleted == 2) {
+      finishTest();
+    }
+  });
+
+  // Set timeout acts as a sync barrier to allow commit to propagate
+  setTimeout(function() {
+    // Verify that commit() asynchronously updates the size of its placeholder canvas.
+    assertWidthAndHeight(placeholder, "placeholder canvas", 10, 20);
+
+    // Verify that width/height attributes are still settable even though they have no effect.
+    placeholder.width = 50;
+    placeholder.height = 60;
+    assertWidthAndHeight(placeholder, "placeholder canvas after size reset", 50, 60);
+
+    createImageBitmap(placeholder).then(image => {
+      // Verify that an image grabbed from the placeholder has the correct dimensions
+      assertWidthAndHeight(image, "imagebitmap from placeholder canvas", 30, 40);
+      asyncStepsCompleted++;
+      if (asyncStepsCompleted == 2) {
+        finishTest();
+      }
+    });
+  }, 0);
+}
+
+if (!window.OffscreenCanvas) {
+    testPassed("No OffscreenCanvas support");
+} else {
+  testResizeOnNewOffscreenCanvas();
+  testResizeOnTransferredOffscreenCanvas();
+}
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
+++ b/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
@@ -99,7 +99,8 @@ function testResizeOnTransferredOffscreenCanvas() {
 }
 
 if (!window.OffscreenCanvas) {
-    testPassed("No OffscreenCanvas support");
+  testPassed("No OffscreenCanvas support");
+  finishTest();
 } else {
   testResizeOnNewOffscreenCanvas();
   testResizeOnTransferredOffscreenCanvas();

--- a/sdk/tests/js/tests/canvas-tests-utils.js
+++ b/sdk/tests/js/tests/canvas-tests-utils.js
@@ -80,6 +80,27 @@ function contextCreation(contextType) {
     }
 }
 
+function transferredOffscreenCanvasCreation(placeholder, width, height) {
+  placeholder.width = width;
+  placeholder.height = height;
+  return placeholder.transferControlToOffscreen();
+}
+
+function assertWidthAndHeight(entity, entityName, width, height) {
+ if (entity.width == width && entity.height == height) {
+   testPassed("The width and height of " + entityName + " are correct.");
+   return;
+ }
+ var errMsg = "";
+ if (entity.width != width) {
+   errMsg += "The width of " + entityName + " is " + entity.width + " while expected value is " + width + ". ";
+ }
+ if (entity.height != height) {
+   errMsg += "The height of " + entityName + " is " + entity.height + " while expected value is " + height + ". ";
+ }
+ testFailed(errMsg);
+}
+
 var webgl1Methods = [
   "getContextAttributes",
   "activeTexture",


### PR DESCRIPTION
@kenrussell 
The two new tests that are adding here are adapted from existing Chromium layout tests:
1. offscreencanvas-resize.html
https://cs.chromium.org/chromium/src/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-resize.html
The resizing behavior is specified in WHATWG spec https://html.spec.whatwg.org/multipage/scripting.html#the-offscreencanvas-interface,

2. context-attribute-preserve-drawing-buffer.html
https://cs.chromium.org/chromium/src/third_party/WebKit/LayoutTests/fast/canvas/OffscreenCanvas-webgl-preserveDrawingBuffer.html

