### PR TITLE
Texture switch performance

### DIFF
--- a/sdk/tests/conformance/rendering/00_test_list.txt
+++ b/sdk/tests/conformance/rendering/00_test_list.txt
@@ -28,3 +28,4 @@ triangle.html
 line-loop-tri-fan.html
 --min-version 1.0.4 framebuffer-texture-clear.html
 --min-version 1.0.4 clear-after-copyTexImage2D.html
+--min-version 1.0.4 texture-switch-performance.html

--- a/sdk/tests/conformance/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance/rendering/texture-switch-performance.html
@@ -73,13 +73,15 @@ if (!gl) {
       gl.drawArrays(gl.TRIANGLES, 0, 6);
     }
 
-    if (++frameCount === 100) {
-      var elapsed = Date.now() - startTime;
-      if (elapsed < 3333) {  // 30FPS
+    ++frameCount;
+
+    if (Date.now() - startTime > 5000) {
+      if (frameCount > 150) {  // 30FPS
         testPassed("Texture switching did not significantly hurt performance");
       } else {
         testFailed("Texture switching significantly hurt performance");
       }
+      console.log(frameCount);
       finishTest();
     } else {
       requestAnimationFrame(draw);

--- a/sdk/tests/conformance/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance/rendering/texture-switch-performance.html
@@ -1,0 +1,95 @@
+<!--
+
+/*
+** Copyright (c) 2012 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Ensures that switching the texture referenced by a sampler uniform performs reasonably well.");
+var wtu = WebGLTestUtils;
+var canvas = document.createElement('canvas');
+canvas.width = 32;
+canvas.height = 32;
+var gl = wtu.create3DContext(canvas);
+if (!gl) {
+  testFailed("context does not exist");
+  finishTest();
+} else {
+  var program = wtu.setupTexturedQuad(gl);
+  var tex = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+  var tex2 = gl.createTexture();
+  gl.activeTexture(gl.TEXTURE1);
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+  var loc = gl.getUniformLocation(program, "tex");
+
+  var startTime = Date.now();
+  var frameCount = 0;
+
+  function draw() {
+    for (var i = 0; i < 200; ++i) {
+      gl.uniform1i(loc, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      gl.uniform1i(loc, 1);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    if (++frameCount === 100) {
+      var elapsed = Date.now() - startTime;
+      if (elapsed < 3333) {  // 30FPS
+        testPassed("Texture switching did not significantly hurt performance");
+      } else {
+        testFailed("Texture switching significantly hurt performance");
+      }
+      finishTest();
+    } else {
+      requestAnimationFrame(draw);
+    }
+  }
+
+  requestAnimationFrame(draw);
+}
+var successfullyParsed = true;
+</script>
+</body>
+</html>
+

--- a/sdk/tests/conformance2/rendering/00_test_list.txt
+++ b/sdk/tests/conformance2/rendering/00_test_list.txt
@@ -31,3 +31,4 @@ out-of-bounds-index-buffers-after-copying.html
 rgb-format-support.html
 uniform-block-buffer-size.html
 --min-version 2.0.1 framebuffer-texture-level1.html
+--min-version 2.0.1 texture-switch-performance.html

--- a/sdk/tests/conformance2/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance2/rendering/texture-switch-performance.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL Texture Switch Conformance Tests</title>
+<title>WebGL 2 Texture Switch Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
@@ -44,7 +44,7 @@ var wtu = WebGLTestUtils;
 var canvas = document.createElement('canvas');
 canvas.width = 32;
 canvas.height = 32;
-var gl = wtu.create3DContext(canvas);
+var gl = wtu.create3DContext(canvas, undefined, 2);
 if (!gl) {
   testFailed("context does not exist");
   finishTest();


### PR DESCRIPTION
A test for the Mac/AMD texture-switching performance problem reported in: https://bugs.chromium.org/p/chromium/issues/detail?id=735483

I've tested on a Mac with an Intel Iris, iPad Air 2, Nexus 10, Pixel Phone, and they all pass as they should. An affected Mac with a Radeon R9 M290 fails as it should. 