### PR TITLE
Add a test case for ambiguous struct parameters HLSL bug

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/angle-ambiguous-function-call.html
+++ b/sdk/tests/conformance/glsl/bugs/angle-ambiguous-function-call.html
@@ -53,6 +53,22 @@ void main()
     gl_FragColor = foo(uv) + foo(um);
 }
 </script>
+<script id="fshaderAmbiguousHLSLStructFunctionCall" type="x-shader/x-fragment">
+precision mediump float;
+uniform float u_zero;
+struct S { float foo; };
+struct S2 { float foo; };
+float get(S s) { return s.foo + u_zero; }
+float get(S2 s2) { return 0.25 + s2.foo + u_zero; }
+void main()
+{
+    S s;
+    s.foo = 0.5;
+    S2 s2;
+    s2.foo = 0.25;
+    gl_FragColor = vec4(0.0, get(s) + get(s2), 0.0, 1.0);
+}
+</script>
 <script type="text/javascript">
 "use strict";
 description("Test overloaded functions with vec4 and mat2 parameters that have had issues in ANGLE. Issues were due to HLSL compiler treating float4 and float2x2 as the same type when resolving which overloaded function to call.");
@@ -62,7 +78,14 @@ GLSLConformanceTester.runTests([
   fShaderId: 'fshaderAmbiguousHLSLFunctionCall',
   fShaderSuccess: true,
   linkSuccess: true,
-  passMsg: "Disambiguate correctly between overloaded function calls"
+  passMsg: "Disambiguate correctly between overloaded function calls with 4-component float parameters"
+},
+{
+  fShaderId: 'fshaderAmbiguousHLSLStructFunctionCall',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Disambiguate correctly between overloaded function calls with struct parameters",
+  render: true
 }
 ]);
 </script>


### PR DESCRIPTION
Cover a missing workaround in ANGLE: The shader translation needs to
work around HLSL compiler treating structs with different names but
identical fields as ambiguous.