### PR TITLE
Add [Exposed] Web IDL attribute to all WebGL interfaces.

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -899,7 +899,8 @@ var context = canvas.getContext('webgl',
         Each <code>WebGLObject</code> has
         an <b><a name="webgl-object-invalidated-flag">invalidated</a></b> flag, which is initially unset.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLObject">WebGLObject</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLObject">WebGLObject</dfn> {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -916,7 +917,8 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteBuffers.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLBuffer">WebGLBuffer</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLBuffer">WebGLBuffer</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -933,7 +935,8 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-4.4.1">OpenGL ES 2.0 &sect;4.4.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteFramebuffers.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLFramebuffer">WebGLFramebuffer</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLFramebuffer">WebGLFramebuffer</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -950,7 +953,8 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.10.3">OpenGL ES 2.0 &sect;2.10.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteProgram.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLProgram">WebGLProgram</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLProgram">WebGLProgram</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -967,7 +971,8 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-4.4.3">OpenGL ES 2.0 &sect;4.4.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteRenderbuffers.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLRenderbuffer">WebGLRenderbuffer</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLRenderbuffer">WebGLRenderbuffer</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -984,7 +989,8 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.10.1">OpenGL ES 2.0 &sect;2.10.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteShader.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLShader">WebGLShader</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLShader">WebGLShader</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -1001,7 +1007,8 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.7.13">OpenGL ES 2.0 &sect;3.7.13</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteTextures.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLTexture">WebGLTexture</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLTexture">WebGLTexture</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -1012,7 +1019,8 @@ var context = canvas.getContext('webgl',
         The <code>WebGLUniformLocation</code> interface represents the location of a uniform variable
         in a shader program.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLUniformLocation">WebGLUniformLocation</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLUniformLocation">WebGLUniformLocation</dfn> {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -1023,7 +1031,8 @@ var context = canvas.getContext('webgl',
         The <code>WebGLActiveInfo</code> interface represents the information returned
         from the getActiveAttrib and getActiveUniform calls.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLActiveInfo">WebGLActiveInfo</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLActiveInfo">WebGLActiveInfo</dfn> {
     readonly attribute GLint size;
     readonly attribute GLenum type;
     readonly attribute DOMString name;
@@ -1073,7 +1082,8 @@ var context = canvas.getContext('webgl',
         The <code>WebGLShaderPrecisionFormat</code> interface represents the information returned
         from the getShaderPrecisionFormat call.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLShaderPrecisionFormat">WebGLShaderPrecisionFormat</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLShaderPrecisionFormat">WebGLShaderPrecisionFormat</dfn> {
     readonly attribute GLint rangeMin;
     readonly attribute GLint rangeMax;
     readonly attribute GLint precision;
@@ -3334,7 +3344,9 @@ WebGLRenderingContext includes WebGLRenderingContextBase;
         given object.
     </p>
     <pre class="idl">
-[Exposed=(Window,Worker), Constructor(DOMString type, optional WebGLContextEventInit eventInit)]
+[Exposed=(Window,Worker),
+ Constructor(DOMString type,
+ optional WebGLContextEventInit eventInit)]
 interface <dfn id="WebGLContextLostEvent">WebGLContextEvent</dfn> : <a href="http://www.w3.org/TR/domcore/#event">Event</a> {
     readonly attribute DOMString statusMessage;
 };

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -899,7 +899,7 @@ var context = canvas.getContext('webgl',
         Each <code>WebGLObject</code> has
         an <b><a name="webgl-object-invalidated-flag">invalidated</a></b> flag, which is initially unset.
     </p>
-    <pre class="idl">interface <dfn id="WebGLObject">WebGLObject</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLObject">WebGLObject</dfn> {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -916,7 +916,7 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteBuffers.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">interface <dfn id="WebGLBuffer">WebGLBuffer</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLBuffer">WebGLBuffer</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -933,7 +933,7 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-4.4.1">OpenGL ES 2.0 &sect;4.4.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteFramebuffers.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">interface <dfn id="WebGLFramebuffer">WebGLFramebuffer</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLFramebuffer">WebGLFramebuffer</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -950,7 +950,7 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.10.3">OpenGL ES 2.0 &sect;2.10.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteProgram.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">interface <dfn id="WebGLProgram">WebGLProgram</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLProgram">WebGLProgram</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -967,7 +967,7 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-4.4.3">OpenGL ES 2.0 &sect;4.4.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteRenderbuffers.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">interface <dfn id="WebGLRenderbuffer">WebGLRenderbuffer</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLRenderbuffer">WebGLRenderbuffer</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -984,7 +984,7 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.10.1">OpenGL ES 2.0 &sect;2.10.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteShader.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">interface <dfn id="WebGLShader">WebGLShader</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLShader">WebGLShader</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -1001,7 +1001,7 @@ var context = canvas.getContext('webgl',
         <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-3.7.13">OpenGL ES 2.0 &sect;3.7.13</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteTextures.xml">man page</a>)</span>
         .
     </p>
-    <pre class="idl">interface <dfn id="WebGLTexture">WebGLTexture</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLTexture">WebGLTexture</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -1012,7 +1012,7 @@ var context = canvas.getContext('webgl',
         The <code>WebGLUniformLocation</code> interface represents the location of a uniform variable
         in a shader program.
     </p>
-    <pre class="idl">interface <dfn id="WebGLUniformLocation">WebGLUniformLocation</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLUniformLocation">WebGLUniformLocation</dfn> {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -1023,7 +1023,7 @@ var context = canvas.getContext('webgl',
         The <code>WebGLActiveInfo</code> interface represents the information returned
         from the getActiveAttrib and getActiveUniform calls.
     </p>
-    <pre class="idl">interface <dfn id="WebGLActiveInfo">WebGLActiveInfo</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLActiveInfo">WebGLActiveInfo</dfn> {
     readonly attribute GLint size;
     readonly attribute GLenum type;
     readonly attribute DOMString name;
@@ -1073,7 +1073,7 @@ var context = canvas.getContext('webgl',
         The <code>WebGLShaderPrecisionFormat</code> interface represents the information returned
         from the getShaderPrecisionFormat call.
     </p>
-    <pre class="idl">interface <dfn id="WebGLShaderPrecisionFormat">WebGLShaderPrecisionFormat</dfn> {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLShaderPrecisionFormat">WebGLShaderPrecisionFormat</dfn> {
     readonly attribute GLint rangeMin;
     readonly attribute GLint rangeMax;
     readonly attribute GLint precision;
@@ -1869,6 +1869,7 @@ interface mixin <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</d
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 };
 
+[Exposed=(Window,Worker)]
 interface <dfn id="WebGLRenderingContext">WebGLRenderingContext</dfn>
 {
 };
@@ -3333,7 +3334,7 @@ WebGLRenderingContext includes WebGLRenderingContextBase;
         given object.
     </p>
     <pre class="idl">
-[Constructor(DOMString type, optional WebGLContextEventInit eventInit)]
+[Exposed=(Window,Worker), Constructor(DOMString type, optional WebGLContextEventInit eventInit)]
 interface <dfn id="WebGLContextLostEvent">WebGLContextEvent</dfn> : <a href="http://www.w3.org/TR/domcore/#event">Event</a> {
     readonly attribute DOMString statusMessage;
 };

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -56,37 +56,47 @@ dictionary WebGLContextAttributes {
     GLboolean failIfMajorPerformanceCaveat = false;
 };
 
-[Exposed=(Window,Worker)] interface WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLBuffer : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLBuffer : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLFramebuffer : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLFramebuffer : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLProgram : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLProgram : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLRenderbuffer : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLRenderbuffer : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLShader : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLShader : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLTexture : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLTexture : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLUniformLocation {
+[Exposed=(Window,Worker)]
+interface WebGLUniformLocation {
 };
 
-[Exposed=(Window,Worker)] interface WebGLActiveInfo {
+[Exposed=(Window,Worker)]
+interface WebGLActiveInfo {
     readonly attribute GLint size;
     readonly attribute GLenum type;
     readonly attribute DOMString name;
 };
 
-[Exposed=(Window,Worker)] interface WebGLShaderPrecisionFormat {
+[Exposed=(Window,Worker)]
+interface WebGLShaderPrecisionFormat {
     readonly attribute GLint rangeMin;
     readonly attribute GLint rangeMax;
     readonly attribute GLint precision;
@@ -737,7 +747,9 @@ interface WebGLRenderingContext
 WebGLRenderingContext includes WebGLRenderingContextBase;
 
 
-[Exposed=(Window,Worker), Constructor(DOMString type, optional WebGLContextEventInit eventInit)]
+[Exposed=(Window,Worker),
+ Constructor(DOMString type,
+ optional WebGLContextEventInit eventInit)]
 interface WebGLContextEvent : Event {
     readonly attribute DOMString statusMessage;
 };

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -56,37 +56,37 @@ dictionary WebGLContextAttributes {
     GLboolean failIfMajorPerformanceCaveat = false;
 };
 
-interface WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLObject {
 };
 
-interface WebGLBuffer : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLBuffer : WebGLObject {
 };
 
-interface WebGLFramebuffer : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLFramebuffer : WebGLObject {
 };
 
-interface WebGLProgram : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLProgram : WebGLObject {
 };
 
-interface WebGLRenderbuffer : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLRenderbuffer : WebGLObject {
 };
 
-interface WebGLShader : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLShader : WebGLObject {
 };
 
-interface WebGLTexture : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLTexture : WebGLObject {
 };
 
-interface WebGLUniformLocation {
+[Exposed=(Window,Worker)] interface WebGLUniformLocation {
 };
 
-interface WebGLActiveInfo {
+[Exposed=(Window,Worker)] interface WebGLActiveInfo {
     readonly attribute GLint size;
     readonly attribute GLenum type;
     readonly attribute DOMString name;
 };
 
-interface WebGLShaderPrecisionFormat {
+[Exposed=(Window,Worker)] interface WebGLShaderPrecisionFormat {
     readonly attribute GLint rangeMin;
     readonly attribute GLint rangeMax;
     readonly attribute GLint precision;
@@ -730,13 +730,14 @@ interface mixin WebGLRenderingContextBase
     void viewport(GLint x, GLint y, GLsizei width, GLsizei height);
 };
 
+[Exposed=(Window,Worker)]
 interface WebGLRenderingContext
 {
 };
 WebGLRenderingContext includes WebGLRenderingContextBase;
 
 
-[Constructor(DOMString type, optional WebGLContextEventInit eventInit)]
+[Exposed=(Window,Worker), Constructor(DOMString type, optional WebGLContextEventInit eventInit)]
 interface WebGLContextEvent : Event {
     readonly attribute DOMString statusMessage;
 };

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -297,7 +297,7 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteQueries.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">interface <dfn id="WebGLQuery">WebGLQuery</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLQuery">WebGLQuery</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -322,7 +322,7 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteSamplers.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">interface <dfn id="WebGLSampler">WebGLSampler</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLSampler">WebGLSampler</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -359,7 +359,7 @@ typedef unsigned long long GLuint64;
     </p>
     <p>
     </p>
-    <pre class="idl">interface <dfn id="WebGLSync">WebGLSync</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLSync">WebGLSync</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -384,7 +384,7 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteTransformFeedbacks.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">interface <dfn id="WebGLTransformFeedback">WebGLTransformFeedback</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLTransformFeedback">WebGLTransformFeedback</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -409,7 +409,7 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteVertexArrays.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">interface <dfn id="WebGLVertexArrayObject">WebGLVertexArrayObject</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLVertexArrayObject">WebGLVertexArrayObject</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -968,6 +968,7 @@ interface mixin <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase<
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
 
+[Exposed=(Window,Worker)]
 interface <dfn id="WebGL2RenderingContext">WebGL2RenderingContext</dfn>
 {
 };

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -297,7 +297,8 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteQueries.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLQuery">WebGLQuery</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLQuery">WebGLQuery</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -322,7 +323,8 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteSamplers.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLSampler">WebGLSampler</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLSampler">WebGLSampler</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -359,7 +361,8 @@ typedef unsigned long long GLuint64;
     </p>
     <p>
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLSync">WebGLSync</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLSync">WebGLSync</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -384,7 +387,8 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteTransformFeedbacks.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLTransformFeedback">WebGLTransformFeedback</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLTransformFeedback">WebGLTransformFeedback</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->
@@ -409,7 +413,8 @@ typedef unsigned long long GLuint64;
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteVertexArrays.xhtml">man page</a>)
         </span>.
     </p>
-    <pre class="idl">[Exposed=(Window,Worker)] interface <dfn id="WebGLVertexArrayObject">WebGLVertexArrayObject</dfn> : WebGLObject {
+    <pre class="idl">[Exposed=(Window,Worker)]
+interface <dfn id="WebGLVertexArrayObject">WebGLVertexArrayObject</dfn> : WebGLObject {
 };</pre>
 
 <!-- ======================================================================================================= -->

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -28,19 +28,24 @@ typedef long long GLint64;
 typedef unsigned long long GLuint64;
 
 
-[Exposed=(Window,Worker)] interface WebGLQuery : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLQuery : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLSampler : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLSampler : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLSync : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLSync : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLTransformFeedback : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLTransformFeedback : WebGLObject {
 };
 
-[Exposed=(Window,Worker)] interface WebGLVertexArrayObject : WebGLObject {
+[Exposed=(Window,Worker)]
+interface WebGLVertexArrayObject : WebGLObject {
 };
 
 typedef ([AllowShared] Uint32Array or sequence<GLuint>) Uint32List;

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -28,19 +28,19 @@ typedef long long GLint64;
 typedef unsigned long long GLuint64;
 
 
-interface WebGLQuery : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLQuery : WebGLObject {
 };
 
-interface WebGLSampler : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLSampler : WebGLObject {
 };
 
-interface WebGLSync : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLSync : WebGLObject {
 };
 
-interface WebGLTransformFeedback : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLTransformFeedback : WebGLObject {
 };
 
-interface WebGLVertexArrayObject : WebGLObject {
+[Exposed=(Window,Worker)] interface WebGLVertexArrayObject : WebGLObject {
 };
 
 typedef ([AllowShared] Uint32Array or sequence<GLuint>) Uint32List;
@@ -589,6 +589,7 @@ interface mixin WebGL2RenderingContextBase
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
 
+[Exposed=(Window,Worker)]
 interface WebGL2RenderingContext
 {
 };


### PR DESCRIPTION
This extended attribute has been required by Web IDL since
heycam/webidl#423 . In order for WebGL to be accessible by web workers
using OffscreenCanvas, the attribute being added to all WebGL
interfaces is:
[Exposed=(Window,Worker)]

Fixes #2571 .