### PR TITLE
Add more tests for vector/scalar arithmetic inside a loop

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -42,3 +42,4 @@
 --min-version 1.0.3 uniforms-should-not-lose-values.html
 --min-version 1.0.4 varying-arrays-should-not-be-reversed.html
 --min-version 1.0.4 vector-scalar-arithmetic-inside-loop.html
+--min-version 1.0.4 vector-scalar-arithmetic-inside-loop-complex.html

--- a/sdk/tests/conformance/glsl/bugs/vector-scalar-arithmetic-inside-loop-complex.html
+++ b/sdk/tests/conformance/glsl/bugs/vector-scalar-arithmetic-inside-loop-complex.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>GLSL vector/scalar arithmetic inside a for loop</title>
+<title>GLSL vector/scalar arithmetic inside a for loop (complex cases)</title>
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
@@ -38,12 +38,16 @@
 <body>
 <div id="description"></div>
 <div id="console"></div>
-<script id="fShaderVectorMulAndAddInsideForLoop" type="x-shader/x-fragment">
-void main(){
+<script id="fShaderVectorCompoundMulAndAddInSeparateStatementsInsideForLoop" type="x-shader/x-fragment">
+precision mediump float;
+
+void main() {
   gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
   for (int i = 0; i < 2; i++)
   {
-    gl_FragColor += (2.0 * gl_FragCoord.x);
+    float x = gl_FragCoord.x;
+    float y = (x *= 2.0);
+    gl_FragColor = gl_FragColor + vec4(y, y, y, y);
   }
   if (gl_FragColor.g == gl_FragColor.r &&
       gl_FragColor.b == gl_FragColor.r &&
@@ -53,7 +57,7 @@ void main(){
   }
 }
 </script>
-<script id="fShaderVectorCompoundMulAndAddInsideForLoop" type="x-shader/x-fragment">
+<script id="fShaderVectorCompoundMulAndAddInSeparateStatementsInsideForLoop2" type="x-shader/x-fragment">
 precision mediump float;
 
 void main() {
@@ -61,25 +65,8 @@ void main() {
   for (int i = 0; i < 2; i++)
   {
     float x = gl_FragCoord.x;
-    gl_FragColor = gl_FragColor + (x *= 2.0);
-  }
-  if (gl_FragColor.g == gl_FragColor.r &&
-      gl_FragColor.b == gl_FragColor.r &&
-      gl_FragColor.a == gl_FragColor.r)
-  {
-    gl_FragColor = vec4(0, 1, 0, 1);
-  }
-}
-</script>
-<script id="fShaderVectorCompoundDivAndAddInsideForLoop" type="x-shader/x-fragment">
-precision mediump float;
-
-void main() {
-  gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
-  for (int i = 0; i < 2; i++)
-  {
-    float x = gl_FragCoord.x;
-    gl_FragColor = gl_FragColor + (x /= 2.0);
+    float y = (x *= 2.0);
+    gl_FragColor = gl_FragColor + vec4(x, y, x, y);
   }
   if (gl_FragColor.g == gl_FragColor.r &&
       gl_FragColor.b == gl_FragColor.r &&
@@ -97,22 +84,16 @@ description();
 
 GLSLConformanceTester.runRenderTests([
 {
-  fShaderId: 'fShaderVectorMulAndAddInsideForLoop',
+  fShaderId: 'fShaderVectorCompoundMulAndAddInSeparateStatementsInsideForLoop',
   fShaderSuccess: true,
   linkSuccess: true,
-  passMsg: "Adding a scalar to a vector inside for loop should work."
+  passMsg: "Adding a vector that's just 4 copies of a scalar to another vector inside for loop should work."
 },
 {
-  fShaderId: 'fShaderVectorCompoundMulAndAddInsideForLoop',
+  fShaderId: 'fShaderVectorCompoundMulAndAddInSeparateStatementsInsideForLoop2',
   fShaderSuccess: true,
   linkSuccess: true,
-  passMsg: "Adding a scalar (target of a compound assignment/multiplication operation) to a vector inside for loop should work."
-},
-{
-  fShaderId: 'fShaderVectorCompoundDivAndAddInsideForLoop',
-  fShaderSuccess: true,
-  linkSuccess: true,
-  passMsg: "Adding a scalar (target of a compound assignment/division operation) to a vector inside for loop should work."
+  passMsg: "Adding a vector that's just 4 copies of a scalar stored in two different variables to another vector inside for loop should work."
 }
 ]);
 </script>


### PR DESCRIPTION
Add more variations of shaders that reproduce the same bug. This adds
better coverage for a workaround under development for ANGLE.

Some more complex variations are put to a separate test file - the
workaround in ANGLE will not be sophisticated enough to handle them,
but they should be fixed by a future driver update.