### PR TITLE
Use Web IDL's new-ish interface mixins concept

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1240,8 +1240,7 @@ typedef (ImageBitmap or
 typedef ([AllowShared] Float32Array or sequence&lt;GLfloat&gt;) Float32List;
 typedef ([AllowShared] Int32Array or sequence&lt;GLint&gt;) Int32List;
 
-[NoInterfaceObject]
-interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
+interface mixin <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 {
 
     /* ClearBufferMask */
@@ -1873,7 +1872,7 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 interface <dfn id="WebGLRenderingContext">WebGLRenderingContext</dfn>
 {
 };
-WebGLRenderingContext implements WebGLRenderingContextBase;
+WebGLRenderingContext includes WebGLRenderingContextBase;
 </pre>
 
 <!-- ======================================================================================================= -->

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -83,8 +83,7 @@ typedef (ImageBitmap or
 typedef ([AllowShared] Float32Array or sequence<GLfloat>) Float32List;
 typedef ([AllowShared] Int32Array or sequence<GLint>) Int32List;
 
-[NoInterfaceObject]
-interface WebGLRenderingContextBase
+interface mixin WebGLRenderingContextBase
 {
 
     /* ClearBufferMask */
@@ -716,7 +715,7 @@ interface WebGLRenderingContextBase
 interface WebGLRenderingContext
 {
 };
-WebGLRenderingContext implements WebGLRenderingContextBase;
+WebGLRenderingContext includes WebGLRenderingContextBase;
 
 
 [Constructor(DOMString type, optional WebGLContextEventInit eventInit)]

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -424,8 +424,7 @@ typedef unsigned long long GLuint64;
     <pre class="idl">
 typedef ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) Uint32List;
 
-[NoInterfaceObject]
-interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
+interface mixin <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
 {
   const GLenum READ_BUFFER                                   = 0x0C02;
   const GLenum UNPACK_ROW_LENGTH                             = 0x0CF2;
@@ -968,12 +967,12 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   [WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
-WebGL2RenderingContextBase implements WebGLRenderingContextBase;
+WebGL2RenderingContextBase includes WebGLRenderingContextBase;
 
 interface <dfn id="WebGL2RenderingContext">WebGL2RenderingContext</dfn>
 {
 };
-WebGL2RenderingContext implements WebGL2RenderingContextBase;
+WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
 </pre>
 

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -27,8 +27,7 @@ interface WebGLVertexArrayObject : WebGLObject {
 
 typedef ([AllowShared] Uint32Array or sequence<GLuint>) Uint32List;
 
-[NoInterfaceObject]
-interface WebGL2RenderingContextBase
+interface mixin WebGL2RenderingContextBase
 {
   const GLenum READ_BUFFER                                   = 0x0C02;
   const GLenum UNPACK_ROW_LENGTH                             = 0x0CF2;
@@ -571,11 +570,11 @@ interface WebGL2RenderingContextBase
   [WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
-WebGL2RenderingContextBase implements WebGLRenderingContextBase;
+WebGL2RenderingContextBase includes WebGLRenderingContextBase;
 
 interface WebGL2RenderingContext
 {
 };
-WebGL2RenderingContext implements WebGL2RenderingContextBase;
+WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
 


### PR DESCRIPTION
WebIDL recently introduced dedicated syntax for mixins [1]. This
replaces the existing [NoInterfaceObject] and "implements" syntax with
"interface mixin" and "includes" in the appropriate places.

This fixes #2538, fixes #2539 issues.

[1] https://github.com/heycam/webidl/commit/45e8173d40ddff8dcf81697326e094bcf8b92920