### PR TITLE
Test initializing an array with another one that has the same name

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -5,6 +5,7 @@ array-complex-indexing.html
 array-element-increment.html
 array-equality.html
 array-in-complex-expression.html
+--min-version 2.0.1 array-initialize-with-same-name-array.html
 array-length-side-effects.html
 attrib-location-length-limits.html
 bool-type-cast-bug-uint-ivec-uvec.html

--- a/sdk/tests/conformance2/glsl3/array-initialize-with-same-name-array.html
+++ b/sdk/tests/conformance2/glsl3/array-initialize-with-same-name-array.html
@@ -1,0 +1,69 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL array initializer that references an array with the same name</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderInitArray" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+out vec4 my_FragColor;
+
+void main()
+{
+    float foo[2] = float[2](1.0, 1.0);
+    {
+        float foo[2] = foo;
+        my_FragColor = vec4(0.0, foo[0], 0.0, foo[1]);
+    }
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description("Initializing an array with another array with the same name should work. See GLSL ES 3.00.6 section 4.2.2.");
+
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderInitArray',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: 'Array that is initialized with an array of the same name from an outer scope'
+},
+], 2);
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
It's possible to initialize variables with a variable with the same
name from an outer scope. This is broken in ANGLE's HLSL backend for
arrays, so add a separate test for the array case.