### PR TITLE
Add a test for instanced rendering with large divisors

### DIFF
--- a/sdk/tests/conformance2/rendering/00_test_list.txt
+++ b/sdk/tests/conformance2/rendering/00_test_list.txt
@@ -30,6 +30,7 @@ framebuffer-unsupported.html
 --min-version 2.0.1 fs-color-type-mismatch-color-buffer-type.html
 instanced-arrays.html
 --min-version 2.0.1 instanced-rendering-bug.html
+--min-version 2.0.1 instanced-rendering-large-divisor.html
 --min-version 2.0.1 line-rendering-quality.html
 --min-version 2.0.1 multisampling-fragment-evaluation.html
 out-of-bounds-index-buffers-after-copying.html

--- a/sdk/tests/conformance2/rendering/instanced-rendering-large-divisor.html
+++ b/sdk/tests/conformance2/rendering/instanced-rendering-large-divisor.html
@@ -1,0 +1,165 @@
+﻿<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Instanced Arrays Conformance Tests - large vertex attrib divisors</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/desktop-gl-constants.js"></script>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<canvas id="canvas"> </canvas>
+<div id="console"></div>
+<script id="outputVertexShader" type="x-shader/x-vertex">#version 300 es
+layout(location = 0) in vec2 a_position;
+layout(location = 1) in float a_positionOffset;
+layout(location = 2) in vec4 a_color;
+out vec4 v_color;
+void main()
+{
+    gl_Position = vec4(a_position.x * 0.05 + a_positionOffset, a_position.y * 0.05, 0.0, 1.0);
+    gl_PointSize = 4.0f;
+    v_color = a_color;
+}
+</script>
+
+<script id="outputFragmentShader" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+in vec4 v_color;
+out vec4 my_FragColor;
+void main()
+{
+    my_FragColor = v_color;
+}
+</script>
+
+<script>
+"use strict";
+description("Test switching vertex attrib divisor of one attribute between different large values");
+// This is a regression test for http://anglebug.com/2832
+
+debug("");
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+canvas.width = 256;
+canvas.height = 256;
+var gl = wtu.create3DContext(canvas, null, 2);
+
+var colorDivisor = 65536 * 2;
+
+if (!gl) {
+    testFailed("WebGL context does not exist");
+} else {
+    testPassed("WebGL context exists");
+
+    runTest();
+}
+
+function runTest() {
+    var program = wtu.setupProgram(gl, ["outputVertexShader", "outputFragmentShader"]);
+
+    gl.clearColor(0.0, 0.0, 1.0, 1.0);
+
+    wtu.setupIndexedQuadWithOptions(gl, {positionLocation: 0});
+
+    var offsetBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, offsetBuf);
+    var offsetData = [];
+    for (var i = 0; i < 4; ++i) {
+        offsetData.push(0.0 + i * 0.25);
+    }
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(offsetData), gl.DYNAMIC_DRAW);
+
+    gl.enableVertexAttribArray(1);
+    gl.vertexAttribPointer(1, 1, gl.FLOAT, false, 0, 0);
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setting up vertex buffer should succeed");
+
+    var colorBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, colorBuf);
+    // Red and green colors.
+    var colorData = new Float32Array([1.0, 0.0, 0.0, 1.0,
+                                      0.0, 1.0, 0.0, 1.0]);
+    gl.bufferData(gl.ARRAY_BUFFER, colorData, gl.DYNAMIC_DRAW);
+
+    gl.enableVertexAttribArray(2);
+    gl.vertexAttribPointer(2, 4, gl.FLOAT, false, 0, 0);
+    gl.vertexAttribDivisor(2, colorDivisor);
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Setting up color buffer should succeed");
+
+    var divisorsToTry = [
+        256,
+        65536,
+        65536 * 2
+    ];
+
+    for (var i = 0; i < divisorsToTry.length; ++i) {
+        runDrawElementsTest(divisorsToTry[i]);
+    }
+}
+
+function runDrawElementsTest(divisor) {
+    debug("Using divisor " + divisor);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.vertexAttribDivisor(1, divisor);
+
+    var instanceCount = divisor + 1;
+    var quadsRendered = (instanceCount - 1) / divisor + 1;
+
+    gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
+
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Instanced draw should succeed");
+
+    for (var quadIndex = 0; quadIndex < quadsRendered + 1; ++quadIndex) {
+        var quadX = Math.floor((quadIndex / 8) * 256 + 128);
+        var quadY = 128;
+        if (quadIndex < quadsRendered) {
+            var quadColorIndex = Math.floor((quadIndex * divisor) / colorDivisor);
+            if (quadColorIndex == 0) {
+                wtu.checkCanvasRect(gl, quadX, quadY, 1, 1, [255, 0, 0, 255]);
+            } else {
+                wtu.checkCanvasRect(gl, quadX, quadY, 1, 1, [0, 255, 0, 255]);
+            }
+        } else {
+            wtu.checkCanvasRect(gl, quadX, quadY, 1, 1, [0, 0, 255, 255]);
+        }
+    }
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/rendering/instanced-rendering-large-divisor.html
+++ b/sdk/tests/conformance2/rendering/instanced-rendering-large-divisor.html
@@ -47,7 +47,6 @@ out vec4 v_color;
 void main()
 {
     gl_Position = vec4(a_position.x * 0.05 + a_positionOffset, a_position.y * 0.05, 0.0, 1.0);
-    gl_PointSize = 4.0f;
     v_color = a_color;
 }
 </script>
@@ -94,6 +93,8 @@ function runTest() {
 
     var offsetBuf = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, offsetBuf);
+    // Note that only the first two offsets below should be used for rendering.
+    // We add some extra ones to the buffer since it can reveal if a too small divisor is used on the WebGL backend.
     var offsetData = [];
     for (var i = 0; i < 4; ++i) {
         offsetData.push(0.0 + i * 0.25);
@@ -135,7 +136,7 @@ function runDrawElementsTest(divisor) {
     gl.vertexAttribDivisor(1, divisor);
 
     var instanceCount = divisor + 1;
-    var quadsRendered = (instanceCount - 1) / divisor + 1;
+    var quadsRendered = Math.floor((instanceCount - 1) / divisor) + 1;
 
     gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_SHORT, 0, instanceCount);
 


### PR DESCRIPTION
This test covers a recently fixed ANGLE bug http://anglebug.com/2832
that was present on the D3D11 backend.