### PR TITLE
Support SharedArrayBuffers

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1238,8 +1238,8 @@ typedef (ImageBitmap or
          HTMLCanvasElement or
          HTMLVideoElement) TexImageSource;
 
-typedef (Float32Array or sequence&lt;GLfloat&gt;) Float32List;
-typedef (Int32Array or sequence&lt;GLint&gt;) Int32List;
+typedef ([AllowShared] Float32Array or sequence&lt;GLfloat&gt;) Float32List;
+typedef ([AllowShared] Int32Array or sequence&lt;GLint&gt;) Int32List;
 
 [NoInterfaceObject]
 interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1232,7 +1232,6 @@ for (var i = 0; i < numVertices; i++) {
     See <a href="#CONTEXT_LOST">the context lost event</a> for further details.
     </p>
     <pre class="idl">
-typedef (ArrayBuffer or ArrayBufferView) BufferDataSource;
 typedef (ImageBitmap or
          ImageData or
          HTMLImageElement or
@@ -1690,9 +1689,8 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
                            GLenum srcAlpha, GLenum dstAlpha);
 
     void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-    void bufferData(GLenum target, ArrayBuffer? data, GLenum usage);
-    void bufferData(GLenum target, ArrayBufferView data, GLenum usage);
-    void bufferSubData(GLenum target, GLintptr offset, BufferDataSource data);
+    void bufferData(GLenum target, [AllowShared] BufferSource? data, GLenum usage);
+    void bufferSubData(GLenum target, GLintptr offset, [AllowShared] BufferSource data);
 
     [WebGLHandlesContextLoss] GLenum checkFramebufferStatus(GLenum target);
     void clear(GLbitfield mask);
@@ -1704,11 +1702,11 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 
     void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                               GLsizei width, GLsizei height, GLint border,
-                              ArrayBufferView data);
+                              [AllowShared] ArrayBufferView data);
     void compressedTexSubImage2D(GLenum target, GLint level,
                                  GLint xoffset, GLint yoffset,
                                  GLsizei width, GLsizei height, GLenum format,
-                                 ArrayBufferView data);
+                                 [AllowShared] ArrayBufferView data);
 
     void copyTexImage2D(GLenum target, GLint level, GLenum internalformat,
                         GLint x, GLint y, GLsizei width, GLsizei height,
@@ -1800,7 +1798,7 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
     void polygonOffset(GLfloat factor, GLfloat units);
 
     void readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
-                    GLenum format, GLenum type, ArrayBufferView? pixels);
+                    GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
 
     void renderbufferStorage(GLenum target, GLenum internalformat,
                              GLsizei width, GLsizei height);
@@ -1818,7 +1816,7 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 
     void texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLsizei width, GLsizei height, GLint border, GLenum format,
-                    GLenum type, ArrayBufferView? pixels);
+                    GLenum type, [AllowShared] ArrayBufferView? pixels);
     void texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
@@ -1827,7 +1825,7 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 
     void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLsizei width, GLsizei height,
-                       GLenum format, GLenum type, ArrayBufferView? pixels);
+                       GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
     void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
@@ -2218,16 +2216,14 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             Set the size of the currently bound WebGLBuffer object for the passed target. The
             buffer is initialized to 0.
 
-        <dt><p class="idl-code">void bufferData(GLenum target, ArrayBuffer? data, GLenum usage)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glBufferData.xml">man page</a>)</span></p>
-            <p class="idl-code">void bufferData(GLenum target, ArrayBufferView data, GLenum usage)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glBufferData.xml">man page</a>)</span></p>
+        <dt class="idl-code">void bufferData(GLenum target, [AllowShared] BufferSource? data, GLenum usage)
+            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glBufferData.xml">man page</a>)</span>
         <dd>
             Set the size of the currently bound WebGLBuffer object for the passed target to the
             size of the passed data, then write the contents of data to the buffer object.
             <br><br>
             If the passed data is null then an <code>INVALID_VALUE</code> error is generated.
