### PR TITLE
Test uploading HTML data (canvas, image, etc.) to luminance and/or alpha textures.

### DIFF
--- a/sdk/tests/conformance/textures/canvas/00_test_list.txt
+++ b/sdk/tests/conformance/textures/canvas/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/canvas/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/canvas/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/canvas_sub_rectangle/00_test_list.txt
+++ b/sdk/tests/conformance/textures/canvas_sub_rectangle/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/canvas_sub_rectangle/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas_sub_rectangle/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/canvas_sub_rectangle/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas_sub_rectangle/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/canvas_sub_rectangle/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/canvas_sub_rectangle/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_blob/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-blob.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_bitmap/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-bitmap.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_image_data/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_bitmap_from_video/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_bitmap_from_video/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_data/00_test_list.txt
+++ b/sdk/tests/conformance/textures/image_data/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/image_data/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_data/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
+</head>
+<body>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_data/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_data/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
+</head>
+<body>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/image_data/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/image_data/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,58 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-image-data.js"></script>
+</head>
+<body>
+<canvas id="texcanvas" width="2" height="2"></canvas>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/svg_image/00_test_list.txt
+++ b/sdk/tests/conformance/textures/svg_image/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/svg_image/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/svg_image/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/svg_image/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/svg_image/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-svg-image.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/video/00_test_list.txt
+++ b/sdk/tests/conformance/textures/video/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/video/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/video/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/video/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/video/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/video/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/video/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-video.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/webgl_canvas/00_test_list.txt
+++ b/sdk/tests/conformance/textures/webgl_canvas/00_test_list.txt
@@ -3,3 +3,6 @@ tex-2d-rgb-rgb-unsigned_short_5_6_5.html
 tex-2d-rgba-rgba-unsigned_byte.html
 tex-2d-rgba-rgba-unsigned_short_4_4_4_4.html
 tex-2d-rgba-rgba-unsigned_short_5_5_5_1.html
+tex-2d-luminance-luminance-unsigned_byte.html
+tex-2d-alpha-alpha-unsigned_byte.html
+tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-2d-alpha-alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-2d-alpha-alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("ALPHA", "ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-2d-luminance-luminance-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-2d-luminance-luminance-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE", "LUMINANCE", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance/textures/webgl_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
+++ b/sdk/tests/conformance/textures/webgl_canvas/tex-2d-luminance_alpha-luminance_alpha-unsigned_byte.html
@@ -1,0 +1,57 @@
+<!--
+
+Copyright (c) 2015 The Khronos Group Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and/or associated documentation files (the
+"Materials"), to deal in the Materials without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Materials, and to
+permit persons to whom the Materials are furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Materials.
+
+THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+
+-->
+
+<!--
+
+This file is auto-generated from py/tex_image_test_generator.py
+DO NOT EDIT!
+
+-->
+
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-utils.js"></script>
+<script src="../../../js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js"></script>
+</head>
+<body>
+<canvas id="example" width="32" height="32"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+function testPrologue(gl) {
+    return true;
+}
+
+generateTest("LUMINANCE_ALPHA", "LUMINANCE_ALPHA", "UNSIGNED_BYTE", testPrologue, "../../../resources/", 1)();
+</script>
+</body>
+</html>

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
@@ -73,6 +73,21 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
           cyanColor = [0, 255, 0];
           break;
 
+        case gl.LUMINANCE:
+        case gl.LUMINANCE_ALPHA:
+          redColor = [255, 255, 255];
+          greenColor = [0, 0, 0];
+          blueColor = [0, 0, 0];
+          cyanColor = [0, 0, 0];
+          break;
+
+        case gl.ALPHA:
+          redColor = [0, 0, 0];
+          greenColor = [0, 0, 0];
+          blueColor = [0, 0, 0];
+          cyanColor = [0, 0, 0];
+          break;
+
         default:
           break;
         }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
@@ -27,8 +27,60 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     var gl = null;
     var successfullyParsed = false;
     var whiteColor = [255, 255, 255, 255];
