### PR TITLE
Texture switch test compares to baseline

### DIFF
--- a/sdk/tests/conformance/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance/rendering/texture-switch-performance.html
@@ -99,7 +99,7 @@ if (!gl) {
     ++testFrameCount;
 
     if (Date.now() - testStartTime > RUNTIME) {
-      var perfString = " - achieved " + testFrameCount + " frames in " + ((Date.now() - testStartTime) / 1000.0) + 
+      var perfString = " - achieved " + testFrameCount + " frames in " + ((Date.now() - testStartTime) / 1000.0) +
         " seconds (" + (testFrameCount / baseFrameCount).toFixed(2) + " times baseline performance)";
       if (testFrameCount > baseFrameCount * THRESHOLD) {
         testPassed("Texture switching did not significantly hurt performance" + perfString);

--- a/sdk/tests/conformance/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance/rendering/texture-switch-performance.html
@@ -62,10 +62,33 @@ if (!gl) {
 
   var loc = gl.getUniformLocation(program, "tex");
 
-  var startTime = Date.now();
-  var frameCount = 0;
+  var RUNTIME = 2000;
+  var THRESHOLD = 0.8;
+  var baseStartTime = 0;
+  var baseFrameCount = 0;
+  var testStartTime = 0;
+  var testFrameCount = 0;
 
-  function draw() {
+  baseStartTime = Date.now();
+  function drawBaseline() {
+    for (var i = 0; i < 400; ++i) {
+      gl.uniform1i(loc, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      gl.uniform1i(loc, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    ++baseFrameCount;
+
+    if (Date.now() - baseStartTime > RUNTIME) {
+      testStartTime = Date.now();
+      requestAnimationFrame(drawTest);
+    } else {
+      requestAnimationFrame(drawBaseline);
+    }
+  }
+
+  function drawTest() {
     for (var i = 0; i < 400; ++i) {
       gl.uniform1i(loc, 0);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
@@ -73,23 +96,24 @@ if (!gl) {
       gl.drawArrays(gl.TRIANGLES, 0, 6);
     }
 
-    ++frameCount;
+    ++testFrameCount;
 
-    if (Date.now() - startTime > 5000) {
-      var perfString = " - achieved " + frameCount + " frames in " + ((Date.now() - startTime) / 1000.0) + " seconds";
-      if (frameCount > 75) {  // 15 FPS
+    if (Date.now() - testStartTime > RUNTIME) {
+      var perfString = " - achieved " + testFrameCount + " frames in " + ((Date.now() - testStartTime) / 1000.0) + 
+        " seconds (" + (testFrameCount / baseFrameCount).toFixed(2) + " times baseline performance)";
+      if (testFrameCount > baseFrameCount * THRESHOLD) {
         testPassed("Texture switching did not significantly hurt performance" + perfString);
       } else {
         testFailed("Texture switching significantly hurt performance" + perfString);
       }
-      console.log(frameCount);
+      console.log(testFrameCount);
       finishTest();
     } else {
-      requestAnimationFrame(draw);
+      requestAnimationFrame(drawTest);
     }
   }
 
-  requestAnimationFrame(draw);
+  requestAnimationFrame(drawBaseline);
 }
 var successfullyParsed = true;
 </script>

--- a/sdk/tests/conformance2/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance2/rendering/texture-switch-performance.html
@@ -99,7 +99,7 @@ if (!gl) {
     ++testFrameCount;
 
     if (Date.now() - testStartTime > RUNTIME) {
-      var perfString = " - achieved " + testFrameCount + " frames in " + ((Date.now() - testStartTime) / 1000.0) + 
+      var perfString = " - achieved " + testFrameCount + " frames in " + ((Date.now() - testStartTime) / 1000.0) +
         " seconds (" + (testFrameCount / baseFrameCount).toFixed(2) + " times baseline performance)";
       if (testFrameCount > baseFrameCount * THRESHOLD) {
         testPassed("Texture switching did not significantly hurt performance" + perfString);

--- a/sdk/tests/conformance2/rendering/texture-switch-performance.html
+++ b/sdk/tests/conformance2/rendering/texture-switch-performance.html
@@ -62,10 +62,33 @@ if (!gl) {
 
   var loc = gl.getUniformLocation(program, "tex");
 
-  var startTime = Date.now();
-  var frameCount = 0;
+  var RUNTIME = 2000;
+  var THRESHOLD = 0.8;
+  var baseStartTime = 0;
+  var baseFrameCount = 0;
+  var testStartTime = 0;
+  var testFrameCount = 0;
 
-  function draw() {
+  baseStartTime = Date.now();
+  function drawBaseline() {
+    for (var i = 0; i < 400; ++i) {
+      gl.uniform1i(loc, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+      gl.uniform1i(loc, 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    ++baseFrameCount;
+
+    if (Date.now() - baseStartTime > RUNTIME) {
+      testStartTime = Date.now();
+      requestAnimationFrame(drawTest);
+    } else {
+      requestAnimationFrame(drawBaseline);
+    }
+  }
+
+  function drawTest() {
     for (var i = 0; i < 400; ++i) {
       gl.uniform1i(loc, 0);
       gl.drawArrays(gl.TRIANGLES, 0, 6);
@@ -73,23 +96,24 @@ if (!gl) {
       gl.drawArrays(gl.TRIANGLES, 0, 6);
     }
 
-    ++frameCount;
+    ++testFrameCount;
 
-    if (Date.now() - startTime > 5000) {
-      var perfString = " - achieved " + frameCount + " frames in " + ((Date.now() - startTime) / 1000.0) + " seconds";
-      if (frameCount > 75) {  // 15 FPS
+    if (Date.now() - testStartTime > RUNTIME) {
+      var perfString = " - achieved " + testFrameCount + " frames in " + ((Date.now() - testStartTime) / 1000.0) + 
+        " seconds (" + (testFrameCount / baseFrameCount).toFixed(2) + " times baseline performance)";
+      if (testFrameCount > baseFrameCount * THRESHOLD) {
         testPassed("Texture switching did not significantly hurt performance" + perfString);
       } else {
         testFailed("Texture switching significantly hurt performance" + perfString);
       }
-      console.log(frameCount);
+      console.log(testFrameCount);
       finishTest();
     } else {
-      requestAnimationFrame(draw);
+      requestAnimationFrame(drawTest);
     }
   }
 
-  requestAnimationFrame(draw);
+  requestAnimationFrame(drawBaseline);
 }
 var successfullyParsed = true;
 </script>


### PR DESCRIPTION
@kenrussell  Set up both the WebGL and WebGL 2 texture switch performance tests to first run for 2 seconds without switching textures to get a baseline frame count, then run again for 2 seconds while switching textures to get a test frame count to compare it to. 

I currently have it set up to fail if the test frame count drops below 80% of the baseline. This is well above what the affected AMD/Mac machine I have to test on can achieve (40-45%). The lowest I've seen from a passing machine is 88% on my Nexus 10, but there's still room to tweak the threshold if you need to.

The test run time and threshold are stored in RUNTIME and THRESHOLD variables near the start of the test so they're easy to tweak. The tests didn't become that much more complicated, so I didn't bother to refactor, but let me know if you still want to do that.