### PR TITLE
Fix negative case of webgl-draw-buffers-feedback-loop.html

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-draw-buffers-feedback-loop.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers-feedback-loop.html
@@ -87,7 +87,6 @@ if (!gl) {
     if (!ext) {
         testPassed("No WEBGL_draw_buffers support -- this is legal");
 
-        runSupportedTest(false);
         finishTest();
     } else {
         testPassed("Successfully enabled WEBGL_draw_buffers extension");


### PR DESCRIPTION
Fix negative case of conformance/extensions/webgl-draw-buffers-feedback-loop.html

This fixes a test failure when WEBGL_draw_buffers is unavailable.

@Richard-Yunchao @zhenyao PTAL