### PR TITLE
transform_feedback: test multiple compiles of the same shaders

### DIFF
--- a/sdk/tests/conformance2/buffers/uniform-buffers-second-compile.html
+++ b/sdk/tests/conformance2/buffers/uniform-buffers-second-compile.html
@@ -105,11 +105,11 @@ function runTest() {
 
         var uniforms1Location = gl.getUniformBlockIndex(program, "Uniforms1");
         gl.uniformBlockBinding(program, uniforms1Location, 0);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uniforms1Location " + uniforms1Location + " probably invalid");
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uniforms1Location was " + uniforms1Location);
 
         var uniforms2Location = gl.getUniformBlockIndex(program, "Uniforms2");
         gl.uniformBlockBinding(program, uniforms2Location, 1);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uniforms2Location " + uniforms2Location + " probably invalid");
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uniforms2Location was " + uniforms2Location);
 
         debug("");
     }

--- a/sdk/tests/conformance2/transform_feedback/transform_feedback.html
+++ b/sdk/tests/conformance2/transform_feedback/transform_feedback.html
@@ -449,6 +449,7 @@ function runVaryingsTest() {
     verifyTransformFeedbackVarying(program, 2, false);
 
     // Test recompiling/relinking the program
+    // Regression test for http://crbug.com/716018
     var skipCompileStatus = true;
     program = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
         ["out_add", "out_mul"], gl.SEPARATE_ATTRIBS,

--- a/sdk/tests/conformance2/transform_feedback/transform_feedback.html
+++ b/sdk/tests/conformance2/transform_feedback/transform_feedback.html
@@ -448,6 +448,18 @@ function runVaryingsTest() {
     verifyTransformFeedbackVarying(program, 1, false);
     verifyTransformFeedbackVarying(program, 2, false);
 
+    // Test recompiling/relinking the program
+    var skipCompileStatus = true;
+    program = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
+        ["out_add", "out_mul"], gl.SEPARATE_ATTRIBS,
+        ["in_data"], undefined, undefined, skipCompileStatus);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking transform feedback shader should not set an error");
+    shouldBeTrue("gl.getProgramParameter(program, gl.LINK_STATUS)");
+    shouldBe("gl.getProgramParameter(program, gl.TRANSFORM_FEEDBACK_VARYINGS)", "2");
+    verifyTransformFeedbackVarying(program, 0, true, "out_add");
+    verifyTransformFeedbackVarying(program, 1, true, "out_mul");
+    verifyTransformFeedbackVarying(program, 2, false);
+
     finishTest();
 }
 

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -297,7 +297,7 @@ var setupProgram = function(
  * @param {boolean} opt_logShaders Whether to log shader source.
  */
 var setupTransformFeedbackProgram = function(
-    gl, shaders, varyings, bufferMode, opt_attribs, opt_locations, opt_logShaders) {
+    gl, shaders, varyings, bufferMode, opt_attribs, opt_locations, opt_logShaders, opt_skipCompileStatus) {
   var realShaders = [];
   var program = gl.createProgram();
   var shaderCount = 0;
@@ -309,13 +309,13 @@ var setupTransformFeedbackProgram = function(
       if (element) {
         if (element.type != "x-shader/x-vertex" && element.type != "x-shader/x-fragment")
           shaderType = ii ? gl.FRAGMENT_SHADER : gl.VERTEX_SHADER;
-        shader = loadShaderFromScript(gl, shader, shaderType, undefined, opt_logShaders);
+        shader = loadShaderFromScript(gl, shader, shaderType, undefined, opt_logShaders, opt_skipCompileStatus);
       } else if (endsWith(shader, ".vert")) {
-        shader = loadShaderFromFile(gl, shader, gl.VERTEX_SHADER, undefined, opt_logShaders);
+        shader = loadShaderFromFile(gl, shader, gl.VERTEX_SHADER, undefined, opt_logShaders, opt_skipCompileStatus);
       } else if (endsWith(shader, ".frag")) {
-        shader = loadShaderFromFile(gl, shader, gl.FRAGMENT_SHADER, undefined, opt_logShaders);
+        shader = loadShaderFromFile(gl, shader, gl.FRAGMENT_SHADER, undefined, opt_logShaders, opt_skipCompileStatus);
       } else {
-        shader = loadShader(gl, shader, ii ? gl.FRAGMENT_SHADER : gl.VERTEX_SHADER, undefined, opt_logShaders);
+        shader = loadShader(gl, shader, ii ? gl.FRAGMENT_SHADER : gl.VERTEX_SHADER, undefined, opt_logShaders, undefined, undefined, opt_skipCompileStatus);
       }
     } else if (opt_logShaders) {
       throw 'Shader source logging requested but no shader source provided';


### PR DESCRIPTION
This extra test recompiles the transform feedback shader program while
preventing getShaderParameter from forcing a bypass of Chromium's shader
cache.

Passes in Firefox, fails in Chrome. Passes in Chrome with a patch.