### PR TITLE
Add a multiple render targets test for discarding fragment

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-draw-buffers-broadcast-return.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers-broadcast-return.html
@@ -39,7 +39,7 @@
 <div id="description"></div>
 <canvas id="canvas" width="64" height="64"> </canvas>
 <div id="console"></div>
-<script id="fshaderRedWithExtensionWithReturn" type="x-shader/x-fragment">
+<script id="fshaderRedWithReturn" type="x-shader/x-fragment">
 #extension GL_EXT_draw_buffers : require
 precision mediump float;
 uniform float u_zero;
@@ -47,6 +47,18 @@ void main() {
     gl_FragColor = vec4(1,0,0,1);
     if (u_zero < 1.0) {
         return;
+    }
+    gl_FragColor = vec4(0,0,1,1);
+}
+</script>
+<script id="fshaderWithDiscard" type="x-shader/x-fragment">
+#extension GL_EXT_draw_buffers : require
+precision mediump float;
+uniform float u_zero;
+void main() {
+    gl_FragColor = vec4(1,0,0,1);
+    if (u_zero < 1.0) {
+        discard;
     }
     gl_FragColor = vec4(0,0,1,1);
 }
@@ -86,7 +98,6 @@ function runDrawTests() {
   var maxUsable = drawBuffersUtils.getMaxUsableColorAttachments();
   var bufs = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
 
-  var redProgramWithExtensionWithReturn = wtu.setupProgram(gl, [wtu.simpleVertexShader, "fshaderRedWithExtensionWithReturn"], ["vPosition"], undefined, true);
   var width = 64;
   var height = 64;
   var attachments = [];
@@ -108,13 +119,27 @@ function runDrawTests() {
   debug("test that gl_FragColor broadcasts if extension is enabled in fragment shader and fragment shader main returns in the middle");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   ext.drawBuffersWEBGL(bufs);
+  var redProgramWithReturn = wtu.setupProgram(gl, [wtu.simpleVertexShader, "fshaderRedWithReturn"], ["vPosition"], undefined, true);
   shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
   gl.clearColor(0, 0, 0, 0);
   gl.clear(gl.COLOR_BUFFER_BIT);
-  gl.useProgram(redProgramWithExtensionWithReturn);
+  gl.useProgram(redProgramWithReturn);
   wtu.drawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after draw");
 
   drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+
+  debug("test that none of the attachments are written in case the fragment shader discards");
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  ext.drawBuffersWEBGL(bufs);
+  var programWithDiscard = wtu.setupProgram(gl, [wtu.simpleVertexShader, "fshaderWithDiscard"], ["vPosition"], undefined, true);
+  gl.clearColor(0, 0, 0, 0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.useProgram(programWithDiscard);
+  wtu.drawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "after draw");
+
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 0, 0, 0]);
 
   gl.bindTexture(gl.TEXTURE_2D, null);
   gl.bindFramebuffer(gl.FRAMEBUFFER, null);
@@ -122,7 +147,8 @@ function runDrawTests() {
   attachments.forEach(function(attachment) {
     gl.deleteTexture(attachment.texture);
   });
-  gl.deleteProgram(redProgramWithExtensionWithReturn);
+  gl.deleteProgram(redProgramWithReturn);
+  gl.deleteProgram(programWithDiscard);
 }
 
 var successfullyParsed = true;

--- a/sdk/tests/conformance2/rendering/draw-buffers.html
+++ b/sdk/tests/conformance2/rendering/draw-buffers.html
@@ -33,6 +33,7 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/webgl-draw-buffers-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -58,6 +59,20 @@ uniform vec4 u_colors[$(numDrawingBuffers)];
 out vec4 my_FragData[$(numDrawingBuffers)];
 void main() {
 $(assignUColorsToFragData)
+}
+</script>
+<script id="fshaderDiscard" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+uniform vec4 u_colors[$(numDrawingBuffers)];
+uniform float u_zero;
+
+// Only one out variable - does not need explicit output layout (ESSL 3 section 4.3.8.2)
+out vec4 my_FragData[$(numDrawingBuffers)];
+void main() {
+$(assignUColorsToFragData)
+    if (u_zero < 1.0) {
+        discard;
+    }
 }
 </script>
 <script id="fshaderRed" type="x-shader/x-fragment">#version 300 es
