### PR TITLE
fix "runTests" to "runRenderTests" in compare-structs-containing-arrays

### DIFF
--- a/sdk/tests/conformance2/glsl3/compare-structs-containing-arrays.html
+++ b/sdk/tests/conformance2/glsl3/compare-structs-containing-arrays.html
@@ -86,7 +86,7 @@ void main() {
 description("Comparing structs containing arrays should work.");
 debug("");
 
-GLSLConformanceTester.runTests([
+GLSLConformanceTester.runRenderTests([
 {
   fShaderId: 'fshader-same-struct',
   fShaderSuccess: true,


### PR DESCRIPTION
These tests are clearly intended to be render tests (i.e. have their output be checked to be green). This passes at least on some machines (e.g. Linux NVIDIA).