### PR TITLE
Add more WEBGL_multiview tests

### DIFF
--- a/sdk/tests/conformance2/extensions/00_test_list.txt
+++ b/sdk/tests/conformance2/extensions/00_test_list.txt
@@ -3,4 +3,7 @@ ext-disjoint-timer-query-webgl2.html
 promoted-extensions.html
 promoted-extensions-in-shaders.html
 --min-version 2.0.1 webgl_multiview.html
+--min-version 2.0.1 webgl_multiview_draw_buffers.html
+--min-version 2.0.1 webgl_multiview_flat_varying.html
+--min-version 2.0.1 webgl_multiview_instanced_draw.html
 --min-version 2.0.1 webgl_multiview_timer_query.html

--- a/sdk/tests/conformance2/extensions/webgl_multiview.html
+++ b/sdk/tests/conformance2/extensions/webgl_multiview.html
@@ -355,15 +355,8 @@ function runVertexShaderRenderTest()
     for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
         gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, viewIndex);
         let expectedColor = getExpectedColor(viewIndex);
-        let colorRegionLeftEdge = (width / views) * viewIndex;
-        let colorRegionRightEdge = (width / views) * (viewIndex + 1);
-        if (viewIndex > 0) {
-            wtu.checkCanvasRect(gl, 0, 0, colorRegionLeftEdge - 1, height, [0, 0, 0, 0], 'the left edge of view ' + viewIndex + ' should be untouched');
-        }
-        if (viewIndex < views - 1) {
-            wtu.checkCanvasRect(gl, colorRegionRightEdge + 1, 0, width - colorRegionRightEdge - 1, height, [0, 0, 0, 0], 'the right edge of view ' + viewIndex + ' should be untouched');
-        }
-        wtu.checkCanvasRect(gl, colorRegionLeftEdge + 1, 0, colorRegionRightEdge - colorRegionLeftEdge - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' should be colored ' + expectedColor);
+
+        checkVerticalStrip(width, height, views, viewIndex, expectedColor, 'view ' + viewIndex);
     }
 }
 
@@ -402,29 +395,8 @@ function runRealisticUseCaseRenderTest()
         let scaleX = 1.0 / views;
         // offsetX is the position of the left edge of the quad we want to get in normalized device coordinates
         let offsetX = viewIndex / views * 2.0 - 1.0;
-        // x position is transformed according to this equation: scaleX * x0 + translateX = offsetX
-        // By substituting x0 with -1 (vertex attribute x value for the left edge), we get the following:
-        let translateX = offsetX + scaleX;
 
-        transformData[viewIndex * 16] = scaleX;
-        transformData[viewIndex * 16 + 1] = 0.0;
-        transformData[viewIndex * 16 + 2] = 0.0;
-        transformData[viewIndex * 16 + 3] = 0.0;
-
-        transformData[viewIndex * 16 + 4] = 0.0;
-        transformData[viewIndex * 16 + 5] = 1.0;
-        transformData[viewIndex * 16 + 6] = 0.0;
-        transformData[viewIndex * 16 + 7] = 0.0;
-
-        transformData[viewIndex * 16 + 8] = 0.0;
-        transformData[viewIndex * 16 + 9] = 0.0;
-        transformData[viewIndex * 16 + 10] = 1.0;
-        transformData[viewIndex * 16 + 11] = 0.0;
-
-        transformData[viewIndex * 16 + 12] = translateX;
-        transformData[viewIndex * 16 + 13] = 0.0;
-        transformData[viewIndex * 16 + 14] = 0.0;
-        transformData[viewIndex * 16 + 15] = 1.0;
+        setupTranslateAndScaleXMatrix(transformData, viewIndex * 16, scaleX, offsetX);
     }
     gl.uniformMatrix4fv(transformLocation, false, transformData);
 
@@ -436,15 +408,8 @@ function runRealisticUseCaseRenderTest()
     for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
         gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, viewIndex);
         let expectedColor = getExpectedColor(viewIndex);
