### PR TITLE
Fix dEQP multisample test tolerance for sample counts >= 64

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fMultisampleTests.js
@@ -617,13 +617,17 @@ goog.scope(function() {
 
         /** @type {number} */ var requiredNumDistinctColors = this.m_numSamples + 1;
 
+        // If the number of samples is high (64 or more), we need to lower the threshold for detecting unique colors, otherwise two expected unique colors would be treated as the same color.
+        var threshold = Math.min(3, Math.floor(255 / this.m_numSamples) - 1);
+        var thresholdRGBA = tcuRGBA.newRGBAComponents(threshold, threshold, threshold, threshold);
+
         for (var y = 0; y < renderedImg.getHeight() && this.m_detectedColors.length < requiredNumDistinctColors; y++)
         for (var x = 0; x < renderedImg.getWidth() && this.m_detectedColors.length < requiredNumDistinctColors; x++) {
             /** @type {tcuRGBA.RGBA} */ var color = new tcuRGBA.RGBA(renderedImg.getPixel(x, y));
 
             /** @type {number} */ var i;
             for (i = 0; i < this.m_detectedColors.length; i++) {
-                if (tcuRGBA.compareThreshold(color, this.m_detectedColors[i], tcuRGBA.newRGBAComponents(3, 3, 3, 3)))
+                if (tcuRGBA.compareThreshold(color, this.m_detectedColors[i], thresholdRGBA))
                     break;
             }
 


### PR DESCRIPTION
Previously the test wasn't able to handle sample counts >= 64. This
was because it's counting unique colors, and it was detecting colors
with <= 3 difference in one channel as the same. But if you have 65
different gray levels between 0 and 255, at least two of them will be
set apart by only 3.

This made the test fail on Quadro drivers that supported 64 samples.

Now the test automatically lowers the tolerance if it is required by
having a high sample count.

After this fix the test at least has a chance of handling high sample
counts correctly, though it still needs to be verified if this fix is
sufficient on its own.