### PR TITLE
Fix texture filtering param for test case integer-cubemap-specificati…

### DIFF
--- a/sdk/tests/conformance2/textures/misc/integer-cubemap-specification-order-bug.html
+++ b/sdk/tests/conformance2/textures/misc/integer-cubemap-specification-order-bug.html
@@ -100,7 +100,7 @@ function createTextureCube(layers, maxLevel) {
         gl.texImage2D(face + gl.TEXTURE_CUBE_MAP_POSITIVE_X, level, gl.RG8I, levelSize, levelSize, 0, gl.RG_INTEGER, gl.BYTE, new Int8Array(backingBuffer));
     });
 
-    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_LINEAR);
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_NEAREST);
     gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);


### PR DESCRIPTION
…on-order-bug

Internal format RG8I cannot do texture filtering according to es 3.1,
table 8.13, modify LINEAR to NEAREST.