### PR TITLE
Transform feedback generic binding point should not block buffer usage

### DIFF
--- a/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
+++ b/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
@@ -59,7 +59,7 @@ void main() {
 </script>
 <script>
 "use strict";
-description("This test verifies that access to a buffer simultaneously bound to TRANSFORM_FEEDBACK_BUFFER and another binding point is forbidden.");
+description("This test verifies that access to a buffer simultaneously bound to a transform feedback object and a non-transform-feedback binding point is forbidden.");
 
 debug("");
 
@@ -163,12 +163,36 @@ for (let [drawArrays, drawElements] of drawFunctions) {
   gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
   gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, 16, gl.STATIC_DRAW);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bufferData to TRANSFORM_FEEDBACK_BUFFER");
-  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should be successful");
   drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements should be successful");
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should be successful");
 
   const expected = [2, 4, 6, 8];
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
+  wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
+
+  debug("<hr/>Test generic bind point set to null");
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, null);
+  drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements should be successful");
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should be successful");
+
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
+  wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
+
+  debug("<hr/>Test generic bind point set to vertex buffer");
+  // The TRANSFORM_FEEDBACK_BUFFER generic binding point is not part of the
+  // transform feedback object and not written to by transform feedback. Only
+  // the indexed binding points are written to. So it should be legal to draw
+  // from a buffer bound to the generic binding point.
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, vertexBuffer);
+  drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements should be successful");
+  drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "transform feedback should be successful");
+
   gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, tfBuffer);
   wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, expected);
 
@@ -242,50 +266,82 @@ for (let [drawArrays, drawElements] of drawFunctions) {
   gl.bindVertexArray(null);
 }
 
-debug("<h3>Non-drawing tests</h3>");
+debug("<h1>Non-drawing tests</h1>");
 
+debug("<hr/>Test bufferData");
 
-debug("<hr/>Test PIXEL_UNPACK_BUFFER");
-const tex = gl.createTexture();
-gl.bindTexture(gl.TEXTURE_2D, tex);
-gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, vertexBuffer);
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, 0);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "PIXEL_UNPACK_BUFFER is not bound for transform feedback");
-
-gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, tfBuffer);
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, 0);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "PIXEL_UNPACK_BUFFER is bound for transform feedback");
-gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
-
-debug("<hr/>Test PIXEL_PACK_BUFFER");
-gl.bindBuffer(gl.PIXEL_PACK_BUFFER, vertexBuffer);
-gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, 0);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "PIXEL_PACK_BUFFER is not bound for transform feedback");
-gl.bindBuffer(gl.PIXEL_PACK_BUFFER, tfBuffer);
-gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, 0);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "PIXEL_PACK_BUFFER is bound for transform feedback");
-gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null)
-
-debug("<hr/>Test bufferData family");
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
 gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, tfBuffer);
 gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, 16, gl.STATIC_DRAW);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bufferData to TRANSFORM_FEEDBACK_BUFFER");
-gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, null) // tfBuffer is still bound at index 0
-
 gl.bindBuffer(gl.COPY_WRITE_BUFFER, tfBuffer);
-gl.bufferData(gl.COPY_WRITE_BUFFER, 16, gl.STATIC_DRAW);
+gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, 16, gl.STATIC_DRAW);
 wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bufferData with double bound buffer");
-gl.bufferSubData(gl.COPY_WRITE_BUFFER, 0, new Uint8Array([0]));
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bufferSubData with double bound buffer");
-gl.getBufferSubData(gl.COPY_WRITE_BUFFER, 0, new Uint8Array([0]), 0, 1);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "getBufferSubData with double bound buffer");
+gl.bindBuffer(gl.COPY_WRITE_BUFFER, null);
 
