### PR TITLE
Include file path fix for a test.

### DIFF
--- a/sdk/tests/conformance2/context/context-sharing-texture2darray-texture3d-data-bug.html
+++ b/sdk/tests/conformance2/context/context-sharing-texture2darray-texture3d-data-bug.html
@@ -30,9 +30,9 @@
 <head>
 <meta charset="utf-8">
 <title>Multiple WebGL2 Context sharing texture2darray/texture3d data bug test</title>
-<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
-<script src="../../../js/js-test-pre.js"></script>
-<script src="../../../js/webgl-test-utils.js"></script>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -165,7 +165,7 @@ else
 debug("");
 var successfullyParsed = true;
 </script>
-<script src="../../../js/js-test-post.js"></script>
+<script src="../../js/js-test-post.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
This test was passing when using python SimpleHTTPServer even if the include
paths were incorrect. This is because python smartly searched for these include
files in other folders. The test failed when command line was used to run test
by bots or when running test directly on chrome without using the simplehttpserver.