### PR TITLE
Clarify what is allowed in global initializers

### DIFF
--- a/sdk/tests/conformance/glsl/misc/global-variable-init.html
+++ b/sdk/tests/conformance/glsl/misc/global-variable-init.html
@@ -210,6 +210,23 @@ void main() {
     gl_FragColor = vec4(0.0, green, 0.0, 1.0);
 }
 </script>
+<script id="builtInConstant" type="x-shader/x-fragment">
+precision mediump float;
+int i = gl_MaxFragmentUniformVectors;
+
+void main() {
+    float green = (i > 0) ? 1.0 : 0.0;
+    gl_FragColor = vec4(0.0, green, 0.0, 1.0);
+}
+</script>
+<script id="builtInNonConstant" type="x-shader/x-fragment">
+precision mediump float;
+vec4 v = gl_FragCoord;
+
+void main() {
+    gl_FragColor = v;
+}
+</script>
 <script type="application/javascript">
 "use strict";
 description();
@@ -306,6 +323,19 @@ GLSLConformanceTester.runTests([
         { name: 'us.one', functionName: 'uniform1i', value: 1 }
     ],
     passMsg: "A global struct initialized with a uniform struct should be accepted by WebGL."
+  },
+  {
+    fShaderId: "builtInConstant",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    render: true,
+    passMsg: "Referencing a built-in constant in a global variable initializer should be accepted by WebGL."
+  },
+  {
+    fShaderId: "builtInNonConstant",
+    fShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: "Referencing a built-in non-constant in a global variable initializer should not be accepted by WebGL."
   }
 ]);
 var successfullyParsed = true;

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3976,8 +3976,8 @@ extensions.
     initializer expressions, which are defined as one of:
 </p>
 <ul>
-<li>a literal value</li>
-<li>a global variable</li>
+<li>a constant expression</li>
+<li>a user-defined global variable</li>
 <li>a uniform</li>
 <li>
     an expression formed by an operator on operands that are global initializer expressions,
@@ -3996,6 +3996,7 @@ extensions.
 <ul>
 <li>User-defined functions</li>
 <li>Attributes and varyings</li>
+<li>Built-in variables with the exception of constant expressions</li>
 <li>Global variables as l-values in an assignment or other operation</li>
 </ul>
 


### PR DESCRIPTION
It should be made clear that referring to built-in globals like
gl_FragCoord is not allowed, but on the other hand referring to
built-in constants like gl_MaxVertexUniformVectors is.

This matches the existing behavior in ANGLE.