### PR TITLE
Regression tests for ANGLE UBO dirty bit bug

### DIFF
--- a/sdk/tests/conformance2/uniforms/00_test_list.txt
+++ b/sdk/tests/conformance2/uniforms/00_test_list.txt
@@ -2,3 +2,5 @@
 --min-version 2.0.1 gl-uniform-arrays-sub-source.html
 --min-version 2.0.1 query-uniform-blocks-after-shader-detach.html
 --min-version 2.0.1 uniform-blocks-with-arrays.html
+--min-version 2.0.1 simple-buffer-change.html
+--min-version 2.0.1 dependent-buffer-change.html

--- a/sdk/tests/conformance2/uniforms/dependent-buffer-change.html
+++ b/sdk/tests/conformance2/uniforms/dependent-buffer-change.html
@@ -1,0 +1,142 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL draw with uniform blocks conformance tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in vec4 a_vertex;
+void main(void) {
+  gl_Position = a_vertex;
+}
+</script>
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+layout (std140) uniform color_ubo {
+  vec4 color;
+};
+out vec4 fragColor;
+void main(void) {
+  fragColor = color;
+}
+</script>
+</head>
+<body>
+<canvas id="example" width="100", height="100"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+debug("");
+
+// Ported from: https://github.com/google/angle/blob/master/src/tests/gl_tests/UniformBufferTest.cpp#L1507
+description("Regression test for https://bugs.chromium.org/p/chromium/issues/detail?id=792966");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example", undefined, 2);
+
+function runTest() {
+    var program = wtu.setupProgram(gl, ['vshader', 'fshader'], ['a_vertex']);
+    var uboIndex = gl.INVALID_INDEX;
+    if (program)
+        uboIndex = gl.getUniformBlockIndex(program, "color_ubo");
+    if (!program || uboIndex == gl.INVALID_INDEX) {
+        testFailed("Loading program failed");
+        return;
+    }
+    testPassed("Loading program succeeded");
+
+    var vertices = new Float32Array([
+        -1, -1, 0,
+         1, -1, 0,
+        -1,  1, 0,
+         1,  1, 0
+    ]);
+    var vertexBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+    var indexBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuf);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int16Array([ 0, 1, 2, 2, 1, 3 ]), gl.STATIC_DRAW);
+
+    var uboDataSize = gl.getActiveUniformBlockParameter(
+        program, uboIndex, gl.UNIFORM_BLOCK_DATA_SIZE);
+    if (uboDataSize == 0) {
+        testFailed("uniform block data size invalid");
+        return;
+    }
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No errors from setup");
+
+    debug("draw lower triangle - should be red");
+    var uboBuf1 = gl.createBuffer();
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uboBuf1);
+    gl.bufferData(gl.UNIFORM_BUFFER, uboDataSize, gl.STATIC_DRAW);
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, new Float32Array([ 1, 0, 0, 1 ]));
+    gl.uniformBlockBinding(program, uboIndex, 0);
+    gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No errors from draw");
+
+    // Resize the buffer - triggers a re-allocation in the D3D11 back-end.
+    debug("draw upper triangle - should be green");
+    var bigData = new Float32Array(128 * 4);
+    bigData.set([ 0, 1, 0, 1 ]);
+    gl.bufferData(gl.UNIFORM_BUFFER, bigData, gl.STATIC_DRAW);
+    gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 6);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No errors from draw");
+
+    var width = 100, height = 100;
+    wtu.checkCanvasRectColor(gl, 0, 0, width/2-5, height/2-5, [255, 0, 0, 255], 2,
+        function() { testPassed("lower left should be red"); },
+        function() { testFailed("lower left should be red"); });
+    wtu.checkCanvasRectColor(gl, width/2+5, height/2+5, width/2-5, height/2-5, [0, 255, 0, 255], 2,
+        function() { testPassed("top right should be green"); },
+        function() { testFailed("top right should be green"); });
+}
+
+if (!gl) {
+    testFailed("WebGL context creation failed");
+} else {
+    testPassed("WebGL context creation succeeded");
+    runTest();
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/uniforms/simple-buffer-change.html
+++ b/sdk/tests/conformance2/uniforms/simple-buffer-change.html
@@ -1,0 +1,143 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL draw with uniform blocks conformance tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in vec4 a_vertex;
+void main(void) {
+  gl_Position = a_vertex;
+}
+</script>
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+layout (std140) uniform color_ubo {
+  vec4 color;
+};
+out vec4 fragColor;
+void main(void) {
+  fragColor = color;
+}
+</script>
+</head>
+<body>
+<canvas id="example" width="100", height="100"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+debug("");
+
+// Ported from: https://github.com/google/angle/blob/master/src/tests/gl_tests/UniformBufferTest.cpp#L1463
+description("Regression test for https://bugs.chromium.org/p/chromium/issues/detail?id=792966");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example", undefined, 2);
+
+function runTest() {
+    var program = wtu.setupProgram(gl, ['vshader', 'fshader'], ['a_vertex']);
+    var uboIndex = gl.INVALID_INDEX;
+    if (program)
+        uboIndex = gl.getUniformBlockIndex(program, "color_ubo");
+    if (!program || uboIndex == gl.INVALID_INDEX) {
+        testFailed("Loading program failed");
+        return;
+    }
+    testPassed("Loading program succeeded");
+
+    var vertices = new Float32Array([
+        -1, -1, 0,
+         1, -1, 0,
+        -1,  1, 0,
+         1,  1, 0
+    ]);
+    var vertexBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+
+    var indexBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuf);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int16Array([ 0, 1, 2, 2, 1, 3 ]), gl.STATIC_DRAW);
+
+    var uboDataSize = gl.getActiveUniformBlockParameter(
+        program, uboIndex, gl.UNIFORM_BLOCK_DATA_SIZE);
+    if (uboDataSize == 0) {
+        testFailed("uniform block data size invalid");
+        return;
+    }
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No errors from setup");
+
+    debug("draw lower triangle - should be red");
+    var uboBuf1 = gl.createBuffer();
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uboBuf1);
+    gl.bufferData(gl.UNIFORM_BUFFER, uboDataSize, gl.STATIC_DRAW);
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, new Float32Array([ 1, 0, 0, 1 ]));
+    gl.uniformBlockBinding(program, uboIndex, 0);
+    gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No errors from draw");
+
+    // Bind a second buffer to the same binding point (0). This should set to draw green.
+    debug("draw upper triangle - should be green");
+    var uboBuf2 = gl.createBuffer();
+    gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uboBuf2);
+    gl.bufferData(gl.UNIFORM_BUFFER, uboDataSize, gl.STATIC_DRAW);
+    gl.bufferSubData(gl.UNIFORM_BUFFER, 0, new Float32Array([ 0, 1, 0, 1 ]));
+    gl.drawElements(gl.TRIANGLES, 3, gl.UNSIGNED_SHORT, 6);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "No errors from draw");
+
+    var width = 100, height = 100;
+    wtu.checkCanvasRectColor(gl, 0, 0, width/2-5, height/2-5, [255, 0, 0, 255], 2,
+        function() { testPassed("lower left should be red"); },
+        function() { testFailed("lower left should be red"); });
+    wtu.checkCanvasRectColor(gl, width/2+5, height/2+5, width/2-5, height/2-5, [0, 255, 0, 255], 2,
+        function() { testPassed("top right should be green"); },
+        function() { testFailed("top right should be green"); });
+}
+
+if (!gl) {
+    testFailed("WebGL context creation failed");
+} else {
+    testPassed("WebGL context creation succeeded");
+    runTest();
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Regression tests for: https://bugs.chromium.org/p/chromium/issues/detail?id=792966

Ported the two ANGLE UBO dirty bit regression tests, SimpleBufferChange and DependentBufferChange, from https://github.com/google/angle/blob/master/src/tests/gl_tests/UniformBufferTest.cpp

I haven't been able to test that this actually catches the bug, since Chrome and Firefox are both updated for me, so this should be verified by someone. (Is there an easy way to get older versions of Chrome to test things like this?)