### PR TITLE
Make some GLSL tests use the GLSL test framework

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/multiplication-assignment.html
+++ b/sdk/tests/conformance/glsl/bugs/multiplication-assignment.html
@@ -33,14 +33,10 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
-<script id="shader-vs" type="x-shader/x-vertex">
-void main(){
-    gl_Position = vec4(0);
-}
-</script>
-<script id="shader-fs" type="x-shader/x-fragment">
+<script id="fshader" type="x-shader/x-fragment">
 precision mediump float;
 uniform mat3 rot;
 float foo(vec3 bar) {
@@ -60,21 +56,16 @@ void main(void){
 description();
 debug("");
 debug('Verify multiplication assignment operator compiles correctly - regression test for <a href="https://code.google.com/p/chromium/issues/detail?id=384847">Chromium bug 384847</a>');
-var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext();
-if (!gl) {
-  testFailed("context does not exist");
-} else {
-  var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], null, null, true);
-  if (program) {
-    testPassed("Program compiled and linked successfully");
-  } else {
-    testFailed("Program failed to compile and link");
-  }
-}
 
-var successfullyParsed = true;
+GLSLConformanceTester.runTests([
+{
+  fShaderId: 'fshader',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "vec3 *= mat3 multiplication assignment operator",
+}
+]);
+
 </script>
-<script src="../../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance/glsl/bugs/struct-constructor-highp-bug.html
+++ b/sdk/tests/conformance/glsl/bugs/struct-constructor-highp-bug.html
@@ -6,19 +6,11 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="256" height="256"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec4 a_position;
-void main() {
-  gl_Position = a_position;
-}
-</script>
-
 <script id="fshader" type="x-shader/x-fragment">
 #ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
@@ -42,22 +34,17 @@ void main() {
 description("Struct constructors should evaluate properly.");
 debug("Regression test for Three.js bug worked around in <a href='https://github.com/mrdoob/three.js/pull/7556'>https://github.com/mrdoob/three.js/pull/7556</a> that reproduced on Nexus 4 and 5 (Adreno 320 and 330).");
 debug("When high precision is used in the fragment shader on these devices, bugs occur in evaluation of structs' constructors. Thanks to Mr. doob for the reduced test case.");
-var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
 
-gl.clearColor(1, 0, 0, 1);
-gl.clear(gl.COLOR_BUFFER_BIT);
-
-var attribBuffers = wtu.setupUnitQuad(gl, 0, 1);
-var program = wtu.setupProgram(gl, ['vshader', 'fshader'], ['a_position'], [0], true);
-if (!program) {
-  testFailed("Shader compilation/link failed");
-} else {
-  // Draw
-  wtu.drawUnitQuad(gl);
-  // Verify output
-  wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green");
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshader',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Struct contstructor evaluation"
 }
+]);
 
-finishTest();
 </script>
+
+</body>
+</html>

--- a/sdk/tests/conformance/glsl/bugs/unary-minus-operator-float-bug.html
+++ b/sdk/tests/conformance/glsl/bugs/unary-minus-operator-float-bug.html
@@ -33,17 +33,11 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>
-<canvas id="canvas" width="64" height="64"> </canvas>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec4 a_position;
-void main() {
-    gl_Position = a_position;
-}
-</script>
 <script id="fshader" type="x-shader/x-fragment">
 precision mediump float;
 void main () {
@@ -59,36 +53,18 @@ description("Test for unary minus operator with float bug on MacOSX 10.11 with I
 debug("This is a regression test for <a href='https://bugs.chromium.org/p/chromium/issues/detail?id=308366'>Chromium Issue 308366</a>");
 debug("");
 
-var wtu = WebGLTestUtils;
-var canvas = document.getElementById("canvas");
-var gl = wtu.create3DContext(canvas);
-
-function runTest() {
-    var width = 64;
-    var height = 64;
-
-    var program = wtu.setupProgram(gl, ["vshader", "fshader"], ['a_position']);
-    gl.viewport(0, 0, width, height);
-    wtu.setupUnitQuad(gl, 0, 1);
-    wtu.drawUnitQuad(gl);
-    var msg = "";
-    var tolerance = 3;
-    wtu.checkCanvas(gl, [127, 0, 0, 255], msg, tolerance);
-    gl.deleteProgram(program);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from testing");
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshader',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Evaluate unary minus operator and atan(x, y)",
+  renderTolerance: 3,
+  renderColor: [127, 0, 0, 255]
 }
+]);
 
-if (!gl) {
-    testFailed("Fail to get a WebGL context");
-} else {
-    testPassed("Created WebGL context successfully");
-    runTest();
-}
-
-debug("");
-var successfullyParsed = true;
 </script>
-<script src="../../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/js/glsl-conformance-test.js
+++ b/sdk/tests/js/glsl-conformance-test.js
@@ -288,7 +288,11 @@ function runOneTest(gl, info) {
   if (info.renderTolerance !== undefined) {
     tolerance = info.renderTolerance;
   }
-  wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", tolerance);
+  if (info.renderColor !== undefined) {
+    wtu.checkCanvas(gl, info.renderColor, "should be expected color " + info.renderColor, tolerance);
+  } else {
+    wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", tolerance);
+  }
 }
 
 function runTests(shaderInfos, opt_contextVersion) {


### PR DESCRIPTION
Use the GLSL test runner instead of having custom procedural code in
the tests. This makes the test code cleaner and the tests easier to
debug, since the GLSL runner prints out the shader source.