### PR TITLE
Change "loss/restoration of state" to "loss/restoration of the context".

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3191,8 +3191,8 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
         WebGL rendering context. Events are sent using the DOM Event System <a href="#refsDOM3EVENTS">[DOM3EVENTS]</a>,
         and are dispatched to the HTMLCanvasElement associated with the WebGL rendering context.
         The types of status changes that can trigger a <code>WebGLContextEvent</code> event are <a href="#CONTEXT_LOST">
-        the loss of state</a>, <a href="#CONTEXT_RESTORED">the restoration of state</a>, and <a href="#CONTEXT_CREATION_ERROR">
-        the inability to create a context</a>.
+        the loss of the context</a>, <a href="#CONTEXT_RESTORED">the restoration of the context</a>, and
+        <a href="#CONTEXT_CREATION_ERROR"> the inability to create a context</a>.
     </p>
     <p>
         To <b><a name="fire-a-webgl-context-event">fire a WebGL context event named e</a></b> means


### PR DESCRIPTION
Follow-up to #2296.