### PR TITLE
constant-precision-qualifier.html is finishing early due to an extra finishTest()

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
+++ b/sdk/tests/conformance/glsl/bugs/constant-precision-qualifier.html
@@ -95,10 +95,12 @@ function test() {
   var gl = wtu.create3DContext();
   if (!gl) {
     testFailed("context does not exist");
+    finishTest();
     return;
   }
   if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision == 0) {
     testPassed("highp precision not supported");
+    finishTest();
   } else {
     GLSLConformanceTester.runRenderTests([
     {
@@ -129,7 +131,6 @@ function test() {
 
 test();
 var successfullyParsed = true;
-finishTest();
 </script>
 </body>
 </html>


### PR DESCRIPTION
finishTest() is called right after test() returns, ending the test prematurely before all the test cases complete. This is because test() has a call to GLSLConformanceTester.runRenderTests(), which runs the tests asynchronously. runRenderTests() also already calls finishTest() after the last test completes.