### PR TITLE
Add a missing include of js-test-post

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/sampler-array-struct-function-arg.html
+++ b/sdk/tests/conformance/glsl/bugs/sampler-array-struct-function-arg.html
@@ -88,5 +88,6 @@ if (!gl) {
 
 var successfullyParsed = true;
 </script>
+<script src="../../../js/js-test-post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The sampler-array-struct-function-arg test did not signal completion
and so could time out in the test harness.