### PR TITLE
Revert "Test drawing with textures from non-ready video uploads."

### DIFF
--- a/sdk/tests/conformance/textures/misc/gl-teximage.html
+++ b/sdk/tests/conformance/textures/misc/gl-teximage.html
@@ -416,13 +416,6 @@ function runTests(imgs) {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from zero sized textures");
 
   debug("");
-  debug("check not-ready upload cases");
-  var video = document.createElement('video');
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
-  wtu.clearAndDrawUnitQuad(gl);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no errors from drawing with uploads from not-ready elements");
-
-  debug("");
   successfullyParsed = true;
   shouldBeTrue("successfullyParsed");
   debug('<br /><span class="pass">TEST COMPLETE</span>');


### PR DESCRIPTION
Reverts KhronosGroup/WebGL#2440.

Please see my comment on the other pull request for why this change was problematic.
