### PR TITLE
Generate errors with non active TF bindings.

### DIFF
--- a/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
+++ b/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
@@ -241,9 +241,9 @@ for (let [drawArrays, drawElements] of drawFunctions) {
   drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, true);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "tf enabled");
   drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays: tf disabled");
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawArrays: tf disabled");
   drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawElements: tf disabled");
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawElements: tf disabled");
   gl.bindBuffer(gl.COPY_READ_BUFFER, null);
 
   debug("<hr/>Test TF buffer bound to disabled vertex attrib");
@@ -255,9 +255,9 @@ for (let [drawArrays, drawElements] of drawFunctions) {
   gl.disableVertexAttribArray(2);
   gl.bindVertexArray(null);
   drawWithFeedbackBound(gl, drawArrays, prog, vao, tf, false);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "tf disabled, draw should succeed");
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "tf disabled, draw should succeed");
   drawWithFeedbackBound(gl, drawElements, prog, vao, tf, false);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "tf disabled, draw should succeed");
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "tf disabled, draw should succeed");
   // Remove the TF buffer binding from the VAO after the test.
   gl.bindVertexArray(vao);
   gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer3);


### PR DESCRIPTION
This simplifies the logic for transform feedback simultaneous use.
Instead of conditionally checking if the TF is active, always check for
simultaneously bound array buffers. This simplifies the validation logic
since we don't need as many separate checks.

PTAL @kenrussell @jdarpinian @jdashg 

The only change to the usage here is making simultaneous use invalid when the user omits the call to glBeginTransformFeedback and calls a draw. In my mind there isn't a difference between validating a pack buffer's simultaneous use when the XFB is disabled vs an array buffer. It also cleans up ANGLE's validation logic as it reduces three separate checks to a single call.