### PR TITLE
Prompt user before reloading webgl-conformance-tests.html

### DIFF
--- a/conformance-suites/2.0.0/webgl-conformance-tests.html
+++ b/conformance-suites/2.0.0/webgl-conformance-tests.html
@@ -165,6 +165,12 @@
 <script type="application/javascript" src="js/webgl-test-harness.js"></script>
 <script>
 "use strict";
+
+window.onbeforeunload = function() {
+  // Prompt user before reloading
+  return false;
+}
+
 var DEFAULT_CONFORMANCE_TEST_VERSION = "2.0.0";
 
 var OPTIONS = {

--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -165,6 +165,12 @@
 <script type="application/javascript" src="js/webgl-test-harness.js"></script>
 <script>
 "use strict";
+
+window.onbeforeunload = function() {
+  // Prompt user before reloading
+  return false;
+}
+
 var DEFAULT_CONFORMANCE_TEST_VERSION = "1.0.4 (beta)";
 
 var OPTIONS = {


### PR DESCRIPTION
Accidental reload makes it easy to lose results in the middle of a conformance run. In Chrome, it's particularly easy if you don't disable "pull-to-refresh" in about:flags. This causes the browser to prompt when reloading.