### PR TITLE
fence_sync.client_wait_sync_finish: Allow TIMEOUT_EXPIRED

### DIFF
--- a/conformance-suites/2.0.0/deqp/functional/gles3/es3fSyncTests.js
+++ b/conformance-suites/2.0.0/deqp/functional/gles3/es3fSyncTests.js
@@ -219,11 +219,6 @@ goog.scope(function() {
 
         gl.finish();
 
-        if (this.m_caseOptions & es3fSyncTests.CaseOptions.FINISH_BEFORE_WAIT && waitValue != gl.ALREADY_SIGNALED) {
-            testOk = false;
-            bufferedLogToConsole('Expected glClientWaitSync to return gl.ALREADY_SIGNALED.');
-        }
-
         // Delete sync object
 
         if (this.m_syncObject && testOk) {

--- a/sdk/tests/deqp/functional/gles3/es3fSyncTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fSyncTests.js
@@ -219,11 +219,6 @@ goog.scope(function() {
 
         gl.finish();
 
-        if (this.m_caseOptions & es3fSyncTests.CaseOptions.FINISH_BEFORE_WAIT && waitValue != gl.ALREADY_SIGNALED) {
-            testOk = false;
-            bufferedLogToConsole('Expected glClientWaitSync to return gl.ALREADY_SIGNALED.');
-        }
-
         // Delete sync object
 
         if (this.m_syncObject && testOk) {


### PR DESCRIPTION
In WebGL, a finish() or flush() may not have any effect. This means
TIMEOUT_EXPIRED is still possible in this test case, even though it
doesn't call clientWaitSync until a frame after the fenceSync() and
finish() operations.

This was seen on Pixel (Android/Qualcomm).