### PR TITLE
Add tests for uninitialized variable corner cases

### DIFF
--- a/sdk/tests/conformance/glsl/misc/uninitialized-local-global-variables.html
+++ b/sdk/tests/conformance/glsl/misc/uninitialized-local-global-variables.html
@@ -155,6 +155,24 @@ void main() {
 }
 </script>
 
+<!-- Uninitialized nameless local struct in fragment shader -->
+<script id="fs_uninit_nameless_local_struct_in_frag" type="x-shader/x-fragment">
+precision mediump float;
+void main() {
+    struct { vec4 v; } uninit; // uninitialized
+    gl_FragColor = uninit.v;
+}
+</script>
+
+<!-- Uninitialized nameless global struct in fragment shader -->
+<script id="fs_uninit_nameless_global_struct_in_frag" type="x-shader/x-fragment">
+precision mediump float;
+struct { vec4 v; } uninit; // uninitialized
+void main() {
+    gl_FragColor = uninit.v;
+}
+</script>
+
 <!-- Uninitialized local bool in fragment shader -->
 <script id="fs_uninit_local_bool_in_frag" type="x-shader/x-fragment">
 precision mediump float;
@@ -234,6 +252,14 @@ var cases = [
   {
     name: "Uninitialized global struct variable in fragment shader",
     prog: ["vs_uninit_in_frag", "fs_uninit_global_struct_in_frag"],
+  },
+  {
+    name: "Uninitialized nameless local struct variable in fragment shader",
+    prog: ["vs_uninit_in_frag", "fs_uninit_nameless_local_struct_in_frag"],
+  },
+  {
+    name: "Uninitialized nameless global struct variable in fragment shader",
+    prog: ["vs_uninit_in_frag", "fs_uninit_nameless_global_struct_in_frag"],
   },
   {
     name: "Uninitialized local bool array variable in fragment shader",

--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -38,6 +38,7 @@ uniform-block-layouts.html
 uniform-block-layout-match.html
 uniform-location-length-limits.html
 --min-version 2.0.1 uniform-struct-with-non-square-matrix.html
+--min-version 2.0.1 uninitialized-local-global-variables.html
 valid-invariant.html
 vector-dynamic-indexing.html
 --min-version 2.0.1 vector-dynamic-indexing-nv-driver-bug.html

--- a/sdk/tests/conformance2/glsl3/uninitialized-local-global-variables.html
+++ b/sdk/tests/conformance2/glsl3/uninitialized-local-global-variables.html
@@ -1,0 +1,119 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Uninitialized local/global variables should be initialized (ESSL 3.00 cases)</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+
+<!--
+This test covers cases that can't be tested with ESSL 1.00 due to Appendix A limitations.
+The ESSL 1.00 cases are covered in conformance/glsl/misc/uninitialized-local-global-variables.html
+-->
+
+<script id="vs_uninit_in_frag" type="x-shader/x-vertex">#version 300 es
+precision highp float;
+in vec4 a_position;
+void main() {
+    gl_Position = a_position;
+}
+</script>
+
+<!-- Uninitialized variables in a for loop initializer in fragment shader -->
+<script id="fs_uninit_variables_in_loop_in_frag" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+out vec4 my_FragColor;
+void main() {
+    int i = 0;
+    for (vec4 uninit, uninit2[2] = vec4[2](uninit, uninit); i < 1; ++i) {
+        my_FragColor = uninit2[0];
+    }
+}
+</script>
+
+<!-- Uninitialized nameless struct in a for loop initializer in fragment shader -->
+<script id="fs_uninit_nameless_struct_in_loop_in_frag" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+out vec4 my_FragColor;
+void main() {
+    int i = 0;
+    for (struct { vec4 v; } uninit; i < 1; ++i) {
+        my_FragColor = uninit.v;
+    }
+}
+</script>
+
+</head>
+<body>
+<canvas id="canvas" width="50" height="50"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description('Uninitialized local/global variables should be initialized: http://anglebug.com/1966');
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas", undefined, 2);
+wtu.setupUnitQuad(gl);
+
+var cases = [
+  {
+    name: "Uninitialized variables in a for loop initializer in fragment shader",
+    prog: ["vs_uninit_in_frag", "fs_uninit_variables_in_loop_in_frag"],
+  },
+  {
+    name: "Uninitialized nameless struct in a for loop initializer in fragment shader",
+    prog: ["vs_uninit_in_frag", "fs_uninit_nameless_struct_in_loop_in_frag"],
+  }
+];
+
+function runTest() {
+  for (var i = 0; i < cases.length; ++i) {
+    debug("");
+    debug(cases[i].name);
+    var program = wtu.setupProgram(gl, cases[i].prog, ["a_position"], undefined, true);
+    gl.clearColor(1.0, 0.0, 0.0, 1.0);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.checkCanvas(gl, [0, 0, 0, 0]);
+  }
+
+  debug("");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+}
+
+runTest();
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Add tests for nameless structs. They don't have constructors, so
initializing them may need special handling.

Also add a WebGL 2.0 test for uninitialized variable declarations in
loop conditions. In WebGL 1.0, this case isn't possible due to ESSL
1.00 Appendix A limitations for loops.