-gl.bindBuffer(gl.COPY_READ_BUFFER, vertexBuffer);
-gl.copyBufferSubData(gl.COPY_WRITE_BUFFER, gl.COPY_READ_BUFFER, 0, 0, 1);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "copyBufferSubData with double bound buffer");
-gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 1);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "copyBufferSubData with double bound buffer");
+// The value of the TRANSFORM_FEEDBACK_BUFFER generic bind point should not
+// affect the legality of any operation.
+let genericBindPointValues = [()=>null, ()=>tfBuffer, ()=>vertexBuffer];
+
+for (let genericBindPointValue of genericBindPointValues) {
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+  debug("<h3>With TRANSFORM_FEEDBACK_BUFFER generic bind point value " + genericBindPointValue + "</h3>");
+  gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, genericBindPointValue());
+
+  debug("<hr/>Test PIXEL_UNPACK_BUFFER");
+  const tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, vertexBuffer);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "PIXEL_UNPACK_BUFFER is not bound for transform feedback");
+
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, tfBuffer);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "PIXEL_UNPACK_BUFFER is bound for transform feedback");
+  gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+
+  debug("<hr/>Test PIXEL_PACK_BUFFER");
+  gl.bindBuffer(gl.PIXEL_PACK_BUFFER, vertexBuffer);
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "PIXEL_PACK_BUFFER is not bound for transform feedback");
+  gl.bindBuffer(gl.PIXEL_PACK_BUFFER, tfBuffer);
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, 0);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "PIXEL_PACK_BUFFER is bound for transform feedback");
+  gl.bindBuffer(gl.PIXEL_PACK_BUFFER, null)
+
+  debug("<hr/>Test bufferData family with tf object bound");
+
+  gl.bindBuffer(gl.COPY_WRITE_BUFFER, tfBuffer);
+  gl.bufferData(gl.COPY_WRITE_BUFFER, 16, gl.STATIC_DRAW);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bufferData with double bound buffer");
+  gl.bufferSubData(gl.COPY_WRITE_BUFFER, 0, new Uint8Array([0]));
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bufferSubData with double bound buffer");
+  gl.getBufferSubData(gl.COPY_WRITE_BUFFER, 0, new Uint8Array([0]), 0, 1);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "getBufferSubData with double bound buffer");
+
+  gl.bindBuffer(gl.COPY_READ_BUFFER, vertexBuffer);
+  gl.copyBufferSubData(gl.COPY_WRITE_BUFFER, gl.COPY_READ_BUFFER, 0, 0, 1);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "copyBufferSubData with double bound buffer");
+  gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 1);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "copyBufferSubData with double bound buffer");
+
+  debug("<hr/>Test bufferData family with tf object unbound");
+
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+  gl.bindBuffer(gl.COPY_WRITE_BUFFER, tfBuffer);
+  gl.bufferData(gl.COPY_WRITE_BUFFER, 16, gl.STATIC_DRAW);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bufferData should succeed");
+  gl.bufferSubData(gl.COPY_WRITE_BUFFER, 0, new Uint8Array([0]));
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bufferSubData should succeed");
+  gl.getBufferSubData(gl.COPY_WRITE_BUFFER, 0, new Uint8Array([0]), 0, 1);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "getBufferSubData should succeed");
+
+  gl.bindBuffer(gl.COPY_READ_BUFFER, vertexBuffer);
+  gl.copyBufferSubData(gl.COPY_WRITE_BUFFER, gl.COPY_READ_BUFFER, 0, 0, 1);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copyBufferSubData should succeed");
+  gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 1);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copyBufferSubData should succeed");
+}
 
 finishTest();
 


### PR DESCRIPTION
The transform feedback generic binding point is not part of the transform feedback object and is not used for transform feedback. Only the indexed binding points are used. A buffer that is bound to the generic binding point should be usable for either transform feedback or non-transform-feedback purposes.

I realized this was a problem in [crbug.com/853978](http://crbug.com/853978). The previous behavior was confusing because unbinding the transform feedback object was not enough to enable drawing from a transform feedback buffer if it was still bound to the generic binding point.