### PR TITLE
Test calling framebufferRenderbuffer before bindRenderbuffer

### DIFF
--- a/sdk/tests/conformance/renderbuffers/framebuffer-object-attachment.html
+++ b/sdk/tests/conformance/renderbuffers/framebuffer-object-attachment.html
@@ -426,6 +426,7 @@ if (checkValidColorDepthCombination()) {
     testFramebufferIncompleteMissingAttachment();
     testUsingIncompleteFramebuffer();
     testReadingFromMissingAttachment();
+    testBindRenderbufferBeforeFramebufferAttach();
 }
 
 function checkFramebuffer(expected) {
@@ -653,6 +654,40 @@ function testReadingFromMissingAttachment() {
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Before CopyTexSubImage2D from missing attachment");
     gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, size, size);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "After CopyTexSubImage2D from missing attachment");
+}
+
+// [OpenGL ES 2.0.25] Section 4.4.3 page 112
+// [OpenGL ES 3.0.2] Section 4.4.2 page 201
+// 'renderbuffer' must be either zero or the name of an existing renderbuffer object of
+// type 'renderbuffertarget', otherwise an INVALID_OPERATION error is generated.
+function testBindRenderbufferBeforeFramebufferAttach() {
+    debug("");
+    debug("Test calling framebufferRenderbuffer before bindRenderbuffer.");
+
+    let fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+
+    let attachmentTypes = [
+        gl.COLOR_ATTACHMENT0,
+        gl.DEPTH_ATTACHMENT,
+        gl.STENCIL_ATTACHMENT,
+        gl.DEPTH_STENCIL_ATTACHMENT
+    ];
+
+    attachmentTypes.forEach(function(attachmentType) {
+        let strAttachmentType = wtu.glEnumToString(gl, attachmentType);
+        debug("");
+        debug("Testing " + strAttachmentType);
+        let rbo = gl.createRenderbuffer();
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachmentType, gl.RENDERBUFFER, rbo);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bindRenderbuffer must be called before attachment to " + strAttachmentType);
+        shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl." + strAttachmentType + ", gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE)", "gl.NONE");
+        shouldBeNull("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl." + strAttachmentType + ", gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)");
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachmentType, gl.RENDERBUFFER, null);
+        gl.deleteRenderbuffer(rbo);
+    });
+
+    gl.deleteFramebuffer(fbo);
 }
 
 var successfullyParsed = true;


### PR DESCRIPTION
Calling framebufferRenderbuffer on a created renderbuffer before calling bindRenderbuffer on the render buffer must flag an invalid operation and the attachment should fail.

From the spec:
[OpenGL ES 2.0.25] Section 4.4.3 page 112
[OpenGL ES 3.0.2] Section 4.4.2 page 201
'renderbuffer' must be either zero or the name of an existing renderbuffer object of
type 'renderbuffertarget', otherwise an INVALID_OPERATION error is generated.