### PR TITLE
Add a test for declaring both gl_FragColor and gl_FragData invariant

### DIFF
--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -5,7 +5,7 @@ embedded-struct-definitions-forbidden.html
 --min-version 1.0.4 empty-declaration.html
 empty_main.vert.html
 --min-version 1.0.3 expression-list-in-declarator-initializer.html
-fragcolor-fragdata-invariant.html
+--min-version 1.0.4 fragcolor-fragdata-invariant.html
 gl_position_unset.vert.html
 --min-version 1.0.4 global-variable-init.html
 # this test is intentionally disabled as it is too strict and to hard to simulate

--- a/sdk/tests/conformance/glsl/misc/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/misc/00_test_list.txt
@@ -5,6 +5,7 @@ embedded-struct-definitions-forbidden.html
 --min-version 1.0.4 empty-declaration.html
 empty_main.vert.html
 --min-version 1.0.3 expression-list-in-declarator-initializer.html
+fragcolor-fragdata-invariant.html
 gl_position_unset.vert.html
 --min-version 1.0.4 global-variable-init.html
 # this test is intentionally disabled as it is too strict and to hard to simulate

--- a/sdk/tests/conformance/glsl/misc/fragcolor-fragdata-invariant.html
+++ b/sdk/tests/conformance/glsl/misc/fragcolor-fragdata-invariant.html
@@ -1,0 +1,61 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests - gl_FragColor and gl_FragData both declared as invariant</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../../resources/glsl-feature-tests.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fragmentShader" type="text/something-not-javascript">
+// Declaring both gl_FragColor and gl_FragData invariant should succeed.
+precision mediump float;
+
+// Static write of both gl_FragColor and gl_FragData is disallowed. However, simply declaring a variable invariant is not really accessing the variable, so it should be ok.
+invariant gl_FragColor;
+invariant gl_FragData;
+
+void main()
+{
+    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
+}
+</script>
+<script>
+"use strict";
+GLSLConformanceTester.runTest();
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Declaring a variable invariant doesn't access it, so it should not
really count as using the variable. Earlier versions of ANGLE would
treat declaring both gl_FragColor and gl_FragData invariant an error,
but recent versions have been fixed to allow this usage.