### PR TITLE
Fetch WebGL 2.0 context by default in object-deletion-behaviour-2 test.

### DIFF
--- a/sdk/tests/conformance2/misc/object-deletion-behaviour-2.html
+++ b/sdk/tests/conformance2/misc/object-deletion-behaviour-2.html
@@ -42,9 +42,8 @@
 description("Tests deletion behavior for WebGL2 buffer, sampler, vertexArray and transformFeedback objects.");
 
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext();
+var gl = wtu.create3DContext(undefined, undefined, 2);
 var shouldGenerateGLError = wtu.shouldGenerateGLError;
-var contextVersion = wtu.getDefault3DContextVersion();
 
 debug("");
 debug("buffer deletion");


### PR DESCRIPTION
Makes it easier to run it from its URL rather than through the harness.