-        let colorRegionLeftEdge = (width / views) * viewIndex;
-        let colorRegionRightEdge = (width / views) * (viewIndex + 1);
-        if (viewIndex > 0) {
-            wtu.checkCanvasRect(gl, 0, 0, colorRegionLeftEdge - 1, height, [0, 0, 0, 0], 'the left edge of view ' + viewIndex + ' should be untouched');
-        }
-        if (viewIndex < views - 1) {
-            wtu.checkCanvasRect(gl, colorRegionRightEdge + 1, 0, width - colorRegionRightEdge - 1, height, [0, 0, 0, 0], 'the right edge of view ' + viewIndex + ' should be untouched');
-        }
-        wtu.checkCanvasRect(gl, colorRegionLeftEdge + 1, 0, colorRegionRightEdge - colorRegionLeftEdge - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' should be colored ' + expectedColor);
+
+        checkVerticalStrip(width, height, views, viewIndex, expectedColor, 'view ' + viewIndex);
     }
 }
 

--- a/sdk/tests/conformance2/extensions/webgl_multiview_draw_buffers.html
+++ b/sdk/tests/conformance2/extensions/webgl_multiview_draw_buffers.html
@@ -1,0 +1,207 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL WEBGL_multiview Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/webgl_multiview_util.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext(null, null, 2);
+let ext = null;
+
+function runClearTest()
+{
+    debug("");
+    debug("Testing that calling clear() clears all views in all draw buffers");
+
+    let width = 256;
+    let height = 256;
+
+    let views = gl.getParameter(ext.MAX_VIEWS_OVR);
+
+    let fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    let colorTex = [null, null, null];
+    let drawBuffers = [0, 0, 0];
+    for (let texIndex = 0; texIndex < colorTex.length; ++texIndex) {
+        colorTex[texIndex] = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
+        gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
+        ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + texIndex, colorTex[texIndex], 0, 0, views);
+        drawBuffers[texIndex] = gl.COLOR_ATTACHMENT0 + texIndex;
+    }
+
+    gl.viewport(0, 0, width, height);
+    gl.drawBuffers(drawBuffers);
+
+    gl.clearColor(0, 1, 1, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from clear");
+
+    let readFb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFb);
+    for (let texIndex = 0; texIndex < colorTex.length; ++texIndex) {
+        for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
+            gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex[texIndex], 0, viewIndex);
+            let expectedColor = [0, 255, 255, 255];
+            wtu.checkCanvasRect(gl, 0, 0, width, height, expectedColor, 'view ' + viewIndex + ' of color attachment ' + texIndex + ' should be cyan');
+        }
+        debug("");
+    }
+}
+
+function runDrawBuffersRenderTest()
+{
+    debug("");
+    debug("Testing rendering into multiple draw buffers with a different transformation matrix chosen from a uniform array according to ViewID");
+
+    let width = 256;
+    let height = 256;
+
+    let views = gl.getParameter(ext.MAX_VIEWS_OVR);
+
+    let fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    let colorTex = [null, null, null];
+    let drawBuffers = [0, 0, 0];
+    for (let texIndex = 0; texIndex < colorTex.length; ++texIndex) {
+        colorTex[texIndex] = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
+        gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
+        ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + texIndex, colorTex[texIndex], 0, 0, views);
+        drawBuffers[texIndex] = gl.COLOR_ATTACHMENT0 + texIndex;
+    }
+
+    let multiviewShaders = [
+      getMultiviewRealisticUseCaseVertexShader(views),
+      getMultiviewColorFragmentShaderForDrawBuffers(colorTex.length)
+    ];
+
+    let testProgram = wtu.setupProgram(gl, multiviewShaders, ['a_position'], [0], true);
+    if (!testProgram) {
+        testFailed("Compilation with extension enabled failed.");
+        return;
+    }
+
+    gl.viewport(0, 0, width, height);
+    gl.drawBuffers(drawBuffers);
+
+    let transformLocation = gl.getUniformLocation(testProgram, 'transform');
+    let transformData = new Float32Array (views * 16);
+    for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
+        let scaleX = 1.0 / views;
+        // offsetX is the position of the left edge of the quad we want to get in normalized device coordinates
+        let offsetX = viewIndex / views * 2.0 - 1.0;
+        // x position is transformed according to this equation: scaleX * x0 + translateX = offsetX
+        // By substituting x0 with -1 (vertex attribute x value for the left edge), we get the following:
+        let translateX = offsetX + scaleX;
+
+        transformData[viewIndex * 16] = scaleX;
+        transformData[viewIndex * 16 + 1] = 0.0;
+        transformData[viewIndex * 16 + 2] = 0.0;
+        transformData[viewIndex * 16 + 3] = 0.0;
+
+        transformData[viewIndex * 16 + 4] = 0.0;
+        transformData[viewIndex * 16 + 5] = 1.0;
+        transformData[viewIndex * 16 + 6] = 0.0;
+        transformData[viewIndex * 16 + 7] = 0.0;
+
+        transformData[viewIndex * 16 + 8] = 0.0;
+        transformData[viewIndex * 16 + 9] = 0.0;
+        transformData[viewIndex * 16 + 10] = 1.0;
+        transformData[viewIndex * 16 + 11] = 0.0;
+
+        transformData[viewIndex * 16 + 12] = translateX;
+        transformData[viewIndex * 16 + 13] = 0.0;
+        transformData[viewIndex * 16 + 14] = 0.0;
+        transformData[viewIndex * 16 + 15] = 1.0;
+    }
+    gl.uniformMatrix4fv(transformLocation, false, transformData);
+
+    wtu.drawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from draw");
+
+    let readFb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFb);
+    for (let texIndex = 0; texIndex < colorTex.length; ++texIndex) {
+        for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
+            gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex[texIndex], 0, viewIndex);
+            let expectedColor = getExpectedColor(viewIndex + texIndex);
+            let colorRegionLeftEdge = (width / views) * viewIndex;
+            let colorRegionRightEdge = (width / views) * (viewIndex + 1);
+            if (viewIndex > 0) {
+                wtu.checkCanvasRect(gl, 0, 0, colorRegionLeftEdge - 1, height, [0, 0, 0, 0], 'the left edge of view ' + viewIndex + ' of color attachment ' + texIndex + ' should be untouched');
+            }
+            if (viewIndex < views - 1) {
+                wtu.checkCanvasRect(gl, colorRegionRightEdge + 1, 0, width - colorRegionRightEdge - 1, height, [0, 0, 0, 0], 'the right edge of view ' + viewIndex + ' of color attachment ' + texIndex + ' should be untouched');
+            }
+            wtu.checkCanvasRect(gl, colorRegionLeftEdge + 1, 0, colorRegionRightEdge - colorRegionLeftEdge - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' of color attachment ' + texIndex + ' should be colored ' + expectedColor);
+        }
+        debug("");
+    }
+}
+
+description("This test verifies the functionality of the WEBGL_multiview extension when used with multiple draw buffers, if it is available.");
+
+debug("");
+
+if (!gl) {
+  testFailed("WebGL context does not exist");
+} else {
+  testPassed("WebGL context exists");
+
+  if (!gl.getExtension("WEBGL_multiview")) {
+      testPassed("No WEBGL_multiview support -- this is legal");
+  } else {
+      testPassed("Successfully enabled WEBGL_multiview extension");
+      ext = gl.getExtension('WEBGL_multiview');
+
+      runClearTest();
+
+      wtu.setupUnitQuad(gl, 0, 1);
+
+      runDrawBuffersRenderTest();
+  }
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/extensions/webgl_multiview_draw_buffers.html
+++ b/sdk/tests/conformance2/extensions/webgl_multiview_draw_buffers.html
@@ -45,7 +45,7 @@ let wtu = WebGLTestUtils;
 let gl = wtu.create3DContext(null, null, 2);
 let ext = null;
 
-function runClearTest()
+function runDrawBuffersClearTest()
 {
     debug("");
     debug("Testing that calling clear() clears all views in all draw buffers");
@@ -126,29 +126,8 @@ function runDrawBuffersRenderTest()
         let scaleX = 1.0 / views;
         // offsetX is the position of the left edge of the quad we want to get in normalized device coordinates
         let offsetX = viewIndex / views * 2.0 - 1.0;
-        // x position is transformed according to this equation: scaleX * x0 + translateX = offsetX
-        // By substituting x0 with -1 (vertex attribute x value for the left edge), we get the following:
-        let translateX = offsetX + scaleX;
 
-        transformData[viewIndex * 16] = scaleX;
-        transformData[viewIndex * 16 + 1] = 0.0;
-        transformData[viewIndex * 16 + 2] = 0.0;
-        transformData[viewIndex * 16 + 3] = 0.0;
-
-        transformData[viewIndex * 16 + 4] = 0.0;
-        transformData[viewIndex * 16 + 5] = 1.0;
-        transformData[viewIndex * 16 + 6] = 0.0;
-        transformData[viewIndex * 16 + 7] = 0.0;
-
-        transformData[viewIndex * 16 + 8] = 0.0;
-        transformData[viewIndex * 16 + 9] = 0.0;
-        transformData[viewIndex * 16 + 10] = 1.0;
-        transformData[viewIndex * 16 + 11] = 0.0;
-
-        transformData[viewIndex * 16 + 12] = translateX;
-        transformData[viewIndex * 16 + 13] = 0.0;
-        transformData[viewIndex * 16 + 14] = 0.0;
-        transformData[viewIndex * 16 + 15] = 1.0;
+        setupTranslateAndScaleXMatrix(transformData, viewIndex * 16, scaleX, offsetX);
     }
     gl.uniformMatrix4fv(transformLocation, false, transformData);
 
@@ -161,15 +140,8 @@ function runDrawBuffersRenderTest()
         for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
             gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex[texIndex], 0, viewIndex);
             let expectedColor = getExpectedColor(viewIndex + texIndex);
