### PR TITLE
Add more stencil validation tests

### DIFF
--- a/sdk/tests/conformance/misc/webgl-specific-stencil-settings.html
+++ b/sdk/tests/conformance/misc/webgl-specific-stencil-settings.html
@@ -43,13 +43,21 @@
 var wtu = WebGLTestUtils;
 description("Tests that stencil mask/func are validated correctly when the front state and back state differ.");
 
-var gl = wtu.create3DContext();
+var gl;
 
-function testStencilMaskCase(mask, error) {
+function checkDrawError(errIfMismatch) {
+    wtu.shouldGenerateGLError(gl, errIfMismatch, "wtu.dummySetProgramAndDrawNothing(gl)");
+}
+
+function setStencilMask(mask) {
     wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.FRONT, " + mask[0] + ")");
     wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.BACK,  " + mask[1] + ")");
+}
+
+function testStencilMaskCase(mask, error) {
+    setStencilMask(mask);
     // If an error is generated, it should be at draw time.
-    wtu.shouldGenerateGLError(gl, error, "wtu.dummySetProgramAndDrawNothing(gl)");
+    checkDrawError(error);
 }
 
 function testStencilMask(errIfMismatch) {
@@ -60,11 +68,15 @@ function testStencilMask(errIfMismatch) {
     wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMask(1023)", "resetting stencilMask");
 }
 
-function testStencilFuncCase(ref, mask, error) {
+function setStencilFunc(ref, mask) {
     wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.FRONT, gl.ALWAYS, " + ref[0] + ", " + mask[0] + ")");
     wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.BACK,  gl.ALWAYS, " + ref[1] + ", " + mask[1] + ")");
+}
+
+function testStencilFuncCase(ref, mask, error) {
+    setStencilFunc(ref, mask);
     // If an error is generated, it should be at draw time.
-    wtu.shouldGenerateGLError(gl, error, "wtu.dummySetProgramAndDrawNothing(gl)");
+    checkDrawError(error);
 }
 
 function testStencilFunc(errIfMismatch) {
@@ -97,6 +109,34 @@ function testStencilFunc(errIfMismatch) {
     wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFunc(gl.ALWAYS, 0, 1023)", "resetting stencilFunc");
 }
 
+//
+// Tests of the default framebuffer
+//
+
+debug("");
+
+debug("Testing default framebuffer with { stencil: true }");
+gl = wtu.create3DContext(undefined, { stencil: true });
+{
+    gl.enable(gl.STENCIL_TEST);
+    testStencilMaskCase([1, 256], gl.INVALID_OPERATION);
+    testStencilFuncCase([256, 0], [1023, 1023], gl.INVALID_OPERATION);
+}
+
+debug("Testing default framebuffer with { stencil: false }");
+gl = wtu.create3DContext(undefined, { stencil: false });
+{
+    // with { stencil: false }
+    gl.enable(gl.STENCIL_TEST);
+    testStencilMaskCase([1, 256], gl.NO_ERROR);
+    testStencilFuncCase([256, 0], [1023, 1023], gl.NO_ERROR);
+}
+// (continue using this GL context for the other tests)
+
+//
+// Tests with a framebuffer object
+//
+
 const fb = gl.createFramebuffer();
 gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
 const colorRB = gl.createRenderbuffer();
@@ -106,14 +146,7 @@ gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER
 
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "initial framebuffer setup")
 
-function testStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTest, errIfMismatch) {
-    debug("");
-    debug("With depthbuffer=" + haveDepthBuffer +
-            ", stencilbuffer=" + haveStencilBuffer +
-            ", stencilTest=" + enableStencilTest +
-            ", expecting error=" + wtu.glEnumToString(gl, errIfMismatch) +
-            " for mismatching mask or func settings.");
-
+function runWithStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTest, fn) {
     let rbo = null;
     let attachment;
     if (haveDepthBuffer || haveStencilBuffer) {
@@ -143,10 +176,7 @@ function testStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTe
         gl.disable(gl.STENCIL_TEST);
     }
 
-    // Errors should be the same for both mask and func, because stencil test
-    // and stencil write are always enabled/disabled in tandem.
-    testStencilMask(errIfMismatch);
-    testStencilFunc(errIfMismatch);
+    fn();
 
     if (rbo) {
         gl.framebufferRenderbuffer(gl.FRAMEBUFFER, attachment, gl.RENDERBUFFER, null);
@@ -157,6 +187,21 @@ function testStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTe
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "depth/stencil renderbuffer cleanup")
 }
 
