### PR TITLE
Simplify WebGLTestUtils.startPlayingAndWaitForVideo.

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -2923,35 +2923,15 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  var gotPlaying = false;
-  var gotTimeUpdate = false;
-
-  var maybeCallCallback = function() {
-    if (gotPlaying && gotTimeUpdate && callback) {
+  var timeWatcher = function() {
+    if (video.currentTime > 0) {
       callback(video);
-      callback = undefined;
-      video.removeEventListener('playing', playingListener, true);
-      video.removeEventListener('timeupdate', timeupdateListener, true);
+    } else {
+      requestAnimFrame.call(window, timeWatcher);
     }
   };
 
-  var playingListener = function() {
-    gotPlaying = true;
-    maybeCallCallback();
-  };
-
-  var timeupdateListener = function() {
-    // Checking to make sure the current time has advanced beyond
-    // the start time seems to be a reliable heuristic that the
-    // video element has data that can be consumed.
-    if (video.currentTime > 0.0) {
-      gotTimeUpdate = true;
-      maybeCallCallback();
-    }
-  };
-
-  video.addEventListener('playing', playingListener, true);
-  video.addEventListener('timeupdate', timeupdateListener, true);
+  requestAnimFrame.call(window, timeWatcher);
   video.loop = true;
   video.play();
 };


### PR DESCRIPTION
Chrome's media team points out that their own internal tests only
watch for video.currentTime > 0, and those tests are reliable. Use the
same structure in WebGLTestUtils. This change should work across all
web browsers.

Addresses feedback given in http://crbug.com/834933 . Attempting to
eliminate test flakiness observed in http://crbug.com/830901 .