### PR TITLE
Clean up uniform buffer tests

### DIFF
--- a/sdk/tests/conformance2/buffers/uniform-buffers.html
+++ b/sdk/tests/conformance2/buffers/uniform-buffers.html
@@ -137,6 +137,8 @@ if (!gl) {
     testPassed("WebGL context exists");
 
     runBindingTest();
+    runBadShaderTest();
+    runUniformBufferOffsetAlignmentTest();
     runDrawTest();
     runNamedDrawTest();
     runNamedArrayDrawTest();
@@ -174,18 +176,52 @@ function runBindingTest() {
     shouldBeNull("gl.getParameter(gl.UNIFORM_BUFFER_BINDING)");
 }
 
-function runDrawTest() {
+function runBadShaderTest() {
     debug("");
-    debug("Testing drawing with uniform buffers");
-
-    wtu.setupUnitQuad(gl);
-
     var testProgram = wtu.setupProgram(gl, ['vshader', 'fbadshader']);
     if (testProgram) {
         testFailed("To define the same uniform in two uniform blocks should fail");
     } else {
         testPassed("To define the same uniform in two uniform blocks should fail");
     }
+}
+
+function runUniformBufferOffsetAlignmentTest() {
+    debug("");
+    var offsetAlignment = gl.getParameter(gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT);
+
+    if (offsetAlignment % 4 != 0) {
+        testFailed("Unexpected UNIFORM_BUFFER_OFFSET_ALIGNMENT - should be aligned on a 4-byte boundary");
+    } else {
+        testPassed("UNIFORM_BUFFER_OFFSET_ALIGNMENT is divisible by four");
+    }
+}
+
+function setRGBValuesToFloat32Array(floatView, red, green, blue) {
+    floatView[0] = red;
+    floatView[1] = green;
+    floatView[2] = blue;
+}
+
+function checkFloat32UniformOffsetsInStd140Layout(uniformOffsets) {
+    // Verify that the uniform offsets are set according to the std140 layout, which WebGL enforces.
+    // This function checks this for 32-bit float values, which are expected to be tightly packed.
+    for (var i = 0; i < uniformOffsets.length; ++i)
+    {
+        if (uniformOffsets[i] != i * Float32Array.BYTES_PER_ELEMENT)
+        {
+            testFailed("Uniform offsets are not according to std140 layout");
+            return false;
+        }
+    }
+    return true;
+}
+
+function runDrawTest() {
+    debug("");
+    debug("Testing drawing with uniform buffers");
+
+    wtu.setupUnitQuad(gl);
 
     var program = wtu.setupProgram(gl, ['vshader', 'fshader']);
     if (!program) {
@@ -208,28 +244,17 @@ function runDrawTest() {
         return;
     }
 
-    // Verify that the uniform offsets are aligned on 4-byte boundries
-    // While unaligned values are allowed by the ES3 spec it would be *really* weird for anyone to actually do that.
-    if (uniformOffsets_1[0] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets_1[0] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets_1[1] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets_1[1] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets_1[2] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets_1[2] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets_2[0] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets_2[0] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets_2[1] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets_2[1] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets_2[2] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets_2[2] / Float32Array.BYTES_PER_ELEMENT)) {
-        testFailed("Uniform offsets are not well aligned");
+    if (!checkFloat32UniformOffsetsInStd140Layout(uniformOffsets_1) || !checkFloat32UniformOffsetsInStd140Layout(uniformOffsets_2))
+    {
         return;
     }
 
     var uboArray_1 = new ArrayBuffer(blockSize_1);
     var uboFloatView_1 = new Float32Array(uboArray_1);
-    uboFloatView_1[uniformOffsets_1[0] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // UBORed
-    uboFloatView_1[uniformOffsets_1[1] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // UBOGreen
-    uboFloatView_1[uniformOffsets_1[2] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // UBOBlue
+    setRGBValuesToFloat32Array(uboFloatView_1, 1.0, 0.0, 0.0); // UBORed, UBOGreen, UBOBlue
     var uboArray_2 = new ArrayBuffer(blockSize_2);
     var uboFloatView_2 = new Float32Array(uboArray_2);
-    uboFloatView_2[uniformOffsets_2[0] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // UBOR
-    uboFloatView_2[uniformOffsets_2[1] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // UBOG
-    uboFloatView_2[uniformOffsets_2[2] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // UBOB
+    setRGBValuesToFloat32Array(uboFloatView_2, 1.0, 1.0, 1.0); // UBOR, UBOG, UBOB
 
     var b_1 = gl.createBuffer();
     gl.bindBuffer(gl.UNIFORM_BUFFER, b_1);
@@ -250,9 +275,7 @@ function runDrawTest() {
     wtu.checkCanvas(gl, [255, 0, 0, 255], "draw call should set canvas to red", 2);
 
     debug("Changing the data in the uniform buffer should automatically update the uniforms exposed to the draw call");
-    uboFloatView_1[uniformOffsets_1[0] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // UBORed
-    uboFloatView_1[uniformOffsets_1[1] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // UBOGreen
-    uboFloatView_1[uniformOffsets_1[2] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // UBOBlue
+    setRGBValuesToFloat32Array(uboFloatView_1, 0.0, 0.0, 1.0); // UBORed, UBOGreen, UBOBlue
     gl.bindBuffer(gl.UNIFORM_BUFFER, b_1);
     gl.bufferData(gl.UNIFORM_BUFFER, uboFloatView_1, gl.DYNAMIC_DRAW);
 
@@ -270,6 +293,7 @@ function runNamedDrawTest() {
     var program = wtu.setupProgram(gl, ['vshader', 'fshadernamed']);
     if (!program) {
         testFailed("Could not compile shader with named uniform blocks without error");
+        return;
     }
 
     var blockIndex = gl.getUniformBlockIndex(program, "UBOData");
@@ -283,20 +307,14 @@ function runNamedDrawTest() {
         return;
     }
 
-    // Verify that the uniform offsets are aligned on 4-byte boundries
-    // While unaligned values are allowed by the ES3 spec it would be *really* weird for anyone to actually do that.
-    if (uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT)) {
-        testFailed("Uniform offsets are not well aligned");
+    if (!checkFloat32UniformOffsetsInStd140Layout(uniformOffsets))
+    {
         return;
     }
 
     var uboArray = new ArrayBuffer(blockSize);
     var uboFloatView = new Float32Array(uboArray);
-    uboFloatView[uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // Red
-    uboFloatView[uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Green
-    uboFloatView[uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Blue
+    setRGBValuesToFloat32Array(uboFloatView, 1.0, 0.0, 0.0);
 
     b1 = gl.createBuffer();
     gl.bindBuffer(gl.UNIFORM_BUFFER, b1);
@@ -312,9 +330,7 @@ function runNamedDrawTest() {
     wtu.checkCanvas(gl, [255, 0, 0, 255], "draw call should set canvas to red", 2);
 
     debug("Changing the data in the uniform buffer should automatically update the uniforms exposed to the draw call");
-    uboFloatView[uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Red
-    uboFloatView[uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Green
-    uboFloatView[uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // Blue
+    setRGBValuesToFloat32Array(uboFloatView, 0.0, 0.0, 1.0);
     gl.bufferData(gl.UNIFORM_BUFFER, uboArray, gl.DYNAMIC_DRAW);
 
     wtu.clearAndDrawUnitQuad(gl);
@@ -362,29 +378,20 @@ function runNamedArrayDrawTest() {
         return;
     }
 
-    var offsetAlignment = gl.getParameter(gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT);
-    var offset = Math.ceil(blockSize[0] / offsetAlignment) * offsetAlignment;
-    // Verify that the uniform offsets are aligned on 4-byte boundries
-    // While unaligned values are allowed by the ES3 spec it would be *really* weird for anyone to actually do that.
-    if (offset / Float32Array.BYTES_PER_ELEMENT != Math.floor(offset / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT) ||
-        uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT != Math.floor(uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT)) {
-        testFailed("Uniform offsets are not well aligned");
+    if (!checkFloat32UniformOffsetsInStd140Layout(uniformOffsets))
+    {
         return;
     }
+
+    var offsetAlignment = gl.getParameter(gl.UNIFORM_BUFFER_OFFSET_ALIGNMENT);
+    var offset = Math.ceil(blockSize[0] / offsetAlignment) * offsetAlignment;
+
     var bufferSize = offset + blockSize[1];
     var uboArray = new ArrayBuffer(bufferSize);
     var uboFloatView = new Float32Array(uboArray);
-    uboFloatView[uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // Red
-    uboFloatView[uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Green
-    uboFloatView[uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Blue
-    uboFloatView[offset / Float32Array.BYTES_PER_ELEMENT +
-                 uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Red
-    uboFloatView[offset / Float32Array.BYTES_PER_ELEMENT +
-                 uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Green
-    uboFloatView[offset / Float32Array.BYTES_PER_ELEMENT +
-                 uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // Blue
+    setRGBValuesToFloat32Array(uboFloatView, 1.0, 0.0, 0.0);
+    var uboFloatView2 = new Float32Array(uboArray, offset);
+    setRGBValuesToFloat32Array(uboFloatView2, 0.0, 0.0, 1.0);
 
     b1 = gl.createBuffer();
     gl.bindBuffer(gl.UNIFORM_BUFFER, b1);
@@ -403,15 +410,8 @@ function runNamedArrayDrawTest() {
     wtu.checkCanvas(gl, [127, 0, 127, 255], "draw call should set canvas to (0.5, 0, 0.5)", 2);
 
     debug("Changing the data in the uniform buffer should automatically update the uniforms exposed to the draw call");
-    uboFloatView[uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Red
-    uboFloatView[uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // Green
-    uboFloatView[uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // Blue
-    uboFloatView[offset / Float32Array.BYTES_PER_ELEMENT +
-                 uniformOffsets[0] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Red
-    uboFloatView[offset / Float32Array.BYTES_PER_ELEMENT +
-                 uniformOffsets[1] / Float32Array.BYTES_PER_ELEMENT] = 0.0; // Green
-    uboFloatView[offset / Float32Array.BYTES_PER_ELEMENT +
-                 uniformOffsets[2] / Float32Array.BYTES_PER_ELEMENT] = 1.0; // Blue
+    setRGBValuesToFloat32Array(uboFloatView, 0.0, 1.0, 1.0);
+    setRGBValuesToFloat32Array(uboFloatView2, 0.0, 0.0, 1.0);
     gl.bufferData(gl.UNIFORM_BUFFER, uboArray, gl.DYNAMIC_DRAW);
 
     wtu.clearAndDrawUnitQuad(gl);

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3900,6 +3900,14 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
            <code>WEBGL_compressed_texture_etc</code>.
     </div>
 
+    <h3>The value of UNIFORM_BUFFER_OFFSET_ALIGNMENT must be divisible by 4</h3>
+
+    <p>The value of <code>UNIFORM_BUFFER_OFFSET_ALIGNMENT</code>, as given in basic machine units, must be divisible by 4.</p>
+
+    <div class="note rationale">
+        If the value of UNIFORM_BUFFER_OFFSET_ALIGNMENT was not divisible by 4, it would make it impractical to upload ArrayBuffers to uniform buffers which are bound with BindBufferRange.
+    </div>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>


### PR DESCRIPTION
Uniform buffer draw tests can check that the uniform buffer is in the
std140 layout, since the WebGL spec mandates std140 layout. This makes
the tests simpler and enables sharing some common functionality
between subtests as well.

This refactoring is done to make way for a few more uniform buffer
tests that are needed for bugs that recently got fixed in ANGLE
related to structs in uniform blocks.

The test was also expecting that the value of
UNIFORM_BUFFER_OFFSET_ALIGNMENT was divisible by 4, but that was
somewhat non-obvious. The test for it is also clearer now. This
requirement didn't seem to be enshrined in the spec previously, but it
is reasonable and the test has been there for a while so put it in the
spec now.