### PR TITLE
Explicitly specify uniform and attribute name collisions

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -4148,6 +4148,22 @@ extensions.
     </div>
 </p>
 
+<h3>Uniform and attribute name collisions</h3>
+
+<p>
+    If any of the shaders attached to a WebGL program declare a uniform that has the same name as a
+    statically used vertex attribute, program linking should fail.
+</p>
+
+<div class="note">
+    This behavior differs from one specified in GLSL ES 3.00.6 section 12.47.
+</div>
+
+<div class="note rationale">
+    WebGL implementations have enforced this behavior for several years now, due to that some OpenGL
+    drivers don't accept uniforms and vertex attributes with the same name.
+</div>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>


### PR DESCRIPTION
WebGL has long enforced behavior that goes against GLSL ES 3.00.6
section 12.47. WebGL requires that uniform and attribute names don't
collide, whereas GLSL ES specifies that there's no collision in this
case. The WebGL test that enforces this is:

conformance\glsl\misc\shaders-with-name-conflicts.html

The test refers to discussion in OpenGL ES working group, but it seems
that the results of the discussion were not put into writing outside
of the test case.

Explicitly specify the WebGL behavior to clear confusion around this.