### PR TITLE
Revert "Test texStorage[2,3]D with non-square sizes."

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
@@ -282,19 +282,6 @@ function runTexStorage2DTest()
             wtu.clearAndDrawUnitQuad(gl);
             wtu.checkCanvas(gl, [255, 0, 0, alpha], "texture should sample as red after uploading red pixels with texSubImage2D");
         }
-
-        // Test non-square images.
-        function expectOk(x,y) {
-            const tex = gl.createTexture();
-            gl.bindTexture(target, tex);
-            gl.texStorage2D(target, levels, testcase.sizedformat, x, y);
-            wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-                                "texStorage2D should succeed with size [" + ([x,y].join(', ')) + "].");
-            gl.deleteTexture(tex);
-        }
-        //expectOk(texsize, texsize);
-        expectOk(texsize,       1);
-        expectOk(      1, texsize);
     });
 }
 

--- a/sdk/tests/conformance2/textures/misc/tex-storage-and-subimage-3d.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-and-subimage-3d.html
@@ -222,23 +222,6 @@ function runTexStorageAndSubImage3DTest()
                          testcase.unsizedformat, testcase.type,
                          pixels);
         wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "texSubImage3D should fail for dimension out of range");
-
-        // Test non-square images.
-        function expectOk(x,y,z) {
-            const tex = gl.createTexture();
-            gl.bindTexture(target, tex);
-            gl.texStorage3D(target, levels, testcase.sizedformat, x, y, z);
-            wtu.glErrorShouldBe(gl, gl.NO_ERROR,
-                                "texStorage3D should succeed with size [" + ([x,y,z].join(', ')) + "].");
-            gl.deleteTexture(tex);
-        }
-        //expectOk(texsize, texsize, texsize);
-        expectOk(texsize, texsize,       1);
-        expectOk(texsize,       1, texsize);
-        expectOk(texsize,       1,       1);
-        expectOk(      1, texsize, texsize);
-        expectOk(      1, texsize,       1);
-        expectOk(      1,       1, texsize);
     });
 }
 


### PR DESCRIPTION
Reverts KhronosGroup/WebGL#2647

There was a bug in the handling of cube map textures.
