### PR TITLE
Remove "normative references" sub-section.

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -4092,7 +4092,6 @@ extensions.
 
     <h2>References</h2>
 
-    <h3>Normative references</h3>
     <dl>
 
         <dt id="refsCANVAS">[CANVAS]</dt>
@@ -4175,8 +4174,6 @@ extensions.
             Leech, J. and Daniell, P., August, 2014.
         </dd>
     </dl>
-
-    <h3>Other references</h3>
 
 <!-- ======================================================================================================= -->
 

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3887,7 +3887,6 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <h2>References</h2>
 
-    <h3>Normative references</h3>
     <dl>
         <dt id="refsWEBGL10">[WEBGL10]</dt>
         <dd><cite><a href="http://www.khronos.org/registry/webgl/specs/latest/1.0/">


### PR DESCRIPTION
The use of the term "normative references" here has implications that
were unintended and undesired for the WebGL specifications. Since the
distinction is not critical for this specification, remove it.