### PR TITLE
Add tex-base-level-bug.html to detect driver bug of texImage2D.

### DIFF
--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -13,6 +13,7 @@ mipmap-fbo.html
 --min-version 2.0.1 npot-video-sizing.html
 --min-version 2.0.1 tex-3d-mipmap-levels-intel-bug.html
 tex-3d-size-limit.html
+--min-version 2.0.1 tex-base-level-bug.html
 tex-image-and-sub-image-with-array-buffer-view-sub-source.html
 tex-image-with-bad-args.html
 tex-image-with-bad-args-from-dom-elements.html

--- a/sdk/tests/conformance2/textures/misc/tex-base-level-bug.html
+++ b/sdk/tests/conformance2/textures/misc/tex-base-level-bug.html
@@ -1,0 +1,97 @@
+﻿<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 texture base level bug conformance test.</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="2" height="2" style="width: 2px; height: 2px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+"use strict";
+description(document.title);
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("example");
+var gl = wtu.create3DContext("example", undefined, 2);
+var tiu = TexImageUtils;
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from setup.");
+
+function runtest() {
+  debug("");
+  debug("This is a regression test for <a href='https://crbug.com/705865'>Chromium Issue 705865</a>");
+  var tex = gl.createTexture();
+  var program = tiu.setupTexturedQuad(gl, "RGBA");
+
+  // Test that filling partial levels is enough for mipmapping.
+  var width = 2;
+  var height = 2;
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  wtu.fillTexture(gl, tex, width, height, [255, 0, 0, 255], 2, gl.RGBA, gl.UNSIGNED_BYTE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, 2);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Texture setup should succeed");
+
+  canvas.width = width;
+  canvas.height = height;
+  gl.viewport(0, 0, width, height);
+
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "clearAndDrawQuad should succeed");
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
+
+  width = 1;
+  height = 1;
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage2D should succeed");
+
+  wtu.clearAndDrawUnitQuad(gl);
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "should draw with [255, 0, 0, 255]");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR,"checkCanvas should succeed");
+
+  gl.deleteTexture(tex);
+
+};
+
+runtest();
+var successfullyParsed = true;
+
+</script>
+<script src="../../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This is a regression test for Chromium Issue 705865.
First, Set texture base level > 0, then set texture level 0
result in pixel comparison error of its base level.

The test case fails on mac and windows.