### PR TITLE
Change dummySetProgramAndDrawNothing to draw >0 elements

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -970,13 +970,16 @@ var drawUnitQuad = function(gl) {
   gl.drawArrays(gl.TRIANGLES, 0, 6);
 };
 
-var noopProgram = null;
+var dummyProgram = null;
 var dummySetProgramAndDrawNothing = function(gl) {
-  if (!noopProgram) {
-    noopProgram = setupProgram(gl, ["void main() {}", "void main() {}"], [], []);
+  if (!dummyProgram) {
+    dummyProgram = setupProgram(gl, [
+      "void main() { gl_Position = vec4(0.0); }",
+      "void main() { gl_FragColor = vec4(0.0); }"
+    ], [], []);
   }
-  gl.useProgram(noopProgram);
-  gl.drawArrays(gl.TRIANGLES, 0, 0);
+  gl.useProgram(dummyProgram);
+  gl.drawArrays(gl.TRIANGLES, 0, 3);
 };
 
 /**


### PR DESCRIPTION
* the program now sets `gl_Position` and `gl_FragColor` to `vec4(0.0)`
* drawArrays now draws one triangle instead of 0
  (but that triangle is of zero size)

This is necessary to make sure the draw call doesn't early out before it
does validation.

(follow-up to #2583)