### PR TITLE
Improve compressed texture tests

### DIFF
--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -27,6 +27,7 @@ webgl-debug-renderer-info.html
 webgl-debug-shaders.html
 --min-version 1.0.4 webgl-compressed-texture-astc.html
 --min-version 1.0.4 webgl-compressed-texture-etc.html
+--min-version 1.0.4 webgl-compressed-texture-etc1.html
 --min-version 1.0.3 webgl-compressed-texture-pvrtc.html
 --min-version 1.0.2 webgl-compressed-texture-s3tc.html
 --min-version 1.0.4 webgl-compressed-texture-s3tc-srgb.html

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
@@ -30,6 +30,7 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/compressed-texture-utils.js"></script>
 <title>WebGL WEBGL_compressed_texture_astc Conformance Tests</title>
 <style>
 img {
@@ -1601,6 +1602,7 @@ var decoded_12x12_argb_hdr = new Uint8Array([
 ]);
 
 var wtu = WebGLTestUtils;
+var ctu = CompressedTextureUtils;
 var contextVersion = wtu.getDefault3DContextVersion();
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
@@ -1641,125 +1643,42 @@ var validFormats = {
 
 };
 var name;
-var supportedFormats;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
 } else {
     testPassed("WebGL context exists");
 
-    // Run tests with extension disabled
-    runTestDisabled();
-    debug("");
+    // The texture size 3 * 5 * 8 below is divisible by all the different block sizes supported by the extension.
+    ctu.testCompressedFormatsUnavailableWhenExtensionDisabled(gl, validFormats, expectedByteLength, 3 * 5 * 8);
 
     // Query the extension and store globally so shouldBe can access it
     ext = wtu.getExtensionWithKnownPrefixes(gl, extFlag);
     if (!ext) {
         testPassed("No WEBGL_compressed_texture_astc support -- this is legal");
-        runSupportedTest(false);
+        wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_astc", false);
     } else {
         testPassed("Successfully enabled WEBGL_compressed_texture_astc extension");
 
         debug("");
-        runSupportedTest(true);
+        wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_astc", true);
         runTestExtension();
     }
-}
-
-function runSupportedTest(extensionEnabled) {
-    var name = wtu.getSupportedExtensionWithKnownPrefixes(gl, extFlag);
-    if (name !== undefined) {
-        if (extensionEnabled) {
-            testPassed("WEBGL_compressed_texture_astc listed as supported and getExtension succeeded");
-        } else {
-            testFailed("WEBGL_compressed_texture_astc listed as supported but getExtension failed");
-        }
-    } else {
-        if (extensionEnabled) {
-            testFailed("WEBGL_compressed_texture_astc not listed as supported but getExtension succeeded");
-        } else {
-            testPassed("WEBGL_compressed_texture_astc not listed as supported and getExtension failed -- this is legal");
-        }
-    }
-}
-
-
-function runTestDisabled() {
-    debug("Testing binding enum with extension disabled");
-
-    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    shouldBe("supportedFormats", "[]");
 }
 
 function runTestExtension() {
     debug("");
     debug("Testing " + extFlag);
 
-    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 28 formats for both WebGL 1.0 and WebGL 2.0.
-    shouldBe("supportedFormats.length", "28");
+    // Test that enum values are listed correctly in supported formats and in the extension object.
+    ctu.testCompressedFormatsListed(gl, validFormats);
+    ctu.testCorrectEnumValuesInExt(ext, validFormats);
+    // Test that texture upload buffer size is validated correctly.
+    ctu.testFormatRestrictionsOnBufferSize(gl, validFormats, expectedByteLength, getBlockDimensions);
 
-    console.log(wtu);
-
-    // check that all 28 formats exist
-    testFormatsExist(supportedFormats);
-    // check that all format enums exist.
-    testCompressionFormatsValidity();
-    // check that the specified restrictions fails with
-    // an INVALID_VALUE error when not respected
-    testASTCFormatsRestrictions();
     // Tests ASTC texture with every format
     testLDRTextures();
     testHDRTextures();
-}
-
-function testFormatsExist(supportedFormats) {
-    debug("");
-    debug("Testing every supported formats exist");
-
-    var failed;
-    for (var name in validFormats) {
-        var format = validFormats[name];
-        failed = true;
-        for (var ii = 0; ii < supportedFormats.length; ++ii) {
-            if (format == supportedFormats[ii]) {
-                testPassed("supported format " + formatToString(format) + " exists");
-                failed = false;
-                break;
-            }
-        }
-        if (failed) {
-            testFailed("supported format " + formatToString(format) + " does not exist");
-        }
-    }
-}
-
-function testCompressionFormatsValidity() {
-    debug("");
-    debug("Testing every supported formats is valid");
-
-    for (name in validFormats) {
-        var expected = "0x" + validFormats[name].toString(16);
-        var actual = "ext['" + name + "']";
-        shouldBe(actual, expected);
-    }
-}
-
-function testASTCFormatsRestrictions() {
-    debug("");
-    debug("Testing format restrictions on buffer size");
-
-    var data = new Uint8Array(17);
-
-    var tex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, tex);
-    for (var formatId in validFormats) {
-        var format = validFormats[formatId];
-        var expectedSize = expectedByteLength(16, 16, format, data.length);
-        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, 16, 16, 0, data);
-        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE,
-            formatToString(format) + " expected size: " + expectedSize);
-    }
 }
 
 function testLDRTextures() {
@@ -1850,7 +1769,7 @@ function testASTCTexture(test, useTexStorage) {
     canvas.height = height;
     gl.viewport(0, 0, width, height);
     debug("");
-    debug("testing " + formatToString(format) + " " + width + "x" + height + " (" + test.mode + ")" +
+    debug("testing " + ctu.formatToString(ext, format) + " " + width + "x" + height + " (" + test.mode + ")" +
           (useTexStorage ? " via texStorage2D" : " via compressedTexImage2D"));
     debug("");
 
@@ -1913,10 +1832,10 @@ function compareRect(
 
     var div = document.createElement("div");
     div.className = "testimages";
-    insertImg(div, "expected", makeImage(
+    ctu.insertCaptionedImg(div, "expected", ctu.makeScaledImage(
             actualWidth, actualHeight, dataWidth, expectedData,
             actualChannels == 4));
-    insertImg(div, "actual", makeImage(
+    ctu.insertCaptionedImg(div, "actual", ctu.makeScaledImage(
             actualWidth, actualHeight, actualWidth, actual,
             actualChannels == 4));
     div.appendChild(document.createElement('br'));
@@ -1975,74 +1894,51 @@ function buildTests(data, formats, raws, mode) {
     return tests;
 }
 
-function formatToString(format) {
-    for (var p in ext) {
-        if (ext[p] == format) {
-            return p;
-        }
-    }
-    return "0x" + format.toString(16);
-}
-
 function expectedByteLength(w, h, format) {
 
-    if (format == ext.COMPRESSED_RGBA_ASTC_4x4_KHR)
+    if (format == validFormats.COMPRESSED_RGBA_ASTC_4x4_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR)
         return Math.floor((w + 3) / 4) * Math.floor((h + 3) / 4) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_5x4_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_5x4_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR)
         return Math.floor((w + 4) / 5) * Math.floor((h + 3) / 4) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_5x5_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_5x5_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR)
         return Math.floor((w + 4) / 5) * Math.floor((h + 4) / 5) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_6x5_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_6x5_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR)
         return Math.floor((w + 5) / 6) * Math.floor((h + 4) / 5) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_6x6_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_6x6_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR)
         return Math.floor((w + 5) / 6) * Math.floor((h + 5) / 6) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_8x5_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_8x5_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR)
         return Math.floor((w + 7) / 8) * Math.floor((h + 4) / 5) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_8x6_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_8x6_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR)
         return Math.floor((w + 7) / 8) * Math.floor((h + 5) / 6) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_8x8_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_8x8_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR)
         return Math.floor((w + 7) / 8) * Math.floor((h + 7) / 8) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_10x5_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_10x5_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR)
         return Math.floor((w + 9) / 10) * Math.floor((h + 4) / 5) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_10x6_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_10x6_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR)
         return Math.floor((w + 9) / 10) * Math.floor((h + 5) / 6) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_10x8_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_10x8_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR)
         return Math.floor((w + 9) / 10) * Math.floor((h + 7) / 8) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_10x10_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_10x10_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR)
         return Math.floor((w + 9) / 10) * Math.floor((h + 9) / 10) * 16;
