### PR TITLE
New tests for texImage* with visible webgl canvas

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -216,7 +216,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
     function runTest()
     {
         var ctx = wtu.create3DContext();
-        canvas = ctx.canvas;
+        var canvas = ctx.canvas;
         // Note: We use preserveDrawingBuffer:true to prevent canvas
         // visibility from interfering with the tests.
         var visibleCtx = wtu.create3DContext(null, { preserveDrawingBuffer:true });

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -118,25 +118,12 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       setCanvasToRedGreen(ctx);
     }
 
-    function setCanvasTo32x32(ctx, bindingTarget) {
-      ctx.canvas.width = ctx.canvas.height = 32;
-      setCanvasToRedGreen(ctx);
-    }
-
-    function runOneIteration(canvas, useTexSubImage2D, flipY, visible, program, bindingTarget, opt_texture)
+    function runOneIteration(canvas, useTexSubImage2D, flipY, program, bindingTarget, opt_texture)
     {
         debug('Testing ' + (useTexSubImage2D ? 'texSubImage2D' : 'texImage2D') + ' with flipY=' +
-              flipY + ' visible=' + visible +
+              flipY + ' visible=' + (canvas.parentNode ? true : false)  +
               ' bindingTarget=' + (bindingTarget == gl.TEXTURE_2D ? 'TEXTURE_2D' : 'TEXTURE_CUBE_MAP') +
               ' canvas size: ' + canvas.width + 'x' + canvas.height + ' with red-green');
-
-        if (visible && !canvas.parentNode) {
-          var descriptionNode = document.getElementById("description");
-          document.body.insertBefore(canvas, descriptionNode);
-        }
-        if (!visible && canvas.parentNode) {
-          document.body.removeChild(canvas);
-        }
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         if (!opt_texture) {
@@ -228,24 +215,30 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function runTest()
     {
+        var ctx = wtu.create3DContext();
+        canvas = ctx.canvas;
         // Note: We use preserveDrawingBuffer:true to prevent canvas
         // visibility from interfering with the tests.
-        var ctx = wtu.create3DContext(null, { preserveDrawingBuffer:true });
-        canvas = ctx.canvas;
+        var visibleCtx = wtu.create3DContext(null, { preserveDrawingBuffer:true });
+        var visibleCanvas = visibleCtx.canvas;
+        visibleCanvas.width = visibleCanvas.height = 32;
+        setCanvasToRedGreen(visibleCtx);
+        var descriptionNode = document.getElementById("description");
+        document.body.insertBefore(visibleCanvas, descriptionNode);
 
         var cases = [
-            { sub: false, flipY: true,  visible: false, init: setCanvasToMin },
-            { sub: false, flipY: false, visible: false },
-            { sub: true,  flipY: true,  visible: false },
-            { sub: true,  flipY: false, visible: false },
-            { sub: false, flipY: true,  visible: false, init: setCanvasTo257x257 },
-            { sub: false, flipY: false, visible: false },
-            { sub: true,  flipY: true,  visible: false },
-            { sub: true,  flipY: false, visible: false },
-            { sub: false, flipY: true,  visible: true, init: setCanvasTo32x32 },
-            { sub: false, flipY: false, visible: true },
-            { sub: true,  flipY: true,  visible: true },
-            { sub: true,  flipY: false, visible: true },
+            { sub: false, flipY: true,  canvas: canvas, init: setCanvasToMin },
+            { sub: false, flipY: false, canvas: canvas },
+            { sub: true,  flipY: true,  canvas: canvas },
+            { sub: true,  flipY: false, canvas: canvas },
+            { sub: false, flipY: true,  canvas: canvas, init: setCanvasTo257x257 },
+            { sub: false, flipY: false, canvas: canvas },
+            { sub: true,  flipY: true,  canvas: canvas },
+            { sub: true,  flipY: false, canvas: canvas },
+            { sub: false, flipY: true,  canvas: visibleCanvas },
+            { sub: false, flipY: false, canvas: visibleCanvas },
+            { sub: true,  flipY: true,  canvas: visibleCanvas },
+            { sub: true,  flipY: false, canvas: visibleCanvas },
         ];
 
         function runTexImageTest(bindingTarget) {
@@ -265,7 +258,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                     if (c.init) {
                       c.init(ctx, bindingTarget);
                     }
-                    texture = runOneIteration(canvas, c.sub, c.flipY, c.visible, program, bindingTarget, texture);
+                    texture = runOneIteration(c.canvas, c.sub, c.flipY, program, bindingTarget, texture);
                     // for the first 2 iterations always make a new texture.
                     if (count > 2) {
                       texture = undefined;

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-webgl-canvas.js
@@ -85,11 +85,25 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
       ctx.canvas.height = 2;
       setCanvasToRedGreen(ctx);
     }
+    function setCanvasTo32x32(ctx, bindingTarget) {
+      ctx.canvas.width = ctx.canvas.height = 32;
+      setCanvasToRedGreen(ctx);
+    }
 
-    function runOneIteration(canvas, flipY, program, bindingTarget, opt_texture)
+    function runOneIteration(canvas, flipY, visible, program, bindingTarget, opt_texture)
     {
-        debug('Testing ' + flipY + ' bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY') +
+        debug('Testing flipY=' + flipY + ' visible=' + visible +
+              ' bindingTarget=' + (bindingTarget == gl.TEXTURE_3D ? 'TEXTURE_3D' : 'TEXTURE_2D_ARRAY') +
               ' canvas size: ' + canvas.width + 'x' + canvas.height + ' with red-green');
+
+        if (visible && !canvas.parentNode) {
+          var descriptionNode = document.getElementById("description");
+          document.body.insertBefore(canvas, descriptionNode);
+        }
+        if (!visible && canvas.parentNode) {
+          document.body.removeChild(canvas);
+        }
+
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         if (!opt_texture) {
             var texture = gl.createTexture();
@@ -145,14 +159,18 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
     function runTest()
     {
-        var ctx = wtu.create3DContext();
+        // Note: We use preserveDrawingBuffer:true to prevent canvas
+        // visibility from interfering with the tests.
+        var ctx = wtu.create3DContext(null, { preserveDrawingBuffer:true });
         var canvas = ctx.canvas;
 
         var cases = [
-            { flipY: true, init: setCanvasToMin },
-            { flipY: false },
-            { flipY: true, init: setCanvasTo257x257 },
-            { flipY: false },
+            { flipY: true,  visible: false, init: setCanvasToMin },
+            { flipY: false, visible: false },
+            { flipY: true,  visible: false, init: setCanvasTo257x257 },
+            { flipY: false, visible: false },
+            { flipY: true,  visible: true, init: setCanvasTo32x32 },
+            { flipY: false, visible: true },
         ];
 
         function runTexImageTest(bindingTarget) {
@@ -172,7 +190,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                     if (c.init) {
                       c.init(ctx, bindingTarget);
                     }
-                    texture = runOneIteration(canvas, c.flipY, program, bindingTarget, texture);
+                    texture = runOneIteration(canvas, c.flipY, c.visible, program, bindingTarget, texture);
                     // for the first 2 iterations always make a new texture.
                     if (count > 2) {
                       texture = undefined;


### PR DESCRIPTION
The new tests cover cases when the source image for a texture upload
is a visible WebGL canvas.  When the canvas is visible (in the DOM)
it gets presented to screen, which alters internal state, which can be a
source of buggy behavior.

Related chrome bug: crbug.com/759180