### PR TITLE
Add sampler operands validation tests (#2391)

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -113,3 +113,4 @@ struct-nesting-under-maximum.html
 --min-version 1.0.3 ternary-operators-in-global-initializers.html
 --min-version 1.0.3 ternary-operators-in-initializers.html
 --min-version 1.0.4 uninitialized-local-global-variables.html
+--min-version 1.0.4 sampler-operand.html

--- a/sdk/tests/conformance/glsl/misc/sampler-operand.html
+++ b/sdk/tests/conformance/glsl/misc/sampler-operand.html
@@ -1,0 +1,72 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests - sampler operands</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+// ESSL(1.00, 3.00, 3.10) section 4.1.7
+// Except for array indexing, structure field selection, and
+// parentheses, samplers are not allowed to be operands in expressions.
+</script>
+
+<script id="samplerAdding" type="x-shader/x-fragment">
+// This covers an ANGLE bug.
+// See https://bugs.chromium.org/p/angleproject/issues/detail?id=2028.
+uniform sampler2D s1;
+uniform sampler2D s2;
+void main() {
+    s1 + s2;
+}
+</script>
+
+<script>
+"use strict";
+GLSLConformanceTester.runTests([
+    { fShaderId: 'samplerAdding',
+      fShaderSuccess: false,
+      linkSuccess: false,
+      passMsg: 'Adding on samplers should fail'
+    },
+]);
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
According to ESSL spec, sampler operands can only be used in array
indexing, structure field selection, and parentheses expresions.
This validates this rule.