### PR TITLE
Use fixed number of iterations in sync-webgl-specific.

### DIFF
--- a/sdk/tests/conformance2/sync/sync-webgl-specific.html
+++ b/sdk/tests/conformance2/sync/sync-webgl-specific.html
@@ -48,6 +48,7 @@ debug("Canvas.getContext");
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext("canvas", null, 2);
 var sync = null;
+var pixel = new Uint8Array(4);
 
 if (!gl) {
   testFailed("context does not exist");
@@ -82,7 +83,12 @@ if (!gl) {
   requestAnimationFrame(runGetSyncParameterTest);
 }
 
-var signaling_retry_ms = 1000;
+var numRetries = 20000;
+var iteration = 0;
+
+function syncWithGLServer() {
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixel);
+}
 
 function runGetSyncParameterTest() {
   debug("");
@@ -91,10 +97,9 @@ function runGetSyncParameterTest() {
   // Verify as best as possible that the implementation doesn't allow a sync
   // object to become signaled until returning control to the event loop, by
   // spin-looping for some time.
-  var startTime = Date.now();
-  while (Date.now() - startTime < signaling_retry_ms) {
-    gl.flush();
-    gl.finish();
+  var iter = numRetries;
+  while (--iter > 0) {
+    syncWithGLServer();
     if (gl.getSyncParameter(sync, gl.SYNC_STATUS) == gl.SYNC_SIGNALED) {
       testFailed("Sync object was signaled too early");
       finishTest();
@@ -102,17 +107,13 @@ function runGetSyncParameterTest() {
     }
   }
   testPassed("Sync object wasn't signaled too early");
-  startTimeOfFinish = Date.now();
+  iteration = numRetries;
   requestAnimationFrame(finishSyncParameterTest);
 }
 
-var startTimeOfFinish = 0;
 
 function finishSyncParameterTest() {
-  if (startTimeOfFinish == 0) {
-    startTimeOfFinish = Date.now();
-  }
-  if (Date.now() - startTimeOfFinish > signaling_retry_ms) {
+  if (--iteration == 0) {
     testFailed("Sync object wasn't signaled in a reasonable timeframe (" + (Date.now() - startTimeOfFinish) + " ms)");
     finishTest();
     return;
@@ -124,6 +125,7 @@ function finishSyncParameterTest() {
     return;
   }
   // Try again.
+  syncWithGLServer();
   requestAnimationFrame(finishSyncParameterTest);
 }
 
@@ -135,10 +137,9 @@ function runClientWaitSyncTest() {
   // Verify as best as possible that the implementation doesn't allow
   // clientWaitSync to return CONDITION_SATISFIED or ALREADY_SIGNALED until
   // returning control to the event loop, by spin-looping for some time.
-  var startTime = Date.now();
-  while (Date.now() - startTime < signaling_retry_ms) {
-    gl.flush();
-    gl.finish();
+  var iter = numRetries;
+  while (--iter > 0) {
+    syncWithGLServer();
     var res = gl.clientWaitSync(sync, 0, 0);
     if (res == gl.CONDITION_SATISFIED || res == gl.ALREADY_SIGNALED) {
       testFailed("clientWaitSync completed successfully too early");
@@ -147,15 +148,12 @@ function runClientWaitSyncTest() {
     }
   }
   testPassed("clientWaitSync didn't complete successfully too early");
-  startTimeOfFinish = 0;
+  iteration = numRetries;
   requestAnimationFrame(finishClientWaitSyncTest);
 }
 
 function finishClientWaitSyncTest() {
-  if (startTimeOfFinish == 0) {
-    startTimeOfFinish = Date.now();
-  }
-  if (Date.now() - startTimeOfFinish > signaling_retry_ms) {
+  if (--iteration == 0) {
     testFailed("clientWaitSync didn't complete in a reasonable timeframe");
     finishTest();
     return;
@@ -168,6 +166,7 @@ function finishClientWaitSyncTest() {
     return;
   }
   // Try again.
+  syncWithGLServer();
   requestAnimationFrame(finishClientWaitSyncTest);
 }
 

--- a/sdk/tests/conformance2/sync/sync-webgl-specific.html
+++ b/sdk/tests/conformance2/sync/sync-webgl-specific.html
@@ -114,7 +114,7 @@ function runGetSyncParameterTest() {
 
 function finishSyncParameterTest() {
   if (--iteration == 0) {
-    testFailed("Sync object wasn't signaled in a reasonable timeframe (" + (Date.now() - startTimeOfFinish) + " ms)");
+    testFailed("Sync object wasn't signaled in a reasonable timeframe (" + numRetries + " iterations)");
     finishTest();
     return;
   }
@@ -154,7 +154,7 @@ function runClientWaitSyncTest() {
 
 function finishClientWaitSyncTest() {
   if (--iteration == 0) {
-    testFailed("clientWaitSync didn't complete in a reasonable timeframe");
+    testFailed("clientWaitSync didn't complete in a reasonable timeframe (" + numRetries + " iterations)");
     finishTest();
     return;
   }


### PR DESCRIPTION
Like the conformance2/query/occlusion-query test, use a fixed number
of iterations, as on slow automated test machines, a fixed duration
based on Date.now() leads to test flakiness.

Improve the synchronization with the GL server by using readPixels
instead of flush or finish.