### PR TITLE
Remove unnecessary GLenums about coverage

### DIFF
--- a/specs/2.0.0/index.html
+++ b/specs/2.0.0/index.html
@@ -1085,8 +1085,6 @@ WebGL2RenderingContext implements WebGL2RenderingContextBase;
                 <tr><td>RASTERIZER_DISCARD</td><td>GLboolean</td></tr>
                 <tr><td>READ_BUFFER</td><td>GLenum</td></tr>
                 <tr><td>READ_FRAMEBUFFER_BINDING</td><td>WebGLFramebuffer</td></tr>
-                <tr><td>SAMPLE_ALPHA_TO_COVERAGE</td><td>GLboolean</td></tr>
-                <tr><td>SAMPLE_COVERAGE</td><td>GLboolean</td></tr>
                 <tr><td>SAMPLER_BINDING</td><td>WebGLSampler</td></tr>
                 <tr><td>TEXTURE_BINDING_2D_ARRAY</td><td>WebGLTexture</td></tr>
                 <tr><td>TEXTURE_BINDING_3D</td><td>WebGLTexture</td></tr>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1088,8 +1088,6 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
                 <tr><td>RASTERIZER_DISCARD</td><td>GLboolean</td></tr>
                 <tr><td>READ_BUFFER</td><td>GLenum</td></tr>
                 <tr><td>READ_FRAMEBUFFER_BINDING</td><td>WebGLFramebuffer</td></tr>
-                <tr><td>SAMPLE_ALPHA_TO_COVERAGE</td><td>GLboolean</td></tr>
-                <tr><td>SAMPLE_COVERAGE</td><td>GLboolean</td></tr>
                 <tr><td>SAMPLER_BINDING</td><td>WebGLSampler</td></tr>
                 <tr><td>TEXTURE_BINDING_2D_ARRAY</td><td>WebGLTexture</td></tr>
                 <tr><td>TEXTURE_BINDING_3D</td><td>WebGLTexture</td></tr>


### PR DESCRIPTION
These 2 GLenums have been added into WebGL 1.0 spec: https://www.khronos.org/registry/webgl/specs/latest/1.0/. So it is not necessary to add them again in WebGL 2.0 spec. You know, WebGL 2.0 spec only show the new added GLenums. 