### PR TITLE
Add a test for a HLSL bug with if, return and else if

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -18,6 +18,7 @@
 --min-version 1.0.3 fragcoord-linking-bug.html
 --min-version 1.0.4 gl-fragcoord-multisampling-bug.html
 --min-version 1.0.4 global-invariant-does-not-leak-across-shaders.html
+--min-version 1.0.4 if-return-and-elseif.html
 --min-version 1.0.4 init-array-with-loop.html
 --min-version 1.0.4 invariant-does-not-leak-across-shaders.html
 --min-version 1.0.4 in-parameter-passed-as-inout-argument-and-global.html

--- a/sdk/tests/conformance/glsl/bugs/if-return-and-elseif.html
+++ b/sdk/tests/conformance/glsl/bugs/if-return-and-elseif.html
@@ -1,0 +1,86 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>If with return and else if in fragment shader</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">
+attribute vec4 pos;
+varying vec2 vPos;
+void main()
+{
+    gl_Position = pos;
+    vPos = pos.xy;
+}
+</script>
+<script id="fshader" type="x-shader/x-fragment">
+precision mediump float;
+
+varying vec2 vPos;
+void main()
+{
+    if(vPos.x < 1.0) // This colors the whole canvas green
+    {
+        gl_FragColor = vec4(0, 1, 0, 1);
+        return;
+    }
+    else if(vPos.x < 1.1) // This should have no effect
+    {
+        gl_FragColor = vec4(1, 0, 0, 1);
+    }
+}
+
+</script>
+<script type="text/javascript">
+"use strict";
+description();
+
+// Minimal test case based on report at http://anglebug.com/2325
+
+GLSLConformanceTester.runRenderTests([
+{
+  vShaderId: 'vshader',
+  vShaderSuccess: true,
+  fShaderId: 'fshader',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: "If and else if in fragment shader"
+}
+]);
+</script>
+</body>
+</html>


### PR DESCRIPTION
An if statement containing a return together with an else if produces
wrong output on Chrome and Firefox on Windows.

This is a minimal test case for this bug: http://anglebug.com/2325