### PR TITLE
2.0.0: disable multisample.fbo_{4,max}_samples.constancy_*

### DIFF
--- a/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
+++ b/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
@@ -323,6 +323,17 @@ goog.scope(function() {
         _setReason("Fails on Android/Qualcomm (Google Pixel).");
         // crbug.com/695677
         _skip("precision.float.mediump_add_fragment");
+
+        _setReason("Fails on Android/Qualcomm (Google Pixel).");
+        // crbug.com/695742
+        _skip("multisample.fbo_4_samples.constancy_sample_coverage*");
+        _skip("multisample.fbo_4_samples.constancy_sample_coverage_inverted");
+        _skip("multisample.fbo_4_samples.constancy_both");
+        _skip("multisample.fbo_4_samples.constancy_both_inverted");
+        _skip("multisample.fbo_max_samples.constancy_sample_coverage");
+        _skip("multisample.fbo_max_samples.constancy_sample_coverage_inverted");
+        _skip("multisample.fbo_max_samples.constancy_both");
+        _skip("multisample.fbo_max_samples.constancy_both_inverted");
     } // if (!runSkippedTests)
 
     /*


### PR DESCRIPTION
These tests are failing in Chrome on Google Pixel (7.1.1).

We've investigated this, and we're pretty confident that it's a driver bug, even though these tests pass in ES3 dEQP and in Firefox - it seems to be due to some unknown interaction with Chrome's architecture.

http://crbug.com/695742