+function testStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTest, errIfMismatch) {
+    debug("");
+    debug("With depthbuffer=" + haveDepthBuffer +
+            ", stencilbuffer=" + haveStencilBuffer +
+            ", stencilTest=" + enableStencilTest +
+            ", expecting error=" + wtu.glEnumToString(gl, errIfMismatch) +
+            " for mismatching mask or func settings.");
+
+    runWithStencilSettings(haveDepthBuffer, haveStencilBuffer, enableStencilTest, () => {
+        // Errors should be the same for both mask and func, because stencil test
+        // and stencil write are always enabled/disabled in tandem.
+        testStencilMask(errIfMismatch);
+        testStencilFunc(errIfMismatch);
+    });
+}
 
 debug("");
 debug("Base case checks:");
@@ -176,6 +221,93 @@ testStencilSettings(false, false,  true, gl.NO_ERROR);
 testStencilSettings( true, false,  true, gl.NO_ERROR);
 testStencilSettings(false,  true,  true, gl.INVALID_OPERATION);
 testStencilSettings( true,  true,  true, gl.INVALID_OPERATION);
+
+//
+// Tests to make sure the stencil validation check, if cached, is invalidated correctly.
+//
+
+debug("");
+
+debug("Setup for stencil validation cache invalidation tests");
+setStencilMask([1, 258]);
+setStencilFunc([0, 256], [1023, 1023]);
+
+debug("Test with enabling/disabling stencil test");
+runWithStencilSettings(false, true, false, () => {
+    checkDrawError(gl.NO_ERROR);
+    gl.enable(gl.STENCIL_TEST);
+    checkDrawError(gl.INVALID_OPERATION);
+    gl.disable(gl.STENCIL_TEST);
+    checkDrawError(gl.NO_ERROR);
+});
+
+debug("Test with swapping in a new FBO");
+runWithStencilSettings(false, false, true, () => {
+    // no error with no stencil buffer
+    checkDrawError(gl.NO_ERROR);
+
+    // swap in a new FBO with a stencil buffer
+    const fb2 = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb2);
+    gl.bindRenderbuffer(gl.RENDERBUFFER, colorRB);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, colorRB);
+    const rbo = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, rbo);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.STENCIL_INDEX8, 1, 1);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, rbo);
+    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+    // this draw sholud detect the new fbo state
+    checkDrawError(gl.INVALID_OPERATION);
+
+    gl.deleteFramebuffer(fb2);
+    gl.deleteRenderbuffer(rbo)
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+});
+
+debug("Test with adding a stencil attachment");
+runWithStencilSettings(false, false, true, () => {
+    // no error with no stencil buffer
+    checkDrawError(gl.NO_ERROR);
+
+    // add a stencil attachment
+    const rbo = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, rbo);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.STENCIL_INDEX8, 1, 1);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.STENCIL_ATTACHMENT, gl.RENDERBUFFER, rbo);
+    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+    // this draw sholud detect the new fbo state
+    checkDrawError(gl.INVALID_OPERATION);
+
+    gl.deleteRenderbuffer(rbo)
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+});
+
+debug("Test with reallocating the DEPTH_STENCIL attachment from depth to depth+stencil");
+runWithStencilSettings(false, false, true, () => {
+    // attach a depth buffer to the DEPTH_STENCIL attachment
+    const rbo = gl.createRenderbuffer();
+    gl.bindRenderbuffer(gl.RENDERBUFFER, rbo);
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, 1, 1);
+    gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, rbo);
+    shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+    // this draw is invalid, but it still might trigger caching of the stencil validation
+    checkDrawError(gl.INVALID_FRAMEBUFFER_OPERATION);
+
+    gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, 1, 1);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+    // this draw sholud detect the new fbo state
+    checkDrawError(gl.INVALID_OPERATION);
+
+    gl.deleteRenderbuffer(rbo)
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+});
 
 gl.deleteFramebuffer(fb);
 gl.deleteRenderbuffer(colorRB);

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -981,15 +981,14 @@ var drawUnitQuad = function(gl) {
   gl.drawArrays(gl.TRIANGLES, 0, 6);
 };
 
-var dummyProgram = null;
 var dummySetProgramAndDrawNothing = function(gl) {
-  if (!dummyProgram) {
-    dummyProgram = setupProgram(gl, [
+  if (!gl._wtuDummyProgram) {
+    gl._wtuDummyProgram = setupProgram(gl, [
       "void main() { gl_Position = vec4(0.0); }",
       "void main() { gl_FragColor = vec4(0.0); }"
     ], [], []);
   }
-  gl.useProgram(dummyProgram);
+  gl.useProgram(gl._wtuDummyProgram);
   gl.drawArrays(gl.TRIANGLES, 0, 3);
 };
 


### PR DESCRIPTION
Add new tests testing
- various transitions from valid to invalid states (in order to test invalidation of the cached validation in Chrome)
- drawing to the default framebuffer

Also modifies dummySetProgramAndDrawNothing to keep one WebGLProgram _per WebGL context_.

https://crbug.com/806557