-            let colorRegionLeftEdge = (width / views) * viewIndex;
-            let colorRegionRightEdge = (width / views) * (viewIndex + 1);
-            if (viewIndex > 0) {
-                wtu.checkCanvasRect(gl, 0, 0, colorRegionLeftEdge - 1, height, [0, 0, 0, 0], 'the left edge of view ' + viewIndex + ' of color attachment ' + texIndex + ' should be untouched');
-            }
-            if (viewIndex < views - 1) {
-                wtu.checkCanvasRect(gl, colorRegionRightEdge + 1, 0, width - colorRegionRightEdge - 1, height, [0, 0, 0, 0], 'the right edge of view ' + viewIndex + ' of color attachment ' + texIndex + ' should be untouched');
-            }
-            wtu.checkCanvasRect(gl, colorRegionLeftEdge + 1, 0, colorRegionRightEdge - colorRegionLeftEdge - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' of color attachment ' + texIndex + ' should be colored ' + expectedColor);
+
+            checkVerticalStrip(width, height, views, viewIndex, expectedColor, 'view ' + viewIndex + ' of color attachment ' + texIndex);
         }
         debug("");
     }
@@ -190,7 +162,7 @@ if (!gl) {
       testPassed("Successfully enabled WEBGL_multiview extension");
       ext = gl.getExtension('WEBGL_multiview');
 
-      runClearTest();
+      runDrawBuffersClearTest();
 
       wtu.setupUnitQuad(gl, 0, 1);
 

--- a/sdk/tests/conformance2/extensions/webgl_multiview_flat_varying.html
+++ b/sdk/tests/conformance2/extensions/webgl_multiview_flat_varying.html
@@ -1,0 +1,114 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL WEBGL_multiview Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/webgl_multiview_util.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext(null, null, 2);
+let ext = null;
+
+function runFlatVaryingTest()
+{
+    debug("");
+    debug("Testing rendering with different colors in fragment shader");
+
+    let width = 256;
+    let height = 256;
+
+    let views = gl.getParameter(ext.MAX_VIEWS_OVR);
+
+    let multiviewShaders = [
+      getMultiviewFlatVaryingVertexShader(views),
+      getMultiviewFlatVaryingFragmentShader()
+    ];
+    let testProgram = wtu.setupProgram(gl, multiviewShaders, ['a_position'], [0], true);
+    if (!testProgram) {
+        testFailed("Compilation with extension enabled failed.");
+        return;
+    }
+
+    let fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
+    gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
+    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+
+    gl.viewport(0, 0, width, height);
+    wtu.drawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from draw");
+
+    let readFb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFb);
+    for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
+        gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, viewIndex);
+        let expectedColor = getExpectedColor(viewIndex);
+        wtu.checkCanvasRect(gl, 0, 0, width, height, expectedColor, 'view ' + viewIndex + ' should be colored ' + expectedColor);
+    }
+}
+
+description("This test verifies instanced draws together with the WEBGL_multiview extension, if it is available.");
+
+debug("");
+
+if (!gl) {
+  testFailed("WebGL context does not exist");
+} else {
+  testPassed("WebGL context exists");
+
+  if (!gl.getExtension("WEBGL_multiview")) {
+      testPassed("No WEBGL_multiview support -- this is legal");
+  } else {
+      testPassed("Successfully enabled WEBGL_multiview extension");
+      ext = gl.getExtension('WEBGL_multiview');
+
+      wtu.setupUnitQuad(gl, 0, 1);
+
+      runFlatVaryingTest();
+  }
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/conformance2/extensions/webgl_multiview_flat_varying.html
+++ b/sdk/tests/conformance2/extensions/webgl_multiview_flat_varying.html
@@ -84,7 +84,7 @@ function runFlatVaryingTest()
     }
 }
 
