### PR TITLE
Test texStorage[2,3]D with non-square sizes.

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-2d.html
@@ -283,6 +283,23 @@ function runTexStorage2DTest()
             wtu.checkCanvas(gl, [255, 0, 0, alpha], "texture should sample as red after uploading red pixels with texSubImage2D");
         }
     });
+
+    debug("");
+    debug("Test non-square images:");
+    const levels = 4;
+    const maxSize = 1 << (levels-1);
+
+    function expectOk(x,y) {
+        const tex = gl.createTexture();
+        gl.bindTexture(gl.TEXTURE_2D, tex);
+        gl.texStorage2D(gl.TEXTURE_2D, levels, gl.RGBA8, x, y);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR,
+                            "texStorage2D should succeed with size [" + ([x,y].join(', ')) + "].");
+        gl.deleteTexture(tex);
+    }
+    expectOk(maxSize, maxSize);
+    expectOk(maxSize,       1);
+    expectOk(      1, maxSize);
 }
 
 debug("");

--- a/sdk/tests/conformance2/textures/misc/tex-storage-and-subimage-3d.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-and-subimage-3d.html
@@ -223,6 +223,35 @@ function runTexStorageAndSubImage3DTest()
                          pixels);
         wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "texSubImage3D should fail for dimension out of range");
     });
+
+    debug("");
+    debug("Test non-square images:");
+    const levels = 4;
+    const maxSize = 1 << (levels-1);
+
+    function expectOk(target, x,y,z, err) {
+        debug("(target=" + target + ", size=[" + ([x,y,z].join(', ')) + "])");
+        const tex = gl.createTexture();
+        gl.bindTexture(gl[target], tex);
+        gl.texStorage3D(gl[target], levels+1, gl.RGBA8, x, y, z);
+        wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "levels=levels+1");
+
+        gl.texStorage3D(gl[target], levels, gl.RGBA8, x, y, z);
+        wtu.glErrorShouldBe(gl, gl[err], "levels=levels");
+        gl.deleteTexture(tex);
+    }
+    expectOk("TEXTURE_3D", maxSize, maxSize, maxSize, "NO_ERROR");
+    expectOk("TEXTURE_3D", maxSize, maxSize,       1, "NO_ERROR");
+    expectOk("TEXTURE_3D", maxSize,       1, maxSize, "NO_ERROR");
+    expectOk("TEXTURE_3D", maxSize,       1,       1, "NO_ERROR");
+    expectOk("TEXTURE_3D",       1, maxSize, maxSize, "NO_ERROR");
+    expectOk("TEXTURE_3D",       1, maxSize,       1, "NO_ERROR");
+    expectOk("TEXTURE_3D",       1,       1, maxSize, "NO_ERROR");
+
+    expectOk("TEXTURE_2D_ARRAY", maxSize, maxSize, 10, "NO_ERROR");
+    expectOk("TEXTURE_2D_ARRAY", maxSize,       1, 10, "NO_ERROR");
+    expectOk("TEXTURE_2D_ARRAY",       1, maxSize, 10, "NO_ERROR");
+    expectOk("TEXTURE_2D_ARRAY",       1,       1, 10, "INVALID_OPERATION");
 }
 
 debug("");


### PR DESCRIPTION
Regression test from Firefox where e.g. level=9, width=512, height=1
fails.

Tested in patched Firefox this time. :)