-    var redColor = [255, 0, 0];
-    var greenColor = [0, 255, 0];
+    var redColor = [255, 0, 0, 255];
+    var greenColor = [0, 255, 0, 255];
+    var semiTransparentRedColor = [127, 0, 0, 127];
+    var semiTransparentGreenColor = [0, 127, 0, 127];
+    var repeatCount;
+
+    function replicateRedChannel(color)
+    {
+        color[1] = color[0];
+        color[2] = color[0];
+    }
+
+    function zapColorChannels(color)
+    {
+        color[0] = 0;
+        color[1] = 0;
+        color[2] = 0;
+    }
+
+    function setAlphaChannelTo1(color)
+    {
+        color[3] = 255;
+    }
+
+    function replicateAllRedChannels()
+    {
+        replicateRedChannel(redColor);
+        replicateRedChannel(semiTransparentRedColor);
+        replicateRedChannel(greenColor);
+        replicateRedChannel(semiTransparentGreenColor);
+    }
+
+    function setAllAlphaChannelsTo1()
+    {
+        setAlphaChannelTo1(redColor);
+        setAlphaChannelTo1(semiTransparentRedColor);
+        setAlphaChannelTo1(greenColor);
+        setAlphaChannelTo1(semiTransparentGreenColor);
+    }
+
+    function shouldRepeatTestForTextureFormat(internalFormat, pixelFormat, pixelType)
+    {
+        // There were bugs in early WebGL 1.0 implementations when repeatedly uploading canvas
+        // elements into textures. In response, this test was changed into a regression test by
+        // repeating all of the cases multiple times. Unfortunately, this means that adding a new
+        // case above significantly increases the run time of the test suite. The problem is made
+        // even worse by the addition of many more texture formats in WebGL 2.0.
+        //
+        // Doing repeated runs with just a couple of WebGL 1.0's supported texture formats acts as a
+        // sufficient regression test for the old bugs. For this reason the test has been changed to
+        // only repeat for those texture formats.
+        return ((internalFormat == 'RGBA' && pixelFormat == 'RGBA' && pixelType == 'UNSIGNED_BYTE') ||
+                (internalFormat == 'RGB' && pixelFormat == 'RGB' && pixelType == 'UNSIGNED_BYTE'));
+    }
 
     function init()
     {
@@ -43,17 +95,65 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             return;
         }
 
+        repeatCount = (shouldRepeatTestForTextureFormat(internalFormat, pixelFormat, pixelType) ? 4 : 1);
+
         switch (gl[pixelFormat]) {
           case gl.RED:
           case gl.RED_INTEGER:
-            whiteColor = [255, 0, 0, 255];
-            greenColor = [0, 0, 0];
+            // Zap green and blue channels.
+            whiteColor[1] = 0;
+            whiteColor[2] = 0;
+            greenColor[1] = 0;
+            semiTransparentGreenColor[1] = 0;
+            // Alpha channel is 1.0.
+            setAllAlphaChannelsTo1();
             break;
           case gl.RG:
           case gl.RG_INTEGER:
-            whiteColor = [255, 255, 0, 255];
+            // Zap blue channel.
+            whiteColor[2] = 0;
+            // Alpha channel is 1.0.
+            setAllAlphaChannelsTo1();
+            break;
+          case gl.LUMINANCE:
+            // Replicate red channels.
+            replicateAllRedChannels();
+            // Alpha channel is 1.0.
+            setAllAlphaChannelsTo1();
+            break;
+          case gl.ALPHA:
+            // Red, green and blue channels are all 0.0.
+            zapColorChannels(redColor);
+            zapColorChannels(semiTransparentRedColor);
+            zapColorChannels(greenColor);
+            zapColorChannels(semiTransparentGreenColor);
+            zapColorChannels(whiteColor);
+            break;
+          case gl.LUMINANCE_ALPHA:
+            // Replicate red channels.
+            replicateAllRedChannels();
+            break;
+          case gl.RGB:
+          case gl.RGB_INTEGER:
+            // Alpha channel is 1.0.
+            setAllAlphaChannelsTo1();
             break;
           default:
+            break;
+        }
+
+        switch (gl[internalFormat]) {
+          case gl.SRGB8:
+          case gl.SRGB8_ALPHA8:
+            semiTransparentRedColor = wtu.sRGBToLinear(semiTransparentRedColor);
+            semiTransparentGreenColor = wtu.sRGBToLinear(semiTransparentGreenColor);
+            break;
+          case gl.RGBA8UI:
+            // For int and uint textures, TexImageUtils outputs 1.0 for the alpha channel all the
+            // time because of differences in behavior when sampling integer textures with and
+            // without alpha channels. Since changing this behavior may have large impact across the
+            // test suite, leave it as is for now.
+            setAllAlphaChannelsTo1();
             break;
         }
 
