### PR TITLE
Clarify WebGL 2 spec for attribute aliasing

### DIFF
--- a/sdk/tests/conformance2/attribs/00_test_list.txt
+++ b/sdk/tests/conformance2/attribs/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 2.0.1 gl-bindAttribLocation-aliasing-inactive.html
 gl-vertex-attrib.html
 gl-vertex-attrib-i-render.html
 --min-version 2.0.1 gl-vertex-attrib-normalized-int.html

--- a/sdk/tests/conformance2/attribs/gl-bindAttribLocation-aliasing-inactive.html
+++ b/sdk/tests/conformance2/attribs/gl-bindAttribLocation-aliasing-inactive.html
@@ -1,6 +1,6 @@
 <!--
 /*
-** Copyright (c) 2014 The Khronos Group Inc.
+** Copyright (c) 2018 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the
@@ -30,29 +30,42 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/gl-bindattriblocation-aliasing.js"></script>
-<title>bindAttribLocation with aliasing</title>
+<title>bindAttribLocation with aliasing - inactive attributes</title>
 </head>
 <body>
 <div id="description"></div>
 <div id="console"></div>
 <canvas id="canvas" width="8" height="8" style="width: 8px; height: 8px;"></canvas>
-<script id="vertexShader" type="text/something-not-javascript">
+<script id="vertexShaderStaticallyUsedButInactive" type="text/something-not-javascript">#version 300 es
 precision mediump float;
-attribute $(type_1) a_1;
-attribute $(type_2) a_2;
+in $(type_1) a_1;
+in $(type_2) a_2;
 void main() {
-    gl_Position = $(gl_Position_1) + $(gl_Position_2);
+    gl_Position = true ? $(gl_Position_1) : $(gl_Position_2);
+}
+</script>
+<script id="vertexShaderUnused" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+in $(type_1) a_1;
+in $(type_2) a_2;
+void main() {
+    gl_Position = vec4(0.0);
 }
 </script>
 <script>
 "use strict";
-description("This test verifies combinations of valid, active attribute types cannot be bound to the same location with bindAttribLocation.");
+description("This test verifies combinations of valid inactive attributes cannot be bound to the same location with bindAttribLocation. GLSL ES 3.00.6 section 12.46.");
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
-var gl = wtu.create3DContext(canvas, {antialias: false});
-var glFragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShader, gl.FRAGMENT_SHADER);
+var gl = wtu.create3DContext(canvas, {antialias: false}, 2);
+var glFragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShaderESSL300, gl.FRAGMENT_SHADER);
 
-runBindAttribLocationAliasingTest(wtu, gl, glFragmentShader, wtu.getScript('vertexShader'));
+debug("Testing with shader that has statically used but inactive attributes.");
+runBindAttribLocationAliasingTest(wtu, gl, glFragmentShader, wtu.getScript('vertexShaderStaticallyUsedButInactive'));
+
+debug("");
+debug("Testing with shader that has entirely unused attributes.");
+runBindAttribLocationAliasingTest(wtu, gl, glFragmentShader, wtu.getScript('vertexShaderUnused'));
 
 var successfullyParsed = true;
 </script>

--- a/sdk/tests/js/tests/gl-bindattriblocation-aliasing.js
+++ b/sdk/tests/js/tests/gl-bindattriblocation-aliasing.js
@@ -1,0 +1,61 @@
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+"use strict";
+
+var runBindAttribLocationAliasingTest = function(wtu, gl, glFragmentShader, vertexShaderTemplate) {
+    var typeInfo = [
+        { type: 'float',    asVec4: 'vec4(0.0, $(var), 0.0, 1.0)' },
+        { type: 'vec2',     asVec4: 'vec4($(var), 0.0, 1.0)' },
+        { type: 'vec3',     asVec4: 'vec4($(var), 1.0)' },
+        { type: 'vec4',     asVec4: '$(var)' },
+    ];
+    var maxAttributes = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+    // Test all type combinations of a_1 and a_2.
+    typeInfo.forEach(function(typeInfo1) {
+        typeInfo.forEach(function(typeInfo2) {
+            debug('attribute_1: ' + typeInfo1.type + ' attribute_2: ' + typeInfo2.type);
+            var replaceParams = {
+                type_1: typeInfo1.type,
+                type_2: typeInfo2.type,
+                gl_Position_1: wtu.replaceParams(typeInfo1.asVec4, {var: 'a_1'}),
+                gl_Position_2: wtu.replaceParams(typeInfo2.asVec4, {var: 'a_2'})
+            };
+            var strVertexShader = wtu.replaceParams(vertexShaderTemplate, replaceParams);
+            var glVertexShader = wtu.loadShader(gl, strVertexShader, gl.VERTEX_SHADER);
+            assertMsg(glVertexShader != null, "Vertex shader compiled successfully.");
+            // Bind both a_1 and a_2 to the same position and verify the link fails.
+            // Do so for all valid positions available.
+            for (var l = 0; l < maxAttributes; l++) {
+                var glProgram = gl.createProgram();
+                gl.bindAttribLocation(glProgram, l, 'a_1');
+                gl.bindAttribLocation(glProgram, l, 'a_2');
+                gl.attachShader(glProgram, glVertexShader);
+                gl.attachShader(glProgram, glFragmentShader);
+                gl.linkProgram(glProgram);
+                var linkStatus = gl.getProgramParameter(glProgram, gl.LINK_STATUS);
+                assertMsg(!linkStatus, "Link should fail when both attributes are aliased to location " + l);
+            }
+        });
+    });
+};

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -191,6 +191,19 @@ var simpleColorFragmentShader = [
   '}'].join('\n');
 
 /**
+ * A fragment shader for a uniform color.
+ * @type {string}
+ */
+var simpleColorFragmentShaderESSL300 = [
+  '#version 300 es',
+  'precision mediump float;',
+  'out vec4 out_color;',
+  'uniform vec4 u_color;',
+  'void main() {',
+  '    out_color = u_color;',
+  '}'].join('\n');
+
+/**
  * A vertex shader for vertex colors.
  * @type {string}
  */
