### PR TITLE
Make test harness result reporter log success message to console

### DIFF
--- a/conformance-suites/1.0.0/resources/webgl-test-harness.js
+++ b/conformance-suites/1.0.0/resources/webgl-test-harness.js
@@ -204,7 +204,7 @@ TestHarness.prototype.startNextFile = function() {
 
 TestHarness.prototype.reportResults = function (success, msg) {
   this.clearTimeout();
-  log(success ? "PASS" : "FAIL", msg);
+  log((success ? "PASS" : "FAIL") + ": " + msg);
   this.reportFunc(TestHarness.reportType.TEST_RESULT, msg, success);
   // For each result we get, reset the timeout
   this.setTimeout();

--- a/conformance-suites/1.0.1/resources/webgl-test-harness.js
+++ b/conformance-suites/1.0.1/resources/webgl-test-harness.js
@@ -493,7 +493,7 @@ TestHarness.prototype.startNextFile = function() {
 
 TestHarness.prototype.reportResults = function (success, msg, skipped) {
   this.clearTimeout();
-  log(success ? "PASS" : "FAIL", msg);
+  log((success ? "PASS" : "FAIL") + ": " + msg);
   this.reportFunc(TestHarness.reportType.TEST_RESULT, msg, success, skipped);
   // For each result we get, reset the timeout
   this.setTimeout();

--- a/conformance-suites/1.0.2/resources/webgl-test-harness.js
+++ b/conformance-suites/1.0.2/resources/webgl-test-harness.js
@@ -540,7 +540,7 @@ TestHarness.prototype.reportResults = function(url, success, msg, skipped) {
   url = FilterURL(url);
   var test = this.getTest(url);
   this.clearTimeout(test);
-  log(success ? "PASS" : "FAIL", msg);
+  log((success ? "PASS" : "FAIL") + ": " + msg);
   this.reportFunc(TestHarness.reportType.TEST_RESULT, url, msg, success, skipped);
   // For each result we get, reset the timeout
   this.setTimeout(test);

--- a/conformance-suites/1.0.3/resources/webgl-test-harness.js
+++ b/conformance-suites/1.0.3/resources/webgl-test-harness.js
@@ -616,7 +616,7 @@ TestHarness.prototype.reportResults = function(url, success, msg, skipped) {
   url = FilterURL(url);
   var test = this.getTest(url);
   this.clearTimeout(test);
-  log(success ? "PASS" : "FAIL", msg);
+  log((success ? "PASS" : "FAIL") + ": " + msg);
   this.reportFunc(TestHarness.reportType.TEST_RESULT, url, msg, success, skipped);
   // For each result we get, reset the timeout
   this.setTimeout(test);

--- a/conformance-suites/2.0.0/js/webgl-test-harness.js
+++ b/conformance-suites/2.0.0/js/webgl-test-harness.js
@@ -613,7 +613,7 @@ TestHarness.prototype.reportResults = function(url, success, msg, skipped) {
   url = FilterURL(url);
   var test = this.getTest(url);
   this.clearTimeout(test);
-  log(success ? "PASS" : "FAIL", msg);
+  log((success ? "PASS" : "FAIL") + ": " + msg);
   this.reportFunc(TestHarness.reportType.TEST_RESULT, url, msg, success, skipped);
   // For each result we get, reset the timeout
   this.setTimeout(test);

--- a/sdk/tests/js/webgl-test-harness.js
+++ b/sdk/tests/js/webgl-test-harness.js
@@ -613,7 +613,7 @@ TestHarness.prototype.reportResults = function(url, success, msg, skipped) {
   url = FilterURL(url);
   var test = this.getTest(url);
   this.clearTimeout(test);
-  log(success ? "PASS" : "FAIL", msg);
+  log((success ? "PASS" : "FAIL") + ": " + msg);
   this.reportFunc(TestHarness.reportType.TEST_RESULT, url, msg, success, skipped);
   // For each result we get, reset the timeout
   this.setTimeout(test);


### PR DESCRIPTION
The wrapped logging function it uses only takes one argument.
Concatenate the message to the success state string rather
than passing it as an unused second argument.