### PR TITLE
Color mask must be preserved during implicit clears.

### DIFF
--- a/sdk/tests/conformance/rendering/00_test_list.txt
+++ b/sdk/tests/conformance/rendering/00_test_list.txt
@@ -1,5 +1,6 @@
 --min-version 1.0.4 canvas-alpha-bug.html
 --min-version 1.0.4 --max-version 1.9.9 clipping-wide-points.html
+--min-version 1.0.4 color-mask-preserved-during-implicit-clears.html
 --min-version 1.0.2 culling.html
 --min-version 1.0.4 default-texture-draw-bug.html
 draw-arrays-out-of-bounds.html

--- a/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
+++ b/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
@@ -80,7 +80,8 @@ function runTest() {
   gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   // Set clear color to transparent green.
   gl.clearColor(0, 1, 0, 0);
-  // Clear. Result should be opaque green.
+  // Clear. Result should be opaque green. Was transparent green when
+  // bug was encountered.
   gl.clear(gl.COLOR_BUFFER_BIT);
   wtu.checkCanvasRect(gl, 0, 0, sz, sz,
                       [ 0, 255, 0, 255 ],

--- a/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
+++ b/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
@@ -1,0 +1,108 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>ColorMask Must Be Preserved During Implicit Clears</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script>
+"use strict";
+const wtu = WebGLTestUtils;
+const sz = 256;
+let frames = 20;
+let gl;
+
+function initTest() {
+  description();
+  debug('ColorMask must be preserved during implicit clears of textures.');
+  debug('Regression test for <a href="http://crbug.com/911918">http://crbug.com/911918</a>');
+
+  let webGLCanvas = document.getElementById('canvas-webgl');
+  gl = wtu.create3DContext(webGLCanvas, { alpha: false, antialias: false });
+
+  requestAnimationFrame(runTest);
+}
+
+function runTest() {
+  // Create a user-defined framebuffer which has an alpha channel.
+  let fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  // Set color mask to disable alpha writes. This is important; see below.
+  gl.colorMask(true, true, true, false);
+  let tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sz, sz, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  // Upload a sub-rectangle. In Chrome, this was lazily clearing level 0 of the
+  // texture using OpenGL, setting the driver's color mask to (true, true, true,
+  // true) in the process. Because the user's color mask was set to (true, true,
+  // true, false) above, incorrect caching code was failing to reset the
+  // driver's color mask later. On macOS, Chrome implements alpha:false WebGL
+  // contexts on top of RGBA textures whose alpha channel is cleared to 1.0 and
+  // where the color mask is set to (true, true, true, false) during all writes.
+  // This bug was allowing that texture's alpha channel to be destroyed.
+  gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(4));
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+  // We have to issue one clear to this framebuffer to get the color mask
+  // latched into the internal caching code.
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  // Switch back to default framebuffer.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  // Set clear color to transparent green.
+  gl.clearColor(0, 1, 0, 0);
+  // Clear. Result should be opaque green.
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  wtu.checkCanvasRect(gl, 0, 0, sz, sz,
+                      [ 0, 255, 0, 255 ],
+                      "default framebuffer should be opaque green");
+
+  gl.deleteFramebuffer(fb);
+  gl.deleteTexture(tex);
+
+  --frames;
+  if (frames == 0) {
+    finishTest();
+  } else {
+    requestAnimationFrame(runTest);
+  }
+}
+
+requestAnimationFrame(initTest);
+</script>
+</head>
+<body>
+<div id="description"></div>
+<canvas id="canvas-webgl" width="256" height="256"></canvas>
+<div id="console"></div>
+</body>
+</html>


### PR DESCRIPTION
Catches a bug that manifested on Chrome on macOS, but could have
affected any other platform. This new test already passes on Firefox.

Regression test for http://crbug.com/911918 .