-        <dt><p class="idl-code">void bufferSubData(GLenum target, GLintptr offset, BufferDataSource data)
+        <dt><p class="idl-code">void bufferSubData(GLenum target, GLintptr offset, [AllowShared] BufferSource data)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glBufferSubData.xml">man page</a>)</span></p>
         <dd>
             For the WebGLBuffer object bound to the passed target write the passed data starting at
@@ -2427,10 +2423,10 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             the current binding will remain untouched.
 
         <dt><p class="idl-code"><a name="COMPRESSEDTEXIMAGE2D">void compressedTexImage2D</a>(GLenum target, GLint level, GLenum internalformat,
-                    GLsizei width, GLsizei height, GLint border, ArrayBufferView pixels)
+                    GLsizei width, GLsizei height, GLint border, [AllowShared] ArrayBufferView pixels)
                 <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.7.3">OpenGL ES 2.0 &sect;3.7.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glCompressedTexImage2D.xml">man page</a>)</span></p>
             <p class="idl-code"><a name="COMPRESSEDTEXSUBIMAGE2D">void compressedTexSubImage2D</a>(GLenum target, GLint level,
-                    GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, ArrayBufferView pixels)
+                    GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, [AllowShared] ArrayBufferView pixels)
                 <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.7.3">OpenGL ES 2.0 &sect;3.7.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glCompressedTexSubImage2D.xml">man page</a>)</span></p>
         <dd>
             If an attempt is made to call these functions with no WebGLTexture bound (see above), an
@@ -2512,7 +2508,7 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             flag</a> is set.
         <dt class="idl-code"><a name="TEXIMAGE2D">void texImage2D</a>(GLenum target, GLint level, GLint internalformat,
                     GLsizei width, GLsizei height, GLint border, GLenum format,
-                    GLenum type, ArrayBufferView? pixels)
+                    GLenum type, [AllowShared] ArrayBufferView? pixels)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.7.1">OpenGL ES 2.0 &sect;3.7.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glTexImage2D.xml">man page</a>)</span>
         <dd>
             If <code>pixels</code> is null, a buffer of sufficient size initialized to 0 is
@@ -2608,7 +2604,7 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
             <code>INVALID_OPERATION</code> error is generated.
         <dt class="idl-code"><a name="TEXSUBIMAGE2D">void texSubImage2D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLsizei width, GLsizei height,
-                       GLenum format, GLenum type, ArrayBufferView? pixels)
+                       GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.7.2">OpenGL ES 2.0 &sect;3.7.2</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glTexSubImage2D.xml">man page</a>)</span>
         <dd>
             See <a href="#TEXIMAGE2D">texImage2D</a> for restrictions on the <em>format</em>
@@ -3073,7 +3069,7 @@ WebGLRenderingContext implements WebGLRenderingContextBase;
 
     <dl class="methods">
         <dt class="idl-code">void readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
-                           GLenum format, GLenum type, ArrayBufferView? pixels)
+                           GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-4.3.1">OpenGL ES 2.0 &sect;4.3.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glReadPixels.xml">man page</a>)</span>
         <dd>
             Fills <code>pixels</code> with the pixel data in the specified rectangle of the frame
@@ -4164,9 +4160,9 @@ extensions.
             I. Hickson, June 2011.
         </dd>
         <dt id="refsWEBIDL">[WEBIDL]</dt>
-        <dd><cite><a href="http://dev.w3.org/2006/webapi/WebIDL/">
+        <dd><cite><a href="https://heycam.github.io/webidl/">
             Web IDL: W3C Editor’s Draft</a></cite>,
-            C. McCormack.
+            C. McCormack, B. Zbarsky, T. Langel.
         </dd>
         <dt id="refsASCII">[ASCII]</dt>
         <dd><cite>International Standard ISO/IEC 646:1991. Information technology -

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -74,7 +74,6 @@ interface WebGLShaderPrecisionFormat {
     readonly attribute GLint precision;
 };
 
