### PR TITLE
Test OffscreenCanvas's transferToImageBitmap function for both webgl and webgl2

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/00_test_list.txt
+++ b/sdk/tests/conformance/offscreencanvas/00_test_list.txt
@@ -8,3 +8,4 @@ context-lost-restored-worker.html
 methods.html
 methods-worker.html
 offscreencanvas-resize.html
+offscreencanvas-transfer-image-bitmap.html

--- a/sdk/tests/conformance/offscreencanvas/00_test_list.txt
+++ b/sdk/tests/conformance/offscreencanvas/00_test_list.txt
@@ -8,4 +8,4 @@ context-lost-restored-worker.html
 methods.html
 methods-worker.html
 offscreencanvas-resize.html
-offscreencanvas-transfer-image-bitmap.html
+--min-version 1.0.4 offscreencanvas-transfer-image-bitmap.html

--- a/sdk/tests/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
+++ b/sdk/tests/conformance/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
@@ -1,0 +1,71 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test for OffscreenCanvas TransferToImageBitmap</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../js/tests/offscreencanvas-transfer-image-bitmap.js"></script>
+</head>
+<body>
+  <div id="description"></div>
+  <div id="console"></div>
+  <script id='myWorker' type='text/worker'>
+  self.onmessage = function(e) {
+      var canvas = new OffscreenCanvas(128, 128);
+      var gl = canvas.getContext("webgl");
+      gl.clearColor(1.0, 1.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      var image = canvas.transferToImageBitmap();
+
+      self.postMessage({ bitmap: image },
+                       [ image ]);
+  };
+  </script>
+  <script>
+    "use strict";
+    description("This test ensures that the transferToImageBitmap function of OffscreenCanvas webgl context is functional.");
+    if (!window.OffscreenCanvas) {
+        testPassed("No OffscreenCanvas support");
+        finishTest();
+    } else {
+      var blob = new Blob([document.getElementById('myWorker').textContent]);
+      var worker = new Worker(URL.createObjectURL(blob));
+
+      worker.onmessage = function(msg) {
+          testTransferToImageBitmap("webgl", msg.data.bitmap);
+          finishTest();
+      }
+      worker.postMessage("Start Worker");
+    }
+  </script>
+</body>
+</html>

--- a/sdk/tests/conformance2/offscreencanvas/00_test_list.txt
+++ b/sdk/tests/conformance2/offscreencanvas/00_test_list.txt
@@ -2,3 +2,4 @@ context-creation.html
 context-creation-worker.html
 methods-2.html
 methods-2-worker.html
+offscreencanvas-transfer-image-bitmap.html

--- a/sdk/tests/conformance2/offscreencanvas/00_test_list.txt
+++ b/sdk/tests/conformance2/offscreencanvas/00_test_list.txt
@@ -2,4 +2,4 @@ context-creation.html
 context-creation-worker.html
 methods-2.html
 methods-2-worker.html
-offscreencanvas-transfer-image-bitmap.html
+--min-version 2.0.1 offscreencanvas-transfer-image-bitmap.html

--- a/sdk/tests/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
+++ b/sdk/tests/conformance2/offscreencanvas/offscreencanvas-transfer-image-bitmap.html
@@ -1,0 +1,71 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test for OffscreenCanvas TransferToImageBitmap</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../js/tests/offscreencanvas-transfer-image-bitmap.js"></script>
+</head>
+<body>
+  <div id="description"></div>
+  <div id="console"></div>
+  <script id='myWorker' type='text/worker'>
+  self.onmessage = function(e) {
+      var canvas = new OffscreenCanvas(128, 128);
+      var gl = canvas.getContext("webgl2");
+      gl.clearColor(1.0, 1.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      var image = canvas.transferToImageBitmap();
+
+      self.postMessage({ bitmap: image },
+                       [ image ]);
+  };
+  </script>
+  <script>
+    "use strict";
+    description("This test ensures that the transferToImageBitmap function of OffscreenCanvas webgl2 context is functional.");
+    if (!window.OffscreenCanvas) {
+        testPassed("No OffscreenCanvas support");
+        finishTest();
+    } else {
+      var blob = new Blob([document.getElementById('myWorker').textContent]);
+      var worker = new Worker(URL.createObjectURL(blob));
+
+      worker.onmessage = function(msg) {
+          testTransferToImageBitmap("webgl2", msg.data.bitmap);
+          finishTest();
+      }
+      worker.postMessage("Start Worker");
+    }
+  </script>
+</body>
+</html>

--- a/sdk/tests/js/tests/offscreencanvas-transfer-image-bitmap.js
+++ b/sdk/tests/js/tests/offscreencanvas-transfer-image-bitmap.js
@@ -1,0 +1,57 @@
+function testTransferToImageBitmap(webglContextVersion, bitmap) { 
+    var internalFormat = "RGBA";
+    var pixelFormat = "RGBA";
+    var pixelType = "UNSIGNED_BYTE";
+
+    var width = 32;
+    var height = 32;
+    var canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    var gl = WebGLTestUtils.create3DContext(canvas);
+    gl.clearColor(0,0,0,1);
+    gl.clearDepth(1);
+    gl.disable(gl.BLEND);
+
+    TexImageUtils.setupTexturedQuad(gl, internalFormat);
+
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    // Enable writes to the RGBA channels
+    gl.colorMask(1, 1, 1, 0);
+    var texture = gl.createTexture();
+    // Bind the texture to texture unit 0
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    // Set up texture parameters
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+
+    var targets = [gl.TEXTURE_2D];
+    // Upload the image into the texture
+    for (var tt = 0; tt < targets.length; ++tt) {
+        gl.texImage2D(targets[tt], 0, gl[internalFormat], gl[pixelFormat], gl[pixelType], bitmap);
+    }
+    for (var tt = 0; tt < targets.length; ++tt) {
+        // Draw the triangles
+        gl.clearColor(0, 0, 0, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+        var buf = new Uint8Array(width * height * 4);
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+        _checkCanvas(buf, width, height, webglContextVersion);
+    }
+}
+
+function _checkCanvas(buf, width, height, webglContextVersion)
+{
+    for (var i = 0; i < width * height; i++) {
+        if (buf[i * 4] != 255 || buf[i * 4 + 1] != 255 ||
+            buf[i * 4 + 2] != 0 || buf[i * 4 + 3] != 255) {
+            testFailed("OffscreenCanvas." + webglContextVersion +
+                ": This pixel should be red, but it is: [" + buf[i * 4] + ", " +
+                buf[i * 4 + 1] + ", " + buf[i * 4 + 2] + ", " + buf[i * 4 + 3] + "].");
+            return;
+        }
+    }
+    testPassed("TransferToImageBitmap test on OffscreenCanvas." + webglContextVersion + " passed");
+}

--- a/sdk/tests/js/tests/offscreencanvas-transfer-image-bitmap.js
+++ b/sdk/tests/js/tests/offscreencanvas-transfer-image-bitmap.js
@@ -48,7 +48,7 @@ function _checkCanvas(buf, width, height, webglContextVersion)
         if (buf[i * 4] != 255 || buf[i * 4 + 1] != 255 ||
             buf[i * 4 + 2] != 0 || buf[i * 4 + 3] != 255) {
             testFailed("OffscreenCanvas." + webglContextVersion +
-                ": This pixel should be red, but it is: [" + buf[i * 4] + ", " +
+                ": This pixel should be [255, 255, 0, 255], but it is: [" + buf[i * 4] + ", " +
                 buf[i * 4 + 1] + ", " + buf[i * 4 + 2] + ", " + buf[i * 4 + 3] + "].");
             return;
         }

--- a/sdk/tests/js/tests/offscreencanvas-transfer-image-bitmap.js
+++ b/sdk/tests/js/tests/offscreencanvas-transfer-image-bitmap.js
@@ -1,4 +1,4 @@
-function testTransferToImageBitmap(webglContextVersion, bitmap) { 
+function testTransferToImageBitmap(webglContextVersion, bitmap) {
     var internalFormat = "RGBA";
     var pixelFormat = "RGBA";
     var pixelType = "UNSIGNED_BYTE";


### PR DESCRIPTION
These two tests are based on an existing Chromium Layout test for OffscreenCanvas webgl (https://cs.chromium.org/chromium/src/third_party/WebKit/LayoutTests/fast/canvas/webgl/offscreenCanvas-transferToImageBitmap-texImage2D.html). One tests for webgl 1 and the other tests for webgl 2. They share the same functions provided in sdk/tests/js/tests/offscreencanvas-transfer-image-bitmap.js.

@zhenyao for review.