### PR TITLE
Fix bogus vertex attribute name in offset test

### DIFF
--- a/sdk/tests/conformance/attribs/00_test_list.txt
+++ b/sdk/tests/conformance/attribs/00_test_list.txt
@@ -1,5 +1,6 @@
 --min-version 1.0.3 gl-bindAttribLocation-aliasing.html
 --min-version 1.0.3 gl-bindAttribLocation-matrix.html
+--min-version 1.0.4 gl-bindAttribLocation-nonexistent-attribute.html
 --min-version 1.0.4 gl-bindAttribLocation-repeated.html
 --min-version 1.0.2 gl-disabled-vertex-attrib.html
 gl-enable-vertex-attrib.html

--- a/sdk/tests/conformance/attribs/gl-bindAttribLocation-nonexistent-attribute.html
+++ b/sdk/tests/conformance/attribs/gl-bindAttribLocation-nonexistent-attribute.html
@@ -1,0 +1,101 @@
+<!--
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<title>bindAttribLocation with nonexistent attribute name</title>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="8" height="8"></canvas>
+<script id="vertexShader" type="text/something-not-javascript">
+precision highp float;
+attribute vec4 attr;
+void main() {
+    gl_Position = vec4(attr);
+}
+</script>
+<script>
+"use strict";
+description("This test verifies that calling bindAttribLocation with a non-existent attribute location is fine.");
+
+// OpenGL ES 2.0.25 section 2.10 page 34.
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas);
+var fragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShader, gl.FRAGMENT_SHADER);
+var vertexShader = wtu.loadShaderFromScript(gl, 'vertexShader', gl.VERTEX_SHADER);
+assertMsg(vertexShader != null, "Vertex shader compiled successfully.");
+
+var checkAttribLocation = function(program, expectedLocation) {
+    var location = gl.getAttribLocation(program, 'attr');
+    if (location != expectedLocation) {
+        testFailed('Unexpected location for attr: ' + location);
+    } else {
+        testPassed('Location of attr is: ' + location);
+    }
+}
+
+var testProgramNonExistentAttributeBound = function() {
+    var program = gl.createProgram();
+    gl.bindAttribLocation(program, 0, 'attr');
+    gl.bindAttribLocation(program, 1, 'bogus_attr');
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    var linkStatus = gl.getProgramParameter(program, gl.LINK_STATUS);
+    expectTrue(linkStatus, "Link should succeed even if a non-existent attribute is bound.");
+    if (linkStatus) {
+        checkAttribLocation(program, 0);
+    }
+};
+var testProgramNonExistentAttributeOverlap = function() {
+    var program = gl.createProgram();
+    gl.bindAttribLocation(program, 1, 'attr');
+    gl.bindAttribLocation(program, 1, 'bogus_attr');
+    gl.attachShader(program, vertexShader);
+    gl.attachShader(program, fragmentShader);
+    gl.linkProgram(program);
+    var linkStatus = gl.getProgramParameter(program, gl.LINK_STATUS);
+    expectTrue(linkStatus, "Link should succeed even if a non-existent attribute is bound to the same location as an attribute that's present in the shader text.");
+    if (linkStatus) {
+        checkAttribLocation(program, 1);
+    }
+};
+
+testProgramNonExistentAttributeBound();
+testProgramNonExistentAttributeOverlap();
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/attribs/gl-vertexattribipointer-offsets.html
+++ b/sdk/tests/conformance2/attribs/gl-vertexattribipointer-offsets.html
@@ -80,8 +80,8 @@ function init()
 
     var wtu = WebGLTestUtils;
     var gl = wtu.create3DContext("example", undefined, 2);
-    var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
-    var program_unsigned = wtu.setupProgram(gl, ["vshader_unsigned", "fshader"], ["vPosition"]);
+    var program = wtu.setupProgram(gl, ["vshader", "fshader"]);
+    var program_unsigned = wtu.setupProgram(gl, ["vshader_unsigned", "fshader"]);
 
     var tests = [
       { data: new Int32Array([ 0, 1, 0, 1, 0, 0, 0, 0, 0 ]),


### PR DESCRIPTION
The attribute locations are specified in the shader text in
gl-vertexattribipointer-offsets.html. Clean up the non-existent
attribute name "vPosition".

Add a new targeted test to cover bindAttribLocation behavior when the
attribute name doesn't exist in the shader. This didn't seem to be
intentionally covered in existing tests.