### PR TITLE
Expanded transform feedback tests

### DIFF
--- a/sdk/tests/conformance2/transform_feedback/00_test_list.txt
+++ b/sdk/tests/conformance2/transform_feedback/00_test_list.txt
@@ -3,4 +3,4 @@ transform_feedback.html
 two-unreferenced-varyings.html
 unwritten-output-defaults-to-zero.html
 --min-version 2.0.1 simultaneous_binding.html
-states-and-errors.html
+--min-version 2.0.1 switching-objects.html

--- a/sdk/tests/conformance2/transform_feedback/00_test_list.txt
+++ b/sdk/tests/conformance2/transform_feedback/00_test_list.txt
@@ -3,3 +3,4 @@ transform_feedback.html
 two-unreferenced-varyings.html
 unwritten-output-defaults-to-zero.html
 --min-version 2.0.1 simultaneous_binding.html
+states-and-errors.html

--- a/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
+++ b/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
@@ -72,13 +72,14 @@ if (!gl) {
     testPassed("WebGL context exists");
 }
 
-function drawWithFeedbackBound(gl, prog, vao, tf, enableFeedback) {
+function drawWithFeedbackBound(gl, drawFunction, prog, vao, tf, enableFeedback) {
   gl.useProgram(prog);
   gl.bindVertexArray(vao);
   gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
   if (enableFeedback) gl.beginTransformFeedback(gl.POINTS);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should not be any errors before drawing");
-  gl.drawArrays(gl.POINTS, 0, 4);
+  let error = gl.getError();
+  if (error != gl.NO_ERROR) testFailed("Unexpected error before drawing: " +  error)
+  drawFunction();
   if (enableFeedback) gl.endTransformFeedback();
   gl.bindVertexArray(null);
   gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
@@ -92,10 +93,11 @@ function createBuffer(gl, dataOrSize) {
   return buf;
 }
 
-function createVAO(gl, buf, inLoc) {
+function createVAO(gl, vertexBuffer, indexBuffer) {
   const vao = gl.createVertexArray();
   gl.bindVertexArray(vao);
-  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
   gl.enableVertexAttribArray(0);
   gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
@@ -109,7 +111,12 @@ const prog = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking transform feedback shader should not set an error");
 
 const vertexBuffer = createBuffer(gl, new Float32Array([1, 2, 3, 4]));
-const vao = createVAO(gl, vertexBuffer);
+
+const indexBuffer = gl.createBuffer();
+gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int16Array([0, 1, 2, 3]), gl.STATIC_DRAW);
+
+const vao = createVAO(gl, vertexBuffer, indexBuffer);
 
 const tfBuffer = createBuffer(gl, new Float32Array([0, 0, 0, 0]));
 
@@ -125,8 +132,14 @@ const ubi = gl.getUniformBlockIndex(prog, "UniformBlock");
 gl.uniformBlockBinding(prog, ubi, 0);
 gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uniformBuffer);
 
-drawWithFeedbackBound(gl, prog, vao, tf, true);
+let drawArrays = ()=>gl.drawArrays(gl.POINTS, 0, 4);
+let drawElements = ()=>gl.drawElements(gl.POINTS, 4, gl.UNSIGNED_SHORT, 0);
+
+debug("<hr/>Test baseline");
+drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should be successful");
+drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements should be successful");
 
 const expected = [2, 4, 6, 8];
 gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
@@ -135,36 +148,52 @@ wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
 debug("<hr/>Test ARRAY_BUFFER");
 // this should fail because the transform feedback's buffer #0 and the
 // badVao's buffer #0 are the same buffer
-const badVao = createVAO(gl, tfBuffer);
-drawWithFeedbackBound(gl, prog, badVao, tf, false);
+const badVao = createVAO(gl, tfBuffer, indexBuffer);
+drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf, false);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawArrays: buffer used as vertex attrib and tf simultaneously");
+drawWithFeedbackBound(gl, drawElements, prog, badVao, tf, false);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawElements: buffer used as vertex attrib and tf simultaneously");
+drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf, true);
 wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as vertex attrib and tf simultaneously");
-drawWithFeedbackBound(gl, prog, badVao, tf, true);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as vertex attrib and tf simultaneously");
-gl.bindVertexArray(vao);
-
 gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
 wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected, "should be the same as before as nothing has executed");
 
 debug("<hr/>Test UNIFORM_BUFFER");
 gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, tfBuffer);
 gl.bindBuffer(gl.UNIFORM_BUFFER, null); // tfBuffer is still bound at index 0