-typedef (ArrayBuffer or ArrayBufferView) BufferDataSource;
 typedef (ImageBitmap or
          ImageData or
          HTMLImageElement or
@@ -532,9 +531,8 @@ interface WebGLRenderingContextBase
                            GLenum srcAlpha, GLenum dstAlpha);
 
     void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-    void bufferData(GLenum target, ArrayBuffer? data, GLenum usage);
-    void bufferData(GLenum target, ArrayBufferView data, GLenum usage);
-    void bufferSubData(GLenum target, GLintptr offset, BufferDataSource data);
+    void bufferData(GLenum target, [AllowShared] BufferSource? data, GLenum usage);
+    void bufferSubData(GLenum target, GLintptr offset, [AllowShared] BufferSource data);
 
     [WebGLHandlesContextLoss] GLenum checkFramebufferStatus(GLenum target);
     void clear(GLbitfield mask);
@@ -546,11 +544,11 @@ interface WebGLRenderingContextBase
 
     void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                               GLsizei width, GLsizei height, GLint border,
-                              ArrayBufferView data);
+                              [AllowShared] ArrayBufferView data);
     void compressedTexSubImage2D(GLenum target, GLint level,
                                  GLint xoffset, GLint yoffset,
                                  GLsizei width, GLsizei height, GLenum format,
-                                 ArrayBufferView data);
+                                 [AllowShared] ArrayBufferView data);
 
     void copyTexImage2D(GLenum target, GLint level, GLenum internalformat,
                         GLint x, GLint y, GLsizei width, GLsizei height,
@@ -642,7 +640,7 @@ interface WebGLRenderingContextBase
     void polygonOffset(GLfloat factor, GLfloat units);
 
     void readPixels(GLint x, GLint y, GLsizei width, GLsizei height,
-                    GLenum format, GLenum type, ArrayBufferView? pixels);
+                    GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
 
     void renderbufferStorage(GLenum target, GLenum internalformat,
                              GLsizei width, GLsizei height);
@@ -660,7 +658,7 @@ interface WebGLRenderingContextBase
 
     void texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLsizei width, GLsizei height, GLint border, GLenum format,
-                    GLenum type, ArrayBufferView? pixels);
+                    GLenum type, [AllowShared] ArrayBufferView? pixels);
     void texImage2D(GLenum target, GLint level, GLint internalformat,
                     GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
@@ -669,7 +667,7 @@ interface WebGLRenderingContextBase
 
     void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLsizei width, GLsizei height,
-                       GLenum format, GLenum type, ArrayBufferView? pixels);
+                       GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
     void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                        GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -80,8 +80,8 @@ typedef (ImageBitmap or
          HTMLCanvasElement or
          HTMLVideoElement) TexImageSource;
 
-typedef (Float32Array or sequence<GLfloat>) Float32List;
-typedef (Int32Array or sequence<GLint>) Int32List;
+typedef ([AllowShared] Float32Array or sequence<GLfloat>) Float32List;
+typedef ([AllowShared] Int32Array or sequence<GLint>) Int32List;
 
 [NoInterfaceObject]
 interface WebGLRenderingContextBase

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -422,7 +422,7 @@ typedef unsigned long long GLuint64;
     </p>
 
     <pre class="idl">
-typedef (Uint32Array or sequence&lt;GLuint&gt;) Uint32List;
+typedef ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) Uint32List;
 
 [NoInterfaceObject]
 interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -699,13 +699,12 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   /* Buffer objects */
   // WebGL1:
   void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-  void bufferData(GLenum target, ArrayBuffer? srcData, GLenum usage);
-  void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage);
-  void bufferSubData(GLenum target, GLintptr dstByteOffset, BufferDataSource srcData);
+  void bufferData(GLenum target, [AllowShared] BufferSource? srcData, GLenum usage);
+  void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] BufferSource srcData);
   // WebGL2:
-  void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
+  void bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
                   optional GLuint length = 0);
