### PR TITLE
Require color_buffer exts if float textures are implicitly renderable.

### DIFF
--- a/sdk/tests/conformance/extensions/oes-texture-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float.html
@@ -82,41 +82,76 @@ var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
 
 if (!gl) {
-  testFailed("WebGL context does not exist");
+    testFailed("WebGL context does not exist");
 } else {
-  testPassed("WebGL context exists");
+    testPassed("WebGL context exists");
 
-  var texturedShaders = [
-      wtu.simpleTextureVertexShader,
-      "testFragmentShader"
-  ];
-  var testProgram =
-      wtu.setupProgram(gl,
-                       texturedShaders,
-                       ['vPosition', 'texCoord0'],
-                       [0, 1]);
-  var quadParameters = wtu.setupUnitQuad(gl, 0, 1);
+    var texturedShaders = [
+        wtu.simpleTextureVertexShader,
+        "testFragmentShader"
+    ];
+    var testProgram =
+        wtu.setupProgram(gl,
+                         texturedShaders,
+                         ['vPosition', 'texCoord0'],
+                         [0, 1]);
+    var quadParameters = wtu.setupUnitQuad(gl, 0, 1);
 
-  // First verify that allocation of floating-point textures fails if
-  // the extension has not been enabled yet.
-  runTextureCreationTest(testProgram, false);
+    // First verify that allocation of floating-point textures fails if
+    // the extension has not been enabled yet.
+    runTextureCreationTest(testProgram, false);
 
-  if (!gl.getExtension("OES_texture_float")) {
-      testPassed("No OES_texture_float support -- this is legal");
-  } else {
-      testPassed("Successfully enabled OES_texture_float extension");
-      // If alpha value is missing from a texture it gets filled to 1 when sampling according to GLES2.0 table 3.12
-      runTextureCreationTest(testProgram, true, gl.RGBA, 4, [10000, 10000, 10000, 10000]);
-      runTextureCreationTest(testProgram, true, gl.RGB, 3, [10000, 10000, 10000, 1]);
-      runTextureCreationTest(testProgram, true, gl.LUMINANCE, 1, [10000, 10000, 10000, 1]);
-      runTextureCreationTest(testProgram, true, gl.ALPHA, 1, [0, 0, 0, 10000]);
-      runTextureCreationTest(testProgram, true, gl.LUMINANCE_ALPHA, 2, [10000, 10000, 10000, 10000]);
-      runRenderTargetAndReadbackTest(testProgram, gl.RGBA, 4, [10000, 10000, 10000, 10000], 0);
-      runRenderTargetAndReadbackTest(testProgram, gl.RGB, 3, [10000, 10000, 10000, 1], 0);
-      runRenderTargetAndReadbackTest(testProgram, gl.RGBA, 4, [10000, 10000, 10000, 10000], 1);
-      runRenderTargetAndReadbackTest(testProgram, gl.RGBA, 4, [10000, 10000, 10000, 10000], 0.5);
-      runUniqueObjectTest();
-  }
+    if (!gl.getExtension("OES_texture_float")) {
+        testPassed("No OES_texture_float support -- this is legal");
+    } else {
+        testPassed("Successfully enabled OES_texture_float extension");
+        // If alpha value is missing from a texture it gets filled to 1 when sampling according to GLES2.0 table 3.12
+        runTextureCreationTest(testProgram, true, gl.RGBA, 4, [10000, 10000, 10000, 10000]);
+        runTextureCreationTest(testProgram, true, gl.RGB, 3, [10000, 10000, 10000, 1]);
+        runTextureCreationTest(testProgram, true, gl.LUMINANCE, 1, [10000, 10000, 10000, 1]);
+        runTextureCreationTest(testProgram, true, gl.ALPHA, 1, [0, 0, 0, 10000]);
+        runTextureCreationTest(testProgram, true, gl.LUMINANCE_ALPHA, 2, [10000, 10000, 10000, 10000]);
+
+        (function() {
+            debug("");
+            var renderableExtName = "WEBGL_color_buffer_float";
+            if (isRenderable(gl)) {
+                var supported = gl.getSupportedExtensions();
+                assertMsg(supported.includes(renderableExtName),
+                          "Implicit renderability requires exposing support for " + renderableExtName);
+            } else {
+                var renderableExt = gl.getExtension(renderableExtName);
+                if (!renderableExt) {
+                    testPassed(renderableExtName + " not supported. This is fine.");
+                    return;
+                }
+                testPassed(renderableExtName + " supported. Proceeding to its tests.");
+            }
+
+            runRenderTargetAndReadbackTest(testProgram, gl.RGBA, 4, [10000, 10000, 10000, 10000], 0);
+            runRenderTargetAndReadbackTest(testProgram, gl.RGB, 3, [10000, 10000, 10000, 1], 0);
+            runRenderTargetAndReadbackTest(testProgram, gl.RGBA, 4, [10000, 10000, 10000, 10000], 1);
+            runRenderTargetAndReadbackTest(testProgram, gl.RGBA, 4, [10000, 10000, 10000, 10000], 0.5);
+        })();
+
+        runUniqueObjectTest();
+    }
+}
+
+function isRenderable(gl) {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.FLOAT, null);
+
+    var fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+
+    var status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(tex);
+
+    return status == gl.FRAMEBUFFER_COMPLETE;
 }
 
 function allocateTexture()