@@ -69,9 +169,21 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       var width = ctx.canvas.width;
       var height = ctx.canvas.height;
       var halfHeight = Math.floor(height / 2);
+      ctx.clearRect(0, 0, width, height);
       ctx.fillStyle = "#ff0000";
       ctx.fillRect(0, 0, width, halfHeight);
       ctx.fillStyle = "#00ff00";
+      ctx.fillRect(0, halfHeight, width, height - halfHeight);
+    }
+
+    function setCanvasToSemiTransparentRedGreen(ctx) {
+      var width = ctx.canvas.width;
+      var height = ctx.canvas.height;
+      var halfHeight = Math.floor(height / 2);
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = "rgba(127, 0, 0, 0.5)";
+      ctx.fillRect(0, 0, width, halfHeight);
+      ctx.fillStyle = "rgba(0, 127, 0, 0.5)";
       ctx.fillRect(0, halfHeight, width, height - halfHeight);
     }
 
@@ -93,6 +205,12 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       setCanvasToRedGreen(ctx);
     }
 
+    function setCanvasTo257x257SemiTransparent(ctx, bindingTarget) {
+      ctx.canvas.width = 257;
+      ctx.canvas.height = 257;
+      setCanvasToSemiTransparentRedGreen(ctx);
+    }
+
     function setCanvasToMin(ctx, bindingTarget) {
       if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
         // cube map texture must be square.
@@ -104,12 +222,23 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       setCanvasToRedGreen(ctx);
     }
 
-    function runOneIteration(canvas, useTexSubImage2D, flipY, program, bindingTarget, opt_texture, opt_fontTest)
+    function setCanvasToMinSemiTransparent(ctx, bindingTarget) {
+      if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+        // cube map texture must be square.
+        ctx.canvas.width = 2;
+      } else {
+        ctx.canvas.width = 1;
+      }
+      ctx.canvas.height = 2;
+      setCanvasToSemiTransparentRedGreen(ctx);
+    }
+
+    function runOneIteration(canvas, useTexSubImage2D, flipY, semiTransparent, program, bindingTarget, opt_texture, opt_fontTest)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') +
               ' with flipY=' + flipY + ' bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP') +
               ' canvas size: ' + canvas.width + 'x' + canvas.height +
