### PR TITLE
Add more cases to multisampled-renderbuffer-initialization

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html
+++ b/sdk/tests/conformance2/renderbuffers/multisampled-renderbuffer-initialization.html
@@ -42,10 +42,6 @@
 var wtu = WebGLTestUtils;
 description('Verify multisampled renderbuffers are initialized to 0 before being read in WebGL');
 
-const ALLOCATE_ATTACH = 0;
-const ATTACH_ALLOCATE = 1;
-const ALLOCATE_ATTACH_CLEAR_REALLOCATE = 2;
-
 var gl = wtu.create3DContext("testbed", null, 2);
 
 if (!gl) {
@@ -54,12 +50,20 @@ if (!gl) {
     // Set the clear color to green. It should never show up.
     gl.clearColor(0, 1, 0, 1);
 
-    runTest(gl, gl.canvas.width, gl.canvas.height, ALLOCATE_ATTACH);
-    runTest(gl, gl.canvas.width, gl.canvas.height, ATTACH_ALLOCATE);
-    runTest(gl, gl.canvas.width, gl.canvas.height, ALLOCATE_ATTACH_CLEAR_REALLOCATE);
-    runTest(gl, gl.canvas.width, gl.canvas.height, ALLOCATE_ATTACH);
-    runTest(gl, gl.canvas.width, gl.canvas.height, ATTACH_ALLOCATE);
-    runTest(gl, gl.canvas.width, gl.canvas.height, ALLOCATE_ATTACH_CLEAR_REALLOCATE);
+    let c = gl.canvas;
+    var maxSamples = gl.getInternalformatParameter(
+        gl.RENDERBUFFER, gl.RGBA8, gl.SAMPLES)[0];
+    for (let i = 0; i < 2; ++i) {
+        runTest(gl, {alloc1: {w: c.width, h: c.height, s: maxSamples}, alloc2: null});
+        runTest(gl, {alloc1: null, alloc2: {w: c.width, h: c.height, s: maxSamples}});
+
+        // Tests for initially allocating at the wrong size.
+        // This is caused by a Qualcomm driver bug: http://crbug.com/696126
+        runTest(gl, {alloc1: {w: 5, h: 5, s: maxSamples}, alloc2: {w: c.width, h: c.height, s: maxSamples}});
+        runTest(gl, {alloc1: {w: 5, h: 5, s: maxSamples}, alloc2: {w: c.width, h: c.height, s: 0}});
+        runTest(gl, {alloc1: {w: 5, h: 5, s: 0}, alloc2: {w: c.width, h: c.height, s: maxSamples}});
+    }
+    // TODO(kainino0x): add tests for depth/stencil?
 
     // Testing buffer clearing won't change the clear values.
     var clearColor = gl.getParameter(gl.COLOR_CLEAR_VALUE);
@@ -67,9 +71,11 @@ if (!gl) {
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, 'should be no errors');
 }
 
-function runTest(gl, width, height, order) {
-    debug("test with width=" + width + ", height=" + height);
-    wtu.checkCanvasRect(gl, 0, 0, width, height, [0, 0, 0, 0],
+function runTest(gl, params) {
+    debug("Test for color buffer: " + JSON.stringify(params));
+    let resolve = params.alloc2 ? params.alloc2 : params.alloc1;
+    wtu.checkCanvasRect(gl, 0, 0, resolve.w, resolve.h,
+                        [0, 0, 0, 0],
                         "internal buffers have been initialized to 0");
 
     // fill the back buffer so we know that reading below happens from
@@ -81,13 +87,14 @@ function runTest(gl, width, height, order) {
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
     var buffer = gl.createRenderbuffer();
     gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
-    gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, width, height);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, resolve.w, resolve.h);
     attachBuffer(buffer);
     shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)",
              "gl.FRAMEBUFFER_COMPLETE");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, 'should be no errors');
     gl.clear(gl.COLOR_BUFFER_BIT);
