### PR TITLE
Fix the ERROR_EPSILON for GL struct tests

### DIFF
--- a/conformance-suites/1.0.3/conformance/ogles/GL/struct/nestedstructcomb_various_frag.frag
+++ b/conformance-suites/1.0.3/conformance/ogles/GL/struct/nestedstructcomb_various_frag.frag
@@ -28,7 +28,7 @@ precision mediump float;
 #endif
 varying vec4 color;
 
-#define ERROR_EPSILON 0.1
+#define ERROR_EPSILON 0.125
 
 void main (void){
       struct second_nest

--- a/conformance-suites/1.0.3/conformance/ogles/GL/struct/nestedstructcomb_various_vert.vert
+++ b/conformance-suites/1.0.3/conformance/ogles/GL/struct/nestedstructcomb_various_vert.vert
@@ -27,7 +27,7 @@ attribute vec4 gtf_Vertex;
 uniform mat4 gtf_ModelViewProjectionMatrix;
 varying vec4 color;
 
-#define ERROR_EPSILON 0.1
+#define ERROR_EPSILON 0.125
 
 void main (void)
 {

--- a/conformance-suites/2.0.0/conformance/ogles/GL/struct/nestedstructcomb_various_frag.frag
+++ b/conformance-suites/2.0.0/conformance/ogles/GL/struct/nestedstructcomb_various_frag.frag
@@ -28,7 +28,7 @@ precision mediump float;
 #endif
 varying vec4 color;
 
-#define ERROR_EPSILON 0.1
+#define ERROR_EPSILON 0.125
 
 void main (void){
   	struct second_nest

--- a/conformance-suites/2.0.0/conformance/ogles/GL/struct/nestedstructcomb_various_vert.vert
+++ b/conformance-suites/2.0.0/conformance/ogles/GL/struct/nestedstructcomb_various_vert.vert
@@ -27,7 +27,7 @@ attribute vec4 gtf_Vertex;
 uniform mat4 gtf_ModelViewProjectionMatrix;
 varying vec4 color;
 
-#define ERROR_EPSILON 0.1
+#define ERROR_EPSILON 0.125
 
 void main (void)
 {

--- a/sdk/tests/conformance/ogles/GL/struct/nestedstructcomb_various_frag.frag
+++ b/sdk/tests/conformance/ogles/GL/struct/nestedstructcomb_various_frag.frag
@@ -28,7 +28,7 @@ precision mediump float;
 #endif
 varying vec4 color;
 
-#define ERROR_EPSILON 0.1
+#define ERROR_EPSILON 0.125
 
 void main (void){
   	struct second_nest

--- a/sdk/tests/conformance/ogles/GL/struct/nestedstructcomb_various_vert.vert
+++ b/sdk/tests/conformance/ogles/GL/struct/nestedstructcomb_various_vert.vert
@@ -27,7 +27,7 @@ attribute vec4 gtf_Vertex;
 uniform mat4 gtf_ModelViewProjectionMatrix;
 varying vec4 color;
 
-#define ERROR_EPSILON 0.1
+#define ERROR_EPSILON 0.125
 
 void main (void)
 {


### PR DESCRIPTION
Affects the ogles/struct/struct_049_to_56.html tests.  The ERROR_EPSILON
value of 0.1 was too strict for FP16 implementation of medium precision.
This change relaxes the epsilon to 0.125.

Fixes #2675 