### PR TITLE
Remove WebGL2 constraint that requires draw*Instanced() calls to fail

### DIFF
--- a/conformance-suites/2.0.0/conformance2/rendering/instanced-arrays.html
+++ b/conformance-suites/2.0.0/conformance2/rendering/instanced-arrays.html
@@ -170,11 +170,6 @@ function runOutputTests() {
     gl.drawArraysInstanced(gl.TRIANGLES, 0, -1, instanceCount);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "drawArraysInstanced cannot have a count less than 0");
 
-    gl.vertexAttribDivisor(positionLoc, 1);
-    gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, instanceCount);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawArraysInstanced");
-    gl.vertexAttribDivisor(positionLoc, 0);
-
     gl.drawArraysInstanced(gl.POINTS, 0, 6, instanceCount);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstanced with POINTS should succeed");
     gl.drawArraysInstanced(gl.LINES, 0, 6, instanceCount);
@@ -207,11 +202,6 @@ function runOutputTests() {
 
     gl.drawElementsInstanced(gl.TRIANGLES, -1, gl.UNSIGNED_SHORT, 0, instanceCount);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "drawElementsInstanced cannot have a count less than 0");
-
-    gl.vertexAttribDivisor(positionLoc, 1);
-    gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawElementsInstanced");
-    gl.vertexAttribDivisor(positionLoc, 0);
 
     gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, instanceCount);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElementsInstanced with UNSIGNED_BYTE should succeed");

--- a/sdk/tests/conformance2/rendering/instanced-arrays.html
+++ b/sdk/tests/conformance2/rendering/instanced-arrays.html
@@ -172,7 +172,7 @@ function runOutputTests() {
 
     gl.vertexAttribDivisor(positionLoc, 1);
     gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, instanceCount);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawArraysInstanced");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "It's allowed for all vertex attributes to have non-zero divisors when calling drawArraysInstanced");
     gl.vertexAttribDivisor(positionLoc, 0);
 
     gl.drawArraysInstanced(gl.POINTS, 0, 6, instanceCount);
@@ -210,7 +210,7 @@ function runOutputTests() {
 
     gl.vertexAttribDivisor(positionLoc, 1);
     gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "There must be at least one vertex attribute with a divisor of zero when calling drawElementsInstanced");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "It's allowed for all vertex attributes to have non-zero divisors when calling drawElementsInstanced");
     gl.vertexAttribDivisor(positionLoc, 0);
 
     gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, instanceCount);


### PR DESCRIPTION
if non of vertex attribs have zero a divisor.

The original limit was introduced in WebGL1 extension due to D3D9 limit.
Such limit does not exist in D3D11, therefore should not be applied to WebGL2.