### PR TITLE
Use glEnumToString helper for format and type names

### DIFF
--- a/sdk/tests/conformance/extensions/oes-texture-half-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float.html
@@ -224,33 +224,6 @@ function getNumberOfChannels(format)
         return 2;
 }
 
-function getFormatName(format)
-{
-    if (format == gl.RGBA)
-        return "RGBA";
-    else if (format == gl.RGB)
-        return "RGB";
-    else if (format == gl.LUMINANCE)
-        return "LUMINANCE";
-    else if (format == gl.ALPHA)
-        return "ALPHA";
-    else if (format == gl.LUMINANCE_ALPHA)
-        return "LUMINANCE_ALPHA";
-}
-
-function getTypeName(type) {
-    if (type === gl.UNSIGNED_BYTE)
-        return "UNSIGNED_BYTE";
-    else if (type === ext.HALF_FLOAT_OES)
-        return "HALF_FLOAT_OES";
-    else if (type === gl.UNSIGNED_SHORT_4_4_4_4)
-        return "UNSIGNED_SHORT_4_4_4_4";
-    else if (type === gl.UNSIGNED_SHORT_5_5_5_1)
-        return "UNSIGNED_SHORT_5_6_5";
-    else if (type === gl.FLOAT)
-        return "FLOAT";
-}
-
 function allocateTexture()
 {
     var texture = gl.createTexture();
@@ -272,7 +245,7 @@ function runTextureCreationTest(extensionEnabled, opt_format, opt_data, opt_expe
     if (!extensionEnabled || !opt_expected)
         expectSuccess = false;
     debug("Testing texture creation with extension " + (extensionEnabled ? "enabled" : "disabled") +
-          ", format " + getFormatName(format) + ", and data " + (data ? "non-null" : "null") +
+          ", format " + wtu.glEnumToString(gl, format) + ", and data " + (data ? "non-null" : "null") +
           ". Expect " + (expectSuccess ? "Success" : "Failure"));
 
     var texture = allocateTexture();
@@ -386,9 +359,9 @@ function runUniqueObjectTest()
 // channels are the ones we expect. If there is a mismatch between the glType and arrayBuffer type,
 // fail the test.
 function verifyReadPixelsColors(red, green, blue, alpha, alphaRGB, glFormat, glType, arrayBufferConstructor) {
-    var typeName = getTypeName(glType);
+    var typeName = wtu.glEnumToString(gl, glType);
 
-    debug(getFormatName(glFormat) + " framebuffer with " + typeName + " readback.");
+    debug(wtu.glEnumToString(gl, glFormat) + " framebuffer with " + typeName + " readback.");
 
     var arrayBuffer = new arrayBufferConstructor(4);
     gl.readPixels(0, 0, 1, 1, gl.RGBA, glType, arrayBuffer);
@@ -437,7 +410,7 @@ function runFramebufferTest() {
     debug("Ensure non-color-renderable formats [LUMINANCE, LUMINANCE_ALPHA, ALPHA] fail.");
     var arrayBufferFloatOutput = new Float32Array(4); // 4 color channels
     [gl.LUMINANCE, gl.LUMINANCE_ALPHA, gl.ALPHA].forEach(function(badFormat) {
-        debug(getFormatName(badFormat) + " framebuffer");
+        debug(wtu.glEnumToString(gl, badFormat) + " framebuffer");
 
         gl.texImage2D(gl.TEXTURE_2D, 0, badFormat, 1, 1, 0, badFormat, ext.HALF_FLOAT_OES, null);
         shouldBe("gl.checkFramebufferStatus(gl.FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT");
@@ -461,7 +434,7 @@ function runFramebufferTest() {
     arrayBufferHalfFloatInput[3] = 0x3A00; // 0.75 in half float
 
     [gl.RGBA, gl.RGB].forEach(function(goodFormat) {
-        debug(getFormatName(goodFormat) + " framebuffer tests");
+        debug(wtu.glEnumToString(gl, goodFormat) + " framebuffer tests");
         debug("");
 
         gl.texImage2D(gl.TEXTURE_2D, 0, goodFormat, 1, 1, 0, goodFormat, ext.HALF_FLOAT_OES, arrayBufferHalfFloatInput);
@@ -479,7 +452,7 @@ function runFramebufferTest() {
 
             var implementationColorReadFormat = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_FORMAT);
             assertMsg(implementationColorReadFormat === gl.RGBA || implementationColorReadFormat === gl.RGB,
-                "IMPLEMENTATION_COLOR_READ_FORMAT should be color renderable: RGBA or RGB. Received: " + getFormatName(implementationColorReadFormat));
+                "IMPLEMENTATION_COLOR_READ_FORMAT should be color renderable: RGBA or RGB. Received: " + wtu.glEnumToString(gl, implementationColorReadFormat));
 
             var implementationColorReadType = gl.getParameter(gl.IMPLEMENTATION_COLOR_READ_TYPE);
 
@@ -494,7 +467,7 @@ function runFramebufferTest() {
                       implementationColorReadType === gl.UNSIGNED_SHORT_5_5_5_1 ||
                       implementationColorReadType === gl.UNSIGNED_SHORT_5_6_5,
                       "IMPLEMENTATION_COLOR_READ_TYPE must be one of UNSIGNED_BYTE, UNSIGNED_SHORT_4_4_4_4, UNSIGNED_SHORT_5_5_5_1, UNSIGNED_SHORT_5_6_5, FLOAT, or HALF_FLOAT_OES. " +
-                      "Received: " + getTypeName(implementationColorReadType));
+                      "Received: " + wtu.glEnumToString(gl, implementationColorReadType));
 
             // Test the RGBA/HALF_FLOAT_OES combination
             if (implementationColorReadFormat === gl.RGBA && implementationColorReadType === ext.HALF_FLOAT_OES) {


### PR DESCRIPTION
Replaces getTypeName and getFormatName with glEnumToString util function.