### PR TITLE
Bikeshedding on WEBGL_video_texture

### DIFF
--- a/extensions/proposals/WEBGL_video_texture/extension.xml
+++ b/extensions/proposals/WEBGL_video_texture/extension.xml
@@ -56,7 +56,7 @@ interface WEBGL_video_texture {
     const GLenum TEXTURE_VIDEO_IMAGE             = 0x851D;
     const GLenum SAMPLER_VIDEO_IMAGE             = 0x8B61;
 
-    [RaisesException] WebGLVideoFrameInfo VideoElementTargetVideoTexture(
+    [RaisesException] WebGLVideoFrameInfo videoTexImage2D(
         GLenum target, HTMLVideoElement video);
 };
   </idl>
@@ -85,7 +85,7 @@ interface WEBGL_video_texture {
         var ext = gl.getExtension('WEBGL_video_texture');
         if(ext !=== null){
             gl.bindTexture(ext.TEXTURE_VIDEO_IMAGE, videoTexture);
-            ext.VideoElementTargetVideoTexture(ext.TEXTURE_VIDEO_IMAGE, videoElement);
+            ext.videoTexImage2D(ext.TEXTURE_VIDEO_IMAGE, videoElement);
             gl.bindTexture(ext.TEXTURE_VIDEO_IMAGE, null);
         }
     }
@@ -134,6 +134,9 @@ interface WEBGL_video_texture {
       <change>Change Extension name to WEBGL_video_texture for abstracion of OES_EGL_image_external extension.</change>
       <change>Define new sampler and texture type, TEXTURE_VIDEO_IMAGE and SAMPLER_VIDEO_IMAGE.</change>
       <change>Change EGLImageTargetTexture2DOES to VideoElementTargetVideoTexture.</change>
+    </revision>
+    <revision date="2018/09/25">
+      <change>Rename VideoElementTargetVideoTexture to videoTexImage2D.</change>
     </revision>
   </history>
 </proposal>


### PR DESCRIPTION
This is a placeholder PR for bikeshedding on WEBGL_video_texture. I've suggested a rename here, because I think the old one was confusing.

I like something like this because it retains the "texImage2D" heritage. Without it, it's not clear that this behaves much like an upload call. However I'm open to other ideas.