### PR TITLE
Backport null-vbo vertexAttribPointer(offset!=0) test, but not offset…

### DIFF
--- a/conformance-suites/1.0.3/conformance/more/functions/vertexAttribPointerBadArgs.html
+++ b/conformance-suites/1.0.3/conformance/more/functions/vertexAttribPointerBadArgs.html
@@ -91,8 +91,8 @@ Tests.testVertexAttribPointerVBO = function(gl, prog, v,n,t) {
   assertFail("bad index (big positive)",
       function(){gl.vertexAttribPointer(8693948, 3, gl.FLOAT, false, 0, 0);});
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
-  assertFail("binding to null buffer",
-      function(){gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);});
+  assertFail("binding to null buffer with offset!=0",
+      function(){gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 16);});
   gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
   gl.vertexAttribPointer(v, 3, gl.FLOAT, false, 0, 0);
   gl.bindBuffer(gl.ARRAY_BUFFER, null);


### PR DESCRIPTION
…==0 test.

Backporting the offset==0 test would cause previously conformant implementations to fail.