### PR TITLE
Remove experimental webgl2

### DIFF
--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -1274,7 +1274,7 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
   var names;
   switch (opt_version) {
     case 2:
-      names = ["webgl2", "experimental-webgl2"]; break;
+      names = ["webgl2"]; break;
     default:
       names = ["webgl", "experimental-webgl"]; break;
   }

--- a/conformance-suites/1.0.3/webgl-conformance-tests.html
+++ b/conformance-suites/1.0.3/webgl-conformance-tests.html
@@ -195,7 +195,7 @@ function start() {
     var names;
     switch (version) {
       case 2:
-        names = ["webgl2", "experimental-webgl2"]; break;
+        names = ["webgl2"]; break;
       default:
         names = ["webgl", "experimental-webgl"]; break;
     }

--- a/conformance-suites/2.0.0/conformance2/context/context-attributes-depth-stencil-antialias-obeyed.html
+++ b/conformance-suites/2.0.0/conformance2/context/context-attributes-depth-stencil-antialias-obeyed.html
@@ -44,7 +44,7 @@ function getWebGL(attribs) {
     return null;
 
   // We can't use wtu.create3DContext because it defaults to antialias=false.
-  var names = ["webgl2", "experimental-webgl2"];
+  var names = ["webgl2"];
   var gl = null;
   for (var i = 0; i < names.length; ++i) {
     try {

--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -1433,7 +1433,7 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
   var names;
   switch (opt_version) {
     case 2:
-      names = ["webgl2", "experimental-webgl2"]; break;
+      names = ["webgl2"]; break;
     default:
       names = ["webgl", "experimental-webgl"]; break;
   }

--- a/conformance-suites/2.0.0/webgl-conformance-tests.html
+++ b/conformance-suites/2.0.0/webgl-conformance-tests.html
@@ -208,7 +208,7 @@ function start() {
     var names;
     switch (version) {
       case 2:
-        names = ["webgl2", "experimental-webgl2"]; break;
+        names = ["webgl2"]; break;
       default:
         names = ["webgl", "experimental-webgl"]; break;
     }

--- a/sdk/tests/conformance2/context/00_test_list.txt
+++ b/sdk/tests/conformance2/context/00_test_list.txt
@@ -3,3 +3,5 @@ context-attributes-depth-stencil-antialias-obeyed.html
 context-type-test-2.html
 --min-version 2.0.1 context-resize-changes-buffer-binding-bug.html
 methods-2.html
+--min-version 2.0.1 no-experimental-webgl2.html
+

--- a/sdk/tests/conformance2/context/context-attributes-depth-stencil-antialias-obeyed.html
+++ b/sdk/tests/conformance2/context/context-attributes-depth-stencil-antialias-obeyed.html
@@ -44,7 +44,7 @@ function getWebGL(attribs) {
     return null;
 
   // We can't use wtu.create3DContext because it defaults to antialias=false.
-  var names = ["webgl2", "experimental-webgl2"];
+  var names = ["webgl2"];
   var gl = null;
   for (var i = 0; i < names.length; ++i) {
     try {

--- a/sdk/tests/conformance2/context/no-experimental-webgl2.html
+++ b/sdk/tests/conformance2/context/no-experimental-webgl2.html
@@ -1,0 +1,56 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 Canvas Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" style="width: 50px; height: 50px;"> </canvas>
+<canvas id="canvas2d" width="40" height="40"> </canvas>
+<script>
+"use strict";
+description("This test ensures WebGL2 implementations do not respond to experimental-webgl2.");
+
+debug("");
+
+var canvas = document.getElementById("canvas");
+shouldBeNull('canvas.getContext("experimental-webgl2")');
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -1458,7 +1458,7 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
   var names;
   switch (opt_version) {
     case 2:
-      names = ["webgl2", "experimental-webgl2"]; break;
+      names = ["webgl2"]; break;
     default:
       names = ["webgl", "experimental-webgl"]; break;
   }

--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -209,7 +209,7 @@ function start() {
     var names;
     switch (version) {
       case 2:
-        names = ["webgl2", "experimental-webgl2"]; break;
+        names = ["webgl2"]; break;
       default:
         names = ["webgl", "experimental-webgl"]; break;
     }


### PR DESCRIPTION
This removes all references to "experimental-webgl2" and adds a test to ensure implementations do not respond to "experimental-webgl2"

Usage of "experimental-webgl2" and mentions of it spread like a virus. Supporting it makes code overly complicated. Let's stop letting this propagate.