### PR TITLE
Specify binding one buffer to two transform feedback outputs

### DIFF
--- a/sdk/tests/conformance2/transform_feedback/00_test_list.txt
+++ b/sdk/tests/conformance2/transform_feedback/00_test_list.txt
@@ -3,5 +3,6 @@ transform_feedback.html
 two-unreferenced-varyings.html
 --min-version 2.0.1 too-small-buffers.html
 unwritten-output-defaults-to-zero.html
+--min-version 2.0.1 same-buffer-two-binding-points.html
 --min-version 2.0.1 simultaneous_binding.html
 --min-version 2.0.1 switching-objects.html

--- a/sdk/tests/conformance2/transform_feedback/same-buffer-two-binding-points.html
+++ b/sdk/tests/conformance2/transform_feedback/same-buffer-two-binding-points.html
@@ -1,0 +1,131 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Transform Feedback Conformance Tests - one buffer bound to two binding points</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+
+in vec4 in_data;
+out vec4 out_add;
+out vec4 out_mul;
+void main(void) {
+    out_add = in_data + vec4(2.0, 3.0, 4.0, 5.0);
+    out_mul = in_data * vec4(2.0, 3.0, 4.0, 5.0);
+}
+</script>
+<script>
+"use strict";
+description();
+
+debug("");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext(null, null, 2);
+var program = null;
+
+if (!gl) {
+    testFailed("WebGL context does not exist");
+} else {
+    testPassed("WebGL context exists");
+    runTwoOutFeedbackTest();
+}
+
+function runTwoOutFeedbackTest() {
+    debug("");
+    debug("Test binding the same buffer to two transform feedback binding points. Buffer should be untouched and an error should be generated.")
+
+    // Build the input and output buffers
+    var in_data = [
+        1.0, 2.0, 3.0, 4.0,
+        2.0, 4.0, 8.0, 16.0,
+        0.75, 0.5, 0.25, 0.0
+    ];
+
+    var in_buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(in_data), gl.STATIC_DRAW);
+
+    // Create the transform feedback shader
+    program = wtu.setupTransformFeedbackProgram(gl, ["vshader", wtu.simpleColorFragmentShaderESSL300],
+        ["out_add", "out_mul"], gl.SEPARATE_ATTRIBS,
+        ["in_data"]);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking transform feedback shader should not set an error");
+    shouldBeNonNull("program");
+
+    // Draw the the transform feedback buffers
+    var tf = gl.createTransformFeedback();
+
+    gl.enableVertexAttribArray(0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
+    gl.vertexAttribPointer(0, 4, gl.FLOAT, false, 16, 0);
+
+    // Test binding the same buffer to two transform feedback binding points.
+
+    gl.enable(gl.RASTERIZER_DISCARD);
+
+    var out_buffer = gl.createBuffer();
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length * 2, gl.STATIC_DRAW);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer);
+
+    gl.beginTransformFeedback(gl.POINTS);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "same buffer bound to two transform feedback varyings");
+    gl.drawArrays(gl.POINTS, 0, 3);
+    gl.endTransformFeedback();
+
+    // Clean up state.
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
+    gl.disable(gl.RASTERIZER_DISCARD);
+
+    var expected = [];
+    for (var i = 0; i < in_data.length * 2; ++i)
+    {
+        expected.push(0.0);
+    }
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
+    debug("");
+    debug("buffer should be untouched - filled with zeroes");
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
+
+    finishTest();
+}
+</script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/transform_feedback/same-buffer-two-binding-points.html
+++ b/sdk/tests/conformance2/transform_feedback/same-buffer-two-binding-points.html
@@ -102,6 +102,7 @@ function runTwoOutFeedbackTest() {
     gl.vertexAttribPointer(0, 4, gl.FLOAT, false, 16, 0);
 
     var out_buffer = gl.createBuffer();
+    var out_buffer2 = gl.createBuffer();
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
 
     // Test binding the same buffer to two transform feedback binding points with bindBufferBase.
@@ -111,7 +112,7 @@ function runTwoOutFeedbackTest() {
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer);
 
-    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback varyings with bindBufferBase");
+    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback binding points with bindBufferBase");
 
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
@@ -134,7 +135,7 @@ function runTwoOutFeedbackTest() {
     gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer, 0, in_data.length * 4);
     gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer, (in_data.length - 1) * 4, in_data.length * 4);
 
-    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback varyings with bindBufferRange, overlapping ranges");
+    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback binding points with bindBufferRange, overlapping ranges");
 
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
@@ -145,31 +146,48 @@ function runTwoOutFeedbackTest() {
     debug("buffer should be untouched - filled with zeroes");
     wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedZeroes);
 
-    // Test non-overlapping ranges. This should work.
+    // Test non-overlapping ranges.
     debug("");
     gl.enable(gl.RASTERIZER_DISCARD);
     gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length * 2, gl.STATIC_DRAW);
     gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer, 0, in_data.length * 4);
     gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer, in_data.length * 4, in_data.length * 4);
 