@@ -91,13 +106,14 @@ debug("");
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
-var output = document.getElementById("console");
 var gl = wtu.create3DContext(canvas, null, 2);
+var drawBuffersUtils;
 
 if (!gl) {
   testFailed("WebGL context does not exist");
 } else {
   testPassed("WebGL context exists");
+  drawBuffersUtils = WebGLDrawBuffersUtils(gl);
 
   if (testParameters()) {
     runShadersTest();
@@ -111,8 +127,7 @@ if (!gl) {
 function createDrawBuffersProgram(scriptId, sub) {
   var fsource = wtu.getScript(scriptId);
   fsource = wtu.replaceParams(fsource, sub);
-  wtu.addShaderSource(output, "fragment shader", fsource);
-  return wtu.setupProgram(gl, ["vshaderESSL3", fsource], ["a_position"]);
+  return wtu.setupProgram(gl, ["vshaderESSL3", fsource], ["a_position"], undefined, true);
 }
 
 function runShadersTest() {
@@ -136,14 +151,6 @@ function makeArray(size, value) {
   return array;
 }
 
-function makeColorAttachmentArray(size) {
-  var array = []
-  for (var ii = 0; ii < size; ++ii) {
-    array.push(gl.COLOR_ATTACHMENT0 + ii);
-  }
-  return array;
-}
-
 function runAttachmentTest() {
   debug("");
   debug("test attachment enabled");
@@ -161,7 +168,7 @@ function runAttachmentTest() {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to attach to the max attachment point: gl.COLOR_ATTACHMENT0 + " + (maxColorAttachments - 1));
   gl.drawBuffers(makeArray(maxDrawingBuffers, gl.NONE));
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with array NONE of size " + maxColorAttachments);
-  var bufs = makeColorAttachmentArray(maxDrawingBuffers);
+  var bufs = drawBuffersUtils.makeColorAttachmentArray(maxDrawingBuffers);
   gl.drawBuffers(bufs);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with array attachments of size " + maxColorAttachments);
   bufs[0] = gl.NONE;
@@ -172,7 +179,7 @@ function runAttachmentTest() {
     bufs[1] = gl.COLOR_ATTACHMENT0;
     gl.drawBuffers(bufs);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should not be able to call drawBuffers with out of order attachments of size " + maxColorAttachments);
-    var bufs = makeColorAttachmentArray(Math.floor(maxDrawingBuffers / 2));
+    var bufs = drawBuffersUtils.makeColorAttachmentArray(Math.floor(maxDrawingBuffers / 2));
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be able to call drawBuffers with short array of attachments of size " + bufs.length);
   }
 
@@ -215,11 +222,9 @@ function runDrawTests() {
   var middleFB = gl.createFramebuffer();
 
   var maxDrawingBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
-  var maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
-  var maxUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
-  var maxUsable = Math.min(maxDrawingBuffers, maxColorAttachments, maxUniformVectors);
+  var maxUsable = drawBuffersUtils.getMaxUsableColorAttachments();
   var half = Math.floor(maxUsable / 2);
-  var bufs = makeColorAttachmentArray(maxUsable);
+  var bufs = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
   var nones = makeArray(maxUsable, gl.NONE);
 
   [fb, fb2, halfFB1, halfFB2, endsFB, middleFB].forEach(function(fbo) {
@@ -269,7 +274,6 @@ function runDrawTests() {
     gl.uniform4fv(location, floatColor);
     attachments.push({
       texture: tex,
-      location: location,
       color: color
     });
   }
@@ -277,30 +281,6 @@ function runDrawTests() {
   shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
   shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
-
-  var checkAttachmentsForColorFn = function(attachments, colorFn) {
-    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    gl.useProgram(checkProgram);
-    attachments.forEach(function(attachment, index) {
-      gl.bindTexture(gl.TEXTURE_2D, attachment.texture);
-      wtu.clearAndDrawUnitQuad(gl);
-      var expectedColor = colorFn(attachment, index);
-      var tolerance = 0;
-      expectedColor.forEach(function(v) {
-        if (v != 0 && v != 255) {
-          tolerance = 8;
-        }
-      });
-      wtu.checkCanvas(gl, expectedColor, "attachment " + index + " should be " + expectedColor.toString(), tolerance);
-    });
-    debug("");
-  };
-
-  var checkAttachmentsForColor = function(attachments, color) {
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
-      return color || attachment.color;
-    });
-  };
 
   var drawAndCheckAttachments = function(testFB, msg, testFn) {
     debug("test clearing " + msg);
@@ -322,7 +302,7 @@ function runDrawTests() {
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
     gl.clearColor(0, 0, 0, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    //checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    //drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
     //  return [0, 0, 0, 0];
     //});
     //debug("--");
@@ -332,7 +312,7 @@ function runDrawTests() {
 
     gl.clearColor(0, 1, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return testFn(attachment, index) ? [0, 255, 0, 255] : [0, 0, 0, 0];
     });
 
@@ -343,7 +323,7 @@ function runDrawTests() {
     gl.bindFramebuffer(gl.FRAMEBUFFER, testFB);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return testFn(attachment, index) ? attachment.color : [0, 0, 0, 0];
     });
   };
@@ -358,14 +338,14 @@ function runDrawTests() {
 
   debug("test that each texture got the correct color.");
 
-  checkAttachmentsForColor(attachments);
+  drawBuffersUtils.checkAttachmentsForColor(attachments);
 
   debug("test clearing clears all the textures");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   gl.clearColor(0, 1, 0, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
-  checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
 
   debug("test that NONE draws nothing");
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
@@ -373,7 +353,7 @@ function runDrawTests() {
   gl.useProgram(redProgram);
   wtu.clearAndDrawUnitQuad(gl);
 
-  checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
 
   // GLES3 spec section 3.9.2 Shader Outputs
   debug("test that gl_FragColor only writes to color number zero");
@@ -382,7 +362,7 @@ function runDrawTests() {
   gl.useProgram(blueProgramESSL1);
   wtu.drawUnitQuad(gl);
 
-  checkAttachmentsForColorFn(attachments, function(attachment, index) {
+  drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
     return (index == 0) ? [0, 0, 255, 255] : [0, 255, 0, 255];
   });
 
@@ -394,7 +374,7 @@ function runDrawTests() {
   gl.useProgram(redProgram);
   wtu.drawUnitQuad(gl);
 
-  checkAttachmentsForColorFn(attachments, function(attachment, index) {
+  drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
     return (index == 0) ? [255, 0, 0, 255] : [0, 255, 0, 255];
   });
 
@@ -405,10 +385,10 @@ function runDrawTests() {
     gl.drawBuffers(bufs);
     gl.clearColor(1, 0, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+    drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
-    var bufs1 = makeColorAttachmentArray(maxUsable);
-    var bufs2 = makeColorAttachmentArray(maxUsable);
+    var bufs1 = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
+    var bufs2 = drawBuffersUtils.makeColorAttachmentArray(maxUsable);
     for (var ii = 0; ii < maxUsable; ++ii) {
       if (ii < half) {
         bufs1[ii] = gl.NONE;
@@ -424,7 +404,7 @@ function runDrawTests() {
     gl.clearColor(0, 1, 0, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? [255, 0, 0, 255] : [0, 255, 0, 255];
     });
 
@@ -434,7 +414,7 @@ function runDrawTests() {
     gl.useProgram(drawProgram);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? [255, 0, 0, 255] : attachment.color;
     });
 
@@ -447,7 +427,7 @@ function runDrawTests() {
     gl.drawBuffers(bufs2);
     gl.clearColor(0, 0, 1, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? [0, 0, 255, 255] : [255, 0, 0, 255];
     });
 
@@ -457,7 +437,7 @@ function runDrawTests() {
     gl.useProgram(drawProgram);
     wtu.drawUnitQuad(gl);
 
-    checkAttachmentsForColorFn(attachments, function(attachment, index) {
+    drawBuffersUtils.checkAttachmentsForColorFn(attachments, function(attachment, index) {
       return index < half ? attachment.color : [255, 0, 0, 255];
     });
 
@@ -505,17 +485,28 @@ function runDrawTests() {
   gl.drawBuffers(bufs);
   gl.clearColor(1, 0, 0, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
-  checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
   gl.useProgram(drawProgram);
   wtu.drawUnitQuad(gl);
-  checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [255, 0, 0, 255]);
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
   gl.useProgram(drawProgram);
   wtu.drawUnitQuad(gl);
-  checkAttachmentsForColor(attachments);
+  drawBuffersUtils.checkAttachmentsForColor(attachments);
+
+  debug("test that none of the attachments are written in case the fragment shader discards");
+  var discardProgram = createDrawBuffersProgram("fshaderDiscard",
+      {numDrawingBuffers: maxDrawingBuffers, assignUColorsToFragData: assignCode.join("\n")});
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  gl.drawBuffers(bufs);
+  gl.clearColor(0, 0, 0, 0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.useProgram(discardProgram);
+  wtu.drawUnitQuad(gl);
+  drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 0, 0, 0]);
 
   debug("test queries");
   debug("check framebuffer with all attachments on");
@@ -532,6 +523,7 @@ function runDrawTests() {
 
   // WebGL generates FRAMEBUFFER_INCOMPLETE_DIMENSIONS when attached images have different sizes.
   // This behavior differs from GLES 3.
+  debug("");
   debug("test attachment size mis-match");
   gl.bindTexture(gl.TEXTURE_2D, attachments[0].texture);
   gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width * 2, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);

--- a/sdk/tests/js/tests/webgl-draw-buffers-utils.js
+++ b/sdk/tests/js/tests/webgl-draw-buffers-utils.js
@@ -21,15 +21,24 @@
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
 
-// This file contains utilities shared between tests for the WEBGL_draw_buffers extension.
+// This file contains utilities shared between tests for the WEBGL_draw_buffers extension and multiple draw buffers functionality in WebGL 2.0.
 
 'use strict';
 
 var WebGLDrawBuffersUtils = function(gl, ext) {
 
   var getMaxUsableColorAttachments = function() {
-    var maxDrawingBuffers = gl.getParameter(ext.MAX_DRAW_BUFFERS_WEBGL);
-    var maxColorAttachments = gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_WEBGL);
+    var maxDrawingBuffers;
+    var maxColorAttachments;
+    if (ext) {
+      // EXT_draw_buffers
+      maxDrawingBuffers = gl.getParameter(ext.MAX_DRAW_BUFFERS_WEBGL);
+      maxColorAttachments = gl.getParameter(ext.MAX_COLOR_ATTACHMENTS_WEBGL);
+    } else {
+      // WebGL 2.0
+      maxDrawingBuffers = gl.getParameter(gl.MAX_DRAW_BUFFERS);
+      maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
+    }
     var maxUniformVectors = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
     return Math.min(maxDrawingBuffers, maxColorAttachments, maxUniformVectors);
   };


### PR DESCRIPTION
Add new multiple render target subtests that do a discard in the
fragment shader. The new subtests are added to both WebGL 1.0
EXT_draw_buffers tests and WebGL 2.0 core tests.

The new subtests are not expected to expose existing bugs.

The patch includes refactoring the WebGL 2.0 draw buffers test so that
it shares utility code with the EXT_draw_buffers test.