-    else if (format == ext.COMPRESSED_RGBA_ASTC_12x10_KHR)
+    else if (format == validFormats.COMPRESSED_RGBA_ASTC_12x10_KHR || format == validFormats.COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR)
         return Math.floor((w + 11) / 12) * Math.floor((h + 9) / 10) * 16;
 
     return Math.floor((w + 11) / 12) * Math.floor((h + 11) / 12) * 16;
 }
 
-function insertImg(element, caption, img) {
-    var div = document.createElement("div");
-    div.appendChild(img);
-    var label = document.createElement("div");
-    label.appendChild(document.createTextNode(caption));
-    div.appendChild(label);
-    element.appendChild(div);
-}
-
-function makeImage(imageWidth, imageHeight, dataWidth, data, alpha) {
-    var scale = 8;
-    var c = document.createElement("canvas");
-    c.width = imageWidth * scale;
-    c.height = imageHeight * scale;
-    var ctx = c.getContext("2d");
-    for (var yy = 0; yy < imageHeight; ++yy) {
-        for (var xx = 0; xx < imageWidth; ++xx) {
-            var offset = (yy * dataWidth + xx) * 4;
-            ctx.fillStyle = "rgba(" +
-                    data[offset + 0] + "," +
-                    data[offset + 1] + "," +
-                    data[offset + 2] + "," +
-                    (alpha ? data[offset + 3] / 255 : 1) + ")";
-            ctx.fillRect(xx * scale, yy * scale, scale, scale);
+function getBlockDimensions(format) {
+    var re = /.*_(\d+)x(\d+)_KHR/;
+    for (name in validFormats) {
+        if (validFormats[name] === format) {
+            var match = name.match(re);
+            return {
+              width: parseInt(match[1], 10),
+              height: parseInt(match[2], 10)
+              };
         }
     }
-    return wtu.makeImageFromCanvas(c);
+    testFailed('Could not find block dimensions for format ' + ctu.formatToString(ext, format));
+    return {width: 4, height: 4};
 }
 
 // Swaps two cells in an arraybuffer.

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-etc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-etc.html
@@ -33,6 +33,7 @@
 <LINK rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/compressed-texture-utils.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -42,25 +43,42 @@
 description("This test verifies the functionality of the WEBGL_compressed_texture_etc extension, if it is available.");
 
 debug("");
-var COMPRESSED_RGB_S3TC_DXT1_EXT              = 0x83F0;
-var COMPRESSED_RGBA_S3TC_DXT1_EXT             = 0x83F1;
-var COMPRESSED_RGBA_S3TC_DXT3_EXT             = 0x83F2;
-var COMPRESSED_RGBA_S3TC_DXT5_EXT             = 0x83F3;
-var COMPRESSED_RGB_PVRTC_4BPPV1_IMG           = 0x8C00;
-var COMPRESSED_RGBA_PVRTC_4BPPV1_IMG          = 0x8C02;
-var ETC1_RGB8_OES                             = 0x8D64;
-var COMPRESSED_R11_EAC                        = 0x9270;
-var COMPRESSED_SIGNED_R11_EAC                 = 0x9271;
-var COMPRESSED_RG11_EAC                       = 0x9272;
-var COMPRESSED_SIGNED_RG11_EAC                = 0x9273;
-var COMPRESSED_RGB8_ETC2                      = 0x9274;
-var COMPRESSED_SRGB8_ETC2                     = 0x9275;
-var COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2  = 0x9276;
-var COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9277;
-var COMPRESSED_RGBA8_ETC2_EAC                 = 0x9278;
-var COMPRESSED_SRGB8_ALPHA8_ETC2_EAC          = 0x9279;
+
+var validFormats = {
+  COMPRESSED_R11_EAC                        : 0x9270,
+  COMPRESSED_SIGNED_R11_EAC                 : 0x9271,
+  COMPRESSED_RG11_EAC                       : 0x9272,
+  COMPRESSED_SIGNED_RG11_EAC                : 0x9273,
+  COMPRESSED_RGB8_ETC2                      : 0x9274,
+  COMPRESSED_SRGB8_ETC2                     : 0x9275,
+  COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2  : 0x9276,
+  COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 : 0x9277,
+  COMPRESSED_RGBA8_ETC2_EAC                 : 0x9278,
+  COMPRESSED_SRGB8_ALPHA8_ETC2_EAC          : 0x9279
+};
+
+function expectedByteLength(width, height, format) {
+  var blockSizeInBytes = 8;
+
+  var largerBlockFormats = [
+    validFormats.COMPRESSED_RG11_EAC,
+    validFormats.COMPRESSED_SIGNED_RG11_EAC,
+    validFormats.COMPRESSED_RGBA8_ETC2_EAC,
+    validFormats.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC];
+
+  if (largerBlockFormats.indexOf(format) >= 0) {
+    blockSizeInBytes = 16;
+  }
+
+  return Math.floor((width + 3) / 4) * Math.floor((height + 3) / 4) * blockSizeInBytes;
+}
+
+function getBlockDimensions(format) {
+  return {width: 4, height: 4};
+}
 
 var wtu = WebGLTestUtils;
+var ctu = CompressedTextureUtils;
 var contextVersion = wtu.getDefault3DContextVersion();
 var gl = wtu.create3DContext();
 var WEBGL_compressed_texture_etc;
@@ -73,84 +91,49 @@ function runTest() {
   } else {
     testPassed("context exists");
 
-    var tex = gl.createTexture();
-    gl.bindTexture(gl.TEXTURE_2D, tex);
+    ctu.testCompressedFormatsUnavailableWhenExtensionDisabled(gl, validFormats, expectedByteLength, 4);
 
-    var haveExt = gl.getSupportedExtensions().indexOf("WEBGL_compressed_texture_etc") >= 0;
     WEBGL_compressed_texture_etc = gl.getExtension("WEBGL_compressed_texture_etc");
 
-    var isPositive = true;
+    wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_etc", WEBGL_compressed_texture_etc !== null);
 
-    if (haveExt) {
-      if (WEBGL_compressed_texture_etc !== null) {
-        testPassed("WEBGL_compressed_texture_etc listed as supported and getExtension succeeded");
-      } else {
-        testFailed("WEBGL_compressed_texture_etc listed as supported but getExtension failed");
-        return;
-      }
-    } else {
-      if (WEBGL_compressed_texture_etc !== null) {
-        testFailed("WEBGL_compressed_texture_etc listed as unsupported but getExtension succeeded");
-        return;
-      } else {
-        testPassed("No WEBGL_compressed_texture_etc support -- this is legal");
-        isPositive = false;
-      }
-    }
+    var isPositive = WEBGL_compressed_texture_etc !== null;
 
     if (isPositive) {
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_R11_EAC", "0x9270");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_SIGNED_R11_EAC", "0x9271");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_RG11_EAC", "0x9272");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_SIGNED_RG11_EAC", "0x9273");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_RGB8_ETC2", "0x9274");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_ETC2", "0x9275");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2", "0x9276");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2", "0x9277");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_RGBA8_ETC2_EAC", "0x9278");
-      shouldBe("WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC", "0x9279");
+      // Test that enum values are listed correctly in supported formats and in the extension object.
+      ctu.testCompressedFormatsListed(gl, validFormats);
+      ctu.testCorrectEnumValuesInExt(WEBGL_compressed_texture_etc, validFormats);
+      // Test that texture upload buffer size is validated correctly.
+      ctu.testFormatRestrictionsOnBufferSize(gl, validFormats, expectedByteLength, getBlockDimensions);
+
+      var tex = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+
+      for (var name in validFormats) {
+        if (validFormats.hasOwnProperty(name)) {
+          var format = validFormats[name];
+          wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, " + format + ", 4, 4, 0, new Uint8Array(" + expectedByteLength(4, 4, format) + "))");
+          wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 4, 4, " + format + ", new Uint8Array(" + expectedByteLength(4, 4, format) + "))");
+        }
+      }
     }
 
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB_S3TC_DXT1_EXT, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA_S3TC_DXT1_EXT, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA_S3TC_DXT5_EXT, 4, 4, 0, new Uint8Array(16))");
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ETC1_RGB8_OES, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_3D, 0, COMPRESSED_R11_EAC, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexSubImage2D(gl.TEXTURE_3D, 0, 0, 0, 4, 4, COMPRESSED_R11_EAC, new Uint8Array(8))");
-
-    var expected = isPositive ? gl.NO_ERROR : gl.INVALID_ENUM;
-    var expectedSub = isPositive ? gl.NO_ERROR : [gl.INVALID_ENUM, gl.INVALID_OPERATION];
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_R11_EAC, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, expectedSub, "gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 4, 4, COMPRESSED_R11_EAC, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_SIGNED_R11_EAC, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RG11_EAC, 4, 4, 0, new Uint8Array(16))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_SIGNED_RG11_EAC, 4, 4, 0, new Uint8Array(16))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB8_ETC2, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_SRGB8_ETC2, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2, 4, 4, 0, new Uint8Array(8))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA8_ETC2_EAC, 4, 4, 0, new Uint8Array(16))");
-    wtu.shouldGenerateGLError(gl, expected, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_SRGB8_ALPHA8_ETC2_EAC, 4, 4, 0, new Uint8Array(16))");
-
-    wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "formats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS)");
-    shouldBeNonNull("formats");
-    shouldBe("formats.length", isPositive ? "10" : "0");
+    var tex2 = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex2);
 
     debug("");
     if (contextVersion >= 2) {
       var expectedError = isPositive ? gl.INVALID_OPERATION: [gl.INVALID_ENUM, gl.INVALID_OPERATION];
       // `null` coerces into `0` for the PBO entrypoint, yielding INVALID_OP due to no PBO bound.
-      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_R11_EAC, 4, 4, 0, 0, null)");
-      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, COMPRESSED_R11_EAC, 0, null)");
-      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, 0, COMPRESSED_R11_EAC, 4, 4, 4, 0, 0, null)");
-      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexSubImage3D(gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, 0, 0, 0, COMPRESSED_R11_EAC, 0, null)");
+      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, validFormats.COMPRESSED_R11_EAC, 4, 4, 0, 0, null)");
+      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, validFormats.COMPRESSED_R11_EAC, 0, null)");
+      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, 0, validFormats.COMPRESSED_R11_EAC, 4, 4, 4, 0, 0, null)");
+      wtu.shouldGenerateGLError(gl, expectedError, "gl.compressedTexSubImage3D(gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, 0, 0, 0, validFormats.COMPRESSED_R11_EAC, 0, null)");
     } else {
-      shouldThrow("gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_R11_EAC, 4, 4, 0, null)");
-      shouldThrow("gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, COMPRESSED_R11_EAC, null)");
-      shouldThrow("gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, 0, COMPRESSED_R11_EAC, 4, 4, 4, 0, null)");
-      shouldThrow("gl.compressedTexSubImage3D(gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, 0, 0, 0, COMPRESSED_R11_EAC, null)");
+      shouldThrow("gl.compressedTexImage2D(gl.TEXTURE_2D, 0, validFormats.COMPRESSED_R11_EAC, 4, 4, 0, null)");
+      shouldThrow("gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, validFormats.COMPRESSED_R11_EAC, null)");
+      shouldThrow("gl.compressedTexImage3D(gl.TEXTURE_2D_ARRAY, 0, validFormats.COMPRESSED_R11_EAC, 4, 4, 4, 0, null)");
+      shouldThrow("gl.compressedTexSubImage3D(gl.TEXTURE_2D_ARRAY, 0, 0, 0, 0, 0, 0, 0, validFormats.COMPRESSED_R11_EAC, null)");
     }
   }
 }

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-etc1.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-etc1.html
@@ -1,0 +1,95 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL WEBGL_compressed_texture_etc1 Conformance Tests</title>
+<LINK rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/compressed-texture-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("This test verifies the functionality of the WEBGL_compressed_texture_etc1 extension, if it is available.");
+
+debug("");
+
+var validFormats = {
+  COMPRESSED_RGB_ETC1_WEBGL: 0x8D64,
+};
+
+function expectedByteLength(width, height, format) {
+  return Math.floor((width + 3) / 4) * Math.floor((height + 3) / 4) * 8;
+}
+
+function getBlockDimensions(format) {
+  return {width: 4, height: 4};
+}
+
+var wtu = WebGLTestUtils;
+var ctu = CompressedTextureUtils;
+var contextVersion = wtu.getDefault3DContextVersion();
+var gl = wtu.create3DContext();
+var WEBGL_compressed_texture_etc1;
+
+var formats = null;
+
+function runTest() {
+  if (!gl) {
+    testFailed("context does not exist");
+  } else {
+    testPassed("context exists");
+
+    ctu.testCompressedFormatsUnavailableWhenExtensionDisabled(gl, validFormats, expectedByteLength, 4);
+
+    WEBGL_compressed_texture_etc1 = gl.getExtension("WEBGL_compressed_texture_etc1");
+
+    wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_etc1", WEBGL_compressed_texture_etc1 !== null);
+
+    if (WEBGL_compressed_texture_etc1 !== null) {
+      // Test that enum values are listed correctly in supported formats and in the extension object.
+      ctu.testCompressedFormatsListed(gl, validFormats);
+      ctu.testCorrectEnumValuesInExt(WEBGL_compressed_texture_etc1, validFormats);
+      // Test that texture upload buffer size is validated correctly.
+      ctu.testFormatRestrictionsOnBufferSize(gl, validFormats, expectedByteLength, getBlockDimensions);
+    }
+  }
+}
+
+runTest();
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html
@@ -32,6 +32,7 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/compressed-texture-utils.js"></script>
 <title>WebGL WEBGL_compressed_texture_s3tc_srgb Conformance Tests</title>
 <style>
 img {
@@ -105,6 +106,7 @@ var img_8x8_rgba_dxt5 = new Uint8Array([
 ]);
 
 var wtu = WebGLTestUtils;
+var ctu = CompressedTextureUtils;
 var contextVersion = wtu.getDefault3DContextVersion();
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
@@ -125,84 +127,40 @@ if (!gl) {
 } else {
     testPassed("WebGL context exists");
 
-    // Run tests with extension disabled
-    runTestDisabled();
+    ctu.testCompressedFormatsUnavailableWhenExtensionDisabled(gl, validFormats, expectedByteLength, 4);
 
     // Query the extension and store globally so shouldBe can access it
     ext = wtu.getExtensionWithKnownPrefixes(gl, "WEBGL_compressed_texture_s3tc_srgb");
     if (!ext) {
         testPassed("No WEBGL_compressed_texture_s3tc_srgb support -- this is legal");
-        runSupportedTest(false);
+        wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_s3tc_srgb", false);
     } else {
         testPassed("Successfully enabled WEBGL_compressed_texture_s3tc_srgb extension");
 
-        runSupportedTest(true);
+        wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_s3tc_srgb", true);
         runTestExtension();
     }
 }
 
-function runSupportedTest(extensionEnabled) {
-    var name = wtu.getSupportedExtensionWithKnownPrefixes(gl, "WEBGL_compressed_texture_s3tc_srgb");
-    if (name !== undefined) {
-        if (extensionEnabled) {
-            testPassed("WEBGL_compressed_texture_s3tc_srgb listed as supported and getExtension succeeded");
-        } else {
-            testFailed("WEBGL_compressed_texture_s3tc_srgb listed as supported but getExtension failed");
-        }
-    } else {
-        if (extensionEnabled) {
-            testFailed("WEBGL_compressed_texture_s3tc_srgb not listed as supported but getExtension succeeded");
-        } else {
-            testPassed("WEBGL_compressed_texture_s3tc_srgb not listed as supported and getExtension failed -- this is legal");
-        }
+function expectedByteLength(width, height, format) {
+    if (format == validFormats.COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT || format == validFormats.COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT) {
+        return Math.floor((width + 3) / 4) * Math.floor((height + 3) / 4) * 16;
     }
+    return Math.floor((width + 3) / 4) * Math.floor((height + 3) / 4) * 8;
 }
 
-
-function runTestDisabled() {
-    debug("Testing binding enum with extension disabled");
-
-    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    shouldBe("supportedFormats", "[]");
-}
-
-function formatExists(format, supportedFormats) {
-    for (var ii = 0; ii < supportedFormats.length; ++ii) {
-        if (format == supportedFormats[ii]) {
-            testPassed("supported format " + formatToString(format) + " is exists");
-            return;
-        }
-    }
-    testFailed("supported format " + formatToString(format) + " does not exist");
-}
-
-function formatToString(format) {
-    for (var p in ext) {
-        if (ext[p] == format) {
-            return p;
-        }
-    }
-    return "0x" + format.toString(16);
+function getBlockDimensions(format) {
+    return {width: 4, height: 4};
 }
 
 function runTestExtension() {
     debug("Testing WEBGL_compressed_texture_s3tc_srgb");
 
-    // check that all format enums exist.
-    for (name in validFormats) {
-        var expected = "0x" + validFormats[name].toString(16);
-        var actual = "ext['" + name + "']";
-        shouldBe(actual, expected);
-    }
-
-    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 4 formats for both WebGL 1.0 and WebGL 2.0.
-    shouldBe("supportedFormats.length", "4");
-
-    // check that all 4 formats exist
-    for (var name in validFormats.length) {
-        formatExists(validFormats[name], supportedFormats);
-    }
+    // Test that enum values are listed correctly in supported formats and in the extension object.
+    ctu.testCompressedFormatsListed(gl, validFormats);
+    ctu.testCorrectEnumValuesInExt(ext, validFormats);
+    // Test that texture upload buffer size is validated correctly.
+    ctu.testFormatRestrictionsOnBufferSize(gl, validFormats, expectedByteLength, getBlockDimensions);
 
     // Test each format
     testDXT1_SRGB();
@@ -466,7 +424,7 @@ function testDXTTexture(test, useTexStorage) {
     canvas.width = width;
     canvas.height = height;
     gl.viewport(0, 0, width, height);
-    debug("testing " + formatToString(format) + " " + width + "x" + height +
+    debug("testing " + ctu.formatToString(ext, format) + " " + width + "x" + height +
           (useTexStorage ? " via texStorage2D" : " via compressedTexImage2D"));
 
     var tex = gl.createTexture();
@@ -612,35 +570,6 @@ function testDXTTexture(test, useTexStorage) {
     }
 }
 
-function insertImg(element, caption, img) {
-    var div = document.createElement("div");
-    div.appendChild(img);
-    var label = document.createElement("div");
-    label.appendChild(document.createTextNode(caption));
-    div.appendChild(label);
-    element.appendChild(div);
-}
-
-function makeImage(imageWidth, imageHeight, dataWidth, data, alpha) {
-    var scale = 8;
-    var c = document.createElement("canvas");
-    c.width = imageWidth * scale;
-    c.height = imageHeight * scale;
-    var ctx = c.getContext("2d");
-    for (var yy = 0; yy < imageHeight; ++yy) {
-        for (var xx = 0; xx < imageWidth; ++xx) {
-            var offset = (yy * dataWidth + xx) * 4;
-            ctx.fillStyle = "rgba(" +
-                    data[offset + 0] + "," +
-                    data[offset + 1] + "," +
-                    data[offset + 2] + "," +
-                    (alpha ? data[offset + 3] / 255 : 1) + ")";
-            ctx.fillRect(xx * scale, yy * scale, scale, scale);
-        }
-    }
-    return wtu.makeImageFromCanvas(c);
-}
-
 // See EXT_texture_sRGB, Section 3.8.x, sRGB Texture Color Conversion.
 function sRGBChannelToLinear(value) {
     value = value / 255;
@@ -663,10 +592,10 @@ function compareRect(
 
     var div = document.createElement("div");
     div.className = "testimages";
-    insertImg(div, "expected", makeImage(
+    ctu.insertCaptionedImg(div, "expected", ctu.makeScaledImage(
             actualWidth, actualHeight, dataWidth, expectedData,
             actualChannels == 4));
-    insertImg(div, "actual", makeImage(
+    ctu.insertCaptionedImg(div, "actual", ctu.makeScaledImage(
             actualWidth, actualHeight, actualWidth, actual,
             actualChannels == 4));
     div.appendChild(document.createElement('br'));

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
@@ -32,6 +32,7 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/compressed-texture-utils.js"></script>
 <title>WebGL WEBGL_compressed_texture_s3tc Conformance Tests</title>
 <style>
 img {
@@ -93,6 +94,7 @@ var img_8x8_rgba_dxt5 = new Uint8Array([
 ]);
 
 var wtu = WebGLTestUtils;
+var ctu = CompressedTextureUtils;
 var contextVersion = wtu.getDefault3DContextVersion();
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
@@ -114,83 +116,41 @@ if (!gl) {
     testPassed("WebGL context exists");
 
     // Run tests with extension disabled
-    runTestDisabled();
+    ctu.testCompressedFormatsUnavailableWhenExtensionDisabled(gl, validFormats, expectedByteLength, 4);
 
     // Query the extension and store globally so shouldBe can access it
     ext = wtu.getExtensionWithKnownPrefixes(gl, "WEBGL_compressed_texture_s3tc");
     if (!ext) {
         testPassed("No WEBGL_compressed_texture_s3tc support -- this is legal");
-        runSupportedTest(false);
+        wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_s3tc", false);
     } else {
         testPassed("Successfully enabled WEBGL_compressed_texture_s3tc extension");
 
-        runSupportedTest(true);
+        wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_s3tc", true);
         runTestExtension();
     }
 }
 
-function runSupportedTest(extensionEnabled) {
-    var name = wtu.getSupportedExtensionWithKnownPrefixes(gl, "WEBGL_compressed_texture_s3tc");
-    if (name !== undefined) {
-        if (extensionEnabled) {
-            testPassed("WEBGL_compressed_texture_s3tc listed as supported and getExtension succeeded");
-        } else {
-            testFailed("WEBGL_compressed_texture_s3tc listed as supported but getExtension failed");
-        }
-    } else {
-        if (extensionEnabled) {
-            testFailed("WEBGL_compressed_texture_s3tc not listed as supported but getExtension succeeded");
-        } else {
-            testPassed("WEBGL_compressed_texture_s3tc not listed as supported and getExtension failed -- this is legal");
-        }
+function expectedByteLength(width, height, format) {
+    if (format == validFormats.COMPRESSED_RGBA_S3TC_DXT3_EXT || format == validFormats.COMPRESSED_RGBA_S3TC_DXT5_EXT) {
+        return Math.floor((width + 3) / 4) * Math.floor((height + 3) / 4) * 16;
     }
+    return Math.floor((width + 3) / 4) * Math.floor((height + 3) / 4) * 8;
 }
 
-
-function runTestDisabled() {
-    debug("Testing binding enum with extension disabled");
-
-    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    shouldBe("supportedFormats", "[]");
-}
-
-function formatExists(format, supportedFormats) {
-    for (var ii = 0; ii < supportedFormats.length; ++ii) {
-        if (format == supportedFormats[ii]) {
-            testPassed("supported format " + formatToString(format) + " is exists");
-            return;
-        }
-    }
-    testFailed("supported format " + formatToString(format) + " does not exist");
-}
-
-function formatToString(format) {
-    for (var p in ext) {
-        if (ext[p] == format) {
-            return p;
-        }
-    }
-    return "0x" + format.toString(16);
+function getBlockDimensions(format) {
+    return {width: 4, height: 4};
 }
 
 function runTestExtension() {
+    debug("");
     debug("Testing WEBGL_compressed_texture_s3tc");
 
-    // check that all format enums exist.
-    for (name in validFormats) {
-        var expected = "0x" + validFormats[name].toString(16);
-        var actual = "ext['" + name + "']";
-        shouldBe(actual, expected);
-    }
-
-    supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
-    // There should be exactly 4 formats for both WebGL 1.0 and WebGL 2.0.
-    shouldBe("supportedFormats.length", "4");
-
-    // check that all 4 formats exist
-    for (var name in validFormats.length) {
-        formatExists(validFormats[name], supportedFormats);
-    }
+    // Test that enum values are listed correctly in supported formats and in the extension object.
+    ctu.testCompressedFormatsListed(gl, validFormats);
+    ctu.testCorrectEnumValuesInExt(ext, validFormats);
+    // Test that texture upload buffer size is validated correctly.
+    ctu.testFormatRestrictionsOnBufferSize(gl, validFormats, expectedByteLength, getBlockDimensions);
 
     // Test each format
     testDXT1_RGB();
@@ -487,7 +447,7 @@ function testDXTTexture(test, useTexStorage) {
     canvas.width = width;
     canvas.height = height;
     gl.viewport(0, 0, width, height);
-    debug("testing " + formatToString(format) + " " + width + "x" + height +
+    debug("testing " + ctu.formatToString(ext, format) + " " + width + "x" + height +
           (useTexStorage ? " via texStorage2D" : " via compressedTexImage2D"));
 
     var tex = gl.createTexture();
@@ -551,15 +511,6 @@ function testDXTTexture(test, useTexStorage) {
         // It's not allowed to redefine textures defined via texStorage2D.
         gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height, 1, data);
         wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "non 0 border");
-
-        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width + 4, height, 0, data);
-        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
-        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height + 4, 0, data);
-        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
-        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 4, height, 0, data);
-        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
-        gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height - 4, 0, data);
-        wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "data size does not match dimensions");
 
         gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width - 1, height, 0, data);
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
@@ -658,35 +609,6 @@ function testDXTTexture(test, useTexStorage) {
     }
 }
 
-function insertImg(element, caption, img) {
-    var div = document.createElement("div");
-    div.appendChild(img);
-    var label = document.createElement("div");
-    label.appendChild(document.createTextNode(caption));
-    div.appendChild(label);
-    element.appendChild(div);
-}
-
-function makeImage(imageWidth, imageHeight, data, alpha) {
-    var scale = 8;
-    var c = document.createElement("canvas");
-    c.width = imageWidth * scale;
-    c.height = imageHeight * scale;
-    var ctx = c.getContext("2d");
-    for (var yy = 0; yy < imageHeight; ++yy) {
-        for (var xx = 0; xx < imageWidth; ++xx) {
-            var offset = (yy * imageWidth + xx) * 4;
-            ctx.fillStyle = "rgba(" +
-                    data[offset + 0] + "," +
-                    data[offset + 1] + "," +
-                    data[offset + 2] + "," +
-                    (alpha ? data[offset + 3] / 255 : 1) + ")";
-            ctx.fillRect(xx * scale, yy * scale, scale, scale);
-        }
-    }
-    return wtu.makeImageFromCanvas(c);
-}
-
 function compareRect(width, height, channels, expectedData, filteringMode) {
     var actual = new Uint8Array(width * height * 4);
     gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, actual);
@@ -694,8 +616,8 @@ function compareRect(width, height, channels, expectedData, filteringMode) {
 
     var div = document.createElement("div");
     div.className = "testimages";
-    insertImg(div, "expected", makeImage(width, height, expectedData, channels == 4));
-    insertImg(div, "actual", makeImage(width, height, actual, channels == 4));
+    ctu.insertCaptionedImg(div, "expected", ctu.makeScaledImage(width, height, width, expectedData, channels == 4));
+    ctu.insertCaptionedImg(div, "actual", ctu.makeScaledImage(width, height, width, actual, channels == 4));
     div.appendChild(document.createElement('br'));
     document.getElementById("console").appendChild(div);
 

--- a/sdk/tests/conformance/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance/textures/misc/00_test_list.txt
@@ -1,5 +1,5 @@
 --min-version 1.0.4 canvas-teximage-after-multiple-drawimages.html
---max-version 1.9.9 compressed-tex-image.html
+compressed-tex-image.html
 copy-tex-image-and-sub-image-2d.html
 --min-version 1.0.2 copy-tex-image-2d-formats.html
 --min-version 1.0.4 copy-tex-image-crash.html

--- a/sdk/tests/conformance/textures/misc/compressed-tex-image.html
+++ b/sdk/tests/conformance/textures/misc/compressed-tex-image.html
@@ -46,7 +46,6 @@ debug("");
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
 
-var ETC1_RGB8_OES                       = 0x8D64;
 var COMPRESSED_RGB_PVRTC_4BPPV1_IMG     = 0x8C00;
 var COMPRESSED_RGBA_PVRTC_4BPPV1_IMG    = 0x8C02;
 
@@ -60,7 +59,6 @@ if (!gl) {
   var tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
 
-  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ETC1_RGB8_OES, 4, 4, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");
 

--- a/sdk/tests/conformance/textures/misc/compressed-tex-image.html
+++ b/sdk/tests/conformance/textures/misc/compressed-tex-image.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL CompressedTexImage and CompressedTexSubImage Tests</title>
+<title>WebGL compressed texture test</title>
 <LINK rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
@@ -39,16 +39,13 @@
 <div id="console"></div>
 <script>
 "use strict";
-description("This test ensures WebGL implementations correctly implement compressedTexImage2D and compressedTexSubImage2D.");
+description("This test ensures WebGL implementations correctly implement querying for compressed textures when extensions are disabled.");
 
 debug("");
 
 var wtu = WebGLTestUtils;
 var gl = wtu.create3DContext();
 
-var COMPRESSED_RGB_S3TC_DXT1_EXT        = 0x83F0;
-var COMPRESSED_RGBA_S3TC_DXT1_EXT       = 0x83F1;
-var COMPRESSED_RGBA_S3TC_DXT5_EXT       = 0x83F3;
 var ETC1_RGB8_OES                       = 0x8D64;
 var COMPRESSED_RGB_PVRTC_4BPPV1_IMG     = 0x8C00;
 var COMPRESSED_RGBA_PVRTC_4BPPV1_IMG    = 0x8C02;
@@ -63,9 +60,6 @@ if (!gl) {
   var tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
 
-  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB_S3TC_DXT1_EXT, 4, 4, 0, new Uint8Array(8))");
-  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA_S3TC_DXT1_EXT, 4, 4, 0, new Uint8Array(8))");
-  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA_S3TC_DXT5_EXT, 4, 4, 0, new Uint8Array(16))");
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ETC1_RGB8_OES, 4, 4, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGBA_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");

--- a/sdk/tests/js/tests/compressed-texture-utils.js
+++ b/sdk/tests/js/tests/compressed-texture-utils.js
@@ -1,0 +1,186 @@
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+"use strict";
+
+var CompressedTextureUtils = (function() {
+
+var formatToString = function(ext, format) {
+    for (var p in ext) {
+        if (ext[p] == format) {
+            return p;
+        }
+    }
+    return "0x" + format.toString(16);
+};
+
+/**
+ * Make an image element from Uint8Array bitmap data.
+ * @param {number} imageHeight Height of the data in pixels.
+ * @param {number} imageWidth Width of the data in pixels.
+ * @param {number} dataWidth Width of each row in the data buffer, in pixels.
+ * @param {Uint8Array} data Image data buffer to display. Each pixel takes up 4 bytes in the array regardless of the alpha parameter.
+ * @param {boolean} alpha True if alpha data should be taken from data. Otherwise alpha channel is set to 255.
+ * @return {HTMLImageElement} The image element.
+ */
+var makeScaledImage = function(imageWidth, imageHeight, dataWidth, data, alpha, opt_scale) {
+    var scale = opt_scale ? opt_scale : 8;
+    var c = document.createElement("canvas");
+    c.width = imageWidth * scale;
+    c.height = imageHeight * scale;
+    var ctx = c.getContext("2d");
+    for (var yy = 0; yy < imageHeight; ++yy) {
+        for (var xx = 0; xx < imageWidth; ++xx) {
+            var offset = (yy * dataWidth + xx) * 4;
+            ctx.fillStyle = "rgba(" +
+                    data[offset + 0] + "," +
+                    data[offset + 1] + "," +
+                    data[offset + 2] + "," +
+                    (alpha ? data[offset + 3] / 255 : 1) + ")";
+            ctx.fillRect(xx * scale, yy * scale, scale, scale);
+        }
+    }
+    return wtu.makeImageFromCanvas(c);
+};
+
+var insertCaptionedImg = function(parent, caption, img) {
+    var div = document.createElement("div");
+    div.appendChild(img);
+    var label = document.createElement("div");
+    label.appendChild(document.createTextNode(caption));
+    div.appendChild(label);
+    parent.appendChild(div);
+};
+
+/**
+ * @param {WebGLRenderingContextBase} gl
+ * @param {Object} compressedFormats Mapping from format names to format enum values.
+ * @param expectedByteLength A function that takes in width, height and format and returns the expected buffer size in bytes.
+ */
+var testCompressedFormatsUnavailableWhenExtensionDisabled = function(gl, compressedFormats, expectedByteLength, testSize) {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    for (var name in compressedFormats) {
+        if (compressedFormats.hasOwnProperty(name)) {
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 0, compressedFormats[name], testSize, testSize, 0, new Uint8Array(expectedByteLength(testSize, testSize, compressedFormats[name])));
+            wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Trying to use format " + name + " with extension disabled.");
+        }
+    }
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.deleteTexture(tex);
+};
+
+/**
+ * @param {WebGLRenderingContextBase} gl
+ * @param {Object} expectedFormats Mapping from format names to format enum values.
+ */
+var testCompressedFormatsListed = function(gl, expectedFormats) {
+    debug("");
+    debug("Testing that every format is listed by the compressed texture formats query");
+
+    var supportedFormats = gl.getParameter(gl.COMPRESSED_TEXTURE_FORMATS);
+
+    var failed;
+    var count = 0;
+    for (var name in expectedFormats) {
+        if (expectedFormats.hasOwnProperty(name)) {
+            ++count;
+            var format = expectedFormats[name];
+            failed = true;
+            for (var ii = 0; ii < supportedFormats.length; ++ii) {
+                if (format == supportedFormats[ii]) {
+                    testPassed("supported format " + name + " exists");
+                    failed = false;
+                    break;
+                }
+            }
+            if (failed) {
+                testFailed("supported format " + name + " does not exist");
+            }
+        }
+    }
+    if (supportedFormats.length != count) {
+        testFailed("Incorrect number of supported formats, was " + supportedFormats.length + " should be " + count);
+    }
+};
+
+/**
+ * @param {Object} ext Compressed texture extension object.
+ * @param {Object} expectedFormats Mapping from format names to format enum values.
+ */
+var testCorrectEnumValuesInExt = function(ext, expectedFormats) {
+    debug("");
+    debug("Testing that format enum values in the extension object are correct");
+
+    for (name in expectedFormats) {
+        if (expectedFormats.hasOwnProperty(name)) {
+            if (isResultCorrect(ext[name], expectedFormats[name])) {
+                testPassed("Enum value for " + name + " matches 0x" + ext[name].toString(16));
+            } else {
+                testFailed("Enum value for " + name + " mismatch: 0x" + ext[name].toString(16) + " should be 0x" + expectedFormats[name].toString(16));
+            }
+        }
+    }
+};
+
+/**
+ * @param {WebGLRenderingContextBase} gl
+ * @param {Object} validFormats Mapping from format names to format enum values.
+ * @param expectedByteLength A function that takes in width, height and format and returns the expected buffer size in bytes.
+ * @param getBlockDimensions A function that takes in a format and returns block size in pixels.
+ */
+var testFormatRestrictionsOnBufferSize = function(gl, validFormats, expectedByteLength, getBlockDimensions) {
+    debug("");
+    debug("Testing format restrictions on texture upload buffer size");
+
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    for (var formatId in validFormats) {
+        if (validFormats.hasOwnProperty(formatId)) {
+            var format = validFormats[formatId];
+            var blockSize = getBlockDimensions(format);
+            var expectedSize = expectedByteLength(blockSize.width * 4, blockSize.height * 4, format);
+            var data = new Uint8Array(expectedSize);
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, blockSize.width * 3, blockSize.height * 4, 0, data);
+            wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, formatId + " data size does not match dimensions (too small width)");
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, blockSize.width * 5, blockSize.height * 4, 0, data);
+            wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, formatId + " data size does not match dimensions (too large width)");
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, blockSize.width * 4, blockSize.height * 3, 0, data);
+            wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, formatId + " data size does not match dimensions (too small height)");
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, blockSize.width * 4, blockSize.height * 5, 0, data);
+            wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, formatId + " data size does not match dimensions (too large height)");
+        }
+    }
+};
+
+return {
+    formatToString: formatToString,
+    insertCaptionedImg: insertCaptionedImg,
+    makeScaledImage: makeScaledImage,
+    testCompressedFormatsListed: testCompressedFormatsListed,
+    testCompressedFormatsUnavailableWhenExtensionDisabled: testCompressedFormatsUnavailableWhenExtensionDisabled,
+    testCorrectEnumValuesInExt: testCorrectEnumValuesInExt,
+    testFormatRestrictionsOnBufferSize: testFormatRestrictionsOnBufferSize
+};
+
+})();

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -2620,6 +2620,28 @@ var getSupportedExtensionWithKnownPrefixes = function(gl, name) {
 };
 
 /**
+ * @param {WebGLRenderingContext} gl The WebGLRenderingContext to use.
+ * @param {string} name Name of extension to look for.
+ * @param {boolean} extensionEnabled True if the extension was enabled successfully via gl.getExtension().
+ */
+var runExtensionSupportedTest = function(gl, name, extensionEnabled) {
+  var prefixedName = getSupportedExtensionWithKnownPrefixes(gl, name);
+  if (prefixedName !== undefined) {
+      if (extensionEnabled) {
+          testPassed(name + " listed as supported and getExtension succeeded");
+      } else {
+          testFailed(name + " listed as supported but getExtension failed");
+      }
+  } else {
+      if (extensionEnabled) {
+          testFailed(name + " not listed as supported but getExtension succeeded");
+      } else {
+          testPassed(name + " not listed as supported and getExtension failed -- this is legal");
+      }
+  }
+}
+
+/**
  * Given an extension name like WEBGL_compressed_texture_s3tc
  * returns the supported version extension, like
  * WEBKIT_WEBGL_compressed_teture_s3tc
@@ -3220,6 +3242,7 @@ var API = {
   makeImageFromCanvas: makeImageFromCanvas,
   makeVideo: makeVideo,
   error: error,
+  runExtensionSupportedTest: runExtensionSupportedTest,
   shallowCopyObject: shallowCopyObject,
   setDefault3DContextVersion: setDefault3DContextVersion,
   setupColorQuad: setupColorQuad,


### PR DESCRIPTION
This refactors code to share some common utilities for testing compressed textures, improves negative test coverage and adds some tests for WEBGL_compressed_texture_etc1.