-    doDrawWithTransformFeedback(gl.NO_ERROR, "same buffer bound to two transform feedback varyings with bindBufferRange, non-overlapping ranges");
+    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback binding points with bindBufferRange, non-overlapping ranges");
 
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
     gl.disable(gl.RASTERIZER_DISCARD);
 
     // Check buffer contents.
-    var expectedNonOverlapping = [
-        3.0, 5.0, 7.0, 9.0,
-        4.0, 7.0, 12.0, 21.0,
-        2.75, 3.5, 4.25, 5.0,
-        2.0, 6.0, 12.0, 20.0,
-        4.0, 12.0, 32.0, 80.0,
-        1.5, 1.5, 1.0, 0.0
-    ];
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
-    debug("buffer should contain results of both transform feedback outputs");
-    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedNonOverlapping);
+    debug("buffer should be untouched - filled with zeroes");
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedZeroes);
+
+    // Test binding the same buffer to a binding point that doesn't have a corresponding output in the vertex shader.
+    debug("");
+    gl.enable(gl.RASTERIZER_DISCARD);
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer2);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length * 2, gl.STATIC_DRAW);
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length * 2, gl.STATIC_DRAW);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer2);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, out_buffer);  // No corresponding output.
+
+    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback binding points with bindBufferBase, but one of the binding points doesn't have a corresponding shader output");
+
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, null);
+    gl.disable(gl.RASTERIZER_DISCARD);
+
+    // Check buffer contents.
+    debug("buffers should be untouched - filled with zeroes");
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedZeroes);
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer2);
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedZeroes);
 
     finishTest();
 }

--- a/sdk/tests/conformance2/transform_feedback/same-buffer-two-binding-points.html
+++ b/sdk/tests/conformance2/transform_feedback/same-buffer-two-binding-points.html
@@ -64,6 +64,14 @@ if (!gl) {
     runTwoOutFeedbackTest();
 }
 
+function doDrawWithTransformFeedback(expectedError, msg) {
+    gl.beginTransformFeedback(gl.POINTS);
+    wtu.glErrorShouldBe(gl, expectedError, msg);
+    gl.drawArrays(gl.POINTS, 0, 3);
+    gl.endTransformFeedback();
+    gl.getError();
+}
+
 function runTwoOutFeedbackTest() {
     debug("");
     debug("Test binding the same buffer to two transform feedback binding points. Buffer should be untouched and an error should be generated.")
@@ -93,35 +101,75 @@ function runTwoOutFeedbackTest() {
     gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
     gl.vertexAttribPointer(0, 4, gl.FLOAT, false, 16, 0);
 
-    // Test binding the same buffer to two transform feedback binding points.
-
-    gl.enable(gl.RASTERIZER_DISCARD);
-
     var out_buffer = gl.createBuffer();
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
+
+    // Test binding the same buffer to two transform feedback binding points with bindBufferBase.
+    debug("");
+    gl.enable(gl.RASTERIZER_DISCARD);
     gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length * 2, gl.STATIC_DRAW);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer);
 
-    gl.beginTransformFeedback(gl.POINTS);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "same buffer bound to two transform feedback varyings");
-    gl.drawArrays(gl.POINTS, 0, 3);
-    gl.endTransformFeedback();
+    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback varyings with bindBufferBase");
 
-    // Clean up state.
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
     gl.disable(gl.RASTERIZER_DISCARD);
 
-    var expected = [];
+    // Check buffer contents.
+    var expectedZeroes = [];
     for (var i = 0; i < in_data.length * 2; ++i)
     {
-        expected.push(0.0);
+        expectedZeroes.push(0.0);
     }
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
-    debug("");
     debug("buffer should be untouched - filled with zeroes");
-    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedZeroes);
+
+    // Test binding the same buffer to two transform feedback binding points with bindBufferRange. The ranges overlap just slightly.
+    debug("");
+    gl.enable(gl.RASTERIZER_DISCARD);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length * 2, gl.STATIC_DRAW);
+    gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer, 0, in_data.length * 4);
+    gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer, (in_data.length - 1) * 4, in_data.length * 4);
+
+    doDrawWithTransformFeedback(gl.INVALID_OPERATION, "same buffer bound to two transform feedback varyings with bindBufferRange, overlapping ranges");
+
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
+    gl.disable(gl.RASTERIZER_DISCARD);
+
+    // Check buffer contents.
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
+    debug("buffer should be untouched - filled with zeroes");
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedZeroes);
+
+    // Test non-overlapping ranges. This should work.
+    debug("");
+    gl.enable(gl.RASTERIZER_DISCARD);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length * 2, gl.STATIC_DRAW);
+    gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_buffer, 0, in_data.length * 4);
+    gl.bindBufferRange(gl.TRANSFORM_FEEDBACK_BUFFER, 1, out_buffer, in_data.length * 4, in_data.length * 4);
+
+    doDrawWithTransformFeedback(gl.NO_ERROR, "same buffer bound to two transform feedback varyings with bindBufferRange, non-overlapping ranges");
+
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
+    gl.disable(gl.RASTERIZER_DISCARD);
+
+    // Check buffer contents.
+    var expectedNonOverlapping = [
+        3.0, 5.0, 7.0, 9.0,
+        4.0, 7.0, 12.0, 21.0,
+        2.75, 3.5, 4.25, 5.0,
+        2.0, 6.0, 12.0, 20.0,
+        4.0, 12.0, 32.0, 80.0,
+        1.5, 1.5, 1.0, 0.0
+    ];
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_buffer);
+    debug("buffer should contain results of both transform feedback outputs");
+    wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expectedNonOverlapping);
 
     finishTest();
 }

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -4075,6 +4075,23 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
         blitFramebuffer is used to scale the framebuffer.
     </div>
 
