### PR TITLE
Add "desynchronized" flag to WebGLContextAttributes.

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -744,6 +744,7 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
     boolean preserveDrawingBuffer = false;
     WebGLPowerPreference powerPreference = "default";
     boolean failIfMajorPerformanceCaveat = false;
+    boolean desynchronized = false;
 };</pre>
 
     <h4>Context creation parameters</h4>
@@ -876,6 +877,35 @@ enum WebGLPowerPreference { "default", "low-power", "high-performance" };
               Alternatively the application can retry WebGL context creation with this parameter
               set to <code>false</code>, with the knowledge that a reduced-fidelity rendering mode
               should be used to improve performance.
+            </dd>
+        <dt> <span class=prop-value>desynchronized</span></dt>
+            <dd>
+              <p>
+                If the value is true, then the user agent may optimize the rendering of the canvas
+                to reduce the latency, as measured from input events to rasterization, by
+                desynchronizing the canvas paint cycle from the event loop, bypassing the ordinary
+                user agent rendering algorithm, or both. Insofar as this mode involves bypassing the
+                usual paint mechanisms, rasterization, or both, it might introduce visible tearing
+                artifacts.
+              </p>
+              <div class="note">
+                <p>
+                  The user agent usually renders on a buffer which is not being displayed, quickly
+                  swapping it and the one being scanned out for presentation; the former buffer is
+                  called back buffer and the latter <i>front buffer</i>. A popular technique for
+                  reducing latency is called front buffer rendering, also known as <i>single
+                  buffer</i> rendering, where rendering happens inparallel and racily with the
+                  scanning out process. This technique reduces the latency at the price of
+                  potentially introducing tearing artifacts and can be used to implement in total or
+                  part of the <code>desynchronized</code>
+                  boolean. <a href="#refsMULTIPLEBUFFERING">[MULTIPLEBUFFERING]</a>
+                </p>
+                <p>
+                  The <code>desynchronized</code> boolean can be useful when implementing certain
+                  kinds of applications, such as drawing applications, where the latency between
+                  input and rasterization is critical.
+                </p>
+              </div>
             </dd>
     </dl>
     <div class="example">
@@ -4449,6 +4479,10 @@ extensions.
         <dd><cide><a href="https://www.opengl.org/registry/specs/KHR/robust_buffer_access_behavior.txt">
             KHR_robust_buffer_access_behavior OpenGL ES extension</a></cite>,
             Leech, J. and Daniell, P., August, 2014.
+        </dd>
+        <dt id="refsMULTIPLEBUFFERING">[MULTIPLEBUFFERING]</dt>
+        <dd>(Non-normative) <cite><a href="https://en.wikipedia.org/wiki/Multiple_buffering">
+            Multiple buffering</a></cite>. Wikipedia.
         </dd>
     </dl>
 

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -3,7 +3,7 @@
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/
 
-// Copyright (c) 2018 The Khronos Group Inc.
+// Copyright (c) 2019 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the
@@ -54,6 +54,7 @@ dictionary WebGLContextAttributes {
     boolean preserveDrawingBuffer = false;
     WebGLPowerPreference powerPreference = "default";
     boolean failIfMajorPerformanceCaveat = false;
+    boolean desynchronized = false;
 };
 
 [Exposed=(Window,Worker)]


### PR DESCRIPTION
Developers of stylus-based drawing applications (e.g. Google Keep)
have found this hint to be critical in order to be competitive with
native applications. It has been prototyped in Chromium and yields
significant latency improvements there.

This is the WebGL analogue of https://github.com/whatwg/html/pull/4360
and partially addresses https://github.com/whatwg/html/issues/4087 .

Principally authored by @yellowdoge, Miguel Casas-Sanchez <mcasas@chromium.org>