### PR TITLE
Add a test for draw framebuffer completeness

### DIFF
--- a/sdk/tests/conformance2/rendering/00_test_list.txt
+++ b/sdk/tests/conformance2/rendering/00_test_list.txt
@@ -22,8 +22,10 @@ draw-buffers.html
 --min-version 2.0.1 draw-buffers-driver-hang.html
 --min-version 2.0.1 draw-with-integer-texture-base-level.html
 element-index-uint.html
+--min-version 2.0.1 framebuffer-completeness-draw-framebuffer.html
 framebuffer-completeness-unaffected.html
 --min-version 2.0.1 framebuffer-texture-changing-base-level.html
+--min-version 2.0.1 framebuffer-texture-level1.html
 framebuffer-unsupported.html
 --min-version 2.0.1 fs-color-type-mismatch-color-buffer-type.html
 instanced-arrays.html
@@ -35,5 +37,4 @@ out-of-bounds-index-buffers-after-copying.html
 --min-version 2.0.1 rendering-sampling-feedback-loop.html
 rgb-format-support.html
 uniform-block-buffer-size.html
---min-version 2.0.1 framebuffer-texture-level1.html
 --min-version 2.0.1 texture-switch-performance.html

--- a/sdk/tests/conformance2/rendering/framebuffer-completeness-draw-framebuffer.html
+++ b/sdk/tests/conformance2/rendering/framebuffer-completeness-draw-framebuffer.html
@@ -39,6 +39,7 @@
 <div id="console"></div>
 <script>
 // This exposes a bug in Chrome 67: If the read framebuffer is incomplete, then draw can fail even if the draw framebuffer is complete.
+// http://anglebug.com/2737
 
 "use strict";
 description();

--- a/sdk/tests/conformance2/rendering/framebuffer-completeness-draw-framebuffer.html
+++ b/sdk/tests/conformance2/rendering/framebuffer-completeness-draw-framebuffer.html
@@ -1,0 +1,94 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test draw framebuffer completeness when an incomplete framebuffer is bound to read framebuffer</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+// This exposes a bug in Chrome 67: If the read framebuffer is incomplete, then draw can fail even if the draw framebuffer is complete.
+
+"use strict";
+description();
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext(undefined, undefined, 2);
+if (!gl) {
+  testFailed("context does not exist");
+} else {
+  testPassed("context exists");
+
+  var incompleteFb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, incompleteFb);
+  var incompleteTex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, incompleteTex);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, incompleteTex, 0);
+  shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT');
+
+  wtu.setupUnitQuad(gl, 0, 1);
+
+  var testProgram = wtu.setupSimpleColorProgram(gl, 0);
+
+  // If this is changed to gl.FRAMEBUFFER, the rendering succeeds on Chrome 67.
+  var drawFbTarget = gl.DRAW_FRAMEBUFFER;
+
+  var completeFb = gl.createFramebuffer();
+  gl.bindFramebuffer(drawFbTarget, completeFb);
+  var completeTex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, completeTex);
+  gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, 128, 128);
+  gl.framebufferTexture2D(drawFbTarget, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, completeTex, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no error after setup");
+
+  shouldBe('gl.checkFramebufferStatus(gl.READ_FRAMEBUFFER)', 'gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT');
+  shouldBe('gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+
+  gl.viewport(0, 0, 128, 128);
+  gl.uniform4f(gl.getUniformLocation(testProgram, 'u_color'), 0, 1, 0, 1);
+  wtu.drawUnitQuad(gl);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no error after draw");
+  gl.bindFramebuffer(gl.READ_FRAMEBUFFER, completeFb);
+  wtu.checkCanvasRect(gl, 0, 0, 128, 128, [0, 255, 0, 255], 'should be green', 2);
+}
+
+debug("");
+var successfullyParsed = true;
+
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
The test checks that the draw framebuffer can still be rendered to
even if the read framebuffer is incomplete.

The new test exposes a bug in Chrome 67. It seems to be specific to
ANGLE's D3D11 backend. Bug link: http://anglebug.com/2737

The latest stable version of Firefox is not affected by the bug.