### PR TITLE
Fix #2274: Add GL_RGB10_A2 to texImageSource variants of tex(Sub)Image*

### DIFF
--- a/sdk/tests/conformance2/textures/canvas/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/canvas/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/canvas/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/canvas_sub_rectangle/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/canvas_sub_rectangle/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/canvas_sub_rectangle/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/canvas_sub_rectangle/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/canvas_sub_rectangle/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/canvas_sub_rectangle/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-canvas-sub-rectangle.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_blob/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-blob.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_bitmap/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-bitmap.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_image_data/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-image-data.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_bitmap_from_video/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-bitmap-from-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_data/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/image_data/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/image_data/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
+</head>
+<body>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/image_data/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/image_data/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-image-data.js"></script>
+</head>
+<body>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/svg_image/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/svg_image/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/svg_image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/svg_image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/svg_image/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-svg-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/video/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/video/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/video/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/video/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/video/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/video/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/webgl_canvas/00_test_list.txt
@@ -25,6 +25,7 @@ tex-2d-rgba8-rgba-unsigned_byte.html
 tex-2d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_byte.html
 tex-2d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-2d-rgba4-rgba-unsigned_byte.html
 tex-2d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba16f-rgba-half_float.html
@@ -58,6 +59,7 @@ tex-3d-rgba8-rgba-unsigned_byte.html
 tex-3d-srgb8_alpha8-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_byte.html
 tex-3d-rgb5_a1-rgba-unsigned_short_5_5_5_1.html
+tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
 tex-3d-rgba4-rgba-unsigned_byte.html
 tex-3d-rgba4-rgba-unsigned_short_4_4_4_4.html
 tex-3d-rgba16f-rgba-half_float.html

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-2d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/textures/webgl_canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
+++ b/sdk/tests/conformance2/textures/webgl_canvas/tex-3d-rgb10_a2-rgba-unsigned_int_2_10_10_10_rev.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-3d-with-webgl-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("RGB10_A2", "RGBA", "UNSIGNED_INT_2_10_10_10_REV", testPrologue, "../../../resources/", 2)();
+</script>
+</body>
+</html>

--- a/sdk/tests/py/tex_image_test_generator.py
+++ b/sdk/tests/py/tex_image_test_generator.py
@@ -118,6 +118,7 @@ _FORMATS_TYPES_WEBGL2 = [
   {'internal_format': 'SRGB8_ALPHA8', 'format': 'RGBA', 'type': 'UNSIGNED_BYTE' },
   {'internal_format': 'RGB5_A1', 'format': 'RGBA', 'type': 'UNSIGNED_BYTE' },
   {'internal_format': 'RGB5_A1', 'format': 'RGBA', 'type': 'UNSIGNED_SHORT_5_5_5_1' },
+  {'internal_format': 'RGB10_A2', 'format': 'RGBA', 'type': 'UNSIGNED_INT_2_10_10_10_REV' },
   {'internal_format': 'RGBA4', 'format': 'RGBA', 'type': 'UNSIGNED_BYTE' },
   {'internal_format': 'RGBA4', 'format': 'RGBA', 'type': 'UNSIGNED_SHORT_4_4_4_4' },
   {'internal_format': 'RGBA16F', 'format': 'RGBA', 'type': 'HALF_FLOAT' },

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1694,6 +1694,7 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
         <tr><td>RGBA8</td><td>RGBA</td><td>UNSIGNED_BYTE</td></tr>
         <tr><td>SRGB8_ALPHA8</td><td>RGBA</td><td>UNSIGNED_BYTE</td></tr>
         <tr><td>RGB5_A1</td><td>RGBA</td><td>UNSIGNED_BYTE<br>UNSIGNED_SHORT_5_5_5_1</td></tr>
+        <tr><td>RGB10_A2</td><td>RGBA</td><td>UNSIGNED_INT_2_10_10_10_REV</td></tr>
         <tr><td>RGBA4</td><td>RGBA</td><td>UNSIGNED_BYTE<br>UNSIGNED_SHORT_4_4_4_4</td></tr>
         <tr><td>RGBA16F</td><td>RGBA</td><td>HALF_FLOAT<br>FLOAT</td></tr>
         <tr><td>RGBA32F</td><td>RGBA</td><td>FLOAT</td></tr>


### PR DESCRIPTION
Chromium implementation landed: https://crrev.com/2821363003/.
Verified by running tests locally on OSX.

@kenrussell , @zhenyao, PTAL.
FYI @Richard-Yunchao.

Sorry for the delay on this. Thanks.