-drawWithFeedbackBound(gl, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as uniform buffer and tf simultaneously");
-drawWithFeedbackBound(gl, prog, vao, tf, true);
+drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawArrays: buffer used as uniform buffer and tf simultaneously");
+drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawElements: buffer used as uniform buffer and tf simultaneously");
+drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
 wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as uniform buffer and tf simultaneously");
 gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uniformBuffer);
-drawWithFeedbackBound(gl, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "tf buffer not used as uniform buffer anymore");
-drawWithFeedbackBound(gl, prog, vao, tf, true);
+drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays: tf buffer not used as uniform buffer anymore");
+drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements: tf buffer not used as uniform buffer anymore");
+drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "tf buffer not used as uniform buffer anymore");
 
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
 const tfBuffer2 = createBuffer(gl, Float32Array.BYTES_PER_ELEMENT * 4);
 gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer2);
-drawWithFeedbackBound(gl, prog, badVao, tf);
+drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "buffer is no longer bound for transform feedback");
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
 gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer);
+
+debug("<hr/>Test TF buffer bound to target unused by draw")
+// Even if the TF buffer is bound to a target that's not used by the draw, it's
+// still an error.
+gl.bindBuffer(gl.COPY_READ_BUFFER, tfBuffer);
+drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "tf enabled");
+drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays: tf disabled");
+drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements: tf disabled");
+gl.bindBuffer(gl.COPY_READ_BUFFER, null);
 
 debug("<hr/>Test PIXEL_UNPACK_BUFFER");
 const tex = gl.createTexture();

--- a/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
+++ b/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
@@ -40,6 +40,7 @@
 <div id="console"></div>
 <script id="vshader" type="x-shader/x-vertex">#version 300 es
 in float in_value;
+in float in_value2;
 out float out_value;
 
 void main() {
@@ -93,13 +94,17 @@ function createBuffer(gl, dataOrSize) {
   return buf;
 }
 
-function createVAO(gl, vertexBuffer, indexBuffer) {
+function createVAO(gl, vertexBuffer, vertexBuffer2, indexBuffer) {
   const vao = gl.createVertexArray();
   gl.bindVertexArray(vao);
-  gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
   gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
   gl.enableVertexAttribArray(0);
   gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer2);
+  gl.enableVertexAttribArray(1);
+  gl.vertexAttribPointer(1, 1, gl.FLOAT, false, 0, 0);
+  gl.vertexAttribDivisor(1, 2);
   gl.bindBuffer(gl.ARRAY_BUFFER, null);
   gl.bindVertexArray(null);
   return vao;
@@ -107,16 +112,17 @@ function createVAO(gl, vertexBuffer, indexBuffer) {
 
 const prog = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
     ["out_value"], gl.SEPARATE_ATTRIBS,
-    ["in_value"]);
+    ["in_value", "in_value2"]);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking transform feedback shader should not set an error");
 
 const vertexBuffer = createBuffer(gl, new Float32Array([1, 2, 3, 4]));
+const vertexBuffer2 = createBuffer(gl, new Float32Array([1, 2, 3, 4]));
 
 const indexBuffer = gl.createBuffer();
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
 gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Int16Array([0, 1, 2, 3]), gl.STATIC_DRAW);
 
-const vao = createVAO(gl, vertexBuffer, indexBuffer);
+const vao = createVAO(gl, vertexBuffer, vertexBuffer2, indexBuffer);
 
 const tfBuffer = createBuffer(gl, new Float32Array([0, 0, 0, 0]));
 
@@ -132,68 +138,89 @@ const ubi = gl.getUniformBlockIndex(prog, "UniformBlock");
 gl.uniformBlockBinding(prog, ubi, 0);
 gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uniformBuffer);
 
-let drawArrays = ()=>gl.drawArrays(gl.POINTS, 0, 4);
-let drawElements = ()=>gl.drawElements(gl.POINTS, 4, gl.UNSIGNED_SHORT, 0);
+const drawFunctions = [
+    [
+      ()=>gl.drawArrays(gl.POINTS, 0, 4),
+      ()=>gl.drawElements(gl.POINTS, 4, gl.UNSIGNED_SHORT, 0),
+    ],
+    [
+      ()=>gl.drawArraysInstanced(gl.POINTS, 0, 4, 1),
+      ()=>gl.drawElementsInstanced(gl.POINTS, 4, gl.UNSIGNED_SHORT, 0, 1),
+    ],
+    [
+      ()=>gl.drawArrays(gl.POINTS, 0, 4),
+      ()=>gl.drawRangeElements(gl.POINTS, 0, 3, 4, gl.UNSIGNED_SHORT, 0),
+    ],
+  ];
 