-  void bufferSubData(GLenum target, GLintptr dstByteOffset, ArrayBufferView srcData,
+  void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData,
                      GLuint srcOffset, optional GLuint length = 0);
 
   void copyBufferSubData(GLenum readTarget, GLenum writeTarget, GLintptr readOffset,
@@ -713,7 +712,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   // MapBufferRange, in particular its read-only and write-only modes,
   // can not be exposed safely to JavaScript. GetBufferSubData
   // replaces it for the purpose of fetching data back from the GPU.
-  void getBufferSubData(GLenum target, GLintptr srcByteOffset, ArrayBufferView dstBuffer,
+  void getBufferSubData(GLenum target, GLintptr srcByteOffset, [AllowShared] ArrayBufferView dstBuffer,
                         optional GLuint dstOffset = 0, optional GLuint length = 0);
 
   /* Framebuffer objects */
@@ -740,13 +739,13 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   // WebGL1 legacy entrypoints:
   void texImage2D(GLenum target, GLint level, GLint internalformat,
                   GLsizei width, GLsizei height, GLint border, GLenum format,
-                  GLenum type, ArrayBufferView? pixels);
+                  GLenum type, [AllowShared] ArrayBufferView? pixels);
   void texImage2D(GLenum target, GLint level, GLint internalformat,
                   GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                      GLsizei width, GLsizei height,
-                     GLenum format, GLenum type, ArrayBufferView? pixels);
+                     GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                      GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
@@ -757,7 +756,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
                   GLint border, GLenum format, GLenum type,
                   TexImageSource source); // May throw DOMException
   void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-                  GLint border, GLenum format, GLenum type, ArrayBufferView srcData,
+                  GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
                   GLuint srcOffset);
 
   void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
@@ -766,9 +765,9 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
                   GLsizei depth, GLint border, GLenum format, GLenum type,
                   TexImageSource source); // May throw DOMException
   void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-                  GLsizei depth, GLint border, GLenum format, GLenum type, ArrayBufferView? srcData);
+                  GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData);
   void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-                  GLsizei depth, GLint border, GLenum format, GLenum type, ArrayBufferView srcData,
+                  GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
                   GLuint srcOffset);
 
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
@@ -777,7 +776,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
                      GLsizei height, GLenum format, GLenum type,
                      TexImageSource source); // May throw DOMException
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
-                     GLsizei height, GLenum format, GLenum type, ArrayBufferView srcData,
+                     GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
                      GLuint srcOffset);
 
   void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
@@ -788,7 +787,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
                      TexImageSource source); // May throw DOMException
   void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                      GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
-                     ArrayBufferView? srcData, optional GLuint srcOffset = 0);
+                     [AllowShared] ArrayBufferView? srcData, optional GLuint srcOffset = 0);
 
   void copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                          GLint x, GLint y, GLsizei width, GLsizei height);
@@ -796,20 +795,20 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                             GLsizei height, GLint border, GLsizei imageSize, GLintptr offset);
   void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
-                            GLsizei height, GLint border, ArrayBufferView srcData,
+                            GLsizei height, GLint border, [AllowShared] ArrayBufferView srcData,
                             optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
   void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                             GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, GLintptr offset);
   void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
-                            GLsizei height, GLsizei depth, GLint border, ArrayBufferView srcData,
+                            GLsizei height, GLsizei depth, GLint border, [AllowShared] ArrayBufferView srcData,
                             optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
   void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, GLintptr offset);
   void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format,
-                               ArrayBufferView srcData,
+                               [AllowShared] ArrayBufferView srcData,
                                optional GLuint srcOffset = 0,
                                optional GLuint srcLengthOverride = 0);
 
@@ -818,7 +817,7 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
                                GLenum format, GLsizei imageSize, GLintptr offset);
   void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
-                               GLenum format, ArrayBufferView srcData,
+                               GLenum format, [AllowShared] ArrayBufferView srcData,
                                optional GLuint srcOffset = 0,
                                optional GLuint srcLengthOverride = 0);
 
@@ -895,12 +894,12 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   /* Reading back pixels */
   // WebGL1:
   void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
-                  ArrayBufferView? dstData);
+                  [AllowShared] ArrayBufferView? dstData);
   // WebGL2:
   void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
                   GLintptr offset);
   void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
