### PR TITLE
Fix ext-color-buffer-float.html to pass valid RGB16F/32F texture formats

### DIFF
--- a/extensions/EXT_color_buffer_float/extension.xml
+++ b/extensions/EXT_color_buffer_float/extension.xml
@@ -39,10 +39,7 @@
       </feature>
 
       <feature>
-        <p>Renderbuffers with these internal formats can be created. These
-        internal formats are valid for CopyTexImage2D. Note that textures
-        with these internal formats can be created with TexImage2D in core
-        WebGL 2.0.</p>
+        <p>Renderbuffers with these internal formats can be created.</p>
       </feature>
 
       <feature>

--- a/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
+++ b/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
@@ -427,11 +427,7 @@ function runCopyTexImageTest(enabled)
         if (enabled) {
             shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
             gl.copyTexImage2D(gl.TEXTURE_2D, level, destInternalformat, 0, 0, width, height, 0);
-            if (destInternalformat == gl.RGB16F || destInternalformat == gl.RGB32F) {
-                wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "CopyTexImage2D should fail.");
-            } else {
-                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "CopyTexImage2D should succeed.");
-            }
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "CopyTexImage2D should succeed.");
         } else {
             shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
             gl.copyTexImage2D(gl.TEXTURE_2D, level, destInternalformat, 0, 0, width, height, 0);


### PR DESCRIPTION
RGB16F and RGB32F are both valid internal texture formats and
should not produce an error when this extension is enabled. The
extension should not be limiting the enums that can be passed
to CopyTexImage.