### PR TITLE
Fix offscreencanvas-resize test to comply with spec

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
+++ b/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
@@ -82,7 +82,7 @@ function testResizeOnTransferredOffscreenCanvas() {
     // Verify that commit() asynchronously updates the size of its placeholder canvas.
     assertWidthAndHeight(placeholder, "placeholder canvas", 30, 40);
 
-    // Verify that width/height attributes are not settable 
+    // Verify that width/height attributes are not settable
     shouldThrow("placeholder.width = 50");
     shouldThrow("placeholder.height = 60");
 

--- a/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
+++ b/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
@@ -80,12 +80,13 @@ function testResizeOnTransferredOffscreenCanvas() {
   // Set timeout acts as a sync barrier to allow commit to propagate
   setTimeout(function() {
     // Verify that commit() asynchronously updates the size of its placeholder canvas.
-    assertWidthAndHeight(placeholder, "placeholder canvas", 10, 20);
+    assertWidthAndHeight(placeholder, "placeholder canvas", 30, 40);
 
-    // Verify that width/height attributes are still settable even though they have no effect.
-    placeholder.width = 50;
-    placeholder.height = 60;
-    assertWidthAndHeight(placeholder, "placeholder canvas after size reset", 50, 60);
+    // Verify that width/height attributes are not settable 
+    shouldThrow("placeholder.width = 50");
+    shouldThrow("placeholder.height = 60");
+
+    assertWidthAndHeight(placeholder, "placeholder canvas after size reset", 30, 40);
 
     createImageBitmap(placeholder).then(image => {
       // Verify that an image grabbed from the placeholder has the correct dimensions


### PR DESCRIPTION
This fix covers two spec compliance issues: 1) When an OffscreenCanvas
is resized, its size must propagate to the placeholder canvas's
width and height attributes; 2) Setting the width and height attributes
on a placeholder canvas throws an exception.

Related spec change: https://github.com/whatwg/html/pull/2951