### PR TITLE
Fix usage of glEnumToString in webgl-specific-stencil-settings

### DIFF
--- a/sdk/tests/conformance/misc/webgl-specific-stencil-settings.html
+++ b/sdk/tests/conformance/misc/webgl-specific-stencil-settings.html
@@ -111,7 +111,7 @@ function testStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTe
     debug("With depthbuffer=" + haveDepthBuffer +
             ", stencilbuffer=" + haveStencilBuffer +
             ", stencilTest=" + enableStencilTest +
-            ", expecting error=" + wtu.glEnumToString(errIfMismatch) +
+            ", expecting error=" + wtu.glEnumToString(gl, errIfMismatch) +
             " for mismatching mask or func settings.");
 
     let rbo = null;

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -57,6 +57,10 @@ var loggingOff = function() {
  * @return {string} The enum as a string.
  */
 var glEnumToString = function(gl, value) {
+  // Avoid returning "NO_ERROR" if the arguments are totally wrong.
+  if (gl.NO_ERROR === undefined || value === undefined) {
+    return undefined;
+  }
   // Optimization for the most common enum:
   if (value === gl.NO_ERROR) {
     return "NO_ERROR";


### PR DESCRIPTION
and add a safeguard against future glEnumToString usage mistakes

(follow-up to #2583)