### PR TITLE
Reset vertex attrib divisors between instancing tests

### DIFF
--- a/sdk/tests/conformance/extensions/angle-instanced-arrays.html
+++ b/sdk/tests/conformance/extensions/angle-instanced-arrays.html
@@ -119,6 +119,8 @@ if (!gl) {
         runDrawArraysWithOffsetTest();
         runVAOInstancingInteractionTest();
         runANGLECorruptionTest();
+        // Note that the ANGLE corruption test leaves vertex attrib divisors dirty at the moment.
+        // This should be cleaned up if more subtests are added after it.
     }
 }
 
@@ -178,6 +180,9 @@ function runDivisorTestEnabled() {
     else{
         testFailed("Set value of VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE should be: 2, returned value was: " + queried_value);
     }
+
+    // Reset vertex attrib divisors so they cannot affect following subtests.
+    ext.vertexAttribDivisorANGLE(max_vertex_attribs-1, 0);
 }
 
 function setupCanvas() {
@@ -351,6 +356,10 @@ function runOutputTests() {
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstancedANGLE with QUADS should return INVALID_ENUM");
     ext.drawElementsInstancedANGLE(desktopGL['POLYGON'], 6, gl.UNSIGNED_SHORT, 0, instanceCount);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawElementsInstancedANGLE with POLYGON should return INVALID_ENUM");
+
+    // Reset vertex attrib divisors so they cannot affect following subtests.
+    ext.vertexAttribDivisorANGLE(colorLoc, 0);
+    ext.vertexAttribDivisorANGLE(offsetLoc, 0);
 }
 
 function runDrawArraysTest(program, first, count, instanceCount, offset)
@@ -404,6 +413,9 @@ function runDrawArraysTest(program, first, count, instanceCount, offset)
     // Do the instanced draw
     ext.drawArraysInstancedANGLE(gl.TRIANGLES, first, count, instanceCount);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArraysInstancedANGLE should succeed");
+
+    // Reset vertex attrib divisors so they cannot affect following subtests.
+    ext.vertexAttribDivisorANGLE(instancePosLoc, 0);
 }
 
 function runDrawArraysWithOffsetTest()


### PR DESCRIPTION
The newest version of the ANGLE_instanced_arrays test runs different
subtests with different shaders, which may have overlapping attrib
locations. Make sure that the different subtests don't interfere with
each other by resetting vertex attrib divisors after each subtest.

Previously the test could pass if attrib locations were automatically
assigned in a certain way, but changes to attribute location
assignment in the WebGL implementation could make it fail when it
should have passed.

This change does not need to be backported to earlier conformance suite
versions nor the WebGL 2 test for instancing, as they only use one
shader and always bind vertex attrib locations explicitly, so the
locations can only be set one way.