### PR TITLE
Add wtu.dispatchTask for use instead of waitForComposite.

### DIFF
--- a/sdk/tests/conformance/textures/misc/texture-size-limit.html
+++ b/sdk/tests/conformance/textures/misc/texture-size-limit.html
@@ -119,7 +119,7 @@ function runNextTest() {
       return;
     }
   }
-  wtu.waitForComposite(runNextTest)
+  wtu.dispatchTask(runNextTest);
 }
 
 function testFormatType(t, test) {

--- a/sdk/tests/js/tests/iterable-test.js
+++ b/sdk/tests/js/tests/iterable-test.js
@@ -33,8 +33,7 @@ IterableTest = (function() {
       debug("Test " + count + " of " + target);
       var success = test();
       if (count < target && success !== false) {
-        wtu.waitForComposite(doNextTest);
-        //setTimeout(doNextTest, 100);
+        wtu.dispatchTask(doNextTest);
       } else {
         finishTest();
       }

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
@@ -457,7 +457,11 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                             return;
                         }
                     }
-                    wtu.waitForComposite(runNextTest);
+                    // While we are working with Canvases, it's really unlikely that
+                    // waiting for composition will change anything here, and it's much
+                    // slower, so just dispatchTask. If we want to test with composites,
+                    // we should test a more narrow subset of tests.
+                    wtu.dispatchTask(runNextTest);
                 }
                 runNextTest();
             });

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -272,7 +272,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                             return;
                         }
                     }
-                    wtu.waitForComposite(runNextTest);
+                    wtu.dispatchTask(runNextTest);
                 }
                 runNextTest();
             });

--- a/sdk/tests/js/tests/webgl-compressed-texture-size-limit.js
+++ b/sdk/tests/js/tests/webgl-compressed-texture-size-limit.js
@@ -146,7 +146,7 @@ var runCompressedTextureSizeLimitTest = function(maxArrayBufferSizeBytes, positi
         return;
       }
     }
-    wtu.waitForComposite(runNextTest);
+    wtu.dispatchTask(runNextTest);
   }
 
   function testFormatType(t, test) {

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -2865,6 +2865,35 @@ var waitForComposite = function(callback) {
   countDown();
 };
 
+var setZeroTimeout = (function() {
+  // See https://dbaron.org/log/20100309-faster-timeouts
+
+  var timeouts = [];
+  var messageName = "zero-timeout-message";
+
+  // Like setTimeout, but only takes a function argument.  There's
+  // no time argument (always zero) and no arguments (you have to
+  // use a closure).
+  function setZeroTimeout(fn) {
+      timeouts.push(fn);
+      window.postMessage(messageName, "*");
+  }
+
+  function handleMessage(event) {
+      if (event.source == window && event.data == messageName) {
+          event.stopPropagation();
+          if (timeouts.length > 0) {
+              var fn = timeouts.shift();
+              fn();
+          }
+      }
+  }
+
+  window.addEventListener("message", handleMessage, true);
+
+  return setZeroTimeout;
+})();
+
 /**
  * Runs an array of functions, yielding to the browser between each step.
  * If you want to know when all the steps are finished add a last step.
@@ -3139,6 +3168,7 @@ var API = {
   clearAndDrawUnitQuad: clearAndDrawUnitQuad,
   clearAndDrawIndexedQuad: clearAndDrawIndexedQuad,
   comparePixels: comparePixels,
+  dispatchTask: setZeroTimeout,
   displayImageDiff: displayImageDiff,
   drawUnitQuad: drawUnitQuad,
   drawIndexedQuad: drawIndexedQuad,

--- a/sdk/tests/test-guidelines.md
+++ b/sdk/tests/test-guidelines.md
@@ -101,6 +101,9 @@ These lines appears at the top of every html and js file under sdk/tests/conform
              As compositing is a browser specific thing this provides a central place to
              update all tests that rely on compositing to function.
 
+            *   If you don't care about composition, `wtu.dispatchTask` makes it easy to
+                yield back to the event loop.
+
     *   Code/Tag Order
 
         Most tests run inline. They don't use window.onload or the load event. This works by placing


### PR DESCRIPTION
Texture upload tests in particular take a long time because they run a max of
60 tests per second, because they rely on waitForComposite to yield execution.
waitForComposite should only be used when necessary. Use dispatchTask if we
want to yield to the event loop.

Before:
all/conformance/textures/canvas (Passed: 3880/3880 in 48.68 seconds)
conformance/textures/canvas/tex-2d-rgb-rgb-unsigned_byte.html (Passed: 1122/1122 in 14113.0 ms)

After:
all/conformance/textures/canvas (Passed: 3880/3880 in 8.90 seconds)
conformance/textures/canvas/tex-2d-rgb-rgb-unsigned_byte.html (Passed: 1122/1122 in 2097.0 ms)