### PR TITLE
WebGL 1.0 spec update: no shader binaries in WebGL

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3481,6 +3481,14 @@ bound in order for texture-related operations and queries to succeed.
 
 </p>
 
+    <h3>No Shader Binaries</h3>
+
+<p>
+
+Accessing binary representations of compiled shaders is not supported in the WebGL API. This includes OpenGL ES 2.0 ShaderBinary entry point. In addition, querying shader binary formats and shader compiler with getParameter is not supported in the WebGL API.
+
+</p>
+
     <h3><a name="BUFFER_OFFSET_AND_STRIDE">Buffer Offset and Stride Requirements</a></h3>
 
 <p>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3485,7 +3485,14 @@ bound in order for texture-related operations and queries to succeed.
 
 <p>
 
-Accessing binary representations of compiled shaders is not supported in the WebGL API. This includes OpenGL ES 2.0 ShaderBinary entry point. In addition, querying shader binary formats and shader compiler with getParameter is not supported in the WebGL API.
+Accessing binary representations of compiled shaders is not supported in the WebGL API. This
+includes the OpenGL ES 2.0 ShaderBinary entry point. In addition, querying shader binary formats
+and the availability of a shader compiler via getParameter is not supported in the WebGL API.
+
+</p>
+<p>
+
+All WebGL implementations must implicitly support an on-line shader compiler.
 
 </p>
 

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3486,8 +3486,9 @@ bound in order for texture-related operations and queries to succeed.
 <p>
 
 Accessing binary representations of compiled shaders is not supported in the WebGL API. This
-includes the OpenGL ES 2.0 ShaderBinary entry point. In addition, querying shader binary formats
-and the availability of a shader compiler via getParameter is not supported in the WebGL API.
+includes the OpenGL ES 2.0 <code>ShaderBinary</code> entry point. In addition, querying shader
+binary formats and the availability of a shader compiler via <code>getParameter</code> is not
+supported in the WebGL API.
 
 </p>
 <p>


### PR DESCRIPTION
PTAL, @zhenyao and @kenrussell .

See the discussion at #2340. 