### PR TITLE
Add more variants of implicit-clear test.

### DIFF
--- a/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
+++ b/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
@@ -36,18 +36,41 @@
 <script>
 "use strict";
 const wtu = WebGLTestUtils;
-const sz = 256;
-let frames = 20;
+const sz = 128;
+let frames;
 let gl;
+let tests = [
+  { alpha: false, antialias: false, premultipliedAlpha: false },
+  { alpha: false, antialias: false, premultipliedAlpha: true  },
+  { alpha: false, antialias: true,  premultipliedAlpha: false },
+  { alpha: false, antialias: true,  premultipliedAlpha: true  },
+];
+let currentTest;
+let testIndex = 0;
 
 function initTest() {
   description();
   debug('ColorMask must be preserved during implicit clears of textures.');
   debug('Regression test for <a href="http://crbug.com/911918">http://crbug.com/911918</a>');
 
-  let webGLCanvas = document.getElementById('canvas-webgl');
-  gl = wtu.create3DContext(webGLCanvas, { alpha: false, antialias: false });
+  requestAnimationFrame(nextTest);
+}
 
+function nextTest() {
+  if (testIndex >= tests.length) {
+    finishTest();
+    return;
+  }
+
+  frames = 20;
+  let canvases = document.getElementById('canvases');
+  let canvas = document.createElement('canvas');
+  canvas.width = sz;
+  canvas.height = sz;
+  canvases.appendChild(canvas);
+  currentTest = tests[testIndex];
+  ++testIndex;
+  gl = wtu.create3DContext(canvas, currentTest);
   requestAnimationFrame(runTest);
 }
 
@@ -85,14 +108,14 @@ function runTest() {
   gl.clear(gl.COLOR_BUFFER_BIT);
   wtu.checkCanvasRect(gl, 0, 0, sz, sz,
                       [ 0, 255, 0, 255 ],
-                      "default framebuffer should be opaque green");
+                      "default framebuffer should be opaque green for " + JSON.stringify(currentTest));
 
   gl.deleteFramebuffer(fb);
   gl.deleteTexture(tex);
 
   --frames;
   if (frames == 0) {
-    finishTest();
+    requestAnimationFrame(nextTest);
   } else {
     requestAnimationFrame(runTest);
   }
@@ -103,7 +126,7 @@ requestAnimationFrame(initTest);
 </head>
 <body>
 <div id="description"></div>
-<canvas id="canvas-webgl" width="256" height="256"></canvas>
+<div id="canvases"></div>
 <div id="console"></div>
 </body>
 </html>


### PR DESCRIPTION
Test against all variants of antialias and premultipliedAlpha.

Follow-on to #2751. Addresses additional scenarios from
http://crbug.com/913033 .