### PR TITLE
Prepare tests for landing texImageSource & GL_RGB10_A2 support.

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
+++ b/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
@@ -49,8 +49,8 @@ var gl = wtu.create3DContext("c", undefined, 2);
 var doTexImage = function(domElement) {
     var tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, domElement);
-    wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM, gl.INVALID_OPERATION], "TexImage2D taking RGB10_A2/RGBA/UNSIGNED_INT_2_10_10_10_REV should fail");
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2UI, gl.RGBA_INTEGER, gl.UNSIGNED_INT_2_10_10_10_REV, domElement);
+    wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM, gl.INVALID_OPERATION], "TexImage2D taking RGB10_A2UI/RGBA_INTEGER/UNSIGNED_INT_2_10_10_10_REV should fail");
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG8, gl.RG, gl.FLOAT, domElement);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "TexImage2D taking RG8/RG/FLOAT should fail");
     gl.deleteTexture(tex);

--- a/sdk/tests/conformance2/textures/misc/tex-image-with-different-data-source.html
+++ b/sdk/tests/conformance2/textures/misc/tex-image-with-different-data-source.html
@@ -51,7 +51,7 @@ var tex = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex);
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, gl.RGBA, gl.UNSIGNED_BYTE, c);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "TexImage2D taking a canvas source should succeed");
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, 16, 16, 0, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, null);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2UI, 16, 16, 0, gl.RGBA_INTEGER, gl.UNSIGNED_INT_2_10_10_10_REV, null);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Teximage2D taking a null array buffer should succeed");
 gl.deleteTexture(tex);
 
@@ -59,10 +59,10 @@ gl.deleteTexture(tex);
 gl = wtu.create3DContext("canvas2", undefined, 2);
 tex = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex);
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, 16, 16, 0, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, null);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2UI, 16, 16, 0, gl.RGBA_INTEGER, gl.UNSIGNED_INT_2_10_10_10_REV, null);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Teximage2D taking a null array buffer should succeed");
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, c);
-wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "TexImage2D taking RGB10_A2 internalformat and a canvas source should fail");
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2UI, gl.RGBA_INTEGER, gl.UNSIGNED_INT_2_10_10_10_REV, c);
+wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "TexImage2D taking RGB10_A2UI internalformat and a canvas source should fail");
 gl.deleteTexture(tex);
 
 var successfullyParsed = true;


### PR DESCRIPTION
Splitting part of the https://github.com/KhronosGroup/WebGL/pull/2375 to
allow landing https://crrev.com/2821363003/ before landing the
https://github.com/KhronosGroup/WebGL/pull/2375.

This is related to #2274: GL_RGB10_A2 and texImageSource variants of tex*Image*