### PR TITLE
Accept INVALID_ENUM or INVALID_OPERATION for glReadPixels invalid parameters.

### DIFF
--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -169,7 +169,7 @@ function continueTestPart2() {
     var format = invalidFormat[ff];
     var buf = new Uint8Array(4);
     gl.readPixels(0, 0, 1, 1, format, gl.UNSIGNED_BYTE, buf);
-    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Should not be able to read as " + wtu.glEnumToString(gl, format));
+    wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "Should not be able to read as " + wtu.glEnumToString(gl, format));
   }
 
   for (var tt = 0; tt < invalidTypeInfo.length; ++tt) {
@@ -177,7 +177,7 @@ function continueTestPart2() {
     var type = info.type;
     var dest = info.dest;
     gl.readPixels(0, 0, 1, 1, gl.RGBA, type, dest);
-    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Should not be able to read as " + wtu.glEnumToString(gl, type));
+    wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "Should not be able to read as " + wtu.glEnumToString(gl, type));
   }
 
   var combinations = [

--- a/sdk/tests/conformance2/reading/read-pixels-into-pixel-pack-buffer.html
+++ b/sdk/tests/conformance2/reading/read-pixels-into-pixel-pack-buffer.html
@@ -50,12 +50,12 @@ function checkFormatAndType()
     for (var ff = 0; ff < invalidFormat.length; ++ff) {
         var format = invalidFormat[ff];
         gl.readPixels(0, 0, 1, 1, format, gl.UNSIGNED_BYTE, 0);
-        wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Format should not be able to read as " + wtu.glEnumToString(gl, format));
+        wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "Format should not be able to read as " + wtu.glEnumToString(gl, format));
     }
     for (var tt = 0; tt < invalidType.length; ++tt) {
         var type = invalidType[tt];
         gl.readPixels(0, 0, 1, 1, gl.RGBA, type, 0);
-        wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Type should not be able to read as " + wtu.glEnumToString(gl, type));
+        wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "Type should not be able to read as " + wtu.glEnumToString(gl, type));
     }
 
     debug("");


### PR DESCRIPTION
This matches dEQP's readPixels tests and ANGLE's implementation because some format/type combinations may have valid enums but be invalid in combination with the other enum.