-    wtu.checkCanvasRect(gl, 0, 0, width, height, [0, 255, 0, 255],
+    wtu.checkCanvasRect(gl, 0, 0, resolve.w, resolve.h,
+                        [0, 255, 0, 255],
                         "user buffer has been cleared to green");
 
     // Set up multisampled buffer to test.
@@ -95,43 +102,33 @@ function runTest(gl, width, height, order) {
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo_m);
     var buffer_m = gl.createRenderbuffer();
     gl.bindRenderbuffer(gl.RENDERBUFFER, buffer_m);
-    switch (order) {
-      case ALLOCATE_ATTACH:
-        debug("allocate then attach");
-        allocStorage(width, height);
-        attachBuffer(buffer_m);
-        break;
-      case ATTACH_ALLOCATE:
-        debug("attach then allocate");
-        attachBuffer(buffer_m);
-        allocStorage(width, height);
-        break;
-      case ALLOCATE_ATTACH_CLEAR_REALLOCATE:
-        // Test for initially allocating at the wrong size.
-        // This is caused by a Qualcomm driver bug: http://crbug.com/696126
-        debug("allocate at the wrong size, then attach and clear, then reallocate");
-        allocStorage(width / 2, height / 2);
-        attachBuffer(buffer_m);
-        // Clear the FBO in order to make sure framebufferRenderbuffer is
-        // committed. (In Firefox, framebufferRenderbuffer is deferred, so this
-        // is needed to trigger the bug.)
-        gl.clear(gl.COLOR_BUFFER_BIT);
-        allocStorage(width, height);
-        break;
+
+    if (params.alloc1) {
+        allocStorage(params.alloc1.w, params.alloc1.h, params.alloc1.s);
+    }
+    attachBuffer(buffer_m);
+    if (params.alloc2) {
+        if (params.alloc1) {
+            // Clear the FBO in order to make sure framebufferRenderbuffer is
+            // committed. (In Firefox, framebufferRenderbuffer is deferred, so
+            // this is needed to trigger the bug.)
+            gl.clear(gl.COLOR_BUFFER_BIT);
+        }
+        allocStorage(params.alloc2.w, params.alloc2.h, params.alloc2.s);
     }
 
-    function allocStorage(width, height) {
-      var samples = gl.getInternalformatParameter(
-          gl.RENDERBUFFER, gl.RGBA8, gl.SAMPLES);
-      gl.renderbufferStorageMultisample(
-          gl.RENDERBUFFER, samples[0], gl.RGBA8, width, height);
-      wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-          "should be no error after renderbufferStorageMultisample(RGBA8).");
+    function allocStorage(width, height, samples) {
+        gl.renderbufferStorageMultisample(
+            gl.RENDERBUFFER, samples, gl.RGBA8, width, height);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "should be no error after renderbufferStorageMultisample(RGBA8).");
     }
 
     function attachBuffer(buffer) {
-      gl.framebufferRenderbuffer(
-          gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, buffer);
+        gl.framebufferRenderbuffer(
+            gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, buffer);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+            "should be no error after framebufferRenderbuffer.");
     }
 
     shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)",
@@ -141,12 +138,15 @@ function runTest(gl, width, height, order) {
     // Blit from multisampled buffer to non-multisampled buffer.
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo_m);
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fbo);
-    gl.blitFramebuffer(0, 0, width, height, 0, 0, width, height,
+    // Blit color from fbo_m (should be black) to fbo (should be green)
+    gl.blitFramebuffer(0, 0, resolve.w, resolve.h,
+                       0, 0, resolve.w, resolve.h,
                        gl.COLOR_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, 'should be no errors');
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
-    wtu.checkCanvasRect(gl, 0, 0, width, height, [0, 0, 0, 0],
+    wtu.checkCanvasRect(gl, 0, 0, resolve.w, resolve.h,
+                        [0, 0, 0, 0],
                         "user buffer has been initialized to 0");
 
     gl.deleteFramebuffer(fbo_m);


### PR DESCRIPTION
These test changing renderbuffers from non-multisampled to multisampled
and vice versa. This caught an extra bug in my workaround in Chrome.
The test function is refactored a little bit to be more flexible.

I spent quite a bit of time trying to add a test for depth renderbuffers, but I wasn't able to get it working. blitFramebuffer on the depth bit from a depth-only FBO to a depth+color FBO doesn't seem to do anything, though I don't know why.