### PR TITLE
Add a GLSL3 test for a HLSL compiler freeze.

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -14,6 +14,7 @@ const-array-init.html
 --min-version 2.0.1 float-parsing.html
 forbidden-operators.html
 frag-depth.html
+--min-version 2.0.1 gradient-in-discontinuous-loop.html
 invalid-default-precision.html
 invalid-invariant.html
 loops-with-side-effects.html

--- a/sdk/tests/conformance2/glsl3/gradient-in-discontinuous-loop.html
+++ b/sdk/tests/conformance2/glsl3/gradient-in-discontinuous-loop.html
@@ -1,0 +1,96 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Short circuit in loop condition test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vertex-shader" type="x-shader/x-vertex">#version 300 es
+  precision highp float;
+  in vec4 aPosition;
+
+  void main() {
+    gl_Position = aPosition;
+  }
+</script>
+<script id="fragment-shader" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+precision highp int;
+
+uniform vec4      iMouse;
+uniform sampler2D iChannel0;
+
+float map(float p)
+{
+    return texture(iChannel0, vec2(p, p), 0.0).y;
+}
+
+out vec4 outColor;
+
+void main(void)
+{
+    float sum = 0.0;
+
+    for(int i=0; i<1000; i++)
+    {
+        if( sum > 0.99 ) break;
+                float p = iMouse.x + gl_FragCoord.x;
+        sum = map(p);
+    }
+
+    outColor = vec4(sum);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description("Test an HLSL compiler freeze on a gradient inside a discontinuous loop.");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext(undefined, undefined, 2);
+wtu.setupUnitQuad(gl);
+
+if (!gl) {
+    testFailed("context does not exist");
+} else {
+    var program = wtu.setupProgram(gl, ["vertex-shader", "fragment-shader"], ['aPosition'], undefined, true);
+    if (!program) {
+        testFailed('Program compilation failed');
+    }
+}
+var successfullyParsed = true;
+finishTest();
+</script>
+</body>
+</html>


### PR DESCRIPTION
The HLSL compiler doesn't handle gradient in discontinuous control flow
nicely, and ANGLE was missing handling for new GLSL ES 300 gradient
builtins in its workaround. This is a regression test.

See http://anglebug.com/1915