### PR TITLE
WebKit (now) supports requestAnimationFrame

### DIFF
--- a/conformance-suites/1.0.2/resources/js-test-pre.js
+++ b/conformance-suites/1.0.2/resources/js-test-pre.js
@@ -49,11 +49,6 @@
       window.console.log = function() { };
       window.console.error = function() { };
       window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
-
-      // RAF doesn't work in LayoutTests. Disable it so the tests will
-      // use setTimeout instead.
-      window.requestAnimationFrame = undefined;
-      window.webkitRequestAnimationFrame = undefined;
     }
 
     /* -- end platform specific code --*/

--- a/conformance-suites/1.0.3/resources/js-test-pre.js
+++ b/conformance-suites/1.0.3/resources/js-test-pre.js
@@ -49,11 +49,6 @@
       window.console.log = function() { };
       window.console.error = function() { };
       window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
-
-      // RAF doesn't work in LayoutTests. Disable it so the tests will
-      // use setTimeout instead.
-      window.requestAnimationFrame = undefined;
-      window.webkitRequestAnimationFrame = undefined;
     }
 
     /* -- end platform specific code --*/

--- a/conformance-suites/2.0.0/js/js-test-pre.js
+++ b/conformance-suites/2.0.0/js/js-test-pre.js
@@ -49,11 +49,6 @@
       window.console.log = function() { };
       window.console.error = function() { };
       window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
-
-      // RAF doesn't work in LayoutTests. Disable it so the tests will
-      // use setTimeout instead.
-      window.requestAnimationFrame = undefined;
-      window.webkitRequestAnimationFrame = undefined;
     }
 
     /* -- end platform specific code --*/

--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -49,11 +49,6 @@
       window.console.log = function() { };
       window.console.error = function() { };
       window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
-
-      // RAF doesn't work in LayoutTests. Disable it so the tests will
-      // use setTimeout instead.
-      window.requestAnimationFrame = undefined;
-      window.webkitRequestAnimationFrame = undefined;
     }
 
     /* -- end platform specific code --*/


### PR DESCRIPTION
LayoutTests have supported window.requestAnimationFrame for a while. I am removing this WebKit-specific code so that window.requestAnimationFrame calls will not fail on WebKit's test framework.