### PR TITLE
Accept INVALID_OPERATION for texSubImage2D when format/type differs

### DIFF
--- a/conformance-suites/1.0.1/conformance/more/functions/texSubImage2DBadArgs.html
+++ b/conformance-suites/1.0.1/conformance/more/functions/texSubImage2DBadArgs.html
@@ -82,10 +82,10 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_VALUE, "negative y", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0,1,-1,1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad format", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad format", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.FLOAT,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad type", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad type", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.TEXTURE_2D, new Uint8Array([0,0,0,0]));
     });
     assertGLError(gl, gl.INVALID_OPERATION, "not enough data", function(){

--- a/conformance-suites/1.0.2/conformance/more/functions/texSubImage2DBadArgs.html
+++ b/conformance-suites/1.0.2/conformance/more/functions/texSubImage2DBadArgs.html
@@ -82,10 +82,10 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_VALUE, "negative y", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0,1,-1,1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad format", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad format", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.FLOAT,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad type", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad type", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.TEXTURE_2D, new Uint8Array([0,0,0,0]));
     });
     assertGLError(gl, gl.INVALID_OPERATION, "not enough data", function(){

--- a/conformance-suites/1.0.3/conformance/more/functions/texSubImage2DBadArgs.html
+++ b/conformance-suites/1.0.3/conformance/more/functions/texSubImage2DBadArgs.html
@@ -82,10 +82,10 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_VALUE, "negative y", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0,1,-1,1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad format", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad format", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.FLOAT,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad type", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad type", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.TEXTURE_2D, new Uint8Array([0,0,0,0]));
     });
     assertGLError(gl, gl.INVALID_OPERATION, "not enough data", function(){

--- a/conformance-suites/2.0.0/conformance/more/functions/texSubImage2DBadArgs.html
+++ b/conformance-suites/2.0.0/conformance/more/functions/texSubImage2DBadArgs.html
@@ -88,10 +88,10 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_VALUE, "negative y", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0,1,-1,1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad format", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad format", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.FLOAT,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad type", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad type", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.TEXTURE_2D, new Uint8Array([0,0,0,0]));
     });
     assertGLError(gl, gl.INVALID_OPERATION, "not enough data", function(){

--- a/sdk/tests/conformance/more/functions/texSubImage2DBadArgs.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DBadArgs.html
@@ -88,10 +88,10 @@ Tests.testTexImage2D = function(gl) {
     assertGLError(gl, gl.INVALID_VALUE, "negative y", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0,1,-1,1,1,gl.RGBA,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad format", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad format", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.FLOAT,gl.UNSIGNED_BYTE, new Uint8Array([0,0,0,0]));
     });
-    assertGLError(gl, gl.INVALID_ENUM, "bad type", function(){
+    assertGLErrorIn(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], "bad type", function(){
         gl.texSubImage2D(gl.TEXTURE_2D, 0, 0,0, 1,1,gl.RGBA,gl.TEXTURE_2D, new Uint8Array([0,0,0,0]));
     });
     assertGLError(gl, gl.INVALID_OPERATION, "not enough data", function(){


### PR DESCRIPTION
INVALID_OPERATION should also be an acceptable result because texSubImage2d could be called with format and type that differ from format and type that was set previously by texImage2D.