### PR TITLE
Security tests for OffscreenCanvas texImage functions

### DIFF
--- a/sdk/tests/conformance/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance/textures/misc/00_test_list.txt
@@ -11,6 +11,7 @@ copy-tex-image-and-sub-image-2d.html
 gl-pixelstorei.html
 gl-teximage.html
 origin-clean-conformance.html
+origin-clean-conformance-offscreencanvas.html
 tex-image-and-sub-image-2d-with-array-buffer-view.html
 tex-image-and-uniform-binding-bugs.html
 --min-version 1.0.3 tex-image-canvas-corruption.html

--- a/sdk/tests/conformance/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance/textures/misc/00_test_list.txt
@@ -11,7 +11,7 @@ copy-tex-image-and-sub-image-2d.html
 gl-pixelstorei.html
 gl-teximage.html
 origin-clean-conformance.html
-origin-clean-conformance-offscreencanvas.html
+--min-version 1.0.4 origin-clean-conformance-offscreencanvas.html
 tex-image-and-sub-image-2d-with-array-buffer-view.html
 tex-image-and-uniform-binding-bugs.html
 --min-version 1.0.3 tex-image-canvas-corruption.html

--- a/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
+++ b/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
@@ -1,0 +1,148 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Origin Restrictions Conformance Tests for OffscreenCanvas</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script>
+"use strict";
+var wtu = WebGLTestUtils;
+
+// Checks if function throws an exception.
+function causedException(func) {
+  var hadException = false;
+  try {
+    func();
+  } catch(e) {
+    hadException = true;
+  }
+  return hadException;
+}
+
+var defaultImgUrl = "https://get.webgl.org/conformance-resources/opengl_logo.jpg";
+var localImgUrl = "../../../resources/opengl_logo.jpg";
+
+var imgDomain;
+var pageDomain;
+var successfullyParsed;
+
+function endTest() {
+  debug("");
+  successfullyParsed = true;
+  shouldBeTrue("successfullyParsed");
+  debug('<br /><span class="pass">TEST COMPLETE</span>');
+  notifyFinishedToHarness();
+}
+
+
+function imageLoaded() {
+  description("This test ensures WebGL implementations for OffscreenCanvas follow proper same-origin restrictions.");
+
+  if (!window.OffscreenCanvas) {
+    testPassed("No OffscreenCanvas support");
+    endTest();
+    return;
+  }
+
+  var img = this;
+
+  assertMsg(img.width > 0 && img.height > 0, "img was loaded");
+  imgDomain = wtu.getBaseDomain(wtu.getHost(img.src));
+  pageDomain = wtu.getBaseDomain(window.location.host);
+  assertMsg(imgDomain != pageDomain,
+            "img domain (" + imgDomain + ") and page domain (" + pageDomain + ") are not the same.");
+
+  function makeTexImage2D(gl, src) {
+    return function() {
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    };
+  }
+
+  function makeTexSubImage2D(gl, src) {
+    return function() {
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    };
+  }
+
+  function makeReadPixels(gl) {
+    return function() {
+      var buf = new Uint8Array(4);
+      gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    };
+  }
+
+  var offscreencanvas = new OffscreenCanvas(10, 10);
+  var gl = wtu.create3DContext(offscreencanvas);
+
+  debug("");
+  debug("check that an attempt to upload an image from another origin throws an exception.");
+  var tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 256, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  assertMsg(causedException(makeTexImage2D(gl, img)),
+            "texImage2D with cross-origin image should throw exception.");
+  assertMsg(causedException(makeTexSubImage2D(gl, img)),
+            "texSubImage2D with cross-origin image should throw exception.");
+
+  debug("check that readPixels continues to work against this offscreencanvas.");
+  assertMsg(!causedException(makeReadPixels(gl)),
+            "readPixels should never throw exception -- not possible to dirty origin of WebGL canvas.");
+
+  debug("check that an attempt to upload a tainted canvas throws an exception.");
+  var canvas = document.getElementById("canvas");
+  var ctx2d = canvas.getContext("2d");
+  ctx2d.drawImage(img, 0, 0);
+  assertMsg(causedException(makeTexImage2D(gl, canvas)),
+            "texImage2D with NON origin clean canvas should throw exception.");
+  assertMsg(causedException(makeTexSubImage2D(gl, canvas)),
+            "texSubImage2D with NON origin clean canvas should throw exception.");
+
+  debug("check that readPixels continues to work against this offscreencanvas.");
+  assertMsg(!causedException(makeReadPixels(gl)),
+            "readPixels should never throw exception -- not possible to dirty origin of WebGL canvas.");
+
+  // TODO: Should check video.
+  // TODO: Should check CORS support.
+
+  endTest();
+}
+
+wtu.setupImageForCrossOriginTest("#img", defaultImgUrl, localImgUrl, imageLoaded);
+</script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas"></canvas>
+<img id="img" style="display:none;">
+</body>
+</html>

