### PR TITLE
Revise spec on untouched fragment outputs to match implementations

### DIFF
--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -74,7 +74,7 @@
         If the WEBGL_draw_buffers extension is enabled, but the fragment shader does not contain the <code>#extension GL_EXT_draw_buffers</code> directive to enable it, then writes to <code>gl_FragColor</code> are only written to <code>COLOR_ATTACHMENT0_WEBGL</code>, and not broadcast to all color attachments. In this scenario, other color attachments are guaranteed to remain untouched.
       </addendum>
       <addendum>
-        If a fragment shader writes to neither <code>gl_FragColor</code> nor <code>gl_FragData</code>, the values of
+        If a fragment shader statically uses neither <code>gl_FragColor</code> nor <code>gl_FragData</code>, the values of
         the fragment colors following shader execution are untouched.
 
         If a fragment shader contains the <code>#extension GL_EXT_draw_buffers</code> directive, all
@@ -180,6 +180,9 @@ interface WEBGL_draw_buffers {
     </revision>
     <revision date="2016/07/23">
       <change>Revised behavior of the same image is attached to more than one color attachment point.</change>
+    </revision>
+    <revision date="2017/07/19">
+      <change>Fragment outputs are not guaranteed to be untouched in case they are statically used, even if they are not written.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -71,12 +71,9 @@
         The value of <code>gl_MaxDrawBuffers</code> must match <code>MAX_DRAW_BUFFERS_WEBGL</code> from the API if the extension is enabled in a WebGL context; otherwise, the value must be 1. Whether or not the extension is enabled with the <code>#extension GL_EXT_draw_buffers</code> directive in a shader does not affect the value of <code>gl_MaxDrawBuffers</code>. The value of <code>gl_MaxDrawBuffers</code> is a constant in the shader, and is guaranteed to be frozen at program link time. It is implementation-dependent whether it is frozen at shader compile time. (A consequence is that if a program is linked, and later the WEBGL_draw_buffers extension is enabled, the value of <code>gl_MaxDrawBuffers</code> seen by that program will still be 1.)
       </addendum>
       <addendum>
-        If the WEBGL_draw_buffers extension is enabled, but the fragment shader does not contain the <code>#extension GL_EXT_draw_buffers</code> directive to enable it, then writes to <code>gl_FragColor</code> are only written to <code>COLOR_ATTACHMENT0_WEBGL</code>, and not broadcast to all color attachments. In this scenario, other color attachments are guaranteed to remain untouched.
+        If the WEBGL_draw_buffers extension is enabled, but the fragment shader does not contain the <code>#extension GL_EXT_draw_buffers</code> directive to enable it, then the value of <code>gl_FragColor</code> is only written to <code>COLOR_ATTACHMENT0_WEBGL</code>, and not broadcast to all color attachments. In this scenario, other color attachments are guaranteed to remain untouched.
       </addendum>
       <addendum>
-        If a fragment shader statically uses neither <code>gl_FragColor</code> nor <code>gl_FragData</code>, the values of
-        the fragment colors following shader execution are untouched.
-
         If a fragment shader contains the <code>#extension GL_EXT_draw_buffers</code> directive, all
         <code>gl_FragData</code> variables (from <code>gl_FragData[0]</code> to <code>gl_FragData[MAX_DRAW_BUFFERS_WEBGL - 1]</code>)
         default to zero if no values are written to them during a shader execution.
@@ -181,8 +178,8 @@ interface WEBGL_draw_buffers {
     <revision date="2016/07/23">
       <change>Revised behavior of the same image is attached to more than one color attachment point.</change>
     </revision>
-    <revision date="2017/07/19">
-      <change>Fragment outputs are not guaranteed to be untouched in case they are statically used, even if they are not written.</change>
+    <revision date="2017/07/20">
+      <change>Fragment outputs are always initialized even if they are not written.</change>
     </revision>
   </history>
 </ratified>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -4090,7 +4090,7 @@ extensions.
 <h3>Fragment shader output</h3>
 
 <p>
-    If a fragment shader writes to neither <code>gl_FragColor</code> nor <code>gl_FragData</code>,
+    If a fragment shader statically uses neither <code>gl_FragColor</code> nor <code>gl_FragData</code>,
     the values of the fragment colors following shader execution are untouched.
 </p>
 

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -4090,9 +4090,23 @@ extensions.
 <h3>Fragment shader output</h3>
 
 <p>
-    If a fragment shader statically uses neither <code>gl_FragColor</code> nor <code>gl_FragData</code>,
-    the values of the fragment colors following shader execution are untouched.
+    If a fragment statically uses neither <code>gl_FragColor</code> nor <code>gl_FragData</code>, it
+    behaves as if (0, 0, 0, 0) would be assigned to <code>gl_FragColor</code> in the beginning of
+    the shader.
 </p>
+
+<p>
+    Statically used fragment output variables default to zero if they are not written during a
+    shader execution.
+</p>
+
+<div class="note rationale">
+    The values written to the framebuffer can be undefined in the GLES specification in case
+    gl_FragColor and gl_FragData are not written. Initializing them should not have a significant
+    performance impact on algorithms that don't need to write color values to the framebuffer, as
+    they may simply use a framebuffer without a color buffer or a color mask to disable writing
+    fragment colors.
+</div>
 
 <h3>Initial values for GLSL local and global variables</h3>
 

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3325,13 +3325,16 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
     </div>
 
     <p>
-        If an ESSL1 fragment shader writes to neither <code>gl_FragColor</code> nor <code>gl_FragData</code>,
-        the values of the fragment colors following shader execution are untouched. If corresponding output
-        variables are not defined in an ESSL3 fragment shader, the values of the fragment colors following
-        shader execution are untouched.
+        If fragment output variables are not defined in an ESSL3 fragment shader, the values of the
+        fragment colors following shader execution are untouched.
     </p>
     <p>
-        All user-defined output variables default to zero if they are not written during a shader execution.
+        All user-defined fragment output variables default to zero if they are not written during a
+        shader execution.
+    </p>
+    <p>
+        Statically used built-in fragment output variables default to zero if they are not written
+        during a shader execution.
     </p>
 
     <div class="note">


### PR DESCRIPTION
At least on ANGLE-based WebGL implementations, fragment color is
always written into the framebuffer if gl_FragColor or gl_FragData is
statically used in the shader.

Since this doesn't seem to be causing any problems, the easiest way
to fix this is to change the spec to match the implementation.