### PR TITLE
Remove extra includes of glsl-conformance-test.js

### DIFF
--- a/sdk/tests/conformance/textures/misc/cube-map-uploads-out-of-order.html
+++ b/sdk/tests/conformance/textures/misc/cube-map-uploads-out-of-order.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
-<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-filter-outofbounds.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-filter-outofbounds.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="example" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-filter-srgb.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-filter-srgb.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="example" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-multisampled-readbuffer.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="canvas" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-outside-readbuffer.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="example" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-resolve-to-back-buffer.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-scissor-enabled.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-scissor-enabled.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="example" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-srgb-and-linear-drawbuffers.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="canvas" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/rendering/blitframebuffer-stencil-only.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-stencil-only.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 
 <script id="vs" type="x-shader/x-vertex">#version 300 es
 in vec4 position;

--- a/sdk/tests/conformance2/rendering/clear-srgb-color-buffer.html
+++ b/sdk/tests/conformance2/rendering/clear-srgb-color-buffer.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="example" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/rendering/read-draw-when-missing-image.html
+++ b/sdk/tests/conformance2/rendering/read-draw-when-missing-image.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="example" width="8" height="8"></canvas>

--- a/sdk/tests/conformance2/textures/misc/angle-stuck-depth-textures.html
+++ b/sdk/tests/conformance2/textures/misc/angle-stuck-depth-textures.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
-<script src="../../../js/glsl-conformance-test.js"></script>
 
 <script id="draw-vs" type="x-shader/x-vertex">#version 100
 attribute vec3 vertex;

--- a/sdk/tests/conformance2/textures/misc/copy-texture-image-luma-format.html
+++ b/sdk/tests/conformance2/textures/misc/copy-texture-image-luma-format.html
@@ -33,7 +33,6 @@
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
-<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <div id="description"></div>

--- a/sdk/tests/conformance2/textures/misc/texel-fetch-undefined.html
+++ b/sdk/tests/conformance2/textures/misc/texel-fetch-undefined.html
@@ -34,7 +34,6 @@
 <link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
-<script src="../../../js/glsl-conformance-test.js"></script>
 </head>
 <body>
 <canvas id="c" width="256" height="256"></canvas>


### PR DESCRIPTION
It was being included in several WebGL 2 conformance tests that were
not using it.