### PR TITLE
Rename BPTC and RGTC extensions to EXT_.

### DIFF
--- a/extensions/EXT_texture_compression_bptc/extension.xml
+++ b/extensions/EXT_texture_compression_bptc/extension.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
-<draft href="WEBGL_compressed_texture_bptc/">
-  <name>WEBGL_compressed_texture_bptc</name>
+<draft href="EXT_texture_compression_bptc/">
+  <name>EXT_texture_compression_bptc</name>
   <contact>
     <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)
   </contact>
@@ -16,22 +16,22 @@
   <overview>
     <p>
       This extension exposes the compressed texture format defined in the
-      <a href="https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_compression_bptc.txt">
-      ARB_texture_compression_bptc</a> OpenGL extension to WebGL. Consult that extension
+      <a href="https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_compression_bptc.txt">
+      EXT_texture_compression_bptc</a> OpenGL ES extension to WebGL. Consult that extension
       specification for behavioral definitions, including error behaviors.
     </p>
     <p>
-      Sampling from textures in the COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB format performs a color space
+      Sampling from textures in the COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT format performs a color space
       conversion as specified for SRGB textures in the
       <a href="https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_sRGB.txt">EXT_sRGB</a> OpenGL ES
       extension.
     </p>
     <features>
       <feature>
-        Compression format <code>COMPRESSED_RGBA_BPTC_UNORM_ARB</code>,
-        <code>COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB</code>,
-        <code>COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB</code>,
-        and <code>COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB</code> may be passed to
+        Compression format <code>COMPRESSED_RGBA_BPTC_UNORM_EXT</code>,
+        <code>COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT</code>,
+        <code>COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT</code>,
+        and <code>COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT</code> may be passed to
         the <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code> entry points.
       </feature>
       <feature>
@@ -54,11 +54,11 @@
   </overview>
   <idl xml:space="preserve">
 [NoInterfaceObject]
