### PR TITLE
Add GLSL 3.00 test for forward declarations of functions.

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -14,6 +14,7 @@ compound-assignment-type-combination.html
 const-array-init.html
 --min-version 2.0.1 float-parsing.html
 forbidden-operators.html
+--min-version 2.0.1 forward-declaration.html
 frag-depth.html
 --min-version 2.0.1 gradient-in-discontinuous-loop.html
 --min-version 2.0.1 input-with-interpotaion-as-lvalue.html

--- a/sdk/tests/conformance2/glsl3/forward-declaration.html
+++ b/sdk/tests/conformance2/glsl3/forward-declaration.html
@@ -1,0 +1,111 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL 3.00 forward declaration test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vertexShaderForwardDecl" type="x-shader/x-vertex">#version 300 es
+precision mediump float;
+
+// Forward declaration. Breaks on Pixel C due to flattening of
+// precision qualifiers. It seems the GLSL compiler can't handle the
+// precision qualifier on the return value.
+float identity(float val);
+
+float identity(float val) {
+  return val;
+}
+
+void main(void) {
+    gl_Position = vec4(identity(1.0), 0.0, 0.0, 1.0);
+}
+</script>
+<script id="vertexShader" type="x-shader/x-vertex">#version 300 es
+void main(void) {
+    gl_Position = vec4(1.0, 0.0, 0.0, 1.0);
+}
+</script>
+<script id="fragmentShader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+void main(void) {
+  my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script id="fragmentShaderForwardDecl" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+// Forward declaration. Breaks on Pixel C due to flattening of
+// precision qualifiers. It seems the GLSL compiler can't handle the
+// precision qualifier on the return value.
+float identity(float val);
+
+float identity(float val) {
+  return val;
+}
+
+out vec4 my_FragColor;
+void main(void) {
+  my_FragColor = vec4(0.0, identity(1.0), 0.0, 1.0);
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description("Forward declarations of functions should succeed.");
+
+GLSLConformanceTester.runTests([
+  {
+    vShaderId: "vertexShaderForwardDecl",
+    vShaderSuccess: true,
+    fShaderId: "fragmentShader",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: "vertex shader with forward declaration must pass",
+  },
+  {
+    vShaderId: "vertexShader",
+    vShaderSuccess: true,
+    fShaderId: "fragmentShaderForwardDecl",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: "fragment shader with forward declaration must pass",
+  },
+], 2);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fails on Pixel C with Chrome because of flattening of precision
qualifiers into variables' types, and because of a bug in the GLSL
compiler on this device.

Thanks to Robert Muth of art.muth.org for reporting.