### PR TITLE
Use GLSL test framework for tests that need to set uniforms

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
+++ b/sdk/tests/conformance/glsl/bugs/compare-loop-index-to-uniform.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="256" height="256"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshader" type="x-shader/x-fragment">
 precision mediump float;
 uniform int uCount;
@@ -62,25 +55,16 @@ void main() {
 <script type="application/javascript">
 "use strict";
 description("Comparing loop index to an uniform in a fragment shader should work.");
-debug("");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas");
-  if (!gl) {
-    testFailed("context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
-  var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["aPosition"], undefined, true);
-  var uniformLoc = gl.getUniformLocation(program, 'uCount');
-  gl.uniform1i(uniformLoc, 5);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-};
 
-test();
-var successfullyParsed = true;
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshader',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Compare a loop index to an uniform',
+  uniforms: [{name: "uCount", functionName: "uniform1i", value: 5}]
+}
+]);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
+++ b/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="256" height="256"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshader" type="x-shader/x-fragment">
 // It is assumed that uTest is set to 0. It's here to make the expression not constant.
 uniform mediump float uTest;
@@ -96,10 +89,10 @@ void main() {
 <script type="application/javascript">
 "use strict";
 description();
-var wtu = WebGLTestUtils;
 
 function test() {
-  var gl = wtu.create3DContext("canvas");
+  var wtu = WebGLTestUtils;
+  var gl = wtu.create3DContext();
   if (!gl) {
     testFailed("context does not exist");
     return;
@@ -107,32 +100,30 @@ function test() {
   if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision == 0) {
     testPassed("highp precision not supported");
   } else {
-    wtu.setupUnitQuad(gl);
-
-    debug("Testing shader where the precision qualifier of a constant affects built-in function results");
-    var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["aPosition"], undefined, true);
-    var uniformLoc = gl.getUniformLocation(program, 'uTest');
-    gl.uniform1f(uniformLoc, 0);
-    wtu.drawUnitQuad(gl);
-    wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);
-
-    debug("");
-    debug("Testing shader where the precision qualifier of a variable affects built-in function results");
-    program = wtu.setupProgram(gl, ["vshader", "fshaderNoConstants"], ["aPosition"], undefined, true);
-    uniformLoc = gl.getUniformLocation(program, 'uTest');
-    gl.uniform1f(uniformLoc, 0);
-    uniformLoc = gl.getUniformLocation(program, 'uTestHigh');
-    gl.uniform1f(uniformLoc, 0);
-    wtu.drawUnitQuad(gl);
-    wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);
-
-    debug("");
-    debug("Testing shader where all variables are qualified as highp");
-    program = wtu.setupProgram(gl, ["vshader", "fshaderAllHighp"], ["aPosition"], undefined, true);
-    uniformLoc = gl.getUniformLocation(program, 'uTest');
-    gl.uniform1f(uniformLoc, 0);
-    wtu.drawUnitQuad(gl);
-    wtu.checkCanvasRect(gl, 0, 0, 256, 256, [0, 255, 0, 255]);
+    GLSLConformanceTester.runRenderTests([
+    {
+      fShaderId: 'fshader',
+      fShaderSuccess: true,
+      linkSuccess: true,
+      passMsg: 'The precision qualifier of a constant affects built-in function results',
+      uniforms: [{name: "uTest", functionName: "uniform1f", value: 0}]
+    },
+    {
+      fShaderId: 'fshaderNoConstants',
+      fShaderSuccess: true,
+      linkSuccess: true,
+      passMsg: 'The precision qualifier of a variable affects built-in function results',
+      uniforms: [{name: "uTest", functionName: "uniform1f", value: 0},
+                 {name: "uTestHigh", functionName: "uniform1f", value: 0}]
+    },
+    {
+      fShaderId: 'fshaderAllHighp',
+      fShaderSuccess: true,
+      linkSuccess: true,
+      passMsg: 'All variables are qualified as highp',
+      uniforms: [{name: "uTest", functionName: "uniform1f", value: 0}]
+    },
+    ]);
   }
 };
 

--- a/sdk/tests/conformance/glsl/bugs/floored-division-accuracy.html
+++ b/sdk/tests/conformance/glsl/bugs/floored-division-accuracy.html
@@ -35,19 +35,19 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 
 <body>
-<canvas id="repro" style="border: none;" width="256" height="256"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 
 <script id="shader-vs" type="x-shader/x-vertex">