-interface WEBGL_compressed_texture_bptc {
-    const GLenum COMPRESSED_RGBA_BPTC_UNORM_ARB = 0x8E8C;
-    const GLenum COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB = 0x8E8D;
-    const GLenum COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB = 0x8E8E;
-    const GLenum COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB = 0x8E8F;
+interface EXT_texture_compression_bptc {
+    const GLenum COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8E8C;
+    const GLenum COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT = 0x8E8D;
+    const GLenum COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT = 0x8E8E;
+    const GLenum COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT = 0x8E8F;
 };
   </idl>
 
@@ -66,20 +66,20 @@ interface WEBGL_compressed_texture_bptc {
     <function name="compressedTexImage2D">
       <param name="internalformat" type="GLenum"/>
       Accepted by the <code>internalformat</code> parameter:
-      <code>COMPRESSED_RGBA_BPTC_UNORM_ARB</code>,
-      <code>COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB</code>,
-      <code>COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB</code>,
-      <code>COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB</code>
+      <code>COMPRESSED_RGBA_BPTC_UNORM_EXT</code>,
+      <code>COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT</code>,
+      <code>COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT</code>,
+      <code>COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT</code>
       <br/>
     </function>
 
     <function name="compressedTexSubImage2D">
       <param name="internalformat" type="GLenum"/>
       Accepted by the <code>internalformat</code> parameter:
-      <code>COMPRESSED_RGBA_BPTC_UNORM_ARB</code>,
-      <code>COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB</code>,
-      <code>COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB</code>,
-      <code>COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB</code>
+      <code>COMPRESSED_RGBA_BPTC_UNORM_EXT</code>,
+      <code>COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT</code>,
+      <code>COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT</code>,
+      <code>COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT</code>
       <br/>
     </function>
   </newtok>
@@ -101,6 +101,10 @@ interface WEBGL_compressed_texture_bptc {
     </revision>
     <revision date="2018/09/18">
       <change>Moved to draft status.</change>
+    </revision>
+    <revision date="2018/09/26">
+      <change>Retarget against EXT_texture_compression_bptc instead of ARB_texture_compression_bptc</change>
+      <change>Rename to EXT_texture_compression_bptc from WEBGL_compressed_texture_bptc</change>
     </revision>
   </history>
 </draft>

--- a/extensions/EXT_texture_compression_rgtc/extension.xml
+++ b/extensions/EXT_texture_compression_rgtc/extension.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
-<draft href="WEBGL_compressed_texture_rgtc/">
-  <name>WEBGL_compressed_texture_rgtc</name>
+<draft href="EXT_texture_compression_rgtc/">
+  <name>EXT_texture_compression_rgtc</name>
   <contact>
     <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)
   </contact>
@@ -64,7 +64,7 @@
   </overview>
   <idl xml:space="preserve">
 [NoInterfaceObject]
-interface WEBGL_compressed_texture_rgtc {
+interface EXT_texture_compression_rgtc {
     const GLenum COMPRESSED_RED_RGTC1_EXT = 0x8DBB;
     const GLenum COMPRESSED_SIGNED_RED_RGTC1_EXT = 0x8DBC;
     const GLenum COMPRESSED_RED_GREEN_RGTC2_EXT = 0x8DBD;
@@ -118,6 +118,9 @@ interface WEBGL_compressed_texture_rgtc {
   <history>
     <revision date="2018/09/26">
       <change>Initial revision.</change>
+    </revision>
+    <revision date="2018/09/26">
+      <change>Rename to EXT_texture_compression_rgtc from WEBGL_compressed_texture_rgtc</change>
     </revision>
   </history>
 </draft>

--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -1,6 +1,8 @@
 --min-version 1.0.3 --max-version 1.9.9 angle-instanced-arrays.html
 --min-version 1.0.3 --max-version 1.9.9 angle-instanced-arrays-out-of-bounds.html
 --min-version 1.0.3 --max-version 1.9.9 ext-blend-minmax.html
+--min-version 1.0.4 ext-texture-compression-bptc.html
+--min-version 1.0.4 ext-texture-compression-rgtc.html
 --min-version 1.0.4 ext-disjoint-timer-query.html
 --min-version 1.0.3 --max-version 1.9.9 ext-frag-depth.html
 --min-version 1.0.3 --max-version 1.9.9 ext-shader-texture-lod.html
@@ -26,11 +28,9 @@
 webgl-debug-renderer-info.html
 webgl-debug-shaders.html
 --min-version 1.0.4 webgl-compressed-texture-astc.html
---min-version 1.0.4 webgl-compressed-texture-bptc.html
 --min-version 1.0.4 webgl-compressed-texture-etc.html
 --min-version 1.0.4 webgl-compressed-texture-etc1.html
 --min-version 1.0.3 webgl-compressed-texture-pvrtc.html
---min-version 1.0.4 webgl-compressed-texture-rgtc.html
 --min-version 1.0.2 webgl-compressed-texture-s3tc.html
 --min-version 1.0.4 webgl-compressed-texture-s3tc-srgb.html
 --min-version 1.0.3 webgl-compressed-texture-size-limit.html

--- a/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_compressed_texture_rgtc Conformance Tests</title>
+<title>WebGL EXT_texture_compression_bptc Conformance Tests</title>
 <LINK rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
@@ -40,24 +40,19 @@
 <div id="console"></div>
 <script>
 "use strict";
-description("This test verifies the functionality of the WEBGL_compressed_texture_rgtc extension, if it is available.");
+description("This test verifies the functionality of the EXT_texture_compression_bptc extension, if it is available.");
 
 debug("");
 
 var validFormats = {
-  COMPRESSED_RED_RGTC1_EXT: 0x8DBB,
-  COMPRESSED_SIGNED_RED_RGTC1_EXT: 0x8DBC,
-  COMPRESSED_RED_GREEN_RGTC2_EXT: 0x8DBD,
-  COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT: 0x8DBE
+  COMPRESSED_RGBA_BPTC_UNORM_EXT: 0x8E8C,
+  COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT: 0x8E8D,
+  COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT: 0x8E8E,
+  COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT: 0x8E8F
 };
 
 function expectedByteLength(width, height, format) {
-  if (format == validFormats.COMPRESSED_RED_RGTC1_EXT || format == validFormats.COMPRESSED_SIGNED_RED_RGTC1_EXT) {
-    return Math.ceil(width / 4) * Math.ceil(height / 4) * 8;
-  }
-  else {
-    return Math.ceil(width / 4) * Math.ceil(height / 4) * 16;
-  }
+  return Math.ceil(width / 4) * Math.ceil(height / 4) * 16;
 }
 
 function getBlockDimensions(format) {
@@ -88,9 +83,9 @@ function runTest() {
 
     ctu.testCompressedFormatsUnavailableWhenExtensionDisabled(gl, validFormats, expectedByteLength, 4);
 
-    ext = gl.getExtension("WEBGL_compressed_texture_rgtc");
+    ext = gl.getExtension("EXT_texture_compression_bptc");
 
-    wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_rgtc", ext !== null);
+    wtu.runExtensionSupportedTest(gl, "EXT_texture_compression_bptc", ext !== null);
 
     if (ext !== null) {
       runTestExtension();

--- a/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
@@ -29,7 +29,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_compressed_texture_bptc Conformance Tests</title>
+<title>WebGL EXT_texture_compression_rgtc Conformance Tests</title>
 <LINK rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
@@ -40,19 +40,24 @@
 <div id="console"></div>
 <script>
 "use strict";
-description("This test verifies the functionality of the WEBGL_compressed_texture_bptc extension, if it is available.");
+description("This test verifies the functionality of the EXT_texture_compression_rgtc extension, if it is available.");
 
 debug("");
 
 var validFormats = {
-  COMPRESSED_RGBA_BPTC_UNORM_ARB: 0x8E8C,
-  COMPRESSED_SRGB_ALPHA_BPTC_UNORM_ARB: 0x8E8D,
-  COMPRESSED_RGB_BPTC_SIGNED_FLOAT_ARB: 0x8E8E,
-  COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_ARB: 0x8E8F
+  COMPRESSED_RED_RGTC1_EXT: 0x8DBB,
+  COMPRESSED_SIGNED_RED_RGTC1_EXT: 0x8DBC,
+  COMPRESSED_RED_GREEN_RGTC2_EXT: 0x8DBD,
+  COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT: 0x8DBE
 };
 
 function expectedByteLength(width, height, format) {
-  return Math.ceil(width / 4) * Math.ceil(height / 4) * 16;
+  if (format == validFormats.COMPRESSED_RED_RGTC1_EXT || format == validFormats.COMPRESSED_SIGNED_RED_RGTC1_EXT) {
+    return Math.ceil(width / 4) * Math.ceil(height / 4) * 8;
+  }
+  else {
+    return Math.ceil(width / 4) * Math.ceil(height / 4) * 16;
+  }
 }
 
 function getBlockDimensions(format) {
@@ -83,9 +88,9 @@ function runTest() {
 
     ctu.testCompressedFormatsUnavailableWhenExtensionDisabled(gl, validFormats, expectedByteLength, 4);
 
-    ext = gl.getExtension("WEBGL_compressed_texture_bptc");
+    ext = gl.getExtension("EXT_texture_compression_rgtc");
 
-    wtu.runExtensionSupportedTest(gl, "WEBGL_compressed_texture_bptc", ext !== null);
+    wtu.runExtensionSupportedTest(gl, "EXT_texture_compression_rgtc", ext !== null);
 
     if (ext !== null) {
       runTestExtension();


### PR DESCRIPTION
Also retarget BPTC from the ARB_ ext to the EXT_ one, since EXT_ is the
ES version.

CC @Oletus, how does this sound?