-                  ArrayBufferView dstData, GLuint dstOffset);
+                  [AllowShared] ArrayBufferView dstData, GLuint dstOffset);
 
   /* Multiple Render Targets */
   void drawBuffers(sequence&lt;GLenum&gt; buffers);
@@ -1168,7 +1167,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <dl class="methods">
 
-      <dt class="idl-code">void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage, GLuint srcOffset, optional GLuint length = 0);
+      <dt class="idl-code">void bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset, optional GLuint length = 0);
           <span class="gl-spec">
           (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10.2">OpenGL ES 3.0.4 &sect;2.10.2</a>,
            <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferData.xhtml" class="nonnormative">man page</a>)
@@ -1203,7 +1202,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         If any error is generated, <code>buf</code>'s size is unmodified, and no data is written to it.
       </dd>
 
-      <dt class="idl-code">void bufferSubData(GLenum target, GLintptr dstByteOffset, ArrayBufferView srcData, GLuint srcOffset, optional GLuint length = 0);
+      <dt class="idl-code">void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData, GLuint srcOffset, optional GLuint length = 0);
           <span class="gl-spec">
           (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10.2">OpenGL ES 3.0.4 &sect;2.10.2</a>,
            <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferSubData.xhtml" class="nonnormative">man page</a>)
@@ -1268,7 +1267,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       <dt>
         <p class="idl-code">
           void getBufferSubData(GLenum target, GLintptr srcByteOffset,
-                                ArrayBufferView dstBuffer,
+                                [AllowShared] ArrayBufferView dstBuffer,
                                 optional GLuint dstOffset = 0,
                                 optional GLuint length = 0)
         </p>
@@ -1616,7 +1615,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       <dt class="idl-code">
         void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                         GLsizei height, GLint border, GLenum format, GLenum type,
-                        ArrayBufferView srcData, GLuint srcOffset)
+                        [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)</span>
       </dt>
       <dd>
@@ -1720,7 +1719,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       <dt class="idl-code"><a name="TEXSUBIMAGE2D">
         void texSubImage2D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format, GLenum type,
-                               ArrayBufferView srcData, GLuint srcOffset)
+                               [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)</span>
       </dt>
       <dd>
@@ -1776,10 +1775,10 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
       <dt class="idl-code">
         <p>void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                            GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
-                           ArrayBufferView? srcData)</p>
+                           [AllowShared] ArrayBufferView? srcData)</p>
         <p>void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                            GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
-                           ArrayBufferView srcData, GLuint srcOffset)
+                           [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
           <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)</span>
         </p>
       </dt>
@@ -1849,7 +1848,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <p class="idl-code">
           void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                              GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
-                             GLenum format, GLenum type, ArrayBufferView? srcData,
+                             GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData,
                              optional GLuint srcOffset = 0)
           <span class="gl-spec">
             (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>,
@@ -1948,7 +1947,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <p class="idl-code">
           void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                                     GLsizei width, GLsizei height, GLint border,
-                                    ArrayBufferView srcData,
+                                    [AllowShared] ArrayBufferView srcData,
                                     optional GLuint srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
@@ -1970,7 +1969,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <p class="idl-code">
           void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                        GLsizei width, GLsizei height, GLenum format,
-                                       ArrayBufferView srcData,
+                                       [AllowShared] ArrayBufferView srcData,
                                        optional GLuint srcOffset = 0,
                                        optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
@@ -1993,7 +1992,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <p class="idl-code">
           void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat,
                                     GLsizei width, GLsizei height, GLsizei depth, GLint border,
-                                    ArrayBufferView srcData,
+                                    [AllowShared] ArrayBufferView srcData,
                                     optional GLuint srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
@@ -2015,7 +2014,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <p class="idl-code">
           void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                        GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
-                                       GLenum format, ArrayBufferView srcData,
+                                       GLenum format, [AllowShared] ArrayBufferView srcData,
                                        optional GLuint srcOffset = 0,
                                        optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
@@ -2351,7 +2350,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
     <dl class="methods">
         <dt class="idl-code">
           void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
-                          GLenum type, ArrayBufferView dstData, GLuint dstOffset)
+                          GLenum type, [AllowShared] ArrayBufferView dstData, GLuint dstOffset)
           <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.3.2">OpenGL ES 3.0 &sect;4.3.2</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glReadPixels.xhtml">man page</a>)</span>
         </dt>
         <dd>
