### PR TITLE
Add deleted object test; strengthen transform feedback test.

### DIFF
--- a/sdk/tests/conformance/context/deleted-object-behavior.html
+++ b/sdk/tests/conformance/context/deleted-object-behavior.html
@@ -1,0 +1,258 @@
+<!--
+
+/*
+** Copyright (c) 2019 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Deleted Object Behavior</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="canvases">
+<canvas id="canvas1">
+</div>
+<div id="console"></div>
+
+<script>
+"use strict";
+description("Verifies behavior of deleted objects");
+
+const wtu = WebGLTestUtils;
+const canvas1 = document.getElementById("canvas1");
+const sz = 64;
+canvas1.width = sz;
+canvas1.height = sz;
+const gl = wtu.create3DContext("canvas1");
+let tex, rb; // for shouldBe
+
+function testBoundFBOTexture() {
+  debug("Verifies that a texture attached to a bound framebuffer and then deleted is automatically detached");
+
+  let fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sz, sz, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors during framebuffer setup");
+  // The WebGL 1.0 spec guarantees that this combination of attachments results
+  // in a complete framebuffer.
+  shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE",
+           "Framebuffer should be complete after setup");
+  debug("Texture should still be bound to the context");
+  shouldBe("gl.getParameter(gl.TEXTURE_BINDING_2D)", "tex");
+  // Delete the texture.
+  gl.deleteTexture(tex);
+  debug("Texture should have been unbound from the context");
+  shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
+  debug("Framebuffer should report that the texture was detached");
+  shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE)", "gl.NONE");
+  debug("Framebuffer should be incomplete after texture was deleted");
+  shouldNotBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+  debug("Texture should not report that it's still a texture after deletion");
+  shouldBe("gl.isTexture(tex)", "false");
+  // Framebuffer should not function.
+  gl.clearColor(0.0, 1.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION, "Framebuffer should not work after deleting its only attachment");
+  // Default framebuffer shouldn't have been touched.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  wtu.checkCanvasRect(gl, 0, 0, sz, sz, [0, 0, 0, 0], "default framebuffer should be transparent black");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors after verifying default framebuffer's contents");
+  // Attempt to bind deleted texture should fail.
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "from binding deleted texture");
+  debug("");
+  gl.deleteFramebuffer(fb);
+}
+
+function testUnboundFBOTexture() {
+  debug("Verifies that a texture attached to an unbound framebuffer and then deleted remains usable until detached");
+
+  let fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sz, sz, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors during framebuffer setup");
+  // The WebGL 1.0 spec guarantees that this combination of attachments results
+  // in a complete framebuffer.
+  shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE",
+           "Framebuffer should be complete after setup");
+  // Unbind the framebuffer from the context so that deleting the texture
+  // doesn't automatically unbind it from the framebuffer.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  debug("Texture should still be bound to the context");
+  shouldBe("gl.getParameter(gl.TEXTURE_BINDING_2D)", "tex");
+  // Delete the texture.
+  gl.deleteTexture(tex);
+  debug("Texture should have been unbound from the context");
+  shouldBeNull("gl.getParameter(gl.TEXTURE_BINDING_2D)");
+  // Framebuffer should still be complete.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  debug("Framebuffer should still be complete after texture was deleted");
+  shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+  debug("Framebuffer should report that the texture is still attached");
+  shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", "tex");
+  debug("Texture should not report that it's still a texture after deletion");
+  shouldBe("gl.isTexture(tex)", "false");
+  // Framebuffer should still function.
+  gl.clearColor(0.0, 1.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  wtu.checkCanvasRect(gl, 0, 0, sz, sz, [0, 255, 0, 255], "framebuffer should be green");
+  // Deleting texture a second time should not unbind it from the framebuffer.
+  gl.deleteTexture(tex);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "deleting an object twice is not an error");
+  debug("Framebuffer should still report that the texture is attached");
+  shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", "tex");
+  // Default framebuffer shouldn't have been touched.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  wtu.checkCanvasRect(gl, 0, 0, sz, sz, [0, 0, 0, 0], "default framebuffer should be transparent black");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors after verifying framebuffers' contents");
+  // Attempt to bind deleted texture should fail.
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "from binding deleted texture");
+  debug("");
+  gl.deleteFramebuffer(fb);
+}
+
+function testBoundFBORenderbuffer() {
+  debug("Verifies that a renderbuffer attached to a bound framebuffer and then deleted is automatically detached");
+
+  let fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  rb = gl.createRenderbuffer();
+  gl.bindRenderbuffer(gl.RENDERBUFFER, rb);
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, sz, sz)
+  gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rb);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors during framebuffer setup");
+  // The WebGL 1.0 spec doesn't guarantee that this framebuffer configuration
+  // will be complete.
+  if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+    debug("Framebuffer with GL_RGBA4 renderbuffer was incomplete; skipping test");
+    return;
+  }
+  debug("Renderbuffer should still be bound to the context");
+  shouldBe("gl.getParameter(gl.RENDERBUFFER_BINDING)", "rb");
+  // Delete the renderbuffer.
+  gl.deleteRenderbuffer(rb);
+  debug("Renderbuffer should have been unbound from the context");
+  shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
+  debug("Framebuffer should report that the texture was detached");
+  shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE)", "gl.NONE");
+  debug("Framebuffer should be incomplete after renderbuffer was deleted");
+  shouldNotBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+  debug("Renderbuffer should not report that it's still a renderbuffer after deletion");
+  shouldBe("gl.isRenderbuffer(rb)", "false");
+  // Framebuffer should not function.
+  gl.clearColor(0.0, 1.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION, "Framebuffer should not work after deleting its only attachment");
+  // Default framebuffer shouldn't have been touched.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  wtu.checkCanvasRect(gl, 0, 0, sz, sz, [0, 0, 0, 0], "default framebuffer should be transparent black");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors after verifying framebuffers' contents");
+  // Attempt to bind deleted renderbuffer should fail.
+  gl.bindRenderbuffer(gl.RENDERBUFFER, rb);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "from binding deleted renderbuffer");
+  debug("");
+  gl.deleteFramebuffer(fb);
+}
+
+function testUnboundFBORenderbuffer() {
+  debug("Verifies that a renderbuffer attached to an unbound framebuffer and then deleted remains usable until detached");
+
+  let fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  rb = gl.createRenderbuffer();
+  gl.bindRenderbuffer(gl.RENDERBUFFER, rb);
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, sz, sz)
+  gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rb);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors during framebuffer setup");
+  // The WebGL 1.0 spec doesn't guarantee that this framebuffer configuration
+  // will be complete.
+  if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+    debug("Framebuffer with GL_RGBA4 renderbuffer was incomplete; skipping test");
+    return;
+  }
+  // Unbind the framebuffer from the context so that deleting the renderbuffer
+  // doesn't automatically unbind it from the framebuffer.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  debug("Renderbuffer should still be bound to the context");
+  shouldBe("gl.getParameter(gl.RENDERBUFFER_BINDING)", "rb");
+  // Delete the renderbuffer.
+  gl.deleteRenderbuffer(rb);
+  debug("Renderbuffer should have been unbound from the context");
+  shouldBeNull("gl.getParameter(gl.RENDERBUFFER_BINDING)");
+  // Framebuffer should still be complete.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+  debug("Framebuffer should still be complete after renderbuffer was deleted");
+  shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+  debug("Framebuffer should report that the renderbuffer is still attached");
+  shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", "rb");
+  debug("Renderbuffer should not report that it's still a renderbuffer after deletion");
+  shouldBe("gl.isRenderbuffer(rb)", "false");
+  // Framebuffer should still function.
+  gl.clearColor(0.0, 1.0, 0.0, 1.0);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  // Use a high tolerance to accommodate low bit depth precision.
+  wtu.checkCanvasRect(gl, 0, 0, sz, sz, [0, 255, 0, 255], "framebuffer should be green", 20);
+  // Deleting renderbuffer a second time should not unbind it from the framebuffer.
+  gl.deleteRenderbuffer(rb);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "deleting an object twice is not an error");
+  debug("Framebuffer should still report that the renderbuffer is attached");
+  shouldBe("gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_NAME)", "rb");
+  // Default framebuffer shouldn't have been touched.
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  wtu.checkCanvasRect(gl, 0, 0, sz, sz, [0, 0, 0, 0], "default framebuffer should be transparent black");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors after verifying framebuffers' contents");
+  // Attempt to bind deleted renderbuffer should fail.
+  gl.bindRenderbuffer(gl.RENDERBUFFER, rb);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "from binding deleted renderbuffer");
+  debug("");
+  gl.deleteFramebuffer(fb);
+}
+
+function runTests() {
+  testBoundFBOTexture();
+  testUnboundFBOTexture();
+  testBoundFBORenderbuffer();
+  testUnboundFBORenderbuffer();
+  finishTest();
+}
+
+requestAnimationFrame(runTests);
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/transform_feedback/transform_feedback.html
+++ b/sdk/tests/conformance2/transform_feedback/transform_feedback.html
@@ -67,6 +67,7 @@ var gl = wtu.create3DContext(canvas, null, 2);
 var tf = null;
 var tf1 = null;
 var buf = null;
+let out_add_buffer = null;
 var program = null;
 var activeInfo = null;
 var query = null;
@@ -81,8 +82,11 @@ if (!gl) {
     runTFBufferBindingTest();
     runObjectTest();
     runGetBufferSubDataTest();
-    runOneOutFeedbackTest();
-    runTwoOutFeedbackTest();
+    runUnboundDeleteTest();
+    runBoundDeleteTest();
+    runOneOutputFeedbackTest();
+    // Must be the last test, since it's asynchronous and calls finishTest().
+    runTwoOutputFeedbackTest();
 }
 
 function runBindingTest() {
@@ -169,9 +173,9 @@ function runObjectTest() {
     tf = null;
 }
 
-function runOneOutFeedbackTest() {
+function runOneOutputFeedbackTest() {
     debug("");
-    debug("Testing transform feedback processing");
+    debug("Testing one-output transform feedback");
 
     // Build the input and output buffers
     var in_data = [
@@ -184,7 +188,7 @@ function runOneOutFeedbackTest() {
     gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(in_data), gl.STATIC_DRAW);
 
-    var out_add_buffer = gl.createBuffer();
+    out_add_buffer = gl.createBuffer();
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
     gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length, gl.STATIC_DRAW);
 
@@ -208,6 +212,13 @@ function runOneOutFeedbackTest() {
     gl.enable(gl.RASTERIZER_DISCARD);
     gl.beginTransformFeedback(gl.POINTS);
 
+    debug("Testing deleting an active transform feedback object");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors before testing deletion");
+    gl.deleteTransformFeedback(tf);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Deleting the transform feedback while active should fail, and have no effect");
+    shouldBe("gl.isTransformFeedback(tf)", "true");
+    debug("Resuming testing of single-output transform feedback");
+
     gl.drawArrays(gl.POINTS, 0, 3);
 
     gl.endTransformFeedback();
@@ -224,13 +235,18 @@ function runOneOutFeedbackTest() {
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
     wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, add_expected);
 
+    gl.deleteBuffer(in_buffer);
+    gl.deleteBuffer(out_add_buffer);
+    gl.deleteProgram(program);
+    gl.deleteTransformFeedback(tf);
+
     tf = null;
     program = null;
 }
 
-function runTwoOutFeedbackTest() {
+function runTwoOutputFeedbackTest() {
     debug("");
-    debug("Testing transform feedback processing");
+    debug("Testing two-output transform feedback");
 
     // Build the input and output buffers
     var in_data = [
@@ -243,7 +259,7 @@ function runTwoOutFeedbackTest() {
     gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(in_data), gl.STATIC_DRAW);
 
-    var out_add_buffer = gl.createBuffer();
+    out_add_buffer = gl.createBuffer();
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
     gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length, gl.STATIC_DRAW);
 
@@ -302,6 +318,12 @@ function runTwoOutFeedbackTest() {
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_mul_buffer);
     wtu.checkFloatBuffer(gl, gl.TRANSFORM_FEEDBACK_BUFFER, mul_expected);
 
+    gl.deleteBuffer(in_buffer);
+    gl.deleteBuffer(out_add_buffer);
+    gl.deleteBuffer(out_mul_buffer);
+    gl.deleteProgram(program);
+    gl.deleteTransformFeedback(tf);
+
     tf = null;
     program = null;
 
@@ -322,6 +344,80 @@ function runTwoOutFeedbackTest() {
 
     // Complete the rest of the test asynchronously.
     requestAnimationFrame(completeTransformFeedbackQueryTest);
+}
+
+function runUnboundDeleteTest() {
+    debug("");
+    debug("Testing deleting buffers attached to an unbound transform feedback object");
+
+    // Theoretically it would be possible to verify the result of performing
+    // transform feedback into a deleted buffer object. The buffer would have to
+    // be latched into a VAO as well as into the transform feedback object. In
+    // order to get the results out of the output buffer, it would be necessary
+    // to run transform feedback again, reading from the buffer bound to the
+    // VAO, and writing into a (non-deleted) buffer object latched into the
+    // transform feedback object. It's not possible to arrange things to be able
+    // to copyBufferSubData from the deleted buffer object into a temporary one
+    // for readback.
+
+    // This would be a lot of code to test an unlikely corner case, so instead,
+    // this test verifies simpler behaviors.
+
+    out_add_buffer = gl.createBuffer();
+    const output_buffer_length = Float32Array.BYTES_PER_ELEMENT * 16;
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, output_buffer_length, gl.STATIC_DRAW);
+
+    // Set up the transform feedback object
+    tf = gl.createTransformFeedback();
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_add_buffer);
+
+    // Unbind transform feedback and delete out_add_buffer.
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+    gl.deleteBuffer(out_add_buffer);
+    debug("isBuffer should report false after deletion");
+    shouldBe("gl.isBuffer(out_add_buffer)", "false");
+
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+    debug("Transform feedback object should keep output buffer alive");
+    shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0)", "out_add_buffer");
+    // Deleting the buffer again while the transform feedback is bound shouldn't unbind it.
+    gl.deleteBuffer(out_add_buffer);
+    debug("Deleting output buffer again should be a no-op");
+    shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0)", "out_add_buffer");
+
+    gl.deleteTransformFeedback(tf);
+
+    tf = null;
+    out_add_buffer = null;
+}
+
+function runBoundDeleteTest() {
+    debug("");
+    debug("Testing deleting buffers attached to a bound transform feedback object");
+
+    out_add_buffer = gl.createBuffer();
+    const output_buffer_length = Float32Array.BYTES_PER_ELEMENT * 16;
+    gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
+    gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, output_buffer_length, gl.STATIC_DRAW);
+
+    // Set up the transform feedback object
+    tf = gl.createTransformFeedback();
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+    gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, out_add_buffer);
+
+    // Delete the output buffer
+    gl.deleteBuffer(out_add_buffer);
+
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+    debug("Buffer should have been unbound from active transform feedback");
+    shouldBeNull("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0)");
+
+    gl.deleteTransformFeedback(tf);
+
+    tf = null;
+    out_add_buffer = null;
 }
 
 var retArray;
@@ -347,7 +443,7 @@ function runGetBufferSubDataTest() {
     gl.bindBuffer(gl.ARRAY_BUFFER, in_buffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(in_data), gl.STATIC_DRAW);
 
-    var out_add_buffer = gl.createBuffer();
+    out_add_buffer = gl.createBuffer();
     gl.bindBuffer(gl.TRANSFORM_FEEDBACK_BUFFER, out_add_buffer);
     gl.bufferData(gl.TRANSFORM_FEEDBACK_BUFFER, Float32Array.BYTES_PER_ELEMENT * in_data.length, gl.STATIC_DRAW);
 
@@ -448,8 +544,8 @@ function runVaryingsTest() {
     debug("");
     debug("Testing transform feedback varyings");
 
-    // Create the transform feedback shader. This is explicitly run after runFeedbackTest,
-    // as re-llinking the shader here will test browser caching.
+    // Create the transform feedback shader. This is explicitly run after runTwoOutputFeedbackTest,
+    // as re-linking the shader here will test browser caching.
     program = wtu.setupTransformFeedbackProgram(gl, ["vshader", "fshader"],
         ["out_add", "out_mul"], gl.SEPARATE_ATTRIBS,
         ["in_data"]);

--- a/sdk/tests/conformance2/transform_feedback/transform_feedback.html
+++ b/sdk/tests/conformance2/transform_feedback/transform_feedback.html
@@ -387,6 +387,13 @@ function runUnboundDeleteTest() {
     debug("Deleting output buffer again should be a no-op");
     shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0)", "out_add_buffer");
 
+    // Try unbinding and rebinding the transform feedback object just
+    // to make sure that has no effect on the attached output buffer.
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+    gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
+    debug("Transform feedback object should still keep output buffer alive");
+    shouldBe("gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0)", "out_add_buffer");
+
     gl.deleteTransformFeedback(tf);
 
     tf = null;


### PR DESCRIPTION
Framebuffers and programs are the primary container objects in the
WebGL 1.0 specification. Test deleting attachments of both bound and
unbound framebuffers. Deleting programs and shaders is well tested
elsewhere.

Strengthen the WebGL 2.0-specific transform feedback test to cover
deleting output buffers, as well as active transform feedback objects.

Vertex Array Objects (VAOs), the last container type, are already well
tested by conformance/extensions/oes-vertex-array-object.html and
conformance2/vertex_arrays/vertex-array-object.html .

Regression test for http://crbug.com/739604 .