### PR TITLE
Test fbo attached to a non-level-0 texture image completeness behavior.

### DIFF
--- a/sdk/tests/conformance2/rendering/framebuffer-texture-level1.html
+++ b/sdk/tests/conformance2/rendering/framebuffer-texture-level1.html
@@ -44,6 +44,9 @@ var wtu = WebGLTestUtils;
 var gl;
 
 function testFramebufferTextureWithNonZeroBaseLevel(level) {
+  if (level < 1) {
+    throw "This test is incorrect if level < 1";
+  }
   var width = 32;
   var height = 16;
   var texture = gl.createTexture();

--- a/sdk/tests/conformance2/rendering/framebuffer-texture-level1.html
+++ b/sdk/tests/conformance2/rendering/framebuffer-texture-level1.html
@@ -43,13 +43,11 @@
 var wtu = WebGLTestUtils;
 var gl;
 
-function testFramebufferTextureWithNonZeroBaseLevel() {
+function testFramebufferTextureWithNonZeroBaseLevel(level) {
   var width = 32;
   var height = 16;
-  var level = 1;
   var texture = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, texture);
-  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, level);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
@@ -58,6 +56,8 @@ function testFramebufferTextureWithNonZeroBaseLevel() {
   var fbo = gl.createFramebuffer();
   gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
   gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, level);
+  shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, level);
   shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setup framebuffer with texture should succeed.");
 
@@ -65,12 +65,12 @@ function testFramebufferTextureWithNonZeroBaseLevel() {
   gl.deleteFramebuffer(fbo);
 }
 
-description();
+description("Test fbo completeness when using non level 0 texture images");
 
 var canvas = document.getElementById("canvas");
 shouldBeNonNull("gl = wtu.create3DContext(canvas, undefined, 2)");
 
-testFramebufferTextureWithNonZeroBaseLevel();
+testFramebufferTextureWithNonZeroBaseLevel(1);
 
 debug("");
 var successfullyParsed = true;


### PR DESCRIPTION
The issue is raised in crbug.com/722684