### PR TITLE
Add a test for broadcasting gl_FragColor when main() returns

### DIFF
--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -34,6 +34,7 @@ webgl-debug-shaders.html
 --min-version 1.0.3 webgl-compressed-texture-size-limit.html
 --min-version 1.0.2 --max-version 1.9.9 webgl-depth-texture.html
 --min-version 1.0.3 --max-version 1.9.9 webgl-draw-buffers.html
+--min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-broadcast-return.html
 --min-version 1.0.3 --max-version 1.9.9 webgl-draw-buffers-feedback-loop.html
 --min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-framebuffer-unsupported.html
 --min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-max-draw-buffers.html

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers-broadcast-return.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers-broadcast-return.html
@@ -1,0 +1,133 @@
+﻿<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL WEBGL_draw_buffers Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/webgl-draw-buffers-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<canvas id="canvas" width="64" height="64"> </canvas>
+<div id="console"></div>
+<script id="fshaderRedWithExtensionWithReturn" type="x-shader/x-fragment">
+#extension GL_EXT_draw_buffers : require
+precision mediump float;
+uniform float u_zero;
+void main() {
+    gl_FragColor = vec4(1,0,0,1);
+    if (u_zero < 1.0) {
+        return;
+    }
+    gl_FragColor = vec4(0,0,1,1);
+}
+</script>
+<script>
+"use strict";
+description("This test verifies gl_FragColor being broadcasted when using WEBGL_draw_buffers extension, if it is available.");
+
+debug("");
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas);
+var ext = null;
+var drawBuffersUtils;
+
+if (!gl) {
+  testFailed("WebGL context does not exist");
+} else {
+  testPassed("WebGL context exists");
+
+  // Query the extension and store globally so shouldBe can access it
+  ext = gl.getExtension("WEBGL_draw_buffers");
+  if (!ext) {
+    testPassed("No WEBGL_draw_buffers support -- this is legal");
+  } else {
+    testPassed("Successfully enabled WEBGL_draw_buffers extension");
+    drawBuffersUtils = WebGLDrawBuffersUtils(gl, ext);
+    runDrawTests();
+  }
+}
+
+function runDrawTests() {
+  debug("");
+  var fb = gl.createFramebuffer();
+
+  var maxUsable = drawBuffersUtils.getMaxUsableColorAttachments();
+  var bufs = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
+
+  var redProgramWithExtensionWithReturn = wtu.setupProgram(gl, [wtu.simpleVertexShader, "fshaderRedWithExtensionWithReturn"], ["vPosition"], undefined, true);
+  var width = 64;
+  var height = 64;
+  var attachments = [];
+  for (var ii = 0; ii < maxUsable; ++ii) {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + ii, gl.TEXTURE_2D, tex, 0);
+    attachments.push({
+      texture: tex
+    });
+  }
+
+  debug("test that gl_FragColor broadcasts if extension is enabled in fragment shader and fragment shader main returns in the middle");
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  ext.drawBuffersWEBGL(bufs);
+  shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+  gl.clearColor(0, 0, 0, 0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.useProgram(redProgramWithExtensionWithReturn);
+  wtu.drawUnitQuad(gl);
+
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+
+  gl.bindTexture(gl.TEXTURE_2D, null);
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  gl.deleteFramebuffer(fb);
+  attachments.forEach(function(attachment) {
+    gl.deleteTexture(attachment.texture);
+  });
+  gl.deleteProgram(redProgramWithExtensionWithReturn);
+}
+
+var successfullyParsed = true;
+
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -33,17 +33,12 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/webgl-draw-buffers-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
 <canvas id="canvas" width="64" height="64"> </canvas>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-attribute vec4 a_position;
-void main() {
-    gl_Position = a_position;
-}
-</script>
 <script id="fshader" type="x-shader/x-fragment">
 #extension GL_EXT_draw_buffers : require
 precision mediump float;
