### PR TITLE
fix typo at renderbuffers-feedback-loop.html

### DIFF
--- a/sdk/tests/conformance/renderbuffers/feedback-loop.html
+++ b/sdk/tests/conformance/renderbuffers/feedback-loop.html
@@ -81,7 +81,7 @@
     assertMsg(gl.checkFramebufferStatus(gl.FRAMEBUFFER) == gl.FRAMEBUFFER_COMPLETE,
         "framebuffer should be FRAMEBUFFER_COMPLETE.");
 
-    var program = wtu.setupProgram(gl, ["vs", "fs"], ["vPosition", "vTexCoord"]);
+    var program = wtu.setupProgram(gl, ["vs", "fs"], ["a_position", "a_texCoord"]);
     gl.uniform1i(gl.getUniformLocation(program, "u_texture"), 0);
     gl.disable(gl.BLEND);
     gl.disable(gl.DEPTH_TEST);


### PR DESCRIPTION
This test, it uses glBindAttribLocation, but the string name is wrong, so it can't bind the correct vertex attribute, and in the shader it also doesn't use layout syntax, so the index will be undefined, the index is based on OpenGL automatic assigned . The Chrome with AMD can work is because just luck that the position and uv is the same as enableattribute index, but Firefox with AMD is position and uv reverse order. 