### PR TITLE
Clarify WebGL specs for attribute aliasing

### DIFF
--- a/sdk/tests/conformance/attribs/00_test_list.txt
+++ b/sdk/tests/conformance/attribs/00_test_list.txt
@@ -1,4 +1,5 @@
 --min-version 1.0.3 gl-bindAttribLocation-aliasing.html
+--min-version 1.0.4 gl-bindAttribLocation-aliasing-inactive.html
 --min-version 1.0.3 gl-bindAttribLocation-matrix.html
 --min-version 1.0.4 gl-bindAttribLocation-nonexistent-attribute.html
 --min-version 1.0.4 gl-bindAttribLocation-repeated.html

--- a/sdk/tests/conformance2/attribs/00_test_list.txt
+++ b/sdk/tests/conformance2/attribs/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 2.0.1 gl-bindAttribLocation-aliasing-inactive-essl3.html
 gl-vertex-attrib.html
 gl-vertex-attrib-i-render.html
 --min-version 2.0.1 gl-vertex-attrib-normalized-int.html

--- a/sdk/tests/conformance2/attribs/gl-bindAttribLocation-aliasing-inactive-essl3.html
+++ b/sdk/tests/conformance2/attribs/gl-bindAttribLocation-aliasing-inactive-essl3.html
@@ -1,6 +1,6 @@
 <!--
 /*
-** Copyright (c) 2014 The Khronos Group Inc.
+** Copyright (c) 2018 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a
 ** copy of this software and/or associated documentation files (the
@@ -30,29 +30,42 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/gl-bindattriblocation-aliasing.js"></script>
-<title>bindAttribLocation with aliasing</title>
+<title>bindAttribLocation with aliasing - inactive attributes</title>
 </head>
 <body>
 <div id="description"></div>
 <div id="console"></div>
 <canvas id="canvas" width="8" height="8" style="width: 8px; height: 8px;"></canvas>
-<script id="vertexShader" type="text/something-not-javascript">
+<script id="vertexShaderStaticallyUsedButInactive" type="text/something-not-javascript">#version 300 es
 precision mediump float;
-attribute $(type_1) a_1;
-attribute $(type_2) a_2;
+in $(type_1) a_1;
+in $(type_2) a_2;
 void main() {
-    gl_Position = $(gl_Position_1) + $(gl_Position_2);
+    gl_Position = true ? $(gl_Position_1) : $(gl_Position_2);
+}
+</script>
+<script id="vertexShaderUnused" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+in $(type_1) a_1;
+in $(type_2) a_2;
+void main() {
+    gl_Position = $(gl_Position_1);
 }
 </script>
 <script>
 "use strict";
-description("This test verifies combinations of valid, active attribute types cannot be bound to the same location with bindAttribLocation.");
+description("This test verifies combinations attributes cannot be bound to the same location with bindAttribLocation, but just in case they are both statically used. WebGL 2.0 spec section Vertex Attribute Aliasing.");
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
-var gl = wtu.create3DContext(canvas, {antialias: false});
-var glFragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShader, gl.FRAGMENT_SHADER);
+var gl = wtu.create3DContext(canvas, {antialias: false}, 2);
+var glFragmentShader = wtu.loadShader(gl, wtu.simpleColorFragmentShaderESSL300, gl.FRAGMENT_SHADER);
 
-runBindAttribLocationAliasingTest(wtu, gl, glFragmentShader, wtu.getScript('vertexShader'), true);
+debug("Testing with ESSL 3.00 shader that has two statically used attributes, but where the static use of one of them can easily be optimized out.");
+runBindAttribLocationAliasingTest(wtu, gl, glFragmentShader, wtu.getScript('vertexShaderStaticallyUsedButInactive'), true);
+
+debug("");
+debug("Testing with ESSL 3.00 shader where only one of the attributes is statically used.");
+runBindAttribLocationAliasingTest(wtu, gl, glFragmentShader, wtu.getScript('vertexShaderUnused'), false);
 
 var successfullyParsed = true;
 </script>

--- a/sdk/tests/js/tests/gl-bindattriblocation-aliasing.js
+++ b/sdk/tests/js/tests/gl-bindattriblocation-aliasing.js
@@ -1,0 +1,68 @@
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+"use strict";
+
+var runBindAttribLocationAliasingTest = function(wtu, gl, glFragmentShader, vertexShaderTemplate, expectLinkFail) {
+    var typeInfo = [
+        { type: 'float',    asVec4: 'vec4(0.0, $(var), 0.0, 1.0)' },
+        { type: 'vec2',     asVec4: 'vec4($(var), 0.0, 1.0)' },
+        { type: 'vec3',     asVec4: 'vec4($(var), 1.0)' },
+        { type: 'vec4',     asVec4: '$(var)' },
+    ];
+    var maxAttributes = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+    // Test all type combinations of a_1 and a_2.
+    typeInfo.forEach(function(typeInfo1) {
+        typeInfo.forEach(function(typeInfo2) {
+            debug('attribute_1: ' + typeInfo1.type + ' attribute_2: ' + typeInfo2.type);
+            var replaceParams = {
+                type_1: typeInfo1.type,
+                type_2: typeInfo2.type,
+                gl_Position_1: wtu.replaceParams(typeInfo1.asVec4, {var: 'a_1'}),
+                gl_Position_2: wtu.replaceParams(typeInfo2.asVec4, {var: 'a_2'})
+            };
+            var strVertexShader = wtu.replaceParams(vertexShaderTemplate, replaceParams);
+            var glVertexShader = wtu.loadShader(gl, strVertexShader, gl.VERTEX_SHADER);
+            assertMsg(glVertexShader != null, "Vertex shader compiled successfully.");
+            // Bind both a_1 and a_2 to the same position and verify the link fails.
+            // Do so for all valid positions available.
+            for (var l = 0; l < maxAttributes; l++) {
+                var glProgram = gl.createProgram();
+                gl.bindAttribLocation(glProgram, l, 'a_1');
+                gl.bindAttribLocation(glProgram, l, 'a_2');
+                gl.attachShader(glProgram, glVertexShader);
+                gl.attachShader(glProgram, glFragmentShader);
+                gl.linkProgram(glProgram);
+                var linkStatus = gl.getProgramParameter(glProgram, gl.LINK_STATUS);
+                if (expectLinkFail)
+                {
+                    assertMsg(!linkStatus, "Link should fail when both attributes are aliased to location " + l);
+                }
+                else
+                {
+                    assertMsg(linkStatus, "Link should succeed even when both attributes are aliased to location " + l);
+                }
+            }
+        });
+    });
+};

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -191,6 +191,19 @@ var simpleColorFragmentShader = [
   '}'].join('\n');
 
 /**
+ * A fragment shader for a uniform color.
+ * @type {string}
+ */
+var simpleColorFragmentShaderESSL300 = [
+  '#version 300 es',
+  'precision mediump float;',
+  'out vec4 out_color;',
+  'uniform vec4 u_color;',
+  'void main() {',
+  '    out_color = u_color;',
+  '}'].join('\n');
+
+/**
  * A vertex shader for vertex colors.
  * @type {string}
  */
