### PR TITLE
Add a test for weird name conflict on NVIDIA GL driver

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -19,6 +19,7 @@
 --min-version 1.0.4 global-invariant-does-not-leak-across-shaders.html
 --min-version 1.0.4 init-array-with-loop.html
 --min-version 1.0.4 invariant-does-not-leak-across-shaders.html
+--min-version 1.0.4 in-parameter-passed-as-inout-argument-and-global.html
 --min-version 1.0.4 logic-inside-block-without-braces.html
 --min-version 1.0.3 long-expressions-should-not-crash.html
 --min-version 1.0.4 loop-if-loop-gradient.html

--- a/sdk/tests/conformance/glsl/bugs/in-parameter-passed-as-inout-argument-and-global.html
+++ b/sdk/tests/conformance/glsl/bugs/in-parameter-passed-as-inout-argument-and-global.html
@@ -1,0 +1,73 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Function in parameter passed as an inout argument and a global variable with the same name</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderParameters" type="x-shader/x-fragment">
+precision mediump float;
+uniform vec3 u_zero;
+vec3 p;
+void G(inout vec3 q) {
+    p += q;
+}
+void F(in vec3 p) {
+    G(p);
+}
+void main(){
+    F(u_zero + vec3(0.0, 1.0, 0.0));
+    gl_FragColor = vec4(p, 1.0);
+}
+</script>
+<script type="text/javascript">
+"use strict";
+description();
+
+// This is intended to test an issue seen on NVIDIA OpenGL drivers (at least up to version 388.59).
+// http://crbug.com/792210
+
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderParameters',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Function in parameter passed as an inout argument and a global variable with the same name"
+}
+]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Some recent versions of NVIDIA GL drivers have an issue with a
function in parameter being passed as an inout argument while there is
a global variable with the same name.

The issue will be fixed in a future NVIDIA driver update.

http://crbug.com/792210