### PR TITLE
Relax texture switch performance test from #2448 .

### DIFF
--- a/sdk/tests/conformance/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance/rendering/texture-switch-performance.html
@@ -76,7 +76,7 @@ if (!gl) {
     ++frameCount;
 
     if (Date.now() - startTime > 5000) {
-      if (frameCount > 150) {  // 30FPS
+      if (frameCount > 50) {  // 10FPS
         testPassed("Texture switching did not significantly hurt performance");
       } else {
         testFailed("Texture switching significantly hurt performance");

--- a/sdk/tests/conformance/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance/rendering/texture-switch-performance.html
@@ -66,7 +66,7 @@ if (!gl) {
   var frameCount = 0;
 
   function draw() {
-    for (var i = 0; i < 200; ++i) {
+    for (var i = 0; i < 400; ++i) {
       gl.uniform1i(loc, 0);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
       gl.uniform1i(loc, 1);
@@ -76,10 +76,11 @@ if (!gl) {
     ++frameCount;
 
     if (Date.now() - startTime > 5000) {
-      if (frameCount > 50) {  // 10FPS
-        testPassed("Texture switching did not significantly hurt performance");
+      var perfString = " - achieved " + frameCount + " frames in " + ((Date.now() - startTime) / 1000.0) + " seconds";
+      if (frameCount > 75) {  // 15 FPS
+        testPassed("Texture switching did not significantly hurt performance" + perfString);
       } else {
-        testFailed("Texture switching significantly hurt performance");
+        testFailed("Texture switching significantly hurt performance" + perfString);
       }
       console.log(frameCount);
       finishTest();

--- a/sdk/tests/conformance2/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance2/rendering/texture-switch-performance.html
@@ -76,7 +76,7 @@ if (!gl) {
     ++frameCount;
 
     if (Date.now() - startTime > 5000) {
-      if (frameCount > 150) {  // 30FPS
+      if (frameCount > 50) {  // 10FPS
         testPassed("Texture switching did not significantly hurt performance");
       } else {
         testFailed("Texture switching significantly hurt performance");

--- a/sdk/tests/conformance2/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance2/rendering/texture-switch-performance.html
@@ -66,7 +66,7 @@ if (!gl) {
   var frameCount = 0;
 
   function draw() {
-    for (var i = 0; i < 200; ++i) {
+    for (var i = 0; i < 400; ++i) {
       gl.uniform1i(loc, 0);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
       gl.uniform1i(loc, 1);
@@ -76,10 +76,11 @@ if (!gl) {
     ++frameCount;
 
     if (Date.now() - startTime > 5000) {
-      if (frameCount > 50) {  // 10FPS
-        testPassed("Texture switching did not significantly hurt performance");
+      var perfString = " - achieved " + frameCount + " frames in " + ((Date.now() - startTime) / 1000.0) + " seconds";
+      if (frameCount > 75) {  // 15 FPS
+        testPassed("Texture switching did not significantly hurt performance" + perfString);
       } else {
-        testFailed("Texture switching significantly hurt performance");
+        testFailed("Texture switching significantly hurt performance" + perfString);
       }
       console.log(frameCount);
       finishTest();


### PR DESCRIPTION
This test assumed it will achieve a steady-state 30 FPS frame rate,
which is optimistic for automated test machines which build and run
debug versions of the browser. Reduce the expectation to 10 FPS.