### PR TITLE
Add a test for assigning twice to a swizzled vec inside a function

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -3,6 +3,7 @@
 --min-version 1.0.3 angle-d3d11-compiler-error.html
 --min-version 1.0.3 angle-dx-variable-bug.html
 --min-version 1.0.3 array-of-struct-with-int-first-position.html
+--min-version 1.0.4 assign-to-swizzled-twice-in-function.html
 --min-version 1.0.4 bool-type-cast-bug-int-float.html
 --min-version 1.0.3 compare-loop-index-to-uniform.html
 --min-version 1.0.3 complex-glsl-does-not-crash.html

--- a/sdk/tests/conformance/glsl/bugs/assign-to-swizzled-twice-in-function.html
+++ b/sdk/tests/conformance/glsl/bugs/assign-to-swizzled-twice-in-function.html
@@ -1,0 +1,73 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Assigning an assignment to a swizzled value inside function</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshader" type="x-shader/x-fragment">
+precision mediump float;
+
+vec2 f()
+{
+    vec2 r = vec2(0);
+    r.x = r.y = 1.0;
+    return r;
+}
+
+void main()
+{
+    gl_FragColor.ga = f();
+}
+
+</script>
+<script type="text/javascript">
+"use strict";
+description();
+
+// Minimal test case based on report at http://crbug.com/798117
+
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshader',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "Assigning an assignment to a swizzled value inside a user-defined function"
+}
+]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
This reproduces a crash at least in Chromium running on recent NVIDIA
OpenGL drivers.

Chrome bug report that this test case is based on is here:
http://crbug.com/798117