### PR TITLE
Assign attribute locations explicitly in luma texture copy test

### DIFF
--- a/conformance-suites/2.0.0/conformance2/textures/misc/copy-texture-image-luma-format.html
+++ b/conformance-suites/2.0.0/conformance2/textures/misc/copy-texture-image-luma-format.html
@@ -121,7 +121,7 @@ function copytexsubimage3D_luma_format() {
             gl.copyTexSubImage3D(gl.TEXTURE_3D, 0, 0, 0, layer, 0, 0,width, height);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
-            var program = wtu.setupProgram(gl, ["vshader", "fshader_luminance_alpha"]);
+            var program = wtu.setupProgram(gl, ["vshader", "fshader_luminance_alpha"], ["a_position", "a_coord"]);
             wtu.setupUnitQuad(gl, 0, 1);
             wtu.drawUnitQuad(gl);
 

--- a/sdk/tests/conformance2/textures/misc/copy-texture-image-luma-format.html
+++ b/sdk/tests/conformance2/textures/misc/copy-texture-image-luma-format.html
@@ -120,7 +120,7 @@ function copytexsubimage3D_luma_format() {
             gl.copyTexSubImage3D(gl.TEXTURE_3D, 0, 0, 0, layer, 0, 0,width, height);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
 
-            var program = wtu.setupProgram(gl, ["vshader", "fshader_luminance_alpha"]);
+            var program = wtu.setupProgram(gl, ["vshader", "fshader_luminance_alpha"], ["a_position", "a_coord"]);
             wtu.setupUnitQuad(gl, 0, 1);
             wtu.drawUnitQuad(gl);
 


### PR DESCRIPTION
The test is not querying attribute locations, so use the test
utilities to bind the attributes to locations 0 and 1. This ensures
that the test runs consistently.

This change is backported also to conformance suite version 2.0.0.