@@ -111,10 +106,10 @@ debug("");
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
-var output = document.getElementById("console");
 var gl = wtu.create3DContext(canvas);
 var ext = null;
 var programWithMaxDrawBuffersEqualOne = null;
+var drawBuffersUtils;
 
 var extensionConstants = [
   { name: "MAX_COLOR_ATTACHMENTS_WEBGL", enum: 0x8CDF, expectedFn: function(v) { return v >= 4; }, passMsg: " should be >= 4"},
@@ -177,6 +172,7 @@ if (!gl) {
   } else {
     testPassed("Successfully enabled WEBGL_draw_buffers extension");
 
+    drawBuffersUtils = WebGLDrawBuffersUtils(gl, ext);
     runSupportedTest(true);
     runEnumTestEnabled();
     runShadersTestEnabled();
@@ -189,7 +185,7 @@ if (!gl) {
 function createExtDrawBuffersProgram(scriptId, sub) {
   var fsource = wtu.getScript(scriptId);
   fsource = wtu.replaceParams(fsource, sub);
-  return wtu.setupProgram(gl, ["vshader", fsource], ["a_position"], undefined, true);
+  return wtu.setupProgram(gl, [wtu.simpleVertexShader, fsource], ["vPosition"], undefined, true);
 }
 
 function runSupportedTest(extensionEnabled) {
@@ -254,8 +250,8 @@ function runEnumTestEnabled() {
 
 function testShaders(tests, sub) {
   tests.forEach(function(test) {
-    var shaders = [wtu.getScript(test.shaders[0]), wtu.replaceParams(wtu.getScript(test.shaders[1]), sub)];
-    var program = wtu.setupProgram(gl, shaders, ["a_position"], undefined, true);
+    var shaders = [wtu.simpleVertexShader, wtu.replaceParams(wtu.getScript(test.fragmentShaderTemplate), sub)];
+    var program = wtu.setupProgram(gl, shaders, ["vPosition"], undefined, true);
     var programLinkedSuccessfully = (program != null);
     var expectedProgramToLinkSuccessfully = (test.expectFailure == true);
     expectTrue(programLinkedSuccessfully != expectedProgramToLinkSuccessfully, test.msg);
@@ -269,10 +265,10 @@ function runShadersTestDisabled() {
 
   var sub = {numDrawingBuffers: 1};
   testShaders([
-    { shaders: ["vshader", "fshaderMacroDisabled"],
+    { fragmentShaderTemplate: "fshaderMacroDisabled",
       msg: "GL_EXT_draw_buffers should not be defined in GLSL",
     },
-    { shaders: ["vshader", "fshader"],
+    { fragmentShaderTemplate: "fshader",
       msg: "#extension GL_EXT_draw_buffers should not be allowed in GLSL",
       expectFailure: true,
     },
@@ -291,11 +287,11 @@ function runShadersTestEnabled() {
 
   var sub = {numDrawingBuffers: gl.getParameter(ext.MAX_DRAW_BUFFERS_WEBGL)};
   testShaders([
-    { shaders: ["vshader", "fshaderMacroEnabled"],
-    msg: "GL_EXT_draw_buffers should be defined as 1 in GLSL",
+    { fragmentShaderTemplate: "fshaderMacroEnabled",
+      msg: "GL_EXT_draw_buffers should be defined as 1 in GLSL",
     },
-    { shaders: ["vshader", "fshader"],
-    msg: "fragment shader containing the #extension directive should compile",
+    { fragmentShaderTemplate: "fshader",
+      msg: "fragment shader containing the #extension directive should compile",
     },
   ], sub);
 
@@ -337,14 +333,6 @@ function makeArray(size, value) {
   return array;
 }
 
-function makeColorAttachmentArray(size) {
-  var array = []
-  for (var ii = 0; ii < size; ++ii) {
-    array.push(gl.COLOR_ATTACHMENT0 + ii);
-  }
-  return array;
-}
-
 function runAttachmentTestEnabled() {
   debug("");
   debug("test attachment enabled");
@@ -362,7 +350,7 @@ function runAttachmentTestEnabled() {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to attach to the max attachment point: gl.COLOR_ATTACHMENT0 + " + (maxColorAttachments - 1));
   ext.drawBuffersWEBGL(makeArray(maxDrawingBuffers, gl.NONE));
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffersWEBGL with array NONE of size " + maxColorAttachments);
-  var bufs = makeColorAttachmentArray(maxDrawingBuffers);
+  var bufs = drawBuffersUtils.makeColorAttachmentArray(maxDrawingBuffers);
   ext.drawBuffersWEBGL(bufs);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffersWEBGL with array attachments of size " + maxColorAttachments);
   bufs[0] = gl.NONE;
@@ -373,7 +361,7 @@ function runAttachmentTestEnabled() {
     bufs[1] = ext.COLOR_ATTACHMENT0_WEBGL;
     ext.drawBuffersWEBGL(bufs);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should not be able to call drawBuffersWEBGL with out of order attachments of size " + maxColorAttachments);
-    var bufs = makeColorAttachmentArray(Math.floor(maxDrawingBuffers / 2));
+    var bufs = drawBuffersUtils.makeColorAttachmentArray(Math.floor(maxDrawingBuffers / 2));
     ext.drawBuffersWEBGL(bufs);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffersWEBGL with short array of attachments of size " + bufs.length);
   }
@@ -417,11 +405,9 @@ function runDrawTests() {
   var middleFB = gl.createFramebuffer();
 
   var maxDrawingBuffers = gl.getParameter(ext.MAX_DRAW_BUFFERS_WEBGL);
-  var maxColorAttachments = gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_WEBGL);
-  var maxUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
-  var maxUsable = Math.min(maxDrawingBuffers, maxColorAttachments, maxUniformVectors);
+  var maxUsable = drawBuffersUtils.getMaxUsableColorAttachments();
   var half = Math.floor(maxUsable / 2);
-  var bufs = makeColorAttachmentArray(maxUsable);
+  var bufs = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
   var nones = makeArray(maxUsable, gl.NONE);
 
   [fb, fb2, halfFB1, halfFB2, endsFB, middleFB].forEach(function(fbo) {
@@ -430,8 +416,8 @@ function runDrawTests() {
   });
 
   var checkProgram = wtu.setupTexturedQuad(gl);
-  var redProgram = wtu.setupProgram(gl, ["vshader", "fshaderRed"], ["a_position"]);
-  var redProgramWithExtension = wtu.setupProgram(gl, ["vshader", "fshaderRedWithExtension"], ["a_position"]);
+  var redProgram = wtu.setupProgram(gl, [wtu.simpleVertexShader, "fshaderRed"], ["vPosition"]);
+  var redProgramWithExtension = wtu.setupProgram(gl, [wtu.simpleVertexShader, "fshaderRedWithExtension"], ["vPosition"]);
   var drawProgram = createExtDrawBuffersProgram("fshader", {numDrawingBuffers: maxDrawingBuffers});
   var width = 64;
   var height = 64;
@@ -464,7 +450,6 @@ function runDrawTests() {
     gl.uniform4fv(location, floatColor);
     attachments.push({
       texture: tex,
-      location: location,
       color: color
     });
   }
@@ -472,30 +457,6 @@ function runDrawTests() {
   shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
   shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
-
-  var checkAttachmentsForColorFn = function(attachments, colorFn) {
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    gl.useProgram(checkProgram);
-    attachments.forEach(function(attachment, index) {
-      gl.bindTexture(gl.TEXTURE_2D, attachment.texture);
-      wtu.clearAndDrawUnitQuad(gl);
-      var expectedColor = colorFn(attachment, index);
-      var tolerance = 0;
-      expectedColor.forEach(function(v) {
-        if (v != 0 && v != 255) {
-          tolerance = 8;
-        }
-      });
-      wtu.checkCanvas(gl, expectedColor, "attachment " + index + " should be " + expectedColor.toString(), tolerance);
-    });
-    debug("");
-  };
-
-  var checkAttachmentsForColor = function(attachments, color) {
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
-      return color || attachment.color;
-    });
-  };
 
   var drawAndCheckAttachments = function(testFB, msg, testFn) {
     debug("test clearing " + msg);
@@ -517,7 +478,7 @@ function runDrawTests() {
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    //checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    //drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
     //  return [0, 0, 0, 0];
     //});
     //debug("--");
@@ -527,7 +488,7 @@ function runDrawTests() {
 
     gl.clearColor(0, 1, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return testFn(attachment, index) ? [0, 255, 0, 255] : [0, 0, 0, 0];
     });
 
@@ -538,7 +499,7 @@ function runDrawTests() {
     gl.bindFramebuffer(gl.FRAMEBUFFER, testFB);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return testFn(attachment, index) ? attachment.color : [0, 0, 0, 0];
     });
   };
@@ -553,17 +514,17 @@ function runDrawTests() {
 
   debug("test that each texture got the correct color.");
 
-  checkAttachmentsForColor(attachments);
+  drawBuffersUtils.checkAttachmentsForColor(attachments);
 
   debug("test clearing clears all the textures");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   gl.clearColor(0, 1, 0, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
-  checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
 
   debug("test a fragment shader writing to neither gl_FragColor nor gl_FragData does not touch attachments");
-  var noWriteProgram = wtu.setupProgram(gl, ["vshader", "fshaderNoWrite"], ["a_position"]);
+  var noWriteProgram = wtu.setupProgram(gl, [wtu.simpleVertexShader, "fshaderNoWrite"], ["vPosition"]);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should be no GL error setting up the program");
   if (!noWriteProgram) {
     testFailed("Setup a program where fragment shader writes nothing failed");
@@ -571,7 +532,7 @@ function runDrawTests() {
     gl.useProgram(noWriteProgram);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
+    drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
     gl.deleteProgram(noWriteProgram);
   }
 
@@ -581,7 +542,7 @@ function runDrawTests() {
   gl.useProgram(redProgram);
   wtu.clearAndDrawUnitQuad(gl);
 
-  checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
 
   debug("test that gl_FragColor does not broadcast unless extension is enabled in fragment shader");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
@@ -589,7 +550,7 @@ function runDrawTests() {
   gl.useProgram(redProgram);
   wtu.drawUnitQuad(gl);
 
-  checkAttachmentsForColorFn(attachments, function(attachment, index) {
+  drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
     return (index == 0) ? [255, 0, 0, 255] : [0, 255, 0, 255];
   });
 
@@ -600,17 +561,17 @@ function runDrawTests() {
   gl.useProgram(redProgramWithExtension);
   wtu.drawUnitQuad(gl);
 
-  checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
   if (maxUsable > 1) {
     // First half of color buffers disable.
-    var bufs1 = makeColorAttachmentArray(maxUsable);
+    var bufs1 = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
     // Second half of color buffers disable.
-    var bufs2 = makeColorAttachmentArray(maxUsable);
+    var bufs2 = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
     // Color buffers with even indices disabled.
-    var bufs3 = makeColorAttachmentArray(maxUsable);
+    var bufs3 = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
     // Color buffers with odd indices disabled.
-    var bufs4 = makeColorAttachmentArray(maxUsable);
+    var bufs4 = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
     for (var ii = 0; ii < maxUsable; ++ii) {
       if (ii < half) {
         bufs1[ii] = gl.NONE;
@@ -637,7 +598,7 @@ function runDrawTests() {
     gl.clearColor(0, 1, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? [255, 0, 0, 255] : [0, 255, 0, 255];
     });
 
@@ -647,7 +608,7 @@ function runDrawTests() {
     gl.useProgram(drawProgram);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? [255, 0, 0, 255] : attachment.color;
     });
 
@@ -661,7 +622,7 @@ function runDrawTests() {
     ext.drawBuffersWEBGL(bufs2);
     gl.clearColor(0, 0, 1, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? [0, 0, 255, 255] : [255, 0, 0, 255];
     });
 
@@ -671,7 +632,7 @@ function runDrawTests() {
     gl.useProgram(drawProgram);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? attachment.color : [255, 0, 0, 255];
     });
 
@@ -685,7 +646,7 @@ function runDrawTests() {
     gl.clearColor(1, 0, 1, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return (index % 2) ? [255, 0, 0, 255] : [255, 0, 255, 255];
     });
 
@@ -699,7 +660,7 @@ function runDrawTests() {
     ext.drawBuffersWEBGL(bufs4);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return (index % 2 == 0) ? [0, 0, 0, 255] : attachment.color;
     });
 
@@ -747,18 +708,18 @@ function runDrawTests() {
   ext.drawBuffersWEBGL(bufs);
   gl.clearColor(1, 0, 0, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
-  checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
   // fb2 still has the NONE draw buffers from before, so this draw should be a no-op.
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
   gl.useProgram(drawProgram);
   wtu.drawUnitQuad(gl);
-  checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   gl.useProgram(drawProgram);
   wtu.drawUnitQuad(gl);
-  checkAttachmentsForColor(attachments);
+  drawBuffersUtils.checkAttachmentsForColor(attachments);
 
   debug("test queries");
   debug("check framebuffer with all attachments on");

--- a/sdk/tests/js/tests/webgl-draw-buffers-utils.js
+++ b/sdk/tests/js/tests/webgl-draw-buffers-utils.js
@@ -1,0 +1,77 @@
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+// This file contains utilities shared between tests for the WEBGL_draw_buffers extension.
+
+'use strict';
+
+var WebGLDrawBuffersUtils = function(gl, ext) {
+
+  var getMaxUsableColorAttachments = function() {
+    var maxDrawingBuffers = gl.getParameter(ext.MAX_DRAW_BUFFERS_WEBGL);
+    var maxColorAttachments = gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_WEBGL);
+    var maxUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
+    return Math.min(maxDrawingBuffers, maxColorAttachments, maxUniformVectors);
+  };
+
+  var makeColorAttachmentArray = function(size) {
+    var array = []
+    for (var ii = 0; ii < size; ++ii) {
+      array.push(gl.COLOR_ATTACHMENT0 + ii);
+    }
+    return array;
+  }
+
+  var checkProgram = wtu.setupTexturedQuad(gl);
+
+  var checkAttachmentsForColorFn = function(attachments, colorFn) {
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.useProgram(checkProgram);
+    attachments.forEach(function(attachment, index) {
+      gl.bindTexture(gl.TEXTURE_2D, attachment.texture);
+      wtu.clearAndDrawUnitQuad(gl);
+      var expectedColor = colorFn(attachment, index);
+      var tolerance = 0;
+      expectedColor.forEach(function(v) {
+        if (v != 0 && v != 255) {
+          tolerance = 8;
+        }
+      });
+      wtu.checkCanvas(gl, expectedColor, "attachment " + index + " should be " + expectedColor.toString(), tolerance);
+    });
+    debug("");
+  };
+
+  var checkAttachmentsForColor = function(attachments, color) {
+    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+      return color || attachment.color;
+    });
+  };
+
+  return {
+    getMaxUsableColorAttachments: getMaxUsableColorAttachments,
+    makeColorAttachmentArray: makeColorAttachmentArray,
+    checkAttachmentsForColorFn: checkAttachmentsForColorFn,
+    checkAttachmentsForColor: checkAttachmentsForColor
+  };
+};


### PR DESCRIPTION
The test verifies that the value written to gl_FragColor is
broadcasted correctly regardless of any return statements in main().

This exposes a bug in ANGLE.

The patch includes refactoring of webgl-draw-buffers.html: Common
functionality with the new test is moved to a new utility file, and
simpleVertexShader from WebGLTestUtils is now used.