### PR TITLE
Trim whitespace from conformance txt download

### DIFF
--- a/conformance-suites/2.0.0/webgl-conformance-tests.html
+++ b/conformance-suites/2.0.0/webgl-conformance-tests.html
@@ -1194,7 +1194,7 @@ function start() {
   var dltextbutton = document.getElementById("dlTextSummary");
   dltextbutton.onclick = function() {
     var textdiv = document.getElementById("testResultsText");
-    download("webgl-conformance-" + OPTIONS.version + ".txt", textdiv.innerText);
+    download("webgl-conformance-" + OPTIONS.version + ".txt", textdiv.innerText.trim());
   };
 
   if (reporter.noSelectedWebGLVersion) {

--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -1195,7 +1195,7 @@ function start() {
   var dltextbutton = document.getElementById("dlTextSummary");
   dltextbutton.onclick = function() {
     var textdiv = document.getElementById("testResultsText");
-    download("webgl-conformance-" + OPTIONS.version + ".txt", textdiv.innerText);
+    download("webgl-conformance-" + OPTIONS.version + ".txt", textdiv.innerText.trim());
   };
 
   if (reporter.noSelectedWebGLVersion) {


### PR DESCRIPTION
Amendment to #2319

Removes a few tabs and newlines from the beginning and end of the downloaded txt file.