### PR TITLE
*TexSubImage on an undefined texture image is INVALID_OPERATION.

### DIFF
--- a/sdk/tests/conformance/textures/misc/compressed-tex-image.html
+++ b/sdk/tests/conformance/textures/misc/compressed-tex-image.html
@@ -58,7 +58,7 @@ if (!gl) {
 
   var tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
-  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM,
+  wtu.shouldGenerateGLError(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
                             "gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 10, 10, COMPRESSED_RGB_PVRTC_4BPPV1_IMG, new Uint8Array(8));");
 
   wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM, "gl.compressedTexImage2D(gl.TEXTURE_2D, 0, COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 8, 8, 0, new Uint8Array(8))");


### PR DESCRIPTION
Since this can happen before we check all our enums, this subtest
should accept either error.