### PR TITLE
Allow arbitrary enums for readPixels via IMPLEMENTATION_COLOR_READ_*.

### DIFF
--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -152,16 +152,17 @@ function runTest(canvas, antialias) {
   }
 
   function continueTestPart2() {
-    let neverValidFormats = [gl.DEPTH_COMPONENT, desktopGL.R8, gl.RGBA4];
-    let maybeValidFormats = [gl.DEPTH_STENCIL, gl.LUMINANCE, gl.LUMINANCE_ALPHA];
+    let neverValidFormats = [gl.DEPTH_COMPONENT, gl.DEPTH_STENCIL, desktopGL.R8, gl.RGBA4];
+    let maybeValidFormats = [gl.LUMINANCE, gl.LUMINANCE_ALPHA];
     if (contextVersion < 2) {
     // They are valid in WebGL 2 or higher
       maybeValidFormats = maybeValidFormats.concat([desktopGL.RED, desktopGL.RG_INTEGER, desktopGL.RGBA_INTEGER]);
     }
 
-    let maybeValidTypeInfo = [
+    let neverValidTypeInfo = [
       {type: desktopGL.UNSIGNED_INT_24_8,       dest: new Uint32Array(4)}
     ];
+    let maybeValidTypeInfo = [];
     if (contextVersion < 2) {
     // They are valid in WebGL 2 or Higher
       maybeValidTypeInfo = maybeValidTypeInfo.concat([
@@ -180,13 +181,18 @@ function runTest(canvas, antialias) {
       gl.readPixels(0, 0, 1, 1, format, gl.UNSIGNED_BYTE, buf);
       wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Should not be able to read as " + wtu.glEnumToString(gl, format));
     }
-
     for (let format of maybeValidFormats) {
       var buf = new Uint8Array(4);
       gl.readPixels(0, 0, 1, 1, format, gl.UNSIGNED_BYTE, buf);
       wtu.glErrorShouldBe(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], "Should not be able to read as " + wtu.glEnumToString(gl, format));
     }
 
+    for (let info of neverValidTypeInfo) {
+      var type = info.type;
+      var dest = info.dest;
+      gl.readPixels(0, 0, 1, 1, gl.RGBA, type, dest);
+      wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Should not be able to read as " + wtu.glEnumToString(gl, type));
+    }
     for (let info of maybeValidTypeInfo) {
       var type = info.type;
       var dest = info.dest;

--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -152,18 +152,19 @@ function runTest(canvas, antialias) {
   }
 
   function continueTestPart2() {
-    var invalidFormat = [gl.DEPTH_COMPONENT, gl.DEPTH_STENCIL, desktopGL.R8, gl.RGBA4, gl.LUMINANCE, gl.LUMINANCE_ALPHA];
+    let neverValidFormats = [gl.DEPTH_COMPONENT, desktopGL.R8, gl.RGBA4];
+    let maybeValidFormats = [gl.DEPTH_STENCIL, gl.LUMINANCE, gl.LUMINANCE_ALPHA];
     if (contextVersion < 2) {
     // They are valid in WebGL 2 or higher
-      invalidFormat = invalidFormat.concat([desktopGL.RED, desktopGL.RG_INTEGER, desktopGL.RGBA_INTEGER]);
+      maybeValidFormats = maybeValidFormats.concat([desktopGL.RED, desktopGL.RG_INTEGER, desktopGL.RGBA_INTEGER]);
     }
 
-    var invalidTypeInfo = [
+    let maybeValidTypeInfo = [
       {type: desktopGL.UNSIGNED_INT_24_8,       dest: new Uint32Array(4)}
     ];
     if (contextVersion < 2) {
     // They are valid in WebGL 2 or Higher
-      invalidTypeInfo = invalidTypeInfo.concat([
+      maybeValidTypeInfo = maybeValidTypeInfo.concat([
         {type: gl.UNSIGNED_SHORT,                     dest: new Uint16Array(4)},
         {type: gl.SHORT,                              dest: new Int16Array(4)},
         {type: gl.BYTE,                               dest: new Int8Array(4)},
@@ -173,20 +174,24 @@ function runTest(canvas, antialias) {
     }
 
     debug("");
-    debug("check invalid format or type");
-    for (var ff = 0; ff < invalidFormat.length; ++ff) {
-      var format = invalidFormat[ff];
+    debug("check non-default format or type");
+    for (let format of neverValidFormats) {
       var buf = new Uint8Array(4);
       gl.readPixels(0, 0, 1, 1, format, gl.UNSIGNED_BYTE, buf);
       wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Should not be able to read as " + wtu.glEnumToString(gl, format));
     }
 
-    for (var tt = 0; tt < invalidTypeInfo.length; ++tt) {
-      var info = invalidTypeInfo[tt];
+    for (let format of maybeValidFormats) {
+      var buf = new Uint8Array(4);
+      gl.readPixels(0, 0, 1, 1, format, gl.UNSIGNED_BYTE, buf);
+      wtu.glErrorShouldBe(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], "Should not be able to read as " + wtu.glEnumToString(gl, format));
+    }
+
+    for (let info of maybeValidTypeInfo) {
       var type = info.type;
       var dest = info.dest;
       gl.readPixels(0, 0, 1, 1, gl.RGBA, type, dest);
-      wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Should not be able to read as " + wtu.glEnumToString(gl, type));
+      wtu.glErrorShouldBe(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION], "Should not be able to read as " + wtu.glEnumToString(gl, type));
     }
 
     var combinations = [

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3241,7 +3241,13 @@ WebGLRenderingContext includes WebGLRenderingContextBase;
             IMPLEMENTATION_COLOR_READ_FORMAT and IMPLEMENTATION_COLOR_READ_TYPE, respectively. The
             implementation-chosen format may vary depending on the format of the currently bound
             rendering surface. Unsupported combinations of <code>format</code> and <code>type</code>
-            will generate an INVALID_OPERATION error. <br><br>
+            will generate an INVALID_OPERATION error.
+            <br><br>
+
+            Because queries of IMPLEMENTATION_COLOR_READ_[FORMAT,TYPE] may return enums not used
+            elsewhere, providing these enums to <code>readPixels</code> will not necessarily
+            generate INVALID_ENUM.
+            <br><br>
 
             If <code>pixels</code> is null, an INVALID_VALUE error is generated. If
             <code>pixels</code> is non-null, but is not large enough to retrieve all of the pixels


### PR DESCRIPTION
This would allow, for example, BGRA readPixels, even though BGRA would
normally be an INVALID_ENUM for webgl.