-              (opt_fontTest ? " with fonts" : " with red-green"));
+              (opt_fontTest ? " with fonts" : " with" + (semiTransparent ? " semi-transparent" : "") + " red-green"));
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         if (!opt_texture) {
             var texture = gl.createTexture();
@@ -195,13 +324,41 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                       },
                       debug);
             } else {
+                var localRed   = semiTransparent ? semiTransparentRedColor : redColor;
+                var localGreen = semiTransparent ? semiTransparentGreenColor : greenColor;
+
+                // Allow a tolerance for premultiplication/unmultiplication, especially for texture
+                // formats with lower bit depths.
+                var tolerance = 0;
+                if (semiTransparent) {
+                    tolerance = 3;
+                    if (pixelType == 'UNSIGNED_SHORT_5_6_5' || internalFormat == 'RGB565') {
+                        tolerance = 6;
+                    } else if (pixelType == 'UNSIGNED_SHORT_4_4_4_4' || internalFormat == 'RGBA4') {
+                        tolerance = 9;
+                    } else if (pixelType == 'UNSIGNED_SHORT_5_5_5_1' || internalFormat == 'RGB5_A1') {
+                        // It's ambiguous whether the one bit of alpha should be treated as:
+                        //   - zero if alpha is zero, otherwise one
+                        // or:
+                        //   - one if alpha is one, otherwise zero
+                        // Different browsers implement different rules, so ignore alpha for these tests.
+                        tolerance = 6;
+                        localRed = localRed.slice(0, 3);
+                        localGreen = localGreen.slice(0, 3);
+                    } else if (internalFormat == 'RGB10_A2') {
+                        // The alpha channel is too low-resolution for any meaningful comparisons.
+                        localRed = localRed.slice(0, 3);
+                        localGreen = localGreen.slice(0, 3);
+                    }
+                }
+
                 // Check the top and bottom halves and make sure they have the right color.
                 debug("Checking " + (flipY ? "top" : "bottom"));
-                wtu.checkCanvasRect(gl, 0, bottom, (skipCorner && flipY) ? halfWidth : width, halfHeight, redColor,
-                                    "shouldBe " + redColor);
+                wtu.checkCanvasRect(gl, 0, bottom, (skipCorner && flipY) ? halfWidth : width, halfHeight, localRed,
+                                    "shouldBe " + localRed, tolerance);
                 debug("Checking " + (flipY ? "bottom" : "top"));
-                wtu.checkCanvasRect(gl, 0, top, (skipCorner && !flipY) ? halfWidth : width, halfHeight, greenColor,
-                                    "shouldBe " + greenColor);
+                wtu.checkCanvasRect(gl, 0, top, (skipCorner && !flipY) ? halfWidth : width, halfHeight, localGreen,
+                                    "shouldBe " + localGreen, tolerance);
             }
 
             if (!useTexSubImage2D && pixelFormat == "RGBA") {
@@ -236,19 +393,33 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var ctx = canvas.getContext("2d");
 
         var cases = [
-            { sub: false, flipY: true,  font: false, init: setCanvasToMin },
-            { sub: false, flipY: false, font: false },
-            { sub: true,  flipY: true,  font: false },
-            { sub: true,  flipY: false, font: false },
-            { sub: false, flipY: true,  font: false, init: setCanvasTo257x257 },
-            { sub: false, flipY: false, font: false },
-            { sub: true,  flipY: true,  font: false },
-            { sub: true,  flipY: false, font: false },
-            { sub: false, flipY: true,  font: true, init: drawTextInCanvas },
-            { sub: false, flipY: false, font: true },
-            { sub: true,  flipY: true,  font: true },
-            { sub: true,  flipY: false, font: true },
+            { sub: false, flipY: true,  semiTransparent: false, font: false, init: setCanvasToMin },
+            { sub: false, flipY: false, semiTransparent: false, font: false },
+            { sub: true,  flipY: true,  semiTransparent: false, font: false },
+            { sub: true,  flipY: false, semiTransparent: false, font: false },
+            { sub: false, flipY: true,  semiTransparent: true,  font: false, init: setCanvasToMinSemiTransparent },
+            { sub: false, flipY: false, semiTransparent: true,  font: false },
+            { sub: true,  flipY: true,  semiTransparent: true,  font: false },
+            { sub: true,  flipY: false, semiTransparent: true,  font: false },
+            { sub: false, flipY: true,  semiTransparent: false, font: false, init: setCanvasTo257x257 },
+            { sub: false, flipY: false, semiTransparent: false, font: false },
+            { sub: true,  flipY: true,  semiTransparent: false, font: false },
+            { sub: true,  flipY: false, semiTransparent: false, font: false },
+            { sub: false, flipY: true,  semiTransparent: true,  font: false, init: setCanvasTo257x257SemiTransparent },
+            { sub: false, flipY: false, semiTransparent: true,  font: false },
+            { sub: true,  flipY: true,  semiTransparent: true,  font: false },
+            { sub: true,  flipY: false, semiTransparent: true,  font: false },
         ];
+
+        // The font tests don't work with ALPHA-only textures since they draw to the color channels.
+        if (internalFormat != 'ALPHA') {
+            cases = cases.concat([
+                { sub: false, flipY: true,  semiTransparent: false, font: true, init: drawTextInCanvas },
+                { sub: false, flipY: false, semiTransparent: false, font: true },
+                { sub: true,  flipY: true,  semiTransparent: false, font: true },
+                { sub: true,  flipY: false, semiTransparent: false, font: true },
+            ]);
+        }
 
         function runTexImageTest(bindingTarget) {
             var program;
@@ -259,7 +430,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             }
 
             return new Promise(function(resolve, reject) {
-                var count = 4;
+                var count = repeatCount;
                 var caseNdx = 0;
                 var texture = undefined;
                 function runNextTest() {
@@ -268,7 +439,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                     if (c.init) {
                       c.init(ctx, bindingTarget);
                     }
-                    texture = runOneIteration(canvas, c.sub, c.flipY, program, bindingTarget, texture, c.font);
+                    texture = runOneIteration(canvas, c.sub, c.flipY, c.semiTransparent, program, bindingTarget, texture, c.font);
                     // for the first 2 iterations always make a new texture.
                     if (count > 2) {
                       gl.deleteTexture(texture);

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
@@ -49,6 +49,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
           case gl.RED_INTEGER:
             greenColor = [0, 0, 0];
             break;
+          case gl.LUMINANCE:
+          case gl.LUMINANCE_ALPHA:
+            redColor = [255, 255, 255];
+            greenColor = [0, 0, 0];
+            break;
+          case gl.ALPHA:
+            redColor = [0, 0, 0];
+            greenColor = [0, 0, 0];
+            break;
           default:
             break;
         }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image.js
@@ -49,6 +49,17 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
           greenColor = [0, 0, 0];
           break;
 
+        case gl.LUMINANCE:
+        case gl.LUMINANCE_ALPHA:
+          redColor = [255, 255, 255];
+          greenColor = [0, 0, 0];
+          break;
+
+        case gl.ALPHA:
+          redColor = [0, 0, 0];
+          greenColor = [0, 0, 0];
+          break;
+
         default:
           break;
         }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-svg-image.js
@@ -48,6 +48,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
           case gl.RED_INTEGER:
             greenColor = [0, 0, 0];
             break;
+          case gl.LUMINANCE:
+          case gl.LUMINANCE_ALPHA:
+            redColor = [255, 255, 255];
+            greenColor = [0, 0, 0];
+            break;
+          case gl.ALPHA:
+            redColor = [0, 0, 0];
+            greenColor = [0, 0, 0];
+            break;
           default:
             break;
         }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
@@ -67,6 +67,15 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
           case gl.RED_INTEGER:
             greenColor = [0, 0, 0];
             break;
+          case gl.LUMINANCE:
+          case gl.LUMINANCE_ALPHA:
+            redColor = [255, 255, 255];
+            greenColor = [0, 0, 0];
+            break;
+          case gl.ALPHA:
+            redColor = [0, 0, 0];
+            greenColor = [0, 0, 0];
+            break;
           default:
             break;
         }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
@@ -37,6 +37,19 @@ function runOneIterationImageBitmapTest(useTexSubImage, bindingTarget, program, 
         greenColor = [0, 0, 0];
         halfGreen = [0, 0, 0];
         break;
+      case gl.LUMINANCE:
+      case gl.LUMINANCE_ALPHA:
+        redColor = [255, 255, 255];
+        greenColor = [0, 0, 0];
+        halfRed = [128, 128, 128];
+        halfGreen = [0, 0, 0];
+        break;
+      case gl.ALPHA:
+        redColor = [0, 0, 0];
+        greenColor = [0, 0, 0];
+        halfRed = [0, 0, 0];
+        halfGreen = [0, 0, 0];
+        break;
       default:
         break;
     }
@@ -44,9 +57,8 @@ function runOneIterationImageBitmapTest(useTexSubImage, bindingTarget, program, 
     switch (gl[internalFormat]) {
       case gl.SRGB8:
       case gl.SRGB8_ALPHA8:
-        // Math.pow((128 / 255 + 0.055) / 1.055, 2.4) * 255 = 55
-        halfRed = [55, 0, 0];
-        halfGreen = [0, 55, 0];
+        halfRed = wtu.sRGBToLinear(halfRed);
+        halfGreen = wtu.sRGBToLinear(halfGreen);
         break;
       default:
         break;
@@ -186,6 +198,19 @@ function runOneIterationImageBitmapTestSubSource(useTexSubImage, bindingTarget, 
         greenColor = [0, 0, 0];
         halfGreen = [0, 0, 0];
         break;
+      case gl.LUMINANCE:
+      case gl.LUMINANCE_ALPHA:
+        redColor = [255, 255, 255];
+        greenColor = [0, 0, 0];
+        halfRed = [128, 128, 128];
+        halfGreen = [0, 0, 0];
+        break;
+      case gl.ALPHA:
+        redColor = [0, 0, 0];
+        greenColor = [0, 0, 0];
+        halfRed = [0, 0, 0];
+        halfGreen = [0, 0, 0];
+        break;
       default:
         break;
     }
@@ -193,9 +218,8 @@ function runOneIterationImageBitmapTestSubSource(useTexSubImage, bindingTarget, 
     switch (gl[internalFormat]) {
       case gl.SRGB8:
       case gl.SRGB8_ALPHA8:
-        // Math.pow((128 / 255 + 0.055) / 1.055, 2.4) * 255 = 55
-        halfRed = [55, 0, 0];
-        halfGreen = [0, 55, 0];
+        halfRed = wtu.sRGBToLinear(halfRed);
+        halfGreen = wtu.sRGBToLinear(halfGreen);
         break;
       default:
         break;

--- a/sdk/tests/py/tex_image_test_generator.py
+++ b/sdk/tests/py/tex_image_test_generator.py
@@ -88,6 +88,9 @@ _FORMATS_TYPES_WEBGL1 = [
   {'internal_format': 'RGBA', 'format': 'RGBA', 'type': 'UNSIGNED_BYTE' },
   {'internal_format': 'RGBA', 'format': 'RGBA', 'type': 'UNSIGNED_SHORT_4_4_4_4' },
   {'internal_format': 'RGBA', 'format': 'RGBA', 'type': 'UNSIGNED_SHORT_5_5_5_1' },
+  {'internal_format': 'LUMINANCE',       'format': 'LUMINANCE',       'type': 'UNSIGNED_BYTE' },
+  {'internal_format': 'ALPHA',           'format': 'ALPHA',           'type': 'UNSIGNED_BYTE' },
+  {'internal_format': 'LUMINANCE_ALPHA', 'format': 'LUMINANCE_ALPHA', 'type': 'UNSIGNED_BYTE' },
 ]
 
 _FORMATS_TYPES_WEBGL2 = [


### PR DESCRIPTION
Test uploading HTML data (canvas, image, etc.) to luminance and/or alpha textures.

The most extensive new tests are under conformance/textures/canvas and conformance2/textures/canvas, where semi-transparent cases have been added for all of the texture formats.

The canvas tests used to repeat multiple times, to act as regression tests for bugs in early WebGL implementations. The repetition has been kept for WebGL 1.0's RGB and RGBA internal formats, but removed for all other texture formats, to avoid dramatically increasing the tests' run time. Overall, the run time of the test suite will decrease with this pull request.

Chrome, Firefox and Safari pass all of the new WebGL 1.0 tests with WebGL 1.0 contexts. Edge passes them, but generates errors about the UNPACK_COLORSPACE_CONVERSION_WEBGL parameter, which it does not support.

Firefox fails the new WebGL 1.0 luminance, alpha, and luminance_alpha tests when run against a WebGL 2.0 context (tested Linux and macOS). Emulation of these texture formats on the Core Profile is needed, as was done for Chrome. There is a preexisting failure of the RGB10_A2 tests in Firefox.

Chrome passes all of the tests with a forthcoming bug fix, and fails several of the tests without it.
