### PR TITLE
Test shadow samplers and TEXTURE_COMPARE_MODE

### DIFF
--- a/sdk/tests/conformance2/uniforms/incompatible-texture-type-for-sampler.html
+++ b/sdk/tests/conformance2/uniforms/incompatible-texture-type-for-sampler.html
@@ -65,73 +65,84 @@ function makeFragmentShader(samplerType, uvType) {
    `;
 }
 
+// Sampler types.
+const FLOAT = 1;
+const SIGNED = 2;
+const UNSIGNED = 3;
+const SHADOW = 4;
+
 const textureInternalFormatInfo = {};
 {
   const t = textureInternalFormatInfo;
   // unsized formats
-  t[gl.ALPHA]              = { textureFormat: gl.ALPHA,           colorRenderable: true,  textureFilterable: true,  bytesPerElement: [1, 2, 2, 4],        type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT], };
-  t[gl.LUMINANCE]          = { textureFormat: gl.LUMINANCE,       colorRenderable: true,  textureFilterable: true,  bytesPerElement: [1, 2, 2, 4],        type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT], };
-  t[gl.LUMINANCE_ALPHA]    = { textureFormat: gl.LUMINANCE_ALPHA, colorRenderable: true,  textureFilterable: true,  bytesPerElement: [2, 4, 4, 8],        type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT], };
-  t[gl.RGB]                = { textureFormat: gl.RGB,             colorRenderable: true,  textureFilterable: true,  bytesPerElement: [3, 6, 6, 12, 2],    type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT, gl.UNSIGNED_SHORT_5_6_5], };
-  t[gl.RGBA]               = { textureFormat: gl.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4, 8, 8, 16, 2, 2], type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT, gl.UNSIGNED_SHORT_4_4_4_4, gl.UNSIGNED_SHORT_5_5_5_1], };
+  t[gl.ALPHA]              = { textureFormat: gl.ALPHA,           samplerType: FLOAT,    depth: false, bytesPerElement: [1, 2, 2, 4],        type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT], };
+  t[gl.LUMINANCE]          = { textureFormat: gl.LUMINANCE,       samplerType: FLOAT,    depth: false, bytesPerElement: [1, 2, 2, 4],        type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT], };
+  t[gl.LUMINANCE_ALPHA]    = { textureFormat: gl.LUMINANCE_ALPHA, samplerType: FLOAT,    depth: false, bytesPerElement: [2, 4, 4, 8],        type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT], };
+  t[gl.RGB]                = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [3, 6, 6, 12, 2],    type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT, gl.UNSIGNED_SHORT_5_6_5], };
+  t[gl.RGBA]               = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [4, 8, 8, 16, 2, 2], type: [gl.UNSIGNED_BYTE, gl.HALF_FLOAT, gl.HALF_FLOAT_OES, gl.FLOAT, gl.UNSIGNED_SHORT_4_4_4_4, gl.UNSIGNED_SHORT_5_5_5_1], };
 
   // sized formats
-  t[gl.R8]                 = { textureFormat: gl.RED,             colorRenderable: true,  textureFilterable: true,  bytesPerElement: [1],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.R8_SNORM]           = { textureFormat: gl.RED,             colorRenderable: false, textureFilterable: true,  bytesPerElement: [1],        type: [gl.BYTE], };
-  t[gl.R16F]               = { textureFormat: gl.RED,             colorRenderable: false, textureFilterable: true,  bytesPerElement: [4, 2],     type: [gl.FLOAT, gl.HALF_FLOAT], };
-  t[gl.R32F]               = { textureFormat: gl.RED,             colorRenderable: false, textureFilterable: false, bytesPerElement: [4],        type: [gl.FLOAT], };
-  t[gl.R8UI]               = { textureFormat: gl.RED_INTEGER,     colorRenderable: true,  textureFilterable: false, bytesPerElement: [1],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.R8I]                = { textureFormat: gl.RED_INTEGER,     colorRenderable: true,  textureFilterable: false, bytesPerElement: [1],        type: [gl.BYTE], };
-  t[gl.R16UI]              = { textureFormat: gl.RED_INTEGER,     colorRenderable: true,  textureFilterable: false, bytesPerElement: [2],        type: [gl.UNSIGNED_SHORT], };
-  t[gl.R16I]               = { textureFormat: gl.RED_INTEGER,     colorRenderable: true,  textureFilterable: false, bytesPerElement: [2],        type: [gl.SHORT], };
-  t[gl.R32UI]              = { textureFormat: gl.RED_INTEGER,     colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.UNSIGNED_INT], };
-  t[gl.R32I]               = { textureFormat: gl.RED_INTEGER,     colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.INT], };
-  t[gl.RG8]                = { textureFormat: gl.RG,              colorRenderable: true,  textureFilterable: true,  bytesPerElement: [2],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.RG8_SNORM]          = { textureFormat: gl.RG,              colorRenderable: false, textureFilterable: true,  bytesPerElement: [2],        type: [gl.BYTE], };
-  t[gl.RG16F]              = { textureFormat: gl.RG,              colorRenderable: false, textureFilterable: true,  bytesPerElement: [8, 4],     type: [gl.FLOAT, gl.HALF_FLOAT], };
-  t[gl.RG32F]              = { textureFormat: gl.RG,              colorRenderable: false, textureFilterable: false, bytesPerElement: [8],        type: [gl.FLOAT], };
-  t[gl.RG8UI]              = { textureFormat: gl.RG_INTEGER,      colorRenderable: true,  textureFilterable: false, bytesPerElement: [2],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.RG8I]               = { textureFormat: gl.RG_INTEGER,      colorRenderable: true,  textureFilterable: false, bytesPerElement: [2],        type: [gl.BYTE], };
-  t[gl.RG16UI]             = { textureFormat: gl.RG_INTEGER,      colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.UNSIGNED_SHORT], };
-  t[gl.RG16I]              = { textureFormat: gl.RG_INTEGER,      colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.SHORT], };
-  t[gl.RG32UI]             = { textureFormat: gl.RG_INTEGER,      colorRenderable: true,  textureFilterable: false, bytesPerElement: [8],        type: [gl.UNSIGNED_INT], };
-  t[gl.RG32I]              = { textureFormat: gl.RG_INTEGER,      colorRenderable: true,  textureFilterable: false, bytesPerElement: [8],        type: [gl.INT], };
-  t[gl.RGB8]               = { textureFormat: gl.RGB,             colorRenderable: true,  textureFilterable: true,  bytesPerElement: [3],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.SRGB8]              = { textureFormat: gl.RGB,             colorRenderable: false, textureFilterable: true,  bytesPerElement: [3],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.RGB565]             = { textureFormat: gl.RGB,             colorRenderable: true,  textureFilterable: true,  bytesPerElement: [3, 2],     type: [gl.UNSIGNED_BYTE, gl.UNSIGNED_SHORT_5_6_5], };
-  t[gl.RGB8_SNORM]         = { textureFormat: gl.RGB,             colorRenderable: false, textureFilterable: true,  bytesPerElement: [3],        type: [gl.BYTE], };
-  t[gl.R11F_G11F_B10F]     = { textureFormat: gl.RGB,             colorRenderable: false, textureFilterable: true,  bytesPerElement: [12, 6, 4], type: [gl.FLOAT, gl.HALF_FLOAT, gl.UNSIGNED_INT_10F_11F_11F_REV], };
-  t[gl.RGB9_E5]            = { textureFormat: gl.RGB,             colorRenderable: false, textureFilterable: true,  bytesPerElement: [12, 6, 4], type: [gl.FLOAT, gl.HALF_FLOAT, gl.UNSIGNED_INT_5_9_9_9_REV], };
-  t[gl.RGB16F]             = { textureFormat: gl.RGB,             colorRenderable: false, textureFilterable: true,  bytesPerElement: [12, 6],    type: [gl.FLOAT, gl.HALF_FLOAT], };
-  t[gl.RGB32F]             = { textureFormat: gl.RGB,             colorRenderable: false, textureFilterable: false, bytesPerElement: [12],       type: [gl.FLOAT], };
-  t[gl.RGB8UI]             = { textureFormat: gl.RGB_INTEGER,     colorRenderable: false, textureFilterable: false, bytesPerElement: [3],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.RGB8I]              = { textureFormat: gl.RGB_INTEGER,     colorRenderable: false, textureFilterable: false, bytesPerElement: [3],        type: [gl.BYTE], };
-  t[gl.RGB16UI]            = { textureFormat: gl.RGB_INTEGER,     colorRenderable: false, textureFilterable: false, bytesPerElement: [6],        type: [gl.UNSIGNED_SHORT], };
-  t[gl.RGB16I]             = { textureFormat: gl.RGB_INTEGER,     colorRenderable: false, textureFilterable: false, bytesPerElement: [6],        type: [gl.SHORT], };
-  t[gl.RGB32UI]            = { textureFormat: gl.RGB_INTEGER,     colorRenderable: false, textureFilterable: false, bytesPerElement: [12],       type: [gl.UNSIGNED_INT], };
-  t[gl.RGB32I]             = { textureFormat: gl.RGB_INTEGER,     colorRenderable: false, textureFilterable: false, bytesPerElement: [12],       type: [gl.INT], };
-  t[gl.RGBA8]              = { textureFormat: gl.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.SRGB8_ALPHA8]       = { textureFormat: gl.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.RGBA8_SNORM]        = { textureFormat: gl.RGBA,            colorRenderable: false, textureFilterable: true,  bytesPerElement: [4],        type: [gl.BYTE], };
-  t[gl.RGB5_A1]            = { textureFormat: gl.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4, 2, 4],  type: [gl.UNSIGNED_BYTE, gl.UNSIGNED_SHORT_5_5_5_1, gl.UNSIGNED_INT_2_10_10_10_REV], };
-  t[gl.RGBA4]              = { textureFormat: gl.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4, 2],     type: [gl.UNSIGNED_BYTE, gl.UNSIGNED_SHORT_4_4_4_4], };
-  t[gl.RGB10_A2]           = { textureFormat: gl.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4],        type: [gl.UNSIGNED_INT_2_10_10_10_REV], };
-  t[gl.RGBA16F]            = { textureFormat: gl.RGBA,            colorRenderable: false, textureFilterable: true,  bytesPerElement: [16, 8],    type: [gl.FLOAT, gl.HALF_FLOAT], };
-  t[gl.RGBA32F]            = { textureFormat: gl.RGBA,            colorRenderable: false, textureFilterable: false, bytesPerElement: [16],       type: [gl.FLOAT], };
-  t[gl.RGBA8UI]            = { textureFormat: gl.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.UNSIGNED_BYTE], };
-  t[gl.RGBA8I]             = { textureFormat: gl.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.BYTE], };
-  t[gl.RGB10_A2UI]         = { textureFormat: gl.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.UNSIGNED_INT_2_10_10_10_REV], };
-  t[gl.RGBA16UI]           = { textureFormat: gl.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement: [8],        type: [gl.UNSIGNED_SHORT], };
-  t[gl.RGBA16I]            = { textureFormat: gl.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement: [8],        type: [gl.SHORT], };
-  t[gl.RGBA32I]            = { textureFormat: gl.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement: [16],       type: [gl.INT], };
-  t[gl.RGBA32UI]           = { textureFormat: gl.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement: [16],       type: [gl.UNSIGNED_INT], };
+  t[gl.R8]                 = { textureFormat: gl.RED,             samplerType: FLOAT,    depth: false, bytesPerElement: [1],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.R8_SNORM]           = { textureFormat: gl.RED,             samplerType: FLOAT,    depth: false, bytesPerElement: [1],                 type: [gl.BYTE], };
+  t[gl.R16F]               = { textureFormat: gl.RED,             samplerType: FLOAT,    depth: false, bytesPerElement: [4, 2],              type: [gl.FLOAT, gl.HALF_FLOAT], };
+  t[gl.R32F]               = { textureFormat: gl.RED,             samplerType: FLOAT,    depth: false, bytesPerElement: [4],                 type: [gl.FLOAT], };
+  t[gl.R8UI]               = { textureFormat: gl.RED_INTEGER,     samplerType: UNSIGNED, depth: false, bytesPerElement: [1],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.R8I]                = { textureFormat: gl.RED_INTEGER,     samplerType: SIGNED,   depth: false, bytesPerElement: [1],                 type: [gl.BYTE], };
+  t[gl.R16UI]              = { textureFormat: gl.RED_INTEGER,     samplerType: UNSIGNED, depth: false, bytesPerElement: [2],                 type: [gl.UNSIGNED_SHORT], };
+  t[gl.R16I]               = { textureFormat: gl.RED_INTEGER,     samplerType: SIGNED,   depth: false, bytesPerElement: [2],                 type: [gl.SHORT], };
+  t[gl.R32UI]              = { textureFormat: gl.RED_INTEGER,     samplerType: UNSIGNED, depth: false, bytesPerElement: [4],                 type: [gl.UNSIGNED_INT], };
+  t[gl.R32I]               = { textureFormat: gl.RED_INTEGER,     samplerType: SIGNED,   depth: false, bytesPerElement: [4],                 type: [gl.INT], };
+  t[gl.RG8]                = { textureFormat: gl.RG,              samplerType: FLOAT,    depth: false, bytesPerElement: [2],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.RG8_SNORM]          = { textureFormat: gl.RG,              samplerType: FLOAT,    depth: false, bytesPerElement: [2],                 type: [gl.BYTE], };
+  t[gl.RG16F]              = { textureFormat: gl.RG,              samplerType: FLOAT,    depth: false, bytesPerElement: [8, 4],              type: [gl.FLOAT, gl.HALF_FLOAT], };
+  t[gl.RG32F]              = { textureFormat: gl.RG,              samplerType: FLOAT,    depth: false, bytesPerElement: [8],                 type: [gl.FLOAT], };
+  t[gl.RG8UI]              = { textureFormat: gl.RG_INTEGER,      samplerType: UNSIGNED, depth: false, bytesPerElement: [2],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.RG8I]               = { textureFormat: gl.RG_INTEGER,      samplerType: SIGNED,   depth: false, bytesPerElement: [2],                 type: [gl.BYTE], };
+  t[gl.RG16UI]             = { textureFormat: gl.RG_INTEGER,      samplerType: UNSIGNED, depth: false, bytesPerElement: [4],                 type: [gl.UNSIGNED_SHORT], };
+  t[gl.RG16I]              = { textureFormat: gl.RG_INTEGER,      samplerType: SIGNED,   depth: false, bytesPerElement: [4],                 type: [gl.SHORT], };
+  t[gl.RG32UI]             = { textureFormat: gl.RG_INTEGER,      samplerType: UNSIGNED, depth: false, bytesPerElement: [8],                 type: [gl.UNSIGNED_INT], };
+  t[gl.RG32I]              = { textureFormat: gl.RG_INTEGER,      samplerType: SIGNED,   depth: false, bytesPerElement: [8],                 type: [gl.INT], };
+  t[gl.RGB8]               = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [3],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.SRGB8]              = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [3],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.RGB565]             = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [3, 2],              type: [gl.UNSIGNED_BYTE, gl.UNSIGNED_SHORT_5_6_5], };
+  t[gl.RGB8_SNORM]         = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [3],                 type: [gl.BYTE], };
+  t[gl.R11F_G11F_B10F]     = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [12, 6, 4],          type: [gl.FLOAT, gl.HALF_FLOAT, gl.UNSIGNED_INT_10F_11F_11F_REV], };
+  t[gl.RGB9_E5]            = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [12, 6, 4],          type: [gl.FLOAT, gl.HALF_FLOAT, gl.UNSIGNED_INT_5_9_9_9_REV], };
+  t[gl.RGB16F]             = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [12, 6],             type: [gl.FLOAT, gl.HALF_FLOAT], };
+  t[gl.RGB32F]             = { textureFormat: gl.RGB,             samplerType: FLOAT,    depth: false, bytesPerElement: [12],                type: [gl.FLOAT], };
+  t[gl.RGB8UI]             = { textureFormat: gl.RGB_INTEGER,     samplerType: UNSIGNED, depth: false, bytesPerElement: [3],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.RGB8I]              = { textureFormat: gl.RGB_INTEGER,     samplerType: SIGNED,   depth: false, bytesPerElement: [3],                 type: [gl.BYTE], };
+  t[gl.RGB16UI]            = { textureFormat: gl.RGB_INTEGER,     samplerType: UNSIGNED, depth: false, bytesPerElement: [6],                 type: [gl.UNSIGNED_SHORT], };
+  t[gl.RGB16I]             = { textureFormat: gl.RGB_INTEGER,     samplerType: SIGNED,   depth: false, bytesPerElement: [6],                 type: [gl.SHORT], };
+  t[gl.RGB32UI]            = { textureFormat: gl.RGB_INTEGER,     samplerType: UNSIGNED, depth: false, bytesPerElement: [12],                type: [gl.UNSIGNED_INT], };
+  t[gl.RGB32I]             = { textureFormat: gl.RGB_INTEGER,     samplerType: SIGNED,   depth: false, bytesPerElement: [12],                type: [gl.INT], };
+  t[gl.RGBA8]              = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [4],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.SRGB8_ALPHA8]       = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [4],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.RGBA8_SNORM]        = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [4],                 type: [gl.BYTE], };
+  t[gl.RGB5_A1]            = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [4, 2, 4],           type: [gl.UNSIGNED_BYTE, gl.UNSIGNED_SHORT_5_5_5_1, gl.UNSIGNED_INT_2_10_10_10_REV], };
+  t[gl.RGBA4]              = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [4, 2],              type: [gl.UNSIGNED_BYTE, gl.UNSIGNED_SHORT_4_4_4_4], };
+  t[gl.RGB10_A2]           = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [4],                 type: [gl.UNSIGNED_INT_2_10_10_10_REV], };
+  t[gl.RGBA16F]            = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [16, 8],             type: [gl.FLOAT, gl.HALF_FLOAT], };
+  t[gl.RGBA32F]            = { textureFormat: gl.RGBA,            samplerType: FLOAT,    depth: false, bytesPerElement: [16],                type: [gl.FLOAT], };
+  t[gl.RGBA8UI]            = { textureFormat: gl.RGBA_INTEGER,    samplerType: UNSIGNED, depth: false, bytesPerElement: [4],                 type: [gl.UNSIGNED_BYTE], };
+  t[gl.RGBA8I]             = { textureFormat: gl.RGBA_INTEGER,    samplerType: SIGNED,   depth: false, bytesPerElement: [4],                 type: [gl.BYTE], };
+  t[gl.RGB10_A2UI]         = { textureFormat: gl.RGBA_INTEGER,    samplerType: UNSIGNED, depth: false, bytesPerElement: [4],                 type: [gl.UNSIGNED_INT_2_10_10_10_REV], };
+  t[gl.RGBA16UI]           = { textureFormat: gl.RGBA_INTEGER,    samplerType: UNSIGNED, depth: false, bytesPerElement: [8],                 type: [gl.UNSIGNED_SHORT], };
+  t[gl.RGBA16I]            = { textureFormat: gl.RGBA_INTEGER,    samplerType: SIGNED,   depth: false, bytesPerElement: [8],                 type: [gl.SHORT], };
+  t[gl.RGBA32I]            = { textureFormat: gl.RGBA_INTEGER,    samplerType: SIGNED,   depth: false, bytesPerElement: [16],                type: [gl.INT], };
+  t[gl.RGBA32UI]           = { textureFormat: gl.RGBA_INTEGER,    samplerType: UNSIGNED, depth: false, bytesPerElement: [16],                type: [gl.UNSIGNED_INT], };
 
   // Sized Internal
-  t[gl.DEPTH_COMPONENT16]  = { textureFormat: gl.DEPTH_COMPONENT, colorRenderable: true,  textureFilterable: false, bytesPerElement: [2, 4],     type: [gl.UNSIGNED_SHORT, gl.UNSIGNED_INT], };
-  t[gl.DEPTH_COMPONENT24]  = { textureFormat: gl.DEPTH_COMPONENT, colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.UNSIGNED_INT], };
-  t[gl.DEPTH_COMPONENT32F] = { textureFormat: gl.DEPTH_COMPONENT, colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.FLOAT], };
-  t[gl.DEPTH24_STENCIL8]   = { textureFormat: gl.DEPTH_STENCIL,   colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.UNSIGNED_INT_24_8], };
-  t[gl.DEPTH32F_STENCIL8]  = { textureFormat: gl.DEPTH_STENCIL,   colorRenderable: true,  textureFilterable: false, bytesPerElement: [4],        type: [gl.FLOAT_32_UNSIGNED_INT_24_8_REV], };
+  // Note that samplerType is FLOAT for depth formats, not SHADOW. Shadow
+  // samplers are handled as a special case in the test code because they have
+  // special rules about TEXTURE_COMPARE_MODE.
+  t[gl.DEPTH_COMPONENT16]  = { textureFormat: gl.DEPTH_COMPONENT, samplerType: FLOAT,    depth: true,  bytesPerElement: [2, 4],              type: [gl.UNSIGNED_SHORT, gl.UNSIGNED_INT], };
+  t[gl.DEPTH_COMPONENT24]  = { textureFormat: gl.DEPTH_COMPONENT, samplerType: FLOAT,    depth: true,  bytesPerElement: [4],                 type: [gl.UNSIGNED_INT], };
+  t[gl.DEPTH_COMPONENT32F] = { textureFormat: gl.DEPTH_COMPONENT, samplerType: FLOAT,    depth: true,  bytesPerElement: [4],                 type: [gl.FLOAT], };
+  t[gl.DEPTH24_STENCIL8]   = { textureFormat: gl.DEPTH_STENCIL,   samplerType: FLOAT,    depth: true,  bytesPerElement: [4],                 type: [gl.UNSIGNED_INT_24_8], };
+  t[gl.DEPTH32F_STENCIL8]  = { textureFormat: gl.DEPTH_STENCIL,   samplerType: FLOAT,    depth: true,  bytesPerElement: [4],                 type: [gl.FLOAT_32_UNSIGNED_INT_24_8_REV], };
+
+  // TODO: Compressed formats.
 
   Object.keys(t).forEach(function(internalFormat) {
     const info = t[internalFormat];
@@ -143,62 +154,11 @@ const textureInternalFormatInfo = {};
   });
 }
 
-const depthTextureFormats = [
-  gl.DEPTH_COMPONENT16,
-  gl.DEPTH_COMPONENT24,
-  gl.DEPTH_COMPONENT32F,
-  gl.DEPTH24_STENCIL8,
-  gl.DEPTH32F_STENCIL8,
-];
-
-const intTextureFormats = [
-  gl.R8I,
-  gl.R16I,
-  gl.R32I,
-  gl.RG8I,
-  gl.RG16I,
-  gl.RG32I,
-  gl.RGB8I,
-  gl.RGB16I,
-  gl.RGB32I,
-  gl.RGBA8I,
-  gl.RGBA16I,
-  gl.RGBA32I,
-];
-
-const unsignedIntTextureFormats = [
-  gl.R8UI,
-  gl.R16UI,
-  gl.R32UI,
-  gl.RG8UI,
-  gl.RG16UI,
-  gl.RG32UI,
-  gl.RGB8UI,
-  gl.RGB16UI,
-  gl.RGB32UI,
-  gl.RGBA8UI,
-  gl.RGB10_A2UI,
-  gl.RGBA16UI,
-  gl.RGBA32UI,
-];
-
-const floatTextureFormats = Object.keys(textureInternalFormatInfo).map(function(v) {
-  return parseInt(v);
-}).filter(function(format) {
-  return intTextureFormats.indexOf(format) < 0 && unsignedIntTextureFormats.indexOf(format) < 0;
-});
-
 const floatSamplerTypes = [
   { type: 'sampler2D',            uvType: 'vec2(0)', target: gl.TEXTURE_2D, },
   { type: 'sampler3D',            uvType: 'vec3(0)', target: gl.TEXTURE_3D, },
   { type: 'samplerCube',          uvType: 'vec3(0)', target: gl.TEXTURE_CUBE_MAP, },
   { type: 'sampler2DArray',       uvType: 'vec3(0)', target: gl.TEXTURE_2D_ARRAY, },
-
-  // these sampler types should probably be tested separtely as they have
-  // various texParameter requirements
-  // { type: 'samplerCubeShadow',    uvType: 'vec4(0)', target: gl.TEXTURE_, },
-  // { type: 'sampler2DShadow',      uvType: 'vec3(0)', target: gl.TEXTURE_, },
-  // { type: 'sampler2DArrayShadow', uvType: 'vec4(0)', target: gl.TEXTURE_, },
 ];
 
 const signedIntSamplerTypes = [
@@ -214,6 +174,12 @@ const unsignedIntSamplerTypes = [
   { type: 'usamplerCube',         uvType: 'vec3(0)', target: gl.TEXTURE_CUBE_MAP, },
   { type: 'usampler2DArray',      uvType: 'vec3(0)', target: gl.TEXTURE_2D_ARRAY, },
 ];
+
+const shadowSamplerTypes = [
+  { type: 'sampler2DShadow',      uvType: 'vec3(0)', target: gl.TEXTURE_2D, },
+  { type: 'samplerCubeShadow',    uvType: 'vec4(0)', target: gl.TEXTURE_CUBE_MAP, },
+  { type: 'sampler2DArrayShadow', uvType: 'vec4(0)', target: gl.TEXTURE_2D_ARRAY, },
+]
 
 /**
  * Gets the number of bytes per element for a given internalFormat / type
@@ -268,7 +234,7 @@ function runTest() {
         targetInfo.textures = [];
         Object.keys(textureInternalFormatInfo).forEach(function(internalFormat) {
             internalFormat = parseInt(internalFormat);
-            const isDepthFormat = depthTextureFormats.indexOf(internalFormat) >= 0;
+            const isDepthFormat = textureInternalFormatInfo[internalFormat].depth;
             if (target === gl.TEXTURE_3D && isDepthFormat) {
               return;
             }
@@ -289,12 +255,26 @@ function runTest() {
         });
     });
 
-    testSamplerTypes(floatSamplerTypes, floatTextureFormats);
-    testSamplerTypes(signedIntSamplerTypes, intTextureFormats);
-    testSamplerTypes(unsignedIntSamplerTypes, unsignedIntTextureFormats);
+    // The rules implemented here are:
 
-    function testSamplerTypes(samplerTypes, compatibleFormats) {
-        samplerTypes.forEach(function(samplerInfo) {
+    // Float samplers accept only float textures and normalized integer textures
+    // (signed or unsigned) and depth textures with TEXTURE_COMPARE_MODE set to
+    // NONE.
+
+    // Signed samplers accept only signed unnormalized integer textures.
+
+    // Unsigned samplers accept only unsigned unnormalized integer textures.
+
+    // Shadow samplers accept only depth textures with
+    // TEXTURE_COMPARE_MODE set to COMPARE_REF_TO_TEXTURE.
+
+    testSamplerType(FLOAT, floatSamplerTypes);
+    testSamplerType(SIGNED, signedIntSamplerTypes);
+    testSamplerType(UNSIGNED, unsignedIntSamplerTypes);
+    testSamplerType(SHADOW, shadowSamplerTypes);
+
+    function testSamplerType(samplerType, samplerInfos) {
+        samplerInfos.forEach(function(samplerInfo) {
             debug(`\nchecking ${samplerInfo.type}`);
             const program = wtu.setupProgram(gl, ['vshader', makeFragmentShader(samplerInfo.type, samplerInfo.uvType)], [], console.log.bind(console));
             if (!program) {
@@ -308,10 +288,18 @@ function runTest() {
             targetInfo.textures.forEach(function(textureInfo) {
                 const internalFormat = textureInfo.internalFormat;
                 const desc = wtu.glEnumToString(gl, internalFormat);
+                const info = textureInternalFormatInfo[internalFormat];
                 gl.bindTexture(target, textureInfo.texture);
+                gl.texParameteri(target, gl.TEXTURE_COMPARE_MODE, gl.NONE);
                 gl.drawArrays(gl.POINTS, 0, 1);
-                const expected = compatibleFormats.indexOf(internalFormat) < 0 ? gl.INVALID_OPERATION : gl.NONE;
+                let expected = samplerType == info.samplerType ? gl.NONE : gl.INVALID_OPERATION;
                 wtu.glErrorShouldBe(gl, expected, `from draw with ${desc}`);
+                gl.texParameteri(target, gl.TEXTURE_COMPARE_MODE, gl.COMPARE_REF_TO_TEXTURE);
+                gl.drawArrays(gl.POINTS, 0, 1);
+                if (info.depth) {
+                  expected = samplerType == SHADOW ? gl.NONE : gl.INVALID_OPERATION;
+                }
+                wtu.glErrorShouldBe(gl, expected, `from draw with ${desc} using TEXTURE_COMPARE_MODE`);
             });
 
         });


### PR DESCRIPTION
Add checks for shadow samplers and add consideration of normalization for integer textures. The rules are:

Float samplers accept only float textures and normalized integer textures (signed or unsigned).

Signed samplers accept only signed integer textures (normalized or unnormalized).

Unsigned samplers accept only unsigned integer textures (normalized or unnormalized).

Shadow samplers accept only depth textures, and only if their TEXTURE_COMPARE_MODE state is set.

As a special extra restriction, depth textures cannot be sampled by non-shadow samplers if their TEXTURE_COMPARE_MODE state is set. Non-depth textures are not affected by this restriction.