-description("This test verifies instanced draws together with the WEBGL_multiview extension, if it is available.");
+description("This test verifies that flat varyings work in multiview shaders using WEBGL_multiview extension, if it is available.");
 
 debug("");
 

--- a/sdk/tests/conformance2/extensions/webgl_multiview_instanced_draw.html
+++ b/sdk/tests/conformance2/extensions/webgl_multiview_instanced_draw.html
@@ -1,0 +1,126 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL WEBGL_multiview Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/webgl_multiview_util.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext(null, null, 2);
+let ext = null;
+
+function runInstancedDrawTest()
+{
+    debug("");
+    debug("Testing instanced rendering");
+
+    let width = 256;
+    let height = 256;
+
+    let views = gl.getParameter(ext.MAX_VIEWS_OVR);
+
+    let multiviewShaders = [
+      getMultiviewInstancedVertexShader(views),
+      getInstanceColorFragmentShader()
+    ];
+
+    let testProgram = wtu.setupProgram(gl, multiviewShaders, ['a_position'], [0], true);
+    if (!testProgram) {
+        testFailed("Compilation with extension enabled failed.");
+        return;
+    }
+
+    let fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
+    gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
+    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+
+    gl.viewport(0, 0, width, height);
+    gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, 2);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from draw");
+
+    let readFb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFb);
+    for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
+        gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, viewIndex);
+        let colorRegionLeftEdge = (width / (views * 2)) * viewIndex;
+        let colorRegionRightEdge = (width / (views * 2)) * (viewIndex + 2);
+        let stripWidth = (colorRegionRightEdge - colorRegionLeftEdge) / 2;
+        if (colorRegionLeftEdge > 0) {
+            wtu.checkCanvasRect(gl, 0, 0, Math.floor(colorRegionLeftEdge) - 1, height, [0, 0, 0, 0], 'the left edge of view ' + viewIndex + ' should be untouched');
+        }
+        if (colorRegionRightEdge < width) {
+            wtu.checkCanvasRect(gl, colorRegionRightEdge + 1, 0, width - colorRegionRightEdge - 1, height, [0, 0, 0, 0], 'the right edge of view ' + viewIndex + ' should be untouched');
+        }
+        let expectedColor = getExpectedColor(0);
+        wtu.checkCanvasRect(gl, colorRegionLeftEdge + 1, 0, stripWidth - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' drawn by instance 0 should be colored ' + expectedColor);
+        expectedColor = getExpectedColor(1);
+        wtu.checkCanvasRect(gl, colorRegionLeftEdge + stripWidth + 1, 0, stripWidth - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' drawn by instance 1 should be colored ' + expectedColor);
+    }
+}
+
+description("This test verifies instanced draws together with the WEBGL_multiview extension, if it is available.");
+
+debug("");
+
+if (!gl) {
+  testFailed("WebGL context does not exist");
+} else {
+  testPassed("WebGL context exists");
+
+  if (!gl.getExtension("WEBGL_multiview")) {
+      testPassed("No WEBGL_multiview support -- this is legal");
+  } else {
+      testPassed("Successfully enabled WEBGL_multiview extension");
+      ext = gl.getExtension('WEBGL_multiview');
+
+      wtu.setupUnitQuad(gl, 0, 1);
+
+      runInstancedDrawTest();
+  }
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This adds tests for different features that interact with
WEBGL_multiview:

1. Multiple draw buffers.
2. Using a flat varying in a multiview shader (this covers a bug that
   was recently worked around in ANGLE).
3. Instanced draw calls. Multiview can be implemented by leveraging
   instancing together with some other GL / D3D11 features, so it's
   important to test this.

All of these tests pass when run against Chrome Canary with WebGL
draft extensions enabled.