### PR TITLE
Limit blitFramebuffer source and destination rectangle size

### DIFF
--- a/sdk/tests/conformance2/rendering/blitframebuffer-size-overflow.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-size-overflow.html
@@ -84,6 +84,11 @@ function blit_region_test() {
     gl.blitFramebuffer(0, 0, max, max, 0, 0, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Using max 32-bit integer as blitFramebuffer parameter should succeed.");
 
+    gl.blitFramebuffer(-1, -1, max - 1, max - 1, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    gl.blitFramebuffer(0, 0, width, height, -1, -1, max - 1, max - 1, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    gl.blitFramebuffer(-1, -1, max - 1, max - 1, -1, -1, max - 1, max - 1, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Using blitFramebuffer parameters where calculated width/height matches max 32-bit integer should succeed.");
+
     gl.blitFramebuffer(-1, -1, max, max, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using source width/height greater than max 32-bit integer should fail.");
     gl.blitFramebuffer(0, 0, width, height, -1, -1, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);

--- a/sdk/tests/conformance2/rendering/blitframebuffer-size-overflow.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-size-overflow.html
@@ -82,13 +82,16 @@ function blit_region_test() {
     gl.blitFramebuffer(0, 0, max, max, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     gl.blitFramebuffer(0, 0, width, height, 0, 0, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     gl.blitFramebuffer(0, 0, max, max, 0, 0, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Using max 32-bit integer as blitFramebuffer parameter should succeed.");
 
     gl.blitFramebuffer(-1, -1, max, max, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using source width/height greater than max 32-bit integer should fail.");
     gl.blitFramebuffer(0, 0, width, height, -1, -1, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using destination width/height greater than max 32-bit integer should fail.");
     gl.blitFramebuffer(-1, -1, max, max, -1, -1, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using both source and destination width/height greater than max 32-bit integer should fail.");
     gl.blitFramebuffer(-max - 1, -max - 1, max, max, -max - 1, -max - 1, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
-
-    testPassed("Congratulations! blitFramebuffer doesn't cause the browser crash when the computed width/height of src and/or dst region might overflow.");
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using minimum and maximum integers for all boundaries should fail.");
 
     gl.bindTexture(gl.TEXTURE_2D, null)
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3954,6 +3954,22 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
         and <a href="#CLIENT_WAIT_SYNC">clientWaitSync</a> for discussion and rationale.
     </p>
 
+    <h3>blitFramebuffer rectangle width/height limitations</h3>
+
+    <p>
+        <code>blitFramebuffer()</code> src* and dst* parameters must be set so that the resulting
+        width and height of the source and destination rectangles are less than or equal to the
+        maximum value that can be stored in a GLint. In case computing any of the width or height
+        values as a GLint results in integer overflow, <code>blitFramebuffer()</code> generates an
+        <code>INVALID_VALUE</code> error.
+    </p>
+
+    <div class="note rationale">
+        Using larger than max 32-bit int sized rectangles for blitFramebuffer triggers issues on
+        most desktop OpenGL drivers, and there is no general workaround for cases where
+        blitFramebuffer is used to scale the framebuffer.
+    </div>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>


### PR DESCRIPTION
BlitFramebuffer bugs that trigger when using large rectangle
dimensions seem to be widespread on all desktop OpenGL drivers. They
have been seen on at least:

AMD Windows OpenGL
Intel Windows OpenGL
Intel Linux OpenGL
NVIDIA OpenGL (all platforms)

In addition there are some issues with handling large dimensions in
existing blitFramebuffer workarounds inside ANGLE.

In some cases these issues can be worked around by clipping the
blitFramebuffer rectangles so that their width and height fit a signed
32-bit integer. However, this approach doesn't work in case
blitFramebuffer is used to scale the framebuffer and the greatest
common divisor of the source and destination dimensions is 1.

Since these issues likely don't have any impact on real-world
applications, it's reasonable to limit the dimensions in the spec so
that rectangles taller or wider than the maximum GLint value are not
allowed.