### PR TITLE
Add tests for blitting to cover width/height overflow.

### DIFF
--- a/sdk/tests/conformance2/rendering/blitframebuffer-size-overflow.html
+++ b/sdk/tests/conformance2/rendering/blitframebuffer-size-overflow.html
@@ -91,7 +91,11 @@ function blit_region_test() {
 
     gl.blitFramebuffer(-1, -1, max, max, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using source width/height greater than max 32-bit integer should fail.");
+    gl.blitFramebuffer(max, max, -1, -1, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using source width/height greater than max 32-bit integer should fail.");
     gl.blitFramebuffer(0, 0, width, height, -1, -1, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using destination width/height greater than max 32-bit integer should fail.");
+    gl.blitFramebuffer(0, 0, width, height, max, max, -1, -1, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using destination width/height greater than max 32-bit integer should fail.");
     gl.blitFramebuffer(-1, -1, max, max, -1, -1, max, max, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Using both source and destination width/height greater than max 32-bit integer should fail.");


### PR DESCRIPTION
The range of an integer is [-0x7fffffff - 1, 0x7fffffff].
We restrict the width/height to the max value that can be
store in an integer in latest WebGL 2 spec. If we
reverse the data order for blitting, an invalid value like
0x7fffffff + 1 would become a valid value for an integer:
-0x7fffffff - 1. But it is invalid for blitting.

The new added tests cover this corner case to make it clear.