### PR TITLE
Removing non-black transparent pixels from createImageBitmap conformance tests

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js
@@ -51,9 +51,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var imageData = new ImageData(new Uint8ClampedArray(
                                       [255, 0, 0, 255,
-                                      255, 0, 0, 0,
+                                      255, 0, 0, 128,
                                       0, 255, 0, 255,
-                                      0, 255, 0, 0]),
+                                      0, 255, 0, 128]),
                                       2, 2);
 
         createImageBitmap(imageData, {imageOrientation: "none", premultiplyAlpha: "none"})
@@ -61,7 +61,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             testPassed("createImageBitmap with options may be rejected if it is not supported. Retrying without options.");
             return createImageBitmap(imageData);
         }).then( bitmap => {
-            return runImageBitmapTest(bitmap, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
+            return runImageBitmapTest(bitmap, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false);
         }, () => {
             testFailed("createImageBitmap(imageData) should succeed.");
         }).then(() => {

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -51,12 +51,12 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var imageData = new ImageData(new Uint8ClampedArray(
                                       [255, 0, 0, 255,
-                                      255, 0, 0, 0,
+                                      255, 0, 0, 128,
                                       0, 255, 0, 255,
-                                      0, 255, 0, 0]),
+                                      0, 255, 0, 128]),
                                       2, 2);
 
-        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+        runImageBitmapTest(imageData, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
         .then(() => {
             finishTest();
         });


### PR DESCRIPTION
This change updates WebGL conformance tests for createImageBitmap from 
ImageBitmap and ImageData to avoid non-black transparent pixels. Skia is
removing support for unpremul operations, which means to do scaling,
color correction, etc. unpremul images must be first converted to
premul. When pixel values are non-black transparent, like 0,255,0,0,
the unpremul->premul->unpremul round-trip results in transparent black,
breaking the previous conformance tests.