### PR TITLE
Add tests for uninitialized multisampled depth renderbuffers

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/00_test_list.txt
+++ b/sdk/tests/conformance2/renderbuffers/00_test_list.txt
@@ -3,5 +3,6 @@ framebuffer-test.html
 framebuffer-texture-layer.html
 invalidate-framebuffer.html
 multisampled-renderbuffer-initialization.html
+--min-version 2.0.1 multisampled-depth-renderbuffer-initialization.html
 --min-version 2.0.1 multisample-with-full-sample-counts.html
 readbuffer.html

--- a/sdk/tests/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html
+++ b/sdk/tests/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html
@@ -1,7 +1,7 @@
 <!--
 
 /*
-** Copyright (c) 2015 The Khronos Group Inc.
+** Copyright (c) 2017 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the
@@ -40,7 +40,7 @@
 <script>
 "use strict";
 var wtu = WebGLTestUtils;
-description('Verify multisampled renderbuffers are initialized to 0 before being read in WebGL');
+description('Verify multisampled depth renderbuffers are initialized to 0 before being read in WebGL');
 
 var gl = wtu.create3DContext("testbed", null, 2);
 
@@ -49,6 +49,7 @@ if (!gl) {
 } else {
     // Set the clear color to green. It should never show up.
     gl.clearColor(0, 1, 0, 1);
+    gl.clearDepth(0);
 
     let c = gl.canvas;
     var maxSamples = gl.getInternalformatParameter(
@@ -60,8 +61,6 @@ if (!gl) {
         // Tests for initially allocating at the wrong size.
         // This is caused by a Qualcomm driver bug: http://crbug.com/696126
         runTest(gl, {alloc1: {w: 5, h: 5, s: maxSamples}, alloc2: {w: c.width, h: c.height, s: maxSamples}});
-        runTest(gl, {alloc1: {w: 5, h: 5, s: maxSamples}, alloc2: {w: c.width, h: c.height, s: 0}});
-        runTest(gl, {alloc1: {w: 5, h: 5, s: 0}, alloc2: {w: c.width, h: c.height, s: maxSamples}});
     }
 
     // Testing buffer clearing won't change the clear values.
@@ -71,32 +70,39 @@ if (!gl) {
 }
 
 function runTest(gl, params) {
-    debug("Test for color buffer: " + JSON.stringify(params));
+    debug("Test for depth buffer: " + JSON.stringify(params));
     let resolve = params.alloc2 ? params.alloc2 : params.alloc1;
+    gl.viewport(0, 0, resolve.w, resolve.h);
     wtu.checkCanvasRect(gl, 0, 0, resolve.w, resolve.h,
                         [0, 0, 0, 0],
                         "internal buffers have been initialized to 0");
 
+    gl.disable(gl.DEPTH_TEST);
+
     // fill the back buffer so we know that reading below happens from
     // the renderbuffer.
-    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-    // Set up non-multisampled buffer to blit to and read back from.
+    // Set up (color+depth) non-multisampled buffer to blit to and read back from.
     var fbo = gl.createFramebuffer();
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
     var buffer = gl.createRenderbuffer();
     gl.bindRenderbuffer(gl.RENDERBUFFER, buffer);
     gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, resolve.w, resolve.h);
-    attachBuffer(buffer);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, buffer);
+    var depthBuffer = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, depthBuffer);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, resolve.w, resolve.h);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depthBuffer);
     shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)",
              "gl.FRAMEBUFFER_COMPLETE");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, 'should be no errors');
-    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     wtu.checkCanvasRect(gl, 0, 0, resolve.w, resolve.h,
                         [0, 255, 0, 255],
                         "user buffer has been cleared to green");
 
-    // Set up multisampled buffer to test.
+    // Set up (depth-only) multisampled buffer to test.
     var fbo_m = gl.createFramebuffer();
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo_m);
     var buffer_m = gl.createRenderbuffer();
@@ -105,56 +111,54 @@ function runTest(gl, params) {
     if (params.alloc1) {
         allocStorage(params.alloc1.w, params.alloc1.h, params.alloc1.s);
     }
-    attachBuffer(buffer_m);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, buffer_m);
     if (params.alloc2) {
         if (params.alloc1) {
             // Clear the FBO in order to make sure framebufferRenderbuffer is
-            // committed. (In Firefox, framebufferRenderbuffer is deferred, so
-            // this is needed to trigger the bug.)
-            gl.clear(gl.COLOR_BUFFER_BIT);
+            // committed. (In Firefox, framebufferRenderbuffer is deferred, so this
+            // is needed to trigger the bug.)
+            gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         }
         allocStorage(params.alloc2.w, params.alloc2.h, params.alloc2.s);
     }
 
     function allocStorage(width, height, samples) {
         gl.renderbufferStorageMultisample(
-            gl.RENDERBUFFER, samples, gl.RGBA8, width, height);
+            gl.RENDERBUFFER, samples, gl.DEPTH_COMPONENT16, width, height);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-            "should be no error after renderbufferStorageMultisample(RGBA8).");
+            "should be no error after renderbufferStorageMultisample(DEPTH_COMPONENT16).");
     }
 
-    function attachBuffer(buffer) {
-        gl.framebufferRenderbuffer(
-            gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, buffer);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-            "should be no error after framebufferRenderbuffer.");
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        debug("Skip: Depth-only framebuffer is allowed to be incomplete.");
+        return;
     }
-
-    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)",
-             "gl.FRAMEBUFFER_COMPLETE");
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, 'should be no errors');
 
     // Blit from multisampled buffer to non-multisampled buffer.
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fbo_m);
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fbo);
-    // Blit color from fbo_m (should be black) to fbo (should be green)
+    gl.clear(gl.DEPTH_BUFFER_BIT);
+    // Blit depth from fbo_m (should be 0) to fbo (should be 1)
     gl.blitFramebuffer(0, 0, resolve.w, resolve.h,
                        0, 0, resolve.w, resolve.h,
-                       gl.COLOR_BUFFER_BIT, gl.NEAREST);
+                       gl.DEPTH_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, 'should be no errors');
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    // Draw a red quad (should pass the depth test)
+    gl.depthFunc(gl.LESS);
+    gl.enable(gl.DEPTH_TEST);
+    wtu.setupColorQuad(gl);
+    wtu.setFloatDrawColor(gl, [0, 0, 1, 1]);
+    wtu.drawUnitQuad(gl);
     wtu.checkCanvasRect(gl, 0, 0, resolve.w, resolve.h,
-                        [0, 0, 0, 0],
-                        "user buffer has been initialized to 0");
+                        [0, 0, 255, 255]);
 
     gl.deleteFramebuffer(fbo_m);
     gl.deleteRenderbuffer(buffer_m);
     gl.deleteFramebuffer(fbo);
     gl.deleteRenderbuffer(buffer);
-
-    // this clear should not matter we are about to resize
-    gl.clear(gl.COLOR_BUFFER_BIT);
 
     gl.canvas.width += 1;
     gl.canvas.height += 1;


### PR DESCRIPTION
Tests for the Qualcomm driver bug in
http://crbug.com/696126
as well as a Mac/Intel bug that I haven't reported yet.