### PR TITLE
Remove setTimeout() from GLSLConformanceTester.runTests()

### DIFF
--- a/sdk/tests/js/glsl-conformance-test.js
+++ b/sdk/tests/js/glsl-conformance-test.js
@@ -311,17 +311,11 @@ function runTests(shaderInfos, opt_contextVersion) {
     return;
   }
 
-  var testIndex = 0;
-  var runNextTest = function() {
-    if (testIndex == shaderInfos.length) {
-      finishTest();
-      return;
-    }
-
-    runOneTest(gl, shaderInfos[testIndex++]);
-    setTimeout(runNextTest, 1);
+  for (var i = 0; i < shaderInfos.length; i++) {
+    runOneTest(gl, shaderInfos[i]);
   }
-  runNextTest();
+
+  finishTest();
 };
 
 function getSource(elem) {


### PR DESCRIPTION
GLSLConformanceTester.runTests() uses setTimeout(.., 1) in between tests, making the tests asynchronous. runOneTest(), the function called in the setTimeout callback, doesn't do intensive work that takes a long time, and it does a checkCanvas at the end of the function that would reset the harness timeout timer. Changing this to a synchronous for loop instead.

This PR is a followup from #2608 