@@ -3221,6 +3234,7 @@ Object.defineProperties(API, {
   noTexCoordTextureVertexShader: { value: noTexCoordTextureVertexShader, writable: false },
   simpleTextureVertexShader: { value: simpleTextureVertexShader, writable: false },
   simpleColorFragmentShader: { value: simpleColorFragmentShader, writable: false },
+  simpleColorFragmentShaderESSL300: { value: simpleColorFragmentShaderESSL300, writable: false },
   simpleVertexShader: { value: simpleVertexShader, writable: false },
   simpleTextureFragmentShader: { value: simpleTextureFragmentShader, writable: false },
   simpleCubeMapTextureFragmentShader: { value: simpleCubeMapTextureFragmentShader, writable: false },

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3527,13 +3527,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
     <h3><a name="VERTEX_ATTRIBUTE_ALIASING">Vertex Attribute Aliasing</a></h3>
     <p>
-        In the WebGL 2.0 API, if more than one active attribute name is bound to the same location, it is considered
-        aliased, regardless whether there exists a path through the shader that consumes more than of these
-        attributes. Such definition of aliasing is broader than what is defined in
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.5">OpenGL ES 3.0.4 &sect;2.11.5</a>)</span>.
-    </p>
-    <p>
-        A link error is required when aliasing exists.
+        WebGL 2.0 API implementations must strictly follow GLSL ES 3.00.6 section 12.46, that
+        specifies that any vertex attribute aliasing is disallowed. In addition, WebGL 1.0 spec
+        section <a href="../1.0/index.html#ATTRIBUTE_ALIASING">Attribute aliasing</a> applies to
+        GLSL ES 1.00 shaders used with the WebGL 2.0 API.
     </p>
 
     <h3><a name="NO_PRIMITIVE_RESTART_FIXED_INDEX">PRIMITIVE_RESTART_FIXED_INDEX is always enabled</a></h3>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3527,10 +3527,11 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
     <h3><a name="VERTEX_ATTRIBUTE_ALIASING">Vertex Attribute Aliasing</a></h3>
     <p>
-        WebGL 2.0 API implementations must strictly follow GLSL ES 3.00.6 section 12.46, that
-        specifies that any vertex attribute aliasing is disallowed. In addition, WebGL 1.0 spec
-        section <a href="../1.0/index.html#ATTRIBUTE_ALIASING">Attribute aliasing</a> applies to
-        GLSL ES 1.00 shaders used with the WebGL 2.0 API.
+        WebGL 2.0 API implementations must strictly follow GLSL ES 3.00.6 section 12.46, which
+        specifies that any vertex attribute aliasing is disallowed. As stated in
+        <a href="#refsGLES30">[GLES30]</a> p57, GLSL ES 1.00 shaders may still alias, as allowed by
+        the WebGL 1.0 spec section <a href="../1.0/index.html#ATTRIBUTE_ALIASING">Attribute
+        aliasing</a>.
     </p>
 
     <h3><a name="NO_PRIMITIVE_RESTART_FIXED_INDEX">PRIMITIVE_RESTART_FIXED_INDEX is always enabled</a></h3>


### PR DESCRIPTION
GLSL ES 3.00.6 already has strict rules when it comes to attribute
aliasing, so WebGL 2.0 can simply refer to those rather than spell out
its own.

A new test is added to fully cover the attribute aliasing rules of
GLSL ES 3.00.6. It shares some code with the older attribute aliasing
test for WebGL 1.0.