### PR TITLE
Replaced invalid "enum" with "GLenum" in disjoint timer query extensi…

### DIFF
--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -65,11 +65,11 @@ interface EXT_disjoint_timer_query {
   WebGLTimerQueryEXT? createQueryEXT();
   void deleteQueryEXT(WebGLTimerQueryEXT? query);
   [WebGLHandlesContextLoss] boolean isQueryEXT(WebGLTimerQueryEXT? query);
-  void beginQueryEXT(enum target, WebGLTimerQueryEXT query);
-  void endQueryEXT(enum target);
-  void queryCounterEXT(WebGLTimerQueryEXT query, enum target);
-  any getQueryEXT(enum target, enum pname);
-  any getQueryObjectEXT(WebGLTimerQueryEXT query, enum pname);
+  void beginQueryEXT(GLenum target, WebGLTimerQueryEXT query);
+  void endQueryEXT(GLenum target);
+  void queryCounterEXT(WebGLTimerQueryEXT query, GLenum target);
+  any getQueryEXT(GLenum target, GLenum pname);
+  any getQueryObjectEXT(WebGLTimerQueryEXT query, GLenum pname);
 };
   </idl>
 

--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -49,7 +49,7 @@ interface EXT_disjoint_timer_query_webgl2 {
   const GLenum TIMESTAMP_EXT               = 0x8E28;
   const GLenum GPU_DISJOINT_EXT            = 0x8FBB;
 
-  void queryCounterEXT(WebGLQuery query, enum target);
+  void queryCounterEXT(WebGLQuery query, GLenum target);
 };
   </idl>
 


### PR DESCRIPTION
…ons.

Verified that these are the only places in the extensions' IDL which
have this mistake.

Fixes #2596.