### PR TITLE
Fix a test coverage issue in webgl-depth-texture.html

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-depth-texture.html
+++ b/sdk/tests/conformance/extensions/webgl-depth-texture.html
@@ -197,7 +197,7 @@ function runTestExtension() {
           'TEXTURE_CUBE_MAP_NEGATIVE_Z'
         ];
         for (var tt = 0; tt < targets.length; ++tt) {
-            wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texImage2D(gl.' + targets[ii] + ', 1, gl.' + typeInfo.format + ', 1, 1, 0, gl.' + typeInfo.format + ', ' + typeStr + ', null)');
+            wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, 'gl.texImage2D(gl.' + targets[ii] + ', 0, gl.' + typeInfo.format + ', 1, 1, 0, gl.' + typeInfo.format + ', ' + typeStr + ', null)');
         }
 
         // The WebGL_depth_texture extension supports both NEAREST and


### PR DESCRIPTION
According to the extension spec, INVALID_OPERATION is generated if
1) level > 0 or
2) target != TEXTURE_2D

When we test with CUBEMAP targets, we used level == 1, so target != TEXTURE_2D
isn't really tested (and therefore, Chrome behaved incorrectly).

ALso, we do test level > 0 with target == TEXTURE_2D and make sure
INVALID_OPERATION is generated in this case.  So it's clear to me when we test
with CUBEMAP targets with level == 1, the intention is to test with level == 0.