### PR TITLE
COMPARE_MODE is required to use shadow samplers

### DIFF
--- a/sdk/tests/deqp/functional/gles3/es3fShaderTextureFunctionTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fShaderTextureFunctionTests.js
@@ -1810,6 +1810,7 @@ goog.scope(function() {
         gl.texParameteri(textureTarget, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
         gl.texParameteri(textureTarget, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
         gl.texParameteri(textureTarget, gl.TEXTURE_BASE_LEVEL, testSize.lodBase);
+        gl.texParameteri(textureTarget, gl.TEXTURE_COMPARE_MODE, gl.COMPARE_REF_TO_TEXTURE);
 
         // set up texture
 


### PR DESCRIPTION
This test uses shadow samplers, so it is required to set TEXTURE_COMPARE_MODE to avoid INVALID_OPERATION. We can set it unconditionally because it is ignored for non-depth textures.