### PR TITLE
Remove STENCIL_INDEX from WebGL 1.0 spec

### DIFF
--- a/conformance-suites/1.0.1/conformance/context/constants.html
+++ b/conformance-suites/1.0.1/conformance/context/constants.html
@@ -391,7 +391,6 @@ RGBA4                          : 0x8056,
 RGB5_A1                        : 0x8057,
 RGB565                         : 0x8D62,
 DEPTH_COMPONENT16              : 0x81A5,
-STENCIL_INDEX                  : 0x1901,
 STENCIL_INDEX8                 : 0x8D48,
 DEPTH_STENCIL                  : 0x84F9,
 

--- a/conformance-suites/1.0.2/conformance/context/constants.html
+++ b/conformance-suites/1.0.2/conformance/context/constants.html
@@ -414,7 +414,6 @@ RGBA4                          : 0x8056,
 RGB5_A1                        : 0x8057,
 RGB565                         : 0x8D62,
 DEPTH_COMPONENT16              : 0x81A5,
-STENCIL_INDEX                  : 0x1901,
 STENCIL_INDEX8                 : 0x8D48,
 DEPTH_STENCIL                  : 0x84F9,
 

--- a/conformance-suites/1.0.3/conformance/context/constants-and-properties.html
+++ b/conformance-suites/1.0.3/conformance/context/constants-and-properties.html
@@ -416,7 +416,6 @@ RGBA4                          : 0x8056,
 RGB5_A1                        : 0x8057,
 RGB565                         : 0x8D62,
 DEPTH_COMPONENT16              : 0x81A5,
-STENCIL_INDEX                  : 0x1901,
 STENCIL_INDEX8                 : 0x8D48,
 DEPTH_STENCIL                  : 0x84F9,
 
@@ -473,6 +472,7 @@ canvas              : "implementation-dependent"
 // added in versions of the spec that are backward-compatible with
 // this version
 var ignoredProperties = [
+  'STENCIL_INDEX',
 ];
 
 // Constants removed from the WebGL spec compared to ES 2.0

--- a/conformance-suites/2.0.0/conformance2/context/constants-and-properties-2.html
+++ b/conformance-suites/2.0.0/conformance2/context/constants-and-properties-2.html
@@ -412,7 +412,6 @@ RGBA4                          : 0x8056,
 RGB5_A1                        : 0x8057,
 RGB565                         : 0x8D62,
 DEPTH_COMPONENT16              : 0x81A5,
-STENCIL_INDEX                  : 0x1901,
 STENCIL_INDEX8                 : 0x8D48,
 DEPTH_STENCIL                  : 0x84F9,
 
@@ -739,6 +738,7 @@ canvas              : "implementation-dependent"
 // added in versions of the spec that are backward-compatible with
 // this version
 var ignoredProperties = [
+  'STENCIL_INDEX',
 ];
 
 // Constants removed from the WebGL spec compared to ES 3.0

--- a/sdk/tests/conformance/context/constants-and-properties.html
+++ b/sdk/tests/conformance/context/constants-and-properties.html
@@ -416,7 +416,6 @@ RGBA4                          : 0x8056,
 RGB5_A1                        : 0x8057,
 RGB565                         : 0x8D62,
 DEPTH_COMPONENT16              : 0x81A5,
-STENCIL_INDEX                  : 0x1901,
 STENCIL_INDEX8                 : 0x8D48,
 DEPTH_STENCIL                  : 0x84F9,
 

--- a/sdk/tests/conformance2/context/constants-and-properties-2.html
+++ b/sdk/tests/conformance2/context/constants-and-properties-2.html
@@ -412,7 +412,6 @@ RGBA4                          : 0x8056,
 RGB5_A1                        : 0x8057,
 RGB565                         : 0x8D62,
 DEPTH_COMPONENT16              : 0x81A5,
-STENCIL_INDEX                  : 0x1901,
 STENCIL_INDEX8                 : 0x8D48,
 DEPTH_STENCIL                  : 0x84F9,
 

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1620,7 +1620,6 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     const GLenum RGB5_A1                        = 0x8057;
     const GLenum RGB565                         = 0x8D62;
     const GLenum DEPTH_COMPONENT16              = 0x81A5;
-    const GLenum STENCIL_INDEX                  = 0x1901;
     const GLenum STENCIL_INDEX8                 = 0x8D48;
     const GLenum DEPTH_STENCIL                  = 0x84F9;
 

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -462,7 +462,6 @@ interface WebGLRenderingContextBase
     const GLenum RGB5_A1                        = 0x8057;
     const GLenum RGB565                         = 0x8D62;
     const GLenum DEPTH_COMPONENT16              = 0x81A5;
-    const GLenum STENCIL_INDEX                  = 0x1901;
     const GLenum STENCIL_INDEX8                 = 0x8D48;
     const GLenum DEPTH_STENCIL                  = 0x84F9;
 


### PR DESCRIPTION
This enum is not used at all in WebGL 1.0 and 2.0.

This is pointed out in https://github.com/KhronosGroup/WebGL/issues/2370