+    <h3>Transform feedback buffer binding limitations</h3>
+
+    <p>
+        In case the same buffer is bound to more than one transform feedback binding point that will
+        be written to, <code>BeginTransformFeedback</code> generates an
+        <code>INVALID_OPERATION</code> error.
+    </p>
+
+    <div class="note">
+        This can happen only in <code>SEPARATE_ATTRIBS</code> mode.
+    </div>
+
+    <div class="note rationale">
+        Behavior in this case is not specified in the OpenGL ES spec and may differ between
+        implementations.
+    </div>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3443,6 +3443,21 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
         OpenGL ES 3.0.5 &sect;2.15.2</a>)</span>
     </div>
 
+    <p>
+        In case the same buffer is bound to more than one transform feedback binding point that will
+        be written to, <code>BeginTransformFeedback</code> generates an
+        <code>INVALID_OPERATION</code> error.
+    </p>
+
+    <div class="note">
+        This can happen only in <code>SEPARATE_ATTRIBS</code> mode.
+    </div>
+
+    <div class="note rationale">
+        Behavior when the same buffer is bound to two outputs is not specified in the OpenGL ES spec
+        and may differ between implementations.
+    </div>
+
     <h3>Draw Buffers</h3>
 
     <p>
@@ -4073,23 +4088,6 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
         Using larger than max 32-bit int sized rectangles for blitFramebuffer triggers issues on
         most desktop OpenGL drivers, and there is no general workaround for cases where
         blitFramebuffer is used to scale the framebuffer.
-    </div>
-
-    <h3>Transform feedback buffer binding limitations</h3>
-
-    <p>
-        In case the same buffer is bound to more than one transform feedback binding point that will
-        be written to, <code>BeginTransformFeedback</code> generates an
-        <code>INVALID_OPERATION</code> error.
-    </p>
-
-    <div class="note">
-        This can happen only in <code>SEPARATE_ATTRIBS</code> mode.
-    </div>
-
-    <div class="note rationale">
-        Behavior in this case is not specified in the OpenGL ES spec and may differ between
-        implementations.
     </div>
 
 <!-- ======================================================================================================= -->

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3445,7 +3445,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
     <p>
         In case the same buffer is bound to more than one binding point in the active transform feedback,
-        <code>BeginTransformFeedback</code> generates an <code>INVALID_OPERATION</code> error.
+        <code>beginTransformFeedback</code> generates an <code>INVALID_OPERATION</code> error.
     </p>
 
     <div class="note">

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3445,8 +3445,9 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
     <p>
         In case the same buffer is bound to more than one transform feedback binding point that will
-        be written to, <code>BeginTransformFeedback</code> generates an
-        <code>INVALID_OPERATION</code> error.
+        be written to, and the buffer has been bound with <code>bindBufferBase</code> or the ranges
+        in the buffer chosen by <code>bindBufferRange</code> overlap, <code>BeginTransformFeedback</code>
+        generates an <code>INVALID_OPERATION</code> error.
     </p>
 
     <div class="note">

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3444,10 +3444,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
     </div>
 
     <p>
-        In case the same buffer is bound to more than one transform feedback binding point that will
-        be written to, and the buffer has been bound with <code>bindBufferBase</code> or the ranges
-        in the buffer chosen by <code>bindBufferRange</code> overlap, <code>BeginTransformFeedback</code>
-        generates an <code>INVALID_OPERATION</code> error.
+        In case the same buffer is bound to more than one binding point in the active transform feedback,
+        <code>BeginTransformFeedback</code> generates an <code>INVALID_OPERATION</code> error.
     </p>
 
     <div class="note">
@@ -3455,8 +3453,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextBase;
     </div>
 
     <div class="note rationale">
-        Behavior when the same buffer is bound to two outputs is not specified in the OpenGL ES spec
-        and may differ between implementations.
+        This is a restriction from D3D11, where writing two different streams to the same buffer is not
+        allowed.
     </div>
 
     <h3>Draw Buffers</h3>


### PR DESCRIPTION
This case used to be underspecified, so behavior varies between
platforms. Particularly on D3D having two stream outputs written to
the same buffer is disallowed, and on OpenGL ES there's some undefined
behavior. Prohibit having the same buffer bound to two transform
feedback outputs when calling BeginTransformFeeback to avoid
non-portable behaviors from now on.

Currently the test doesn't yet generate the expected error on any of
the platforms tested. On Chromium or Firefox running on ANGLE's D3D
backend, the buffer is not touched by transform feedback.
On Chromium's GL backend, only one of the outputs is written to the
buffer by transform feedback.

The behavior is the same on recent HW/drivers from both NVIDIA and
Intel.