### PR TITLE
Run canvas-teximage-after-multiple-drawimages test in onload handler.

### DIFF
--- a/sdk/tests/conformance/textures/misc/canvas-teximage-after-multiple-drawimages.html
+++ b/sdk/tests/conformance/textures/misc/canvas-teximage-after-multiple-drawimages.html
@@ -111,11 +111,9 @@ function runTest() {
 
   finishTest();
 }
-
-loadImageAndStart(runTest);
 </script>
 </head>
-<body>
+<body onload="loadImageAndStart(runTest)">
 <div id="description"></div>
 <div id="console"></div>
 <canvas id="canvas" width="40" height="40"></canvas>


### PR DESCRIPTION
The JavaScript execution was racing with document parsing, causing the
test to fail intermittently. Follow-on to #2706.

Chromium bug: http://crbug.com/905682 .