### PR TITLE
wtu.loadShader's gl.shaderSource should be treated as infallible.

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -1922,11 +1922,6 @@ var loadShader = function(
 
   // Load the shader source
   gl.shaderSource(shader, shaderSource);
-  var err = gl.getError();
-  if (err != gl.NO_ERROR) {
-    errFn("*** Error loading shader '" + shader + "':" + glEnumToString(gl, err));
-    return null;
-  }
 
   // Compile the shader
   gl.compileShader(shader);


### PR DESCRIPTION
loadShader thinks shaderSource generated an error, but really it's an error from a previous call. We can either assert before calling shaderSource that there's no current GL error, OR we can just treat shaderSource as infallible, which it really should be here.