### PR TITLE
Improve logging for tex-video-using-tex-unit-non-zero.html .

### DIFF
--- a/sdk/tests/conformance/textures/misc/tex-video-using-tex-unit-non-zero.html
+++ b/sdk/tests/conformance/textures/misc/tex-video-using-tex-unit-non-zero.html
@@ -105,6 +105,7 @@ var videos = [
   { src: resourcePath + "red-green.theora.ogv",
     type: 'video/ogg; codecs="theora, vorbis"' },
 ];
+var currentVideo = null;
 
 function runAllTests() {
   return new Promise(function(resolve, reject) {
@@ -119,6 +120,7 @@ function runAllTests() {
         return;
       }
       var info = videos[videoNdx++];
+      currentVideo = info;
       debug("");
       debug("testing: " + info.type);
       video = document.createElement("video");
@@ -188,17 +190,12 @@ function runAllTests() {
       // <-- End Expected -->
 
       // Compare results
-      var compareOk = true;
-      for (var index = 0; index < expectedPixels.length; ++index) {
-        if (observedPixels[index] != expectedPixels[index]) {
-          compareOk = false;
-          break;
-        }
-      }
-      if (compareOk) {
-        testPassed("Texture states were correct, rendering as expected");
+      var numDifferentPixels = wtu.comparePixels(observedPixels, expectedPixels, 0, undefined);
+      if (numDifferentPixels) {
+        testFailed("Texture states were incorrect for " + currentVideo.type +
+                   ", rendering was wrong: found " + numDifferentPixels + " differing pixels");
       } else {
-        testFailed("Texture states were incorrect, rendering was wrong");
+        testPassed("Texture states were correct, rendering as expected");
       }
       wtu.glErrorShouldBe(gl, gl.NO_ERROR);
 
@@ -217,4 +214,3 @@ runAllTests().then(function(val) {
 
 </body>
 </html>
-

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3098,10 +3098,12 @@ function comparePixels(cmp, ref, tolerance, diff) {
 
     var count = 0;
     for (var i = 0; i < cmp.length; i++) {
-        diff[i * 4] = 0;
-        diff[i * 4 + 1] = 255;
-        diff[i * 4 + 2] = 0;
-        diff[i * 4 + 3] = 255;
+        if (diff) {
+            diff[i * 4] = 0;
+            diff[i * 4 + 1] = 255;
+            diff[i * 4 + 2] = 0;
+            diff[i * 4 + 3] = 255;
+        }
         if (Math.abs(cmp[i * 4] - ref[i * 4]) > tolerance ||
             Math.abs(cmp[i * 4 + 1] - ref[i * 4 + 1]) > tolerance ||
             Math.abs(cmp[i * 4 + 2] - ref[i * 4 + 2]) > tolerance ||
@@ -3112,8 +3114,10 @@ function comparePixels(cmp, ref, tolerance, diff) {
                 [cmp[i * 4], cmp[i * 4 + 1], cmp[i * 4 + 2], cmp[i * 4 + 3]] + ")");
             }
             count++;
-            diff[i * 4] = 255;
-            diff[i * 4 + 1] = 0;
+            if (diff) {
+                diff[i * 4] = 255;
+                diff[i * 4 + 1] = 0;
+            }
         }
     }
 


### PR DESCRIPTION
Use WebGLTestUtils.comparePixels, and include failing video type in
error messages.

Intended to diagnose intermittent failures of this test in
http://crbug.com/830901 .