@@ -3221,6 +3234,7 @@ Object.defineProperties(API, {
   noTexCoordTextureVertexShader: { value: noTexCoordTextureVertexShader, writable: false },
   simpleTextureVertexShader: { value: simpleTextureVertexShader, writable: false },
   simpleColorFragmentShader: { value: simpleColorFragmentShader, writable: false },
+  simpleColorFragmentShaderESSL300: { value: simpleColorFragmentShaderESSL300, writable: false },
   simpleVertexShader: { value: simpleVertexShader, writable: false },
   simpleTextureFragmentShader: { value: simpleTextureFragmentShader, writable: false },
   simpleCubeMapTextureFragmentShader: { value: simpleCubeMapTextureFragmentShader, writable: false },

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3979,7 +3979,7 @@ extensions.
 <p>
     It is possible for an application to bind more than one attribute name to the
     same location. This is referred to as aliasing. When more than one attributes that
-    are aliased to the same location are active in the executable program,
+    are aliased to the same location are statically used in the executable program,
     <code>linkProgram</code> should fail.
 </p>
 

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3527,13 +3527,16 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
     <h3><a name="VERTEX_ATTRIBUTE_ALIASING">Vertex Attribute Aliasing</a></h3>
     <p>
-        In the WebGL 2.0 API, if more than one active attribute name is bound to the same location, it is considered
-        aliased, regardless whether there exists a path through the shader that consumes more than of these
-        attributes. Such definition of aliasing is broader than what is defined in
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.5">OpenGL ES 3.0.4 &sect;2.11.5</a>)</span>.
+        The WebGL 2.0 API relaxes the restrictions in GLSL ES 3.00.6 section 12.46. In the WebGL 2.0
+        API, two attributes that are bound to the same location are only considered to be aliased in
+        case they are both statically used. Otherwise the resolution of GLSL ES 3.00.6 section 12.46
+        applies to all shader programs used with the WebGL 2.0 API, so aliasing of statically used
+        attributes does cause linking to fail.
     </p>
     <p>
-        A link error is required when aliasing exists.
+        This rule is consistent with WebGL 1.0 spec section
+        <a href="../1.0/index.html#ATTRIBUTE_ALIASING">Attribute Aliasing</a>, so GLSL ES 1.00
+        shaders behave the same in WebGL 2.0 and WebGL 1.0 with respect to attribute aliasing.
     </p>
 
     <h3><a name="NO_PRIMITIVE_RESTART_FIXED_INDEX">PRIMITIVE_RESTART_FIXED_INDEX is always enabled</a></h3>


### PR DESCRIPTION
The intent with WebGL attribute aliasing rules has been to ensure
interoperability and that the rules are consistent between WebGL 1.0
and WebGL 2.0.

The WebGL 2.0 attribute aliasing chapter did not previously take
into account that GLSL ES 3.00.6 has strict rules when it comes to
attribute aliasing. To make the rules match with WebGL 1.0, WebGL 2.0
needs to explicitly relax the rules from GLSL ES.

The spec sections on attribute aliasing are also clarified to talk
about statically used attributes rather than "active attributes". This
makes WebGL more testable, since which attributes are active can
depend on compiler optimizations, whereas static use has a clear
definition.

New tests are added to enforce the rule that statically used
attributes are validated for aliasing.