### PR TITLE
Add a test that doesn't write gl_FragColor or gl_FragData

### DIFF
--- a/sdk/tests/conformance/glsl/variables/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/variables/00_test_list.txt
@@ -4,3 +4,4 @@ gl-pointcoord.html
 --min-version 1.0.2 glsl-built-ins.html
 --min-version 1.0.3 gl-fragcoord-xy-values.html
 --min-version 1.0.3 gl-fragdata-and-fragcolor.html
+--min-version 1.0.4 gl-fragcolor-unwritten.html

--- a/sdk/tests/conformance/glsl/variables/gl-fragcolor-unwritten.html
+++ b/sdk/tests/conformance/glsl/variables/gl-fragcolor-unwritten.html
@@ -1,0 +1,109 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gl_FragColor and gl_FragData unwritten</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragmentShaderEmpty" type="text/something-not-javascript">
+// fragment shader that doesn't write to gl_FragColor or gl_FragData should leave the fragment color untouched.
+// WebGL 1.0 spec section "Fragment shader output"
+precision mediump float;
+void main()
+{
+}
+</script>
+<script id="fragmentShaderReadsFragColor" type="text/something-not-javascript">
+// fragment shader that doesn't write to gl_FragColor or gl_FragData should leave the fragment color untouched.
+// WebGL 1.0 spec section "Fragment shader output"
+precision mediump float;
+
+void main()
+{
+    vec4 foo = gl_FragColor;
+}
+</script>
+<script id="fragmentShaderReadsFragData" type="text/something-not-javascript">
+// fragment shader that doesn't write to gl_FragColor or gl_FragData should leave the fragment color untouched.
+// WebGL 1.0 spec section "Fragment shader output"
+precision mediump float;
+
+void main()
+{
+    vec4 foo = gl_FragData[0];
+}
+</script>
+<script id="fragmentShaderStaticWriteOfFragColorNotReached" type="text/something-not-javascript">
+// fragment shader that doesn't write to gl_FragColor or gl_FragData should leave the fragment color untouched.
+// WebGL 1.0 spec section "Fragment shader output"
+precision mediump float;
+uniform bool u_false;
+
+void main()
+{
+    if (u_false) {
+        gl_FragColor = vec4(0);
+    }
+}
+</script>
+<script>
+"use strict";
+description();
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext();
+
+var test = function(fragShader, shaderDescription) {
+    debug("");
+    debug("Clearing canvas to green and drawing with " + shaderDescription);
+    wtu.setupProgram(gl, [wtu.simpleVertexShader, fragShader], undefined, undefined, true);
+    gl.clearColor(0, 1, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.disable(gl.BLEND);
+    wtu.setupUnitQuad(gl);
+    wtu.drawUnitQuad(gl);
+    wtu.checkCanvas(gl, [0, 255, 0, 255], 'should be green');
+};
+
+test('fragmentShaderEmpty', 'empty fragment shader');
+test('fragmentShaderReadsFragColor', 'fragment shader that only reads gl_FragColor');
+test('fragmentShaderReadsFragData', 'fragment shader that only reads gl_FragData');
+test('fragmentShaderStaticWriteOfFragColorNotReached', 'fragment shader where gl_FragColor is statically written but the write is not reached');
+
+var successfullyParsed = true;
+</script>
+<script src="../../../js/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
In this case, the fragment color should be left untouched according to
the WebGL spec.

This exposes a bug in ANGLE that writes the fragment color in case it
is read by the shader.