### PR TITLE
Test queueing multiple context restored event after context is lost

### DIFF
--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -157,6 +157,8 @@ function testLosingAndRestoringContext()
       // restore the context after this event has exited.
       setTimeout(function() {
         shouldGenerateGLError(gl, gl.NO_ERROR, "WEBGL_lose_context.restoreContext()");
+        // Calling restoreContext() twice should not cause error or crash
+        shouldGenerateGLError(gl, gl.NO_ERROR, "WEBGL_lose_context.restoreContext()");
         // The context should still be lost. It will not get restored until the
         // webglrestorecontext event is fired.
         shouldBeTrue("gl.isContextLost()");


### PR DESCRIPTION
When calling restoreContext() multiple times after context is lost, each function call will cause a context restored event queued. All queued context restored events should be merged before a context restored event is fired. 
Calling restoreContext() multiple times should not cause error or crash. Added a test to test the behavior.