@@ -3928,9 +3927,9 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
             S. Bradner. IETF, March 1997.
         </dd>
         <dt id="refsWEBIDL">[WEBIDL]</dt>
-        <dd><cite><a href="http://dev.w3.org/2006/webapi/WebIDL/">
+        <dd><cite><a href="https://heycam.github.io/webidl/">
             Web IDL: W3C Editor’s Draft</a></cite>,
-            C. McCormack.
+            C. McCormack, B. Zbarsky, T. Langel.
         </dd>
     </dl>
 

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -25,7 +25,7 @@ interface WebGLTransformFeedback : WebGLObject {
 interface WebGLVertexArrayObject : WebGLObject {
 };
 
-typedef (Uint32Array or sequence<GLuint>) Uint32List;
+typedef ([AllowShared] Uint32Array or sequence<GLuint>) Uint32List;
 
 [NoInterfaceObject]
 interface WebGL2RenderingContextBase

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -302,13 +302,12 @@ interface WebGL2RenderingContextBase
   /* Buffer objects */
   // WebGL1:
   void bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-  void bufferData(GLenum target, ArrayBuffer? srcData, GLenum usage);
-  void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage);
-  void bufferSubData(GLenum target, GLintptr dstByteOffset, BufferDataSource srcData);
+  void bufferData(GLenum target, [AllowShared] BufferSource? srcData, GLenum usage);
+  void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] BufferSource srcData);
   // WebGL2:
-  void bufferData(GLenum target, ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
+  void bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
                   optional GLuint length = 0);
-  void bufferSubData(GLenum target, GLintptr dstByteOffset, ArrayBufferView srcData,
+  void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData,
                      GLuint srcOffset, optional GLuint length = 0);
 
   void copyBufferSubData(GLenum readTarget, GLenum writeTarget, GLintptr readOffset,
@@ -316,7 +315,7 @@ interface WebGL2RenderingContextBase
   // MapBufferRange, in particular its read-only and write-only modes,
   // can not be exposed safely to JavaScript. GetBufferSubData
   // replaces it for the purpose of fetching data back from the GPU.
-  void getBufferSubData(GLenum target, GLintptr srcByteOffset, ArrayBufferView dstBuffer,
+  void getBufferSubData(GLenum target, GLintptr srcByteOffset, [AllowShared] ArrayBufferView dstBuffer,
                         optional GLuint dstOffset = 0, optional GLuint length = 0);
 
   /* Framebuffer objects */
@@ -343,13 +342,13 @@ interface WebGL2RenderingContextBase
   // WebGL1 legacy entrypoints:
   void texImage2D(GLenum target, GLint level, GLint internalformat,
                   GLsizei width, GLsizei height, GLint border, GLenum format,
-                  GLenum type, ArrayBufferView? pixels);
+                  GLenum type, [AllowShared] ArrayBufferView? pixels);
   void texImage2D(GLenum target, GLint level, GLint internalformat,
                   GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                      GLsizei width, GLsizei height,
-                     GLenum format, GLenum type, ArrayBufferView? pixels);
+                     GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                      GLenum format, GLenum type, TexImageSource source); // May throw DOMException
 
@@ -360,7 +359,7 @@ interface WebGL2RenderingContextBase
                   GLint border, GLenum format, GLenum type,
                   TexImageSource source); // May throw DOMException
   void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-                  GLint border, GLenum format, GLenum type, ArrayBufferView srcData,
+                  GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
                   GLuint srcOffset);
 
   void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
