### PR TITLE
Avoid using window's named getter on a couple of tests

### DIFF
--- a/sdk/tests/conformance/rendering/framebuffer-switch.html
+++ b/sdk/tests/conformance/rendering/framebuffer-switch.html
@@ -42,6 +42,7 @@
 "use strict";
 description("Test framebuffer switching. The test switches between two framebuffers, copying rendering results from one to the other.");
 var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
 
 var gl = wtu.create3DContext("canvas");
 var program = wtu.setupTexturedQuad(gl);

--- a/sdk/tests/conformance/rendering/framebuffer-texture-switch.html
+++ b/sdk/tests/conformance/rendering/framebuffer-texture-switch.html
@@ -42,6 +42,7 @@
 "use strict";
 description("Test framebuffer texture attachment switching. The test uses one framebuffer object and switches its color attachment.");
 var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
 
 var gl = wtu.create3DContext("canvas");
 var program = wtu.setupTexturedQuad(gl);


### PR DESCRIPTION
Servo doesn't implement the named getter yet and thus those tests fail for
reasons unrelated to our WebGL support.