--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -82,6 +82,7 @@ var gl = wtu.create3DContext(canvas);
 var halfFloatOESEnum = 0x8D61;
 var ext = null;
 
+
 if (!gl) {
     testFailed("WebGL context does not exists");
 } else {
@@ -173,15 +174,47 @@ if (!gl) {
             runRenderTest(format, f.subtractor, uint16Data);
         });
 
-        // Check if attaching texture as FBO target succeeds (Not mandatory)
-        runRenderTest(gl.RGBA, [10000, 10000, 10000, 10000], null);
-        runRenderTest(gl.RGB, [10000, 10000, 10000, 1], null);
+        (function() {
+            debug("");
+            var renderableExtName = "EXT_color_buffer_half_float";
+            if (isRenderable(gl, ext)) {
+                var supported = gl.getSupportedExtensions();
+                assertMsg(supported.includes(renderableExtName),
+                          "Implicit renderability requires exposing support for " + renderableExtName);
+            } else {
+                var renderableExt = gl.getExtension(renderableExtName);
+                if (!renderableExt) {
+                    testPassed(renderableExtName + " not supported. This is fine.");
+                    return;
+                }
+                testPassed(renderableExtName + " supported. Proceeding to its tests.");
+            }
 
-        runFramebufferTest();
+            if (runFramebufferTest()) {
+                runRenderTest(gl.RGBA, [10000, 10000, 10000, 10000], null);
+                runRenderTest(gl.RGB, [10000, 10000, 10000, 1], null);
+            }
+        })();
 
         // Check of getExtension() returns same object
         runUniqueObjectTest();
     }
+}
+
+function isRenderable(gl, ext) {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, ext.HALF_FLOAT_OES, null);
+
+    var fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+
+    var status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(tex);
+
+    return status == gl.FRAMEBUFFER_COMPLETE;
 }
 
 function getNumberOfChannels(format)
@@ -307,7 +340,7 @@ function runRenderTest(format, subtractor, data)
         // It is legal for a WebGL implementation exposing the OES_texture_half_float extension to
         // support half floating point textures but not as attachments to framebuffer objects.
         if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
-            debug("Half floating point render targets not supported -- this is legal");
+            testFailed(formatString + " render targets not supported.");
             return;
         }
 
@@ -403,9 +436,10 @@ function runFramebufferTest() {
     gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
     gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
     if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
-        debug("Half floating point render targets not supported -- this is legal");
-        return;
+        testFailed("Half floating point render targets not actually supported.");
+        return false;
     }
+
     debug("Ensure non-color-renderable formats [LUMINANCE, LUMINANCE_ALPHA, ALPHA] fail");
     var arrayBufferFloatOutput = new Float32Array(4); // 4 color channels
     [gl.LUMINANCE, gl.LUMINANCE_ALPHA, gl.ALPHA].forEach(function(badFormat) {
@@ -485,6 +519,7 @@ function runFramebufferTest() {
         }
         debug("");
     });
+    return true;
 }
 
 debug("");


### PR DESCRIPTION
Also fixes some indent levels.