--- a/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
+++ b/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
@@ -53,23 +53,13 @@ var localImgUrl = "../../../resources/opengl_logo.jpg";
 
 var imgDomain;
 var pageDomain;
-var successfullyParsed;
-
-function endTest() {
-  debug("");
-  successfullyParsed = true;
-  shouldBeTrue("successfullyParsed");
-  debug('<br /><span class="pass">TEST COMPLETE</span>');
-  notifyFinishedToHarness();
-}
-
 
 function imageLoaded() {
   description("This test ensures WebGL implementations for OffscreenCanvas follow proper same-origin restrictions.");
 
   if (!window.OffscreenCanvas) {
     testPassed("No OffscreenCanvas support");
-    endTest();
+    finishTest();
     return;
   }
 
@@ -133,7 +123,7 @@ function imageLoaded() {
   // TODO: Should check video.
   // TODO: Should check CORS support.
 
-  endTest();
+  finishTest();
 }
 
 wtu.setupImageForCrossOriginTest("#img", defaultImgUrl, localImgUrl, imageLoaded);

--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -12,7 +12,7 @@ gl-get-tex-parameter.html
 mipmap-fbo.html
 --min-version 2.0.1 npot-video-sizing.html
 --min-version 2.0.1 tex-3d-mipmap-levels-intel-bug.html
-origin-clean-conformance-offscreencanvas.html
+--min-version 2.0.1 origin-clean-conformance-offscreencanvas.html
 tex-3d-size-limit.html
 tex-image-and-sub-image-with-array-buffer-view-sub-source.html
 tex-image-with-bad-args.html

--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -12,6 +12,7 @@ gl-get-tex-parameter.html
 mipmap-fbo.html
 --min-version 2.0.1 npot-video-sizing.html
 --min-version 2.0.1 tex-3d-mipmap-levels-intel-bug.html
+origin-clean-conformance-offscreencanvas.html
 tex-3d-size-limit.html
 tex-image-and-sub-image-with-array-buffer-view-sub-source.html
 tex-image-with-bad-args.html

--- a/sdk/tests/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html
+++ b/sdk/tests/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html
@@ -1,0 +1,168 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 Origin Restrictions Conformance Tests for OffscreenCanvas</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script>
+"use strict";
+var wtu = WebGLTestUtils;
+
+// Checks if function throws an exception.
+function causedException(func) {
+  var hadException = false;
+  try {
+    func();
+  } catch(e) {
+    hadException = true;
+  }
+  return hadException;
+}
+
+var defaultImgUrl = "https://get.webgl.org/conformance-resources/opengl_logo.jpg";
+var localImgUrl = "../../../resources/opengl_logo.jpg";
+
+var imgDomain;
+var pageDomain;
+var successfullyParsed;
+
+function endTest() {
+  debug("");
+  successfullyParsed = true;
+  shouldBeTrue("successfullyParsed");
+  debug('<br /><span class="pass">TEST COMPLETE</span>');
+  notifyFinishedToHarness();
+}
+
+function imageLoaded() {
+  description("This test ensures WebGL2 implementations for OffscreenCanvas follow proper same-origin restrictions.");
+
+  if (!window.OffscreenCanvas) {
+    testPassed("No OffscreenCanvas support");
+    endTest();
+    return;
+  }
+
+  var img = this;
+
+  assertMsg(img.width > 0 && img.height > 0, "img was loaded");
+  imgDomain = wtu.getBaseDomain(wtu.getHost(img.src));
+  pageDomain = wtu.getBaseDomain(window.location.host);
+  assertMsg(imgDomain != pageDomain,
+            "img domain (" + imgDomain + ") and page domain (" + pageDomain + ") are not the same.");
+
+  function makeTexImage2D(gl, src) {
+    return function() {
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 10, 10, 0, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    };
+  }
+
+  function makeTexSubImage2D(gl, src) {
+    return function() {
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 10, 10, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    };
+  }
+
+  function makeTexImage3D(gl, src) {
+    return function() {
+      gl.texImage3D(gl.TEXTURE_3D, 0, gl.RGBA, 10, 10, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    };
+  }
+
+  function makeTexSubImage3D(gl, src) {
+    return function() {
+      gl.texSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, 10, 10, 1, gl.RGBA, gl.UNSIGNED_BYTE, src);
+    };
+  }
+
+  function makeReadPixels(gl) {
+    return function() {
+      var buf = new Uint8Array(4);
+      gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    };
+  }
+
+  var offscreencanvas = new OffscreenCanvas(10, 10);
+  var gl = wtu.create3DContext(offscreencanvas, null, 2);
+
+  debug("");
+  debug("check that an attempt to upload an image from another origin throws an exception.");
+  var tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 256, 256, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  assertMsg(causedException(makeTexImage2D(gl, img)),
+            "texImage2D with cross-origin image should throw exception.");
+  assertMsg(causedException(makeTexSubImage2D(gl, img)),
+            "texSubImage2D with cross-origin image should throw exception.");
+  assertMsg(causedException(makeTexImage3D(gl, img)),
+            "texImage3D with cross-origin image should throw exception.");
+  assertMsg(causedException(makeTexSubImage3D(gl, img)),
+            "texSubImage3D with cross-origin image should throw exception.");
+
+
+  debug("check that readPixels continues to work against this offscreencanvas.");
+  assertMsg(!causedException(makeReadPixels(gl)),
+            "readPixels should never throw exception -- not possible to dirty origin of WebGL canvas.");
+
+  debug("check that an attempt to upload a tainted canvas throws an exception.");
+  var canvas = document.getElementById("canvas");
+  var ctx2d = canvas.getContext("2d");
+  ctx2d.drawImage(img, 0, 0);
+  assertMsg(causedException(makeTexImage2D(gl, canvas)),
+            "texImage2D with NON origin clean canvas should throw exception.");
+  assertMsg(causedException(makeTexSubImage2D(gl, canvas)),
+            "texSubImage2D with NON origin clean canvas should throw exception.");
+  assertMsg(causedException(makeTexImage3D(gl, canvas)),
+            "texImage3D with NON origin clean canvas should throw exception.");
+  assertMsg(causedException(makeTexSubImage3D(gl, canvas)),
+            "texSubImage3D with NON origin clean canvas should throw exception.");
+
+  debug("check that readPixels continues to work against this offscreencanvas.");
+  assertMsg(!causedException(makeReadPixels(gl)),
+            "readPixels should never throw exception -- not possible to dirty origin of WebGL canvas.");
+
+  // TODO: Should check video.
+  // TODO: Should check CORS support.
+
+  endTest();
+}
+
+wtu.setupImageForCrossOriginTest("#img", defaultImgUrl, localImgUrl, imageLoaded);
+</script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas"></canvas>
+<img id="img" style="display:none;">
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html
+++ b/sdk/tests/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html
@@ -53,22 +53,13 @@ var localImgUrl = "../../../resources/opengl_logo.jpg";
 
 var imgDomain;
 var pageDomain;
-var successfullyParsed;
-
-function endTest() {
-  debug("");
-  successfullyParsed = true;
-  shouldBeTrue("successfullyParsed");
-  debug('<br /><span class="pass">TEST COMPLETE</span>');
-  notifyFinishedToHarness();
-}
 
 function imageLoaded() {
   description("This test ensures WebGL2 implementations for OffscreenCanvas follow proper same-origin restrictions.");
 
   if (!window.OffscreenCanvas) {
     testPassed("No OffscreenCanvas support");
-    endTest();
+    finishTest();
     return;
   }
 
@@ -131,7 +122,7 @@ function imageLoaded() {
 
   debug("check that readPixels continues to work against this offscreencanvas.");
   assertMsg(!causedException(makeReadPixels(gl)),
-            "readPixels should never throw exception -- not possible to dirty origin of WebGL canvas.");
+            "readPixels should never throw exception -- not possible to dirty origin of WebGL2 canvas.");
 
   debug("check that an attempt to upload a tainted canvas throws an exception.");
   var canvas = document.getElementById("canvas");
@@ -148,12 +139,12 @@ function imageLoaded() {
 
   debug("check that readPixels continues to work against this offscreencanvas.");
   assertMsg(!causedException(makeReadPixels(gl)),
-            "readPixels should never throw exception -- not possible to dirty origin of WebGL canvas.");
+            "readPixels should never throw exception -- not possible to dirty origin of WebGL2 canvas.");
 
   // TODO: Should check video.
   // TODO: Should check CORS support.
 
-  endTest();
+  finishTest();
 }
 
 wtu.setupImageForCrossOriginTest("#img", defaultImgUrl, localImgUrl, imageLoaded);


### PR DESCRIPTION
@kenrussell  Adding two security tests:
1. sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html tests whether texImage2D and texSubImage2D functions in OffscreenCanvas Webgl context correctly throw security exception when cross-origin image sources are updated
2. sdk/tests/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html tests whether texImage2D, texImage3D, texSubImage2D, texSubImage3D in OffscreenCanvas Webgl2 context correctly throw security exceptions.

Note that although these two tests look similar to sdk/tests/conformance/textures/misc/origin-clean-conformance.html (for HTMLCanvasElement), they have many differences: (1) toDataURL is not present
in OffscreenCanvas so not tested (2) the functions in webgl2 are completely different from those in webgl1 (3) OffscreenCanvas is used instead of HTMLCanvasElement and test messages are all changed.