-debug("<hr/>Test baseline");
-drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should be successful");
-drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements should be successful");
+for (let [drawArrays, drawElements] of drawFunctions) {
+  debug("<h3>With draw functions " + drawArrays + " and " + drawElements + "</h3>");
+  debug("<hr/>Test baseline");
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
+  gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, 16, gl.STATIC_DRAW);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bufferData to TRANSFORM_FEEDBACK_BUFFER");
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should be successful");
+  drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements should be successful");
 
-const expected = [2, 4, 6, 8];
-gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
-wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
+  const expected = [2, 4, 6, 8];
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
+  wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
 
-debug("<hr/>Test ARRAY_BUFFER");
-// this should fail because the transform feedback's buffer #0 and the
-// badVao's buffer #0 are the same buffer
-const badVao = createVAO(gl, tfBuffer, indexBuffer);
-drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf, false);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawArrays: buffer used as vertex attrib and tf simultaneously");
-drawWithFeedbackBound(gl, drawElements, prog, badVao, tf, false);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawElements: buffer used as vertex attrib and tf simultaneously");
-drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf, true);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as vertex attrib and tf simultaneously");
-gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
-wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected, "should be the same as before as nothing has executed");
+  debug("<hr/>Test ARRAY_BUFFER");
+  // this should fail because the transform feedback's buffer #0 and the
+  // badVao's buffer #0 are the same buffer
+  const badVao = createVAO(gl, tfBuffer, vertexBuffer2, indexBuffer);
+  drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawArrays: buffer used as vertex attrib and tf simultaneously");
+  drawWithFeedbackBound(gl, drawElements, prog, badVao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawElements: buffer used as vertex attrib and tf simultaneously");
+  drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as vertex attrib and tf simultaneously");
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
+  wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected, "should be the same as before as nothing has executed");
 
-debug("<hr/>Test UNIFORM_BUFFER");
-gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, tfBuffer);
-gl.bindBuffer(gl.UNIFORM_BUFFER, null); // tfBuffer is still bound at index 0
-drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawArrays: buffer used as uniform buffer and tf simultaneously");
-drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawElements: buffer used as uniform buffer and tf simultaneously");
-drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as uniform buffer and tf simultaneously");
-gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uniformBuffer);
-drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays: tf buffer not used as uniform buffer anymore");
-drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements: tf buffer not used as uniform buffer anymore");
-drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "tf buffer not used as uniform buffer anymore");
+  debug("<hr/>Test UNIFORM_BUFFER");
+  gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, tfBuffer);
+  gl.bindBuffer(gl.UNIFORM_BUFFER, null); // tfBuffer is still bound at index 0
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawArrays: buffer used as uniform buffer and tf simultaneously");
+  drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawElements: buffer used as uniform buffer and tf simultaneously");
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "buffer used as uniform buffer and tf simultaneously");
+  gl.bindBufferBase(gl.UNIFORM_BUFFER, 0, uniformBuffer);
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays: tf buffer not used as uniform buffer anymore");
+  drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements: tf buffer not used as uniform buffer anymore");
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "tf buffer not used as uniform buffer anymore");
 
-gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
-const tfBuffer2 = createBuffer(gl, Float32Array.BYTES_PER_ELEMENT * 4);
-gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer2);
-drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "buffer is no longer bound for transform feedback");
-gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
-gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer);
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+  const tfBuffer2 = createBuffer(gl, Float32Array.BYTES_PER_ELEMENT * 4);
+  gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer2);
+  drawWithFeedbackBound(gl, drawArrays, prog, badVao, tf);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "buffer is no longer bound for transform feedback");
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+  gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer);
 