@@ -369,9 +368,9 @@ interface WebGL2RenderingContextBase
                   GLsizei depth, GLint border, GLenum format, GLenum type,
                   TexImageSource source); // May throw DOMException
   void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-                  GLsizei depth, GLint border, GLenum format, GLenum type, ArrayBufferView? srcData);
+                  GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData);
   void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
-                  GLsizei depth, GLint border, GLenum format, GLenum type, ArrayBufferView srcData,
+                  GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
                   GLuint srcOffset);
 
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
@@ -380,7 +379,7 @@ interface WebGL2RenderingContextBase
                      GLsizei height, GLenum format, GLenum type,
                      TexImageSource source); // May throw DOMException
   void texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
-                     GLsizei height, GLenum format, GLenum type, ArrayBufferView srcData,
+                     GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
                      GLuint srcOffset);
 
   void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
@@ -391,7 +390,7 @@ interface WebGL2RenderingContextBase
                      TexImageSource source); // May throw DOMException
   void texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                      GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
-                     ArrayBufferView? srcData, optional GLuint srcOffset = 0);
+                     [AllowShared] ArrayBufferView? srcData, optional GLuint srcOffset = 0);
 
   void copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                          GLint x, GLint y, GLsizei width, GLsizei height);
@@ -399,20 +398,20 @@ interface WebGL2RenderingContextBase
   void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                             GLsizei height, GLint border, GLsizei imageSize, GLintptr offset);
   void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
-                            GLsizei height, GLint border, ArrayBufferView srcData,
+                            GLsizei height, GLint border, [AllowShared] ArrayBufferView srcData,
                             optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
   void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                             GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, GLintptr offset);
   void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
-                            GLsizei height, GLsizei depth, GLint border, ArrayBufferView srcData,
+                            GLsizei height, GLsizei depth, GLint border, [AllowShared] ArrayBufferView srcData,
                             optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
   void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, GLintptr offset);
   void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format,
-                               ArrayBufferView srcData,
+                               [AllowShared] ArrayBufferView srcData,
                                optional GLuint srcOffset = 0,
                                optional GLuint srcLengthOverride = 0);
 
@@ -421,7 +420,7 @@ interface WebGL2RenderingContextBase
                                GLenum format, GLsizei imageSize, GLintptr offset);
   void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
-                               GLenum format, ArrayBufferView srcData,
+                               GLenum format, [AllowShared] ArrayBufferView srcData,
                                optional GLuint srcOffset = 0,
                                optional GLuint srcLengthOverride = 0);
 
@@ -498,12 +497,12 @@ interface WebGL2RenderingContextBase
   /* Reading back pixels */
   // WebGL1:
   void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
-                  ArrayBufferView? dstData);
+                  [AllowShared] ArrayBufferView? dstData);
   // WebGL2:
   void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
                   GLintptr offset);
   void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
-                  ArrayBufferView dstData, GLuint dstOffset);
+                  [AllowShared] ArrayBufferView dstData, GLuint dstOffset);
 
   /* Multiple Render Targets */
   void drawBuffers(sequence<GLenum> buffers);


### PR DESCRIPTION
This annotates all ArrayBuffer or ArrayBufferView types with [AllowShared], per the proto-specification at https://tc39.github.io/ecmascript_sharedmem/dom_shmem.html#webgl, extended to also modify the Web GL 2.0 entrypoints. This allows the backing data to be a SharedArrayBuffer, instead of only non-shared ArrayBuffers, per https://github.com/heycam/webidl/pull/353.

This also makes some related editorial changes, removing the redundant BufferDataSource typedef in favor of the defined-in-Web IDL BufferSource type, and consolidating two overloads of bufferData (one accepting ArrayBuffer? and the other accepting ArrayBufferView) into a single overload accepting BufferSource?.

---

This is my first time contributing to the Web GL spec, so help appreciated with any policies, procedures, or style issues.

I also imagine we'll want to update the conformance test suite as well, but that's outside my capabilities. @binji or @flagxor may be able to help with that. I've left "allow edits from maintainers" checked so that others can push such test additions directly to this PR, if they like.

This should not be merged until https://github.com/heycam/webidl/pull/353 is.