### PR TITLE
Add a regression test for crbug.com/913301

### DIFF
--- a/sdk/tests/conformance2/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/textures/misc/00_test_list.txt
@@ -7,6 +7,7 @@ copy-texture-image.html
 copy-texture-image-luma-format.html
 --min-version 2.0.1 copy-texture-image-same-texture.html
 copy-texture-image-webgl-specific.html
+--min-version 2.0.1 generate-mipmap-with-large-base-level.html
 gl-get-tex-parameter.html
 --min-version 2.0.1 integer-cubemap-texture-sampling.html
 --min-version 2.0.1 integer-cubemap-specification-order-bug.html

--- a/sdk/tests/conformance2/textures/misc/generate-mipmap-with-large-base-level.html
+++ b/sdk/tests/conformance2/textures/misc/generate-mipmap-with-large-base-level.html
@@ -1,0 +1,77 @@
+<!--
+
+/*
+** Copyright (c) 2018 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test if GenerateMipmap on immutable texture with large BASE_LEVEL triggers a crash</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<canvas id="example" width="24" height="24"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("This is a regression test for crbug.com/913301");
+debug("");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example", null, 2);
+gl.clearColor(0, 1, 0, 1);
+
+var targets = [gl.TEXTURE_2D, gl.TEXTURE_3D];
+for (var ii = 0; ii < targets.length; ++ii) {
+  gl.clear(gl.COLOR_BUFFER);
+  var target = targets[ii];
+  var tex = gl.createTexture();
+  gl.bindTexture(target, tex);
+  gl.texParameteri(target, gl.TEXTURE_BASE_LEVEL, 1416354905);
+  gl.texParameteri(target, gl.TEXTURE_MAX_LEVEL, 5);
+  gl.texParameteri(target, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+  gl.texParameteri(target, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  if (target == gl.TEXTURE_2D)
+    gl.texStorage2D(target, 5, gl.R8, 32, 32);
+  else
+    gl.texStorage3D(target, 5, gl.R8, 32, 32, 32);
+  // Should not crash calling generateMipmap.
+  gl.generateMipmap(target);
+  gl.deleteTexture(tex);
+  // If crashed, readPixels() won't be able to work correctly.
+  wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green", 5);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../../js/js-test-post.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
On MacOSX, if we set a large TEXTURE_BASE_LEVEL on an immutable texture, then
call GenerateMipmap() on it will trigger a driver crash.