### PR TITLE
Update Chrome troubleshooting URL.

### DIFF
--- a/other/get.webgl.org/troubleshooting/DoNotCopyOrLinkThisFileElseYouWillNotGetAutoUpdatedHelpForYourUsers.js
+++ b/other/get.webgl.org/troubleshooting/DoNotCopyOrLinkThisFileElseYouWillNotGetAutoUpdatedHelpForYourUsers.js
@@ -215,7 +215,7 @@ var BrowserDetect = {
   urls: {
     "Chrome": {
       upgradeUrl: "http://www.google.com/support/chrome/bin/answer.py?answer=95346",
-      troubleshootingUrl: "http://www.google.com/support/chrome/bin/answer.py?answer=1220892"
+      troubleshootingUrl: "https://support.google.com/chrome#topic=7438008"
     },
     "Firefox": {
       upgradeUrl: "http://www.mozilla.com/en-US/firefox/new/",


### PR DESCRIPTION
Make it point to the top-level help for Chrome. The previous URL has
been redirected to a "tips and tricks" page which is not very useful.

Thanks to webmaster James Riordon for raising the issue.