### PR TITLE
Test repeated rendering of WebGL canvas to 2D canvas.

### DIFF
--- a/sdk/tests/conformance/rendering/00_test_list.txt
+++ b/sdk/tests/conformance/rendering/00_test_list.txt
@@ -4,6 +4,7 @@
 --min-version 1.0.4 default-texture-draw-bug.html
 draw-arrays-out-of-bounds.html
 draw-elements-out-of-bounds.html
+--min-version 1.0.4 draw-webgl-to-canvas-2d-repeatedly.html
 --min-version 1.0.4 draw-with-changing-start-vertex-bug.html
 --min-version 1.0.3 framebuffer-switch.html
 --min-version 1.0.3 framebuffer-texture-switch.html

--- a/sdk/tests/conformance/rendering/draw-webgl-to-canvas-2d-repeatedly.html
+++ b/sdk/tests/conformance/rendering/draw-webgl-to-canvas-2d-repeatedly.html
@@ -1,0 +1,113 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Draw WebGL to Canvas2D Repeatedly</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script>
+"use strict";
+const wtu = WebGLTestUtils;
+
+const sz = 256;
+
+function drawTo2DCanvas(c2, webGLCanvas) {
+  // Always clear 2D canvas to solid green first.
+  c2.fillRect(0, 0, sz, sz);
+  c2.fillStyle = 'rgb(0,255,0)';
+  c2.fillRect(0, 0, sz, sz);
+  // Draw WebGL canvas to this canvas.
+  c2.drawImage(webGLCanvas, 0, 0);
+}
+
+function runTest() {
+  description();
+  debug('Repeatedly drawing a WebGL canvas to a 2D canvas should only draw the most recently rendered WebGL content.');
+  debug('Regression test for <a href="http://crbug.com/894021">http://crbug.com/894021</a>');
+
+  let c2 = document.getElementById('canvas-2d').getContext('2d');
+  let webGLCanvas = document.getElementById('canvas-webgl');
+  let gl = wtu.create3DContext(webGLCanvas, { alpha: true, antialias: false, premultipliedAlpha: true });
+  let boxOffset = 64;
+  let tolerance = 2;
+
+  // Clear left half of WebGL canvas to red and right half to
+  // transparent black.
+  gl.disable(gl.SCISSOR_TEST);
+  gl.clearColor(0.0, 0.0, 0.0, 0.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.scissor(0, 0, sz / 2, sz);
+  gl.enable(gl.SCISSOR_TEST);
+  gl.clearColor(1.0, 0.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  // Draw to 2D canvas.
+  drawTo2DCanvas(c2, webGLCanvas);
+
+  // Clear right half of WebGL canvas to red and left half to
+  // transparent black.
+  gl.disable(gl.SCISSOR_TEST);
+  gl.clearColor(0.0, 0.0, 0.0, 0.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.scissor(sz / 2, 0, sz / 2, sz);
+  gl.enable(gl.SCISSOR_TEST);
+  gl.clearColor(1.0, 0.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  // Draw to 2D canvas.
+  drawTo2DCanvas(c2, webGLCanvas);
+
+  // Clear WebGL canvas to transparent black.
+  gl.disable(gl.SCISSOR_TEST);
+  gl.clearColor(0.0, 0.0, 0.0, 0.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  // Draw to 2D canvas.
+  drawTo2DCanvas(c2, webGLCanvas);
+  
+  // 2D canvas should be green.
+  // In the error case, the rendering results from earlier draws were
+  // being accumulated, so the 2D canvas was ultimately red.
+  wtu.checkCanvasRect(c2, 0, 0, sz, sz,
+                      [ 0, 255, 0, 255 ],
+                      "should be green",
+                      tolerance);
+
+  finishTest();
+}
+
+requestAnimationFrame(runTest);
+</script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas-webgl" width="256" height="256"></canvas>
+<canvas id="canvas-2d" width="256" height="256"></canvas>
+</body>
+</html>


### PR DESCRIPTION
Each draw should show only the most recently rendered content from the
WebGL canvas. This was not the case when rendering via SwiftShader.

Regression test for http://crbug.com/894021 .