### PR TITLE
Only complain on stencil writemask/value_mask/ref front/back mismatch…

### DIFF
--- a/sdk/tests/conformance/misc/00_test_list.txt
+++ b/sdk/tests/conformance/misc/00_test_list.txt
@@ -13,3 +13,4 @@ shader-precision-format.html
 type-conversion-test.html
 uninitialized-test.html
 webgl-specific.html
+--min-version 1.0.4 webgl-specific-stencil-settings.html

--- a/sdk/tests/conformance/misc/webgl-specific-stencil-settings.html
+++ b/sdk/tests/conformance/misc/webgl-specific-stencil-settings.html
@@ -1,0 +1,188 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL stencil mask/func front-state-back-state equality test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+"use strict";
+var wtu = WebGLTestUtils;
+description("Tests that stencil mask/func are validated correctly when the front state and back state differ.");
+
+var gl = wtu.create3DContext();
+
+function testStencilMaskCase(mask, error) {
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.FRONT, " + mask[0] + ")");
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.BACK,  " + mask[1] + ")");
+    // If an error is generated, it should be at draw time.
+    wtu.shouldGenerateGLError(gl, error, "wtu.dummySetProgramAndDrawNothing(gl)");
+}
+
+function testStencilMask(errIfMismatch) {
+    testStencilMaskCase([0, 256], gl.NO_ERROR);
+    testStencilMaskCase([1, 256], errIfMismatch);
+    testStencilMaskCase([1, 257], gl.NO_ERROR);
+    testStencilMaskCase([1, 258], errIfMismatch);
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMask(1023)", "resetting stencilMask");
+}
+
+function testStencilFuncCase(ref, mask, error) {
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.FRONT, gl.ALWAYS, " + ref[0] + ", " + mask[0] + ")");
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.BACK,  gl.ALWAYS, " + ref[1] + ", " + mask[1] + ")");
+    // If an error is generated, it should be at draw time.
+    wtu.shouldGenerateGLError(gl, error, "wtu.dummySetProgramAndDrawNothing(gl)");
+}
+
+function testStencilFunc(errIfMismatch) {
+    testStencilFuncCase([ 256,  257], [1023, 1023], gl.NO_ERROR);
+    testStencilFuncCase([ 256,  254], [1023, 1023], errIfMismatch);
+
+    testStencilFuncCase([  -1,    0], [1023, 1023], gl.NO_ERROR);
+    testStencilFuncCase([  -1,  254], [1023, 1023], errIfMismatch);
+
+    testStencilFuncCase([   0,    0], [   1,  257], gl.NO_ERROR);
+    testStencilFuncCase([   0,    0], [   1,  258], errIfMismatch);
+
+    testStencilFuncCase([   1,    1], [1024, 2048], gl.NO_ERROR);
+    testStencilFuncCase([   1,    1], [2048, 1024], gl.NO_ERROR);
+
+    testStencilFuncCase([  -1,   -1], [1023, 1023], gl.NO_ERROR);
+    testStencilFuncCase([  -1,    0], [1023, 1023], gl.NO_ERROR);
+    testStencilFuncCase([   0,   -1], [1023, 1023], gl.NO_ERROR);
+    testStencilFuncCase([   0,    0], [1023, 1023], gl.NO_ERROR);
+
+    testStencilFuncCase([  -1,  255], [1023, 1023], errIfMismatch);
+    testStencilFuncCase([   0,  256], [1023, 1023], errIfMismatch);
+    testStencilFuncCase([   0, 1024], [1023, 1023], errIfMismatch);
+    testStencilFuncCase([   1,  257], [1023, 1023], errIfMismatch);
+    testStencilFuncCase([ 255,   -1], [1023, 1023], errIfMismatch);
+    testStencilFuncCase([ 256,    0], [1023, 1023], errIfMismatch);
+    testStencilFuncCase([1024,    0], [1023, 1023], errIfMismatch);
+    testStencilFuncCase([ 257,    1], [1023, 1023], errIfMismatch);
+
+    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFunc(gl.ALWAYS, 0, 1023)", "resetting stencilFunc");
+}
+
+const fb = gl.createFramebuffer();
+gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+const colorRB = gl.createRenderbuffer();
+gl.bindRenderbuffer(gl.RENDERBUFFER, colorRB);
+gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, 1, 1);
+gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, colorRB);
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "initial framebuffer setup")
+
+function testStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTest, errIfMismatch) {
+    debug("");
+    debug("With depthbuffer=" + haveDepthBuffer +
+            ", stencilbuffer=" + haveStencilBuffer +
+            ", stencilTest=" + enableStencilTest +
+            ", expecting error=" + wtu.glEnumToString(errIfMismatch) +
+            " for mismatching mask or func settings.");
+
+    let rbo = null;
+    let attachment;
+    if (haveDepthBuffer || haveStencilBuffer) {
+        rbo = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, rbo);
+
+        let internalformat;
+        if (haveDepthBuffer && haveStencilBuffer) {
+            internalformat = gl.DEPTH_STENCIL;
+            attachment = gl.DEPTH_STENCIL_ATTACHMENT;
+        } else if (haveDepthBuffer) {
+            internalformat = gl.DEPTH_COMPONENT16;
+            attachment = gl.DEPTH_ATTACHMENT;
+        } else if (haveStencilBuffer) {
+            internalformat = gl.STENCIL_INDEX8;
+            attachment = gl.STENCIL_ATTACHMENT;
+        }
+        gl.renderbufferStorage(gl.RENDERBUFFER, internalformat, 1, 1);
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachment, gl.RENDERBUFFER, rbo);
+    }
+    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "depth/stencil renderbuffer setup")
+
+    if (enableStencilTest) {
+        gl.enable(gl.STENCIL_TEST);
+    } else {
+        gl.disable(gl.STENCIL_TEST);
+    }
+
+    // Errors should be the same for both mask and func, because stencil test
+    // and stencil write are always enabled/disabled in tandem.
+    testStencilMask(errIfMismatch);
+    testStencilFunc(errIfMismatch);
+
+    if (rbo) {
+        gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachment, gl.RENDERBUFFER, null);
+        gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+        gl.deleteRenderbuffer(rbo);
+    }
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "depth/stencil renderbuffer cleanup")
+}
+
+
+debug("");
+debug("Base case checks:");
+testStencilMaskCase([0, 0], gl.NO_ERROR);
+testStencilFuncCase([0, 0], [1023, 1023], gl.NO_ERROR);
+
+//                  haveDepthBuffer
+//                  |      haveStencilBuffer
+//                  |      |      enableStencilTest
+//                  |      |      |      errIfMismatch
+testStencilSettings(false, false, false, gl.NO_ERROR);
+testStencilSettings( true, false, false, gl.NO_ERROR);
+testStencilSettings(false,  true, false, gl.NO_ERROR);
+testStencilSettings( true,  true, false, gl.NO_ERROR);
+
+testStencilSettings(false, false,  true, gl.NO_ERROR);
+testStencilSettings( true, false,  true, gl.NO_ERROR);
+testStencilSettings(false,  true,  true, gl.INVALID_OPERATION);
+testStencilSettings( true,  true,  true, gl.INVALID_OPERATION);
+
+gl.deleteFramebuffer(fb);
+gl.deleteRenderbuffer(colorRB);
+
+var successfullyParsed = true;
+</script>
+
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance/misc/webgl-specific.html
+++ b/sdk/tests/conformance/misc/webgl-specific.html
@@ -77,26 +77,6 @@ debug("Verify that in depthRange zNear <= zFar");
 wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.depthRange(20, 10)");
 
 debug("");
