### PR TITLE
Spec & test that local and global variables are initialized

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -112,3 +112,4 @@ struct-nesting-under-maximum.html
 --min-version 1.0.4 ternary-operator-on-arrays.html
 --min-version 1.0.3 ternary-operators-in-global-initializers.html
 --min-version 1.0.3 ternary-operators-in-initializers.html
+--min-version 1.0.4 uninitialized-local-global-variables.html

--- a/sdk/tests/conformance/glsl/misc/uninitialized-local-global-variables.html
+++ b/sdk/tests/conformance/glsl/misc/uninitialized-local-global-variables.html
@@ -1,0 +1,159 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Uninitialized local/global variables should be initialized</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"> </script>
+
+<!-- Uninitialized local in vertex shader -->
+<script id="vs_uninit_local_in_vert" type="x-shader/x-vertex">
+precision highp float;
+attribute vec4 a_position;
+varying vec4 v_uninit;
+void main() {
+    vec4 uninit; // uninitialized
+    v_uninit = uninit;
+    gl_Position = a_position;
+}
+</script>
+<script id="fs_uninit_local_in_vert" type="x-shader/x-fragment">
+precision highp float;
+varying vec4 v_uninit;
+void main() {
+    gl_FragColor = v_uninit;
+}
+</script>
+
+<!-- Uninitialized local in fragment shader -->
+<script id="vs_uninit_local_in_frag" type="x-shader/x-vertex">
+precision highp float;
+attribute vec4 a_position;
+void main() {
+    gl_Position = a_position;
+}
+</script>
+<script id="fs_uninit_local_in_frag" type="x-shader/x-fragment">
+precision highp float;
+void main() {
+    vec4 uninit; // uninitialized
+    gl_FragColor = uninit;
+}
+</script>
+
+<!-- Uninitialized global in vertex shader -->
+<script id="vs_uninit_global_in_vert" type="x-shader/x-vertex">
+precision highp float;
+attribute vec4 a_position;
+varying vec4 v_uninit;
+vec4 uninit; // uninitialized
+void main() {
+    v_uninit = uninit;
+    gl_Position = a_position;
+}
+</script>
+<script id="fs_uninit_global_in_vert" type="x-shader/x-fragment">
+precision highp float;
+varying vec4 v_uninit;
+void main() {
+    gl_FragColor = v_uninit;
+}
+</script>
+
+<!-- Uninitialized global in fragment shader -->
+<script id="vs_uninit_global_in_frag" type="x-shader/x-vertex">
+precision highp float;
+attribute vec4 a_position;
+void main() {
+    gl_Position = a_position;
+}
+</script>
+<script id="fs_uninit_global_in_frag" type="x-shader/x-fragment">
+precision highp float;
+vec4 uninit; // uninitialized
+void main() {
+    gl_FragColor = uninit;
+}
+</script>
+
+</head>
+<body>
+<canvas id="canvas" width="50" height="50"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description('Uninitialized local/global variables should be initialized: http://anglebug.com/1966');
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+wtu.setupUnitQuad(gl);
+
+var cases = [
+  {
+    name: "Uninitialized local variable in vertex shader",
+    prog: ["vs_uninit_local_in_vert", "fs_uninit_local_in_vert"],
+  },
+  {
+    name: "Uninitialized local variable in fragment shader",
+    prog: ["vs_uninit_local_in_frag", "fs_uninit_local_in_frag"],
+  },
+  {
+    name: "Uninitialized global variable in vertex shader",
+    prog: ["vs_uninit_global_in_vert", "fs_uninit_global_in_vert"],
+  },
+  {
+    name: "Uninitialized global variable in fragment shader",
+    prog: ["vs_uninit_global_in_frag", "fs_uninit_global_in_frag"],
+  },
+];
+
+function runTest() {
+  for (var i = 0; i < cases.length; ++i) {
+    debug("");
+    debug(cases[i].name);
+    var program = wtu.setupProgram(gl, cases[i].prog, ["a_position"], undefined, true);
+    gl.clearColor(1.0, 0.0, 0.0, 1.0);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.checkCanvas(gl, [0, 0, 0, 255]);
+  }
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+}
+
+runTest();
+
+var successfullyParsed = true;
+</script>
+<script src="../../../js/js-test-post.js"></script>
+</body>
+</html>
+

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -4088,6 +4088,15 @@ extensions.
     the values of the fragment colors following shader execution are untouched.
 </p>
 
+<h3>Initial values for GLSL local and global variables</h3>
+
+<p>
+    The GLSL ES <a href="#refsGLES20GLSL">[GLES20GLSL]</a> spec leaves the value of
+    local and global variables as undefined unless they are initialized by the
+    shader. WebGL guarantees that such variables are initialized to zero:
+    <code>0.0</code>, <code>vec4(0.0)</code>, <code>0</code>, <code>false</code>, etc.
+</p>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>


### PR DESCRIPTION
This test is currently failed by Chrome and Firefox (it needs to be implemented in the ANGLE shader translator, http://anglebug.com/1966

According to @kenrussell,
> the WebGL WG resolved to make this spec and conformance test change a while ago.