### PR TITLE
Moved WebGL 2.0.0 to final state per ratification vote by Khronos

### DIFF
--- a/specs/2.0.0/index.html
+++ b/specs/2.0.0/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <title>WebGL 2 Specification</title>
-    <link rel="stylesheet" type="text/css" href="../../resources/Khronos-WD.css" />
+    <link rel="stylesheet" type="text/css" href="../../resources/Khronos-Final.css" />
     <script src="../../resources/jquery-1.3.2.min.js" type="application/javascript"></script>
     <script src="../../resources/generateTOC.js" type="application/javascript"></script>
 </head>
@@ -3863,7 +3863,6 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
 
     <h2>References</h2>
 
-    <h3>Normative references</h3>
     <dl>
         <dt id="refsWEBGL10">[WEBGL10]</dt>
         <dd><cite><a href="http://www.khronos.org/registry/webgl/specs/1.0/">


### PR DESCRIPTION
Promoters on June 30, 2017.

Synced with snapshotted version.