-debug("<hr/>Test TF buffer bound to target unused by draw")
-// Even if the TF buffer is bound to a target that's not used by the draw, it's
-// still an error.
-gl.bindBuffer(gl.COPY_READ_BUFFER, tfBuffer);
-drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "tf enabled");
-drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays: tf disabled");
-drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements: tf disabled");
-gl.bindBuffer(gl.COPY_READ_BUFFER, null);
+  debug("<hr/>Test TF buffer bound to target unused by draw")
+  // Even if the TF buffer is bound to a target that's not used by the draw, it's
+  // still an error.
+  gl.bindBuffer(gl.COPY_READ_BUFFER, tfBuffer);
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "tf enabled");
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays: tf disabled");
+  drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements: tf disabled");
+  gl.bindBuffer(gl.COPY_READ_BUFFER, null);
+}
+
+debug("<h3>Non-drawing tests</h3>");
+
 
 debug("<hr/>Test PIXEL_UNPACK_BUFFER");
 const tex = gl.createTexture();

--- a/sdk/tests/conformance2/transform_feedback/states-and-errors.html
+++ b/sdk/tests/conformance2/transform_feedback/states-and-errors.html
@@ -1,0 +1,280 @@
+<!--
+
+/*
+** Copyright (c) 2017 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>States</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<canvas id="canvas" style="width: 50px; height: 50px;"> </canvas>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+in float in_value;
+out float out_value1;
+out float out_value2;
+
+void main() {
+   out_value1 = in_value * 2.;
+   out_value2 = in_value * 4.;
+}
+</script>
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out vec4 dummy;
+void main() {
+  dummy = vec4(0.);
+}
+</script>
+<script>
+"use strict";
+description("Tests states and errors related to transform feedback objects.");
+
+debug("<h3>Setup</h3>")
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas, null, 2);
+if (!gl) {
+    testFailed("WebGL context does not exist");
+}
+
+// Setup
+const prog_interleaved = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
+    ["out_value1", "out_value2"], gl.INTERLEAVED_ATTRIBS,
+    ["in_value"]);
+const prog_no_varyings = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
+    [], gl.INTERLEAVED_ATTRIBS,
+    ["in_value"]);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "shader compilation");
+const vertexBuffer = createBuffer(gl, new Float32Array([1, 2, 3, 4]));
+gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+gl.enableVertexAttribArray(0);
+gl.vertexAttribPointer(0, 1, gl.FLOAT, false, 0, 0);
+gl.useProgram(prog_interleaved);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "vertex buffer and program setup");
+
+const tf1 = gl.createTransformFeedback();
+const tf2 = gl.createTransformFeedback();
+const tfBuffer1 = createBuffer(gl, new Float32Array([0, 0]));
+const tfBuffer2 = createBuffer(gl, new Float32Array([0, 0]));
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf1);
+gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer1);
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
+gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer2);
+const expected_tf_output = [2, 4];
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "TF object setup");
+
+debug("<h3>Baseline transform feedback success case</h3>");
+
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf1);
+gl.beginTransformFeedback(gl.POINTS);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "begin TF");
+gl.drawArrays(gl.POINTS, 0, 1);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw");
+gl.endTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "end TF");
+
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer1);
+wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected_tf_output);
+
+debug("<h3>Generic binding is not changed when switching TF object</h3>");
+
+// Set each buffer to contain its buffer number. We use this to check which
+// buffer is *really* bound at the driver level by reading the buffer contents.
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer1);
+gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, new Float32Array([1]), gl.STREAM_READ);
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer2);
+gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, new Float32Array([2]), gl.STREAM_READ);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bufferData");
+
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf1);
+checkParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, tfBuffer2);
+checkIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0, tfBuffer1);
+wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, [2]);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "readback");
+
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, null);
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
+checkParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, null);
+checkIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0, tfBuffer2);
+
+debug("<h3>Error switching TF object while TF is enabled</h3>");
+
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf1);
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer1);
+gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, new Float32Array([0, 0]), gl.STREAM_READ);
+gl.beginTransformFeedback(gl.POINTS);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "begin");
+checkParameter(gl.TRANSFORM_FEEDBACK_BINDING, tf1);
+
+// gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
+// wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bind while unpaused");
+// Check that nothing actually changed and rendering still works
+checkParameter(gl.TRANSFORM_FEEDBACK_BINDING, tf1);
+gl.drawArrays(gl.POINTS, 0, 1);
+gl.endTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should complete successfully");
+wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected_tf_output);
+
+
+debug("<h3>Successfully switching TF object while TF is paused</h3>");
+
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer1);
+gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, new Float32Array([0, 0]), gl.STREAM_READ);
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer2);
+gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, new Float32Array([0, 0]), gl.STREAM_READ);
+
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
+gl.beginTransformFeedback(gl.POINTS);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "begin on tf2");
+checkParameter(gl.TRANSFORM_FEEDBACK_BINDING, tf2);
+
+gl.pauseTransformFeedback();
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf1);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bind while paused");
+gl.beginTransformFeedback(gl.POINTS);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "begin on tf1");
+checkParameter(gl.TRANSFORM_FEEDBACK_BINDING, tf1);
+gl.drawArrays(gl.POINTS, 0, 1);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw should succeed");
+gl.endTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "end on tf1");
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer1);
+wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected_tf_output);
+
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
+gl.endTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "end on tf2");
+
+debug("<h3>Invalid operations</h3>")
+
+gl.endTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "endTransformFeedback before begin");
+gl.pauseTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "pauseTransformFeedback when not active");
+gl.resumeTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "pauseTransformFeedback when not active");
+
+gl.beginTransformFeedback(gl.POINTS);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should begin successfully");
+gl.drawArrays(gl.TRIANGLE_STRIP, 0, 1);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "wrong primitive mode");
+gl.useProgram(prog_no_varyings);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "switch program while active");
+gl.resumeTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "resumeTransformFeedback when not paused");
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bindTransformFeedback when active");
+gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer2);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bindBuffer(TRANSFORM_FEEDBACK_BUFFER) when active");
+gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer2);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bindBufferBase(TRANSFORM_FEEDBACK_BUFFER) when active");
+
+gl.pauseTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "pause");
+gl.pauseTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "already paused");
+gl.endTransformFeedback();
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "end while paused");
+
+finishTest();
+
+// debug("<h3>Leaving TF enabled while creating contexts</h3>");
+
+// checkParameter(gl.TRANSFORM_FEEDBACK_ACTIVE, false);
+// checkParameter(gl.TRANSFORM_FEEDBACK_PAUSED, false);
+// gl.beginTransformFeedback(gl.POINTS);
+// checkParameter(gl.TRANSFORM_FEEDBACK_ACTIVE, true);
+// checkParameter(gl.TRANSFORM_FEEDBACK_PAUSED, false);
+// gl.clear(gl.COLOR_BUFFER_BIT);
+
+// var frame = 0;
+// function rafCallback() {
+//   checkParameter(gl.TRANSFORM_FEEDBACK_ACTIVE, true);
+//   checkParameter(gl.TRANSFORM_FEEDBACK_PAUSED, false);
+//   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([frame]), gl.STREAM_READ);
+//   gl.drawArrays(gl.POINTS, 0, 1);
+//   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw should succeed");
+//   gl.clear(gl.COLOR_BUFFER_BIT);
+//   const newCanvas = document.createElement("canvas");
+//   document.body.appendChild(newCanvas);
+//   const newGl = newCanvas.getContext("webgl");
+//   if (!newGl) {
+//     testFailed("failed to create context");
+//     return;
+//   }
+//   newGl.clear(gl.COLOR_BUFFER_BIT);
+//   if (++frame < 4) {
+//     requestAnimationFrame(rafCallback);
+//   } else {
+//     gl.endTransformFeedback();
+//     wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER,
+//         [0, 0, 2, 0.5, 4, 1, 6, 1.5]);
+//     finishTest();
+//   }
+// };
+// rafCallback();
+
+// Helper functions
+function createBuffer(gl, dataOrSize) {
+  const buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(gl.ARRAY_BUFFER, dataOrSize, gl.STATIC_DRAW);
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+  return buf;
+}
+
+function checkParameter(param, expected) {
+  const value = gl.getParameter(param);
+  if (value != expected) {
+    testFailed(wtu.glEnumToString(gl, param) + " was " + value + ", but expected " + expected);
+  } else {
+    testPassed(wtu.glEnumToString(gl, param) + " was " + value + ", matching expected " + expected);
+  }
+}
+
+function checkIndexedParameter(param, index, expected) {
+  const value = gl.getIndexedParameter(param, index);
+  if (value != expected) {
+    testFailed(wtu.glEnumToString(gl, param) + "[" + index + "] was " + value + ", but expected " + expected);
+  } else {
+    testPassed(wtu.glEnumToString(gl, param) + "[" + index + "] was " + value + ", matching expected " + expected);
+  }
+}
+
+
+</script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/transform_feedback/states-and-errors.html
+++ b/sdk/tests/conformance2/transform_feedback/states-and-errors.html
@@ -138,8 +138,9 @@ gl.beginTransformFeedback(gl.POINTS);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "begin");
 checkParameter(gl.TRANSFORM_FEEDBACK_BINDING, tf1);
 
-// gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
-// wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bind while unpaused");
+gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bind while unpaused");
+
 // Check that nothing actually changed and rendering still works
 checkParameter(gl.TRANSFORM_FEEDBACK_BINDING, tf1);
 gl.drawArrays(gl.POINTS, 0, 1);

--- a/sdk/tests/conformance2/transform_feedback/states-and-errors.html
+++ b/sdk/tests/conformance2/transform_feedback/states-and-errors.html
@@ -210,42 +210,6 @@ wtu.glErrorShouldBe(gl, gl.NO_ERROR, "end while paused");
 
 finishTest();
 
-// debug("<h3>Leaving TF enabled while creating contexts</h3>");
-
-// checkParameter(gl.TRANSFORM_FEEDBACK_ACTIVE, false);
-// checkParameter(gl.TRANSFORM_FEEDBACK_PAUSED, false);
-// gl.beginTransformFeedback(gl.POINTS);
-// checkParameter(gl.TRANSFORM_FEEDBACK_ACTIVE, true);
-// checkParameter(gl.TRANSFORM_FEEDBACK_PAUSED, false);
-// gl.clear(gl.COLOR_BUFFER_BIT);
-
-// var frame = 0;
-// function rafCallback() {
-//   checkParameter(gl.TRANSFORM_FEEDBACK_ACTIVE, true);
-//   checkParameter(gl.TRANSFORM_FEEDBACK_PAUSED, false);
-//   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([frame]), gl.STREAM_READ);
-//   gl.drawArrays(gl.POINTS, 0, 1);
-//   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw should succeed");
-//   gl.clear(gl.COLOR_BUFFER_BIT);
-//   const newCanvas = document.createElement("canvas");
-//   document.body.appendChild(newCanvas);
-//   const newGl = newCanvas.getContext("webgl");
-//   if (!newGl) {
-//     testFailed("failed to create context");
-//     return;
-//   }
-//   newGl.clear(gl.COLOR_BUFFER_BIT);
-//   if (++frame < 4) {
-//     requestAnimationFrame(rafCallback);
-//   } else {
-//     gl.endTransformFeedback();
-//     wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER,
-//         [0, 0, 2, 0.5, 4, 1, 6, 1.5]);
-//     finishTest();
-//   }
-// };
-// rafCallback();
-
 // Helper functions
 function createBuffer(gl, dataOrSize) {
   const buf = gl.createBuffer();

--- a/sdk/tests/conformance2/transform_feedback/switching-objects.html
+++ b/sdk/tests/conformance2/transform_feedback/switching-objects.html
@@ -1,7 +1,7 @@
 <!--
 
 /*
-** Copyright (c) 2017 The Khronos Group Inc.
+** Copyright (c) 2018 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the

--- a/sdk/tests/conformance2/transform_feedback/switching-objects.html
+++ b/sdk/tests/conformance2/transform_feedback/switching-objects.html
@@ -57,7 +57,7 @@ void main() {
 </script>
 <script>
 "use strict";
-description("Tests states and errors related to transform feedback objects.");
+description("Tests switching transform feedback objects.");
 
 debug("<h3>Setup</h3>")
 
@@ -178,7 +178,7 @@ gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf2);
 gl.endTransformFeedback();
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "end on tf2");
 
-debug("<h3>Invalid operations</h3>")
+debug("<h3>Misc. invalid operations</h3>")
 
 gl.endTransformFeedback();
 wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "endTransformFeedback before begin");

--- a/sdk/tests/conformance2/transform_feedback/switching-objects.html
+++ b/sdk/tests/conformance2/transform_feedback/switching-objects.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>States</title>
+<title>Switching transform feedback objects</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>


### PR DESCRIPTION
Adds a new test switching-objects.html which tests various consequences of switching transform feedback objects. This includes a test for the new behavior where TRANSFORM_FEEDBACK_BUFFER is not modified when switching transform feedback objects. The OpenGL/ES working group just approved the spec change for this new behavior.

Also adds testing of drawElements cases in simultaneous_binding.html, in addition to existing drawArrays cases.