-debug("Verify that front/back settings should be the same for stenclMask and stencilFunc");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMask(255)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.FRONT, 1)");
-wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.BACK, 1)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFunc(gl.ALWAYS, 0, 255)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.BACK, gl.ALWAYS, 1, 255)");
-wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.FRONT, gl.ALWAYS, 1, 255)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.BACK, gl.ALWAYS, 1, 1)");
-wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.FRONT, gl.ALWAYS, 1, 1)");
-wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-
-debug("");
 debug("Verify that *LENGTH are undefined");
 shouldBeUndefined(gl.INFO_LOG_LENGTH);
 shouldBeUndefined(gl.SHADER_SOURCE_LENGTH);

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -953,6 +953,15 @@ var drawUnitQuad = function(gl) {
   gl.drawArrays(gl.TRIANGLES, 0, 6);
 };
 
+var noopProgram = null;
+var dummySetProgramAndDrawNothing = function(gl) {
+  if (!noopProgram) {
+    noopProgram = setupProgram(gl, ["void main() {}", "void main() {}"], [], []);
+  }
+  gl.useProgram(noopProgram);
+  gl.drawArrays(gl.TRIANGLES, 0, 0);
+};
+
 /**
  * Clears then Draws a previously setupUnitQuad.
  * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
@@ -3110,6 +3119,7 @@ var API = {
   drawIndexedQuad: drawIndexedQuad,
   drawUByteColorQuad: drawUByteColorQuad,
   drawFloatColorQuad: drawFloatColorQuad,
+  dummySetProgramAndDrawNothing: dummySetProgramAndDrawNothing,
   dumpShadersInfo: dumpShadersInfo,
   endsWith: endsWith,
   failIfGLError: failIfGLError,

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3728,16 +3728,29 @@ destination range for any pixel outside the bound framebuffer.
 <h3><a name="STENCIL_SEPARATE_LIMIT">Stencil Separate Mask and Reference Value</a></h3>
 
 <p>
-In the WebGL API it is illegal to specify a different mask or reference value for front facing and
-back facing triangles in stencil operations. A call to <code>drawArrays</code>
-or <code>drawElements</code> will generate an <code>INVALID_OPERATION</code> error if:
+In the WebGL API, if stencil testing is enabled and the currently bound framebuffer has a stencil buffer,
+then it is illegal to draw while any of the following cases are true.
+Doing so will generate an <code>INVALID_OPERATION</code> error.
+</p>
 
 <ul>
-<li> <code>STENCIL_WRITEMASK</code> != <code>STENCIL_BACK_WRITEMASK</code> (as specified by <code>stencilMaskSeparate</code> for the <code>mask</code> parameter associated with the FRONT and BACK values of <code>face</code>, respectively)
-<li> <code>STENCIL_VALUE_MASK</code> != <code>STENCIL_BACK_VALUE_MASK</code> (as specified by <code>stencilFuncSeparate</code> for the <code>mask</code> parameter associated with the FRONT and BACK values of <code>face</code>, respectively)
-<li> <code>STENCIL_REF</code> != <code>STENCIL_BACK_REF</code> (as specified by <code>stencilFuncSeparate</code> for the <code>ref</code> parameter associated with the FRONT and BACK values of <code>face</code>, respectively)
+<li><code>(STENCIL_WRITEMASK &amp; maxStencilValue) != (STENCIL_BACK_WRITEMASK &amp; maxStencilValue)</code>
+<br>
+(as specified by <code>stencilMaskSeparate</code> for the <code>mask</code> parameter associated with the FRONT and BACK values of <code>face</code>, respectively)
+
+<li><code>(STENCIL_VALUE_MASK &amp; maxStencilValue) != (STENCIL_BACK_VALUE_MASK &amp; maxStencilValue)</code>
+<br>
+(as specified by <code>stencilFuncSeparate</code> for the <code>mask</code> parameter associated with the FRONT and BACK values of <code>face</code>, respectively)
+
+<li><code>clamp(STENCIL_REF, 0, maxStencilValue) != clamp(STENCIL_BACK_REF, 0, maxStencilValue)</code>
+<br>
+(as specified by <code>stencilFuncSeparate</code> for the <code>ref</code> parameter associated with the FRONT and BACK values of <code>face</code>, respectively)
 </ul>
 
+<p>
+where <code>maxStencilValue</code> is <code>((1 &lt;&lt; s) - 1)</code>,
+where <code>s</code> is the number of stencil bits in the draw framebuffer.
+(When no stencil bits are present, these checks always pass.)
 </p>
 
     <h3><a name="VERTEX_STRIDE">Vertex Attribute Data Stride</a></h3>


### PR DESCRIPTION
… for the `s` stencil bits of the draw framebuffer.

No one seems to implement this yet. Is this what we want?