### PR TITLE
Remove incorrect context version from sampler array test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/sampler-array-struct-function-arg.html
+++ b/sdk/tests/conformance/glsl/bugs/sampler-array-struct-function-arg.html
@@ -64,7 +64,7 @@ description();
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("output");
-var gl = wtu.create3DContext(canvas, undefined, 2);
+var gl = wtu.create3DContext(canvas);
 
 if (!gl) {
     testFailed("Could not create a GL context.");


### PR DESCRIPTION
This test is not intended to be specific to WebGL 2.0.

Fixes issue #2514.