-attribute vec2 pos;
+attribute vec4 vPosition;
 uniform float divisor;
 varying vec4 vColor;
 void main(void) {
-  gl_Position = vec4(pos, 0.0, 1.0);
+  gl_Position = vPosition;
   float index = 9.0;
   // Floating point operations don't have any guaranteed precision, but they
   // should at least be accurate to 1 part in 10^5.
@@ -65,31 +65,26 @@ void main(void) {
 </script>
 <script>
 "use strict";
-
 description();
+
 debug("");
 // Reproduces bug seen on Mac OS X with AMD Radeon HD 6490 GPU
 debug("If things are working correctly, then the square will be green.");
 debug("If your card thinks floor(9. / 3.) is not 3 to within 1 part in 10^5, ");
 debug("then the square will be red.");
 
-var wtu = WebGLTestUtils;
-var canvas = document.getElementById("repro");
-var gl = wtu.create3DContext(canvas);
-if (!gl) {
-  testFailed("context does not exist");
-} else {
-  gl.clearColor(0.0, 0.0, 0.0, 1.0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  wtu.setupUnitQuad(gl);
-  var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"], undefined, true);
-  gl.uniform1f(gl.getUniformLocation(program, "divisor"), 3);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvasRect(gl, 128, 128, 128, 128, [ 0, 255, 0, 255 ], "should be green", 1);
+GLSLConformanceTester.runRenderTests([
+{
+  vShaderId: 'shader-vs',
+  vShaderSuccess: true,
+  fShaderId: 'shader-fs',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Test that floor(9. / 3.) is 3 to within 1 part in 10^5',
+  uniforms: [{name: "divisor", functionName: "uniform1f", value: 3}]
 }
+]);
 
-var successfullyParsed = true;
 </script>
-<script src="../../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance/glsl/bugs/logic-inside-block-without-braces.html
+++ b/sdk/tests/conformance/glsl/bugs/logic-inside-block-without-braces.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="256" height="256"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderIf" type="x-shader/x-fragment">
 precision mediump float;
 uniform bool uFalse;
@@ -92,33 +85,22 @@ void main() {
 "use strict";
 description("Short-circuiting logic operator with side effects inside if/for statement without braces should work.");
 debug("");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas");
-  if (!gl) {
-    testFailed("context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
 
-  debug("");
-  debug("Testing if");
-  var program = wtu.setupProgram(gl, ["vshader", "fshaderIf"], ["aPosition"], undefined, true);
-  var uniformLoc = gl.getUniformLocation(program, 'uFalse');
-  gl.uniform1i(uniformLoc, 0);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Testing for");
-  var program = wtu.setupProgram(gl, ["vshader", "fshaderFor"], ["aPosition"], undefined, true);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-};
-
-test();
-var successfullyParsed = true;
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderIf',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Short-circuiting operator inside if statement without braces',
+  uniforms: [{name: "uFalse", functionName: "uniform1i", value: 0}]
+},
+{
+  fShaderId: 'fshaderFor',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Short-circuiting operator inside for statement without braces'
+}
+]);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/glsl/bugs/modulo-arithmetic-accuracy.html
+++ b/sdk/tests/conformance/glsl/bugs/modulo-arithmetic-accuracy.html
@@ -35,19 +35,19 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 
 <body>
-<canvas id="repro" style="border: none;" width="256" height="256"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 
 <script id="shader-vs" type="x-shader/x-vertex">
-attribute vec2 pos;
+attribute vec4 vPosition;
 uniform float divisor;
 varying vec4 vColor;
 void main(void) {
-  gl_Position = vec4(pos, 0.0, 1.0);
+  gl_Position = vPosition;
   float index = 9.0;
   // mod(x, y) is computed as x-y*floor(x/y).  There are no guarantees on
   // the precision of floating point operations in WebGL shaders, but division
@@ -73,23 +73,17 @@ debug("");
 debug("If things are working correctly, then the square will be green.");
 debug("If your card thinks mod(9,3) is not 0, then the square will be red.");
 
-var wtu = WebGLTestUtils;
-var canvas = document.getElementById("repro");
-var gl = wtu.create3DContext(canvas);
-if (!gl) {
-  testFailed("context does not exist");
-} else {
-  gl.clearColor(0.0, 0.0, 0.0, 1.0);
-  gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-  wtu.setupUnitQuad(gl);
-  var program = wtu.setupProgram(gl, ["shader-vs", "shader-fs"], ["pos"], undefined, true);
-  gl.uniform1f(gl.getUniformLocation(program, "divisor"), 3);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvasRect(gl, 128, 128, 128, 128, [ 0, 255, 0, 255 ], "should be green", 1);
+GLSLConformanceTester.runRenderTests([
+{
+  vShaderId: 'shader-vs',
+  vShaderSuccess: true,
+  fShaderId: 'shader-fs',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Test that mod(9/3) is 0',
+  uniforms: [{name: "divisor", functionName: "uniform1f", value: 3}]
 }
-
-var successfullyParsed = true;
+]);
 </script>
-<script src="../../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance2/glsl3/array-assign-constructor.html
+++ b/sdk/tests/conformance2/glsl3/array-assign-constructor.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
-<canvas id="canvas" width="64" height="64"> </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">#version 300 es
-in vec3 aPosition;
-
-void main() {
-    gl_Position = vec4(aPosition, 1);
-}
-</script>
 <script id="fshaderNonConstantConstructorParameter" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 uniform int u;
@@ -95,34 +88,24 @@ void main() {
 "use strict";
 description("Assigning return values of array constructors should work.");
 debug("");
-var wtu = WebGLTestUtils;
-function test() {
-  var gl = wtu.create3DContext("canvas", undefined, 2);
-  if (!gl) {
-    testFailed("WebGL 2 context does not exist");
-    return;
-  }
-  wtu.setupUnitQuad(gl);
 
-  // This test only covers cases which are not covered by the dEQP tests.
+// This test only covers cases which are not covered by the dEQP tests.
 
-  debug("Testing with a non-constant integer");
-  var program = wtu.setupProgram(gl, ["vshader", "fshaderNonConstantConstructorParameter"], ["aPosition"], undefined, true);
-  var uniformLoc = gl.getUniformLocation(program, 'u');
-  gl.uniform1i(uniformLoc, 5);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-
-  debug("");
-  debug("Testing with an array of structs");
-  wtu.setupProgram(gl, ["vshader", "fshaderArrayOfStructs"], ["aPosition"], undefined, true);
-  wtu.drawUnitQuad(gl);
-  wtu.checkCanvas(gl, [0, 255, 0, 255]);
-};
-
-test();
-var successfullyParsed = true;
-finishTest();
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderNonConstantConstructorParameter',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Assigning a constructor result',
+  uniforms: [{name: "u", functionName: "uniform1i", value: 5}]
+},
+{
+  fShaderId: 'fshaderArrayOfStructs',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Assigning an array of structs'
+}
+], 2);
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance2/glsl3/short-circuiting-in-loop-condition.html
+++ b/sdk/tests/conformance2/glsl3/short-circuiting-in-loop-condition.html
@@ -33,18 +33,11 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vertex-shader" type="x-shader/x-vertex">#version 300 es
-  precision highp float;
-  in vec4 aPosition;
-
-  void main() {
-    gl_Position = aPosition;
-  }
-</script>
 <script id="fshaderWhile" type="x-shader/x-fragment">#version 300 es
 precision mediump float;
 uniform bool u;
@@ -151,40 +144,33 @@ void main() {
 "use strict";
 description("Test behavior of a short-circuiting operator in a loop using a function call with side effects");
 
-var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext(undefined, undefined, 2);
-wtu.setupUnitQuad(gl);
+var testShaders = [
+  {fShaderId: 'fshaderWhile', description: 'in while loop condition'},
+  {fShaderId: 'fshaderFor', description: 'in for loop expression'},
+  {fShaderId: 'fshaderDoWhile', description: 'in do-while loop condition'},
+  {fShaderId: 'fshaderSequence', description: 'inside a sequence in while loop condition'}
+];
 
-var testShader = function(fshaderId, subTestDescription) {
-    debug("");
-    debug(subTestDescription);
-    var program = wtu.setupProgram(gl, ["vertex-shader", fshaderId], ['aPosition'], undefined, true);
-    if (!program) {
-        testFailed('Program compilation failed');
-        return;
-    }
+var testList = [];
 
-    debug("Test short-circuiting operator with a true condition.");
-    gl.uniform1i(gl.getUniformLocation(program, "u"), 1);
-    wtu.clearAndDrawUnitQuad(gl);
-    wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
-
-    debug("Test short-circuiting operator with a false condition.");
-    gl.uniform1i(gl.getUniformLocation(program, "u"), 0);
-    wtu.clearAndDrawUnitQuad(gl);
-    wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 0);
-};
-
-if (!gl) {
-    testFailed("context does not exist");
-} else {
-    testShader("fshaderWhile", "in while loop condition");
-    testShader("fshaderFor", "in for loop expression");
-    testShader("fshaderDoWhile", "in do-while loop condition");
-    testShader("fshaderSequence", "inside a sequence in while loop condition");
+for (var i = 0; i < testShaders.length; ++i) {
+  testList.push({
+    fShaderId: testShaders[i].fShaderId,
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: 'Short-circuiting operator with a true condition ' + testShaders[i].description,
+    uniforms: [{name: "u", functionName: "uniform1i", value: 1}]
+  });
+  testList.push({
+    fShaderId: testShaders[i].fShaderId,
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: 'Short-circuiting operator with a false condition ' + testShaders[i].description,
+    uniforms: [{name: "u", functionName: "uniform1i", value: 0}]
+  });
 }
-var successfullyParsed = true;
-finishTest();
+
+GLSLConformanceTester.runRenderTests(testList, 2);
 </script>
 </body>
 </html>

--- a/sdk/tests/js/glsl-conformance-test.js
+++ b/sdk/tests/js/glsl-conformance-test.js
@@ -270,8 +270,12 @@ function runOneTest(gl, info) {
   if (info.uniforms !== undefined) {
     for (var i = 0; i < info.uniforms.length; ++i) {
       var uniformLocation = gl.getUniformLocation(program, info.uniforms[i].name);
-      gl[info.uniforms[i].functionName](uniformLocation, info.uniforms[i].value);
-      debug(info.uniforms[i].name + ' set to ' + info.uniforms[i].value);
+      if (uniformLocation !== null) {
+        gl[info.uniforms[i].functionName](uniformLocation, info.uniforms[i].value);
+        debug(info.uniforms[i].name + ' set to ' + info.uniforms[i].value);
+      } else {
+        debug('uniform ' + info.uniforms[i].name + ' had null location and was not set');
+      }
     }
   }
 


### PR DESCRIPTION
This unifies test output and reduces duplication of trivial code
without losing coverage.