### PR TITLE
Fix href of rejected WEBGL_get_buffer_sub_data_async extension.

### DIFF
--- a/extensions/rejected/WEBGL_get_buffer_sub_data_async/extension.xml
+++ b/extensions/rejected/WEBGL_get_buffer_sub_data_async/extension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<rejected href="WEBGL_get_buffer_sub_data_async/">
+<rejected href="rejected/WEBGL_get_buffer_sub_data_async/">
   <name>WEBGL_get_buffer_sub_data_async</name>
   <contact>
     <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)


### PR DESCRIPTION
This was causing the extension registry to fail to rebuild
successfully.