### PR TITLE
Stencil mismatch is only an error if there are active stencil bits.

### DIFF
--- a/conformance-suites/1.0.3/conformance/misc/webgl-specific.html
+++ b/conformance-suites/1.0.3/conformance/misc/webgl-specific.html
@@ -43,7 +43,7 @@
 var wtu = WebGLTestUtils;
 description("Tests the few differences between WebGL and GLES2");
 
-var gl = wtu.create3DContext();
+var gl = wtu.create3DContext(undefined, {stencil:true});
 var program = wtu.loadStandardProgram(gl);
 gl.useProgram(program);
 var vertexObject = gl.createBuffer();
@@ -81,10 +81,11 @@ debug("Verify that front/back settings should be the same for stenclMask and ste
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMask(255)");
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.FRONT, 1)");
+gl.enable(gl.STENCIL_TEST);
+shouldBe("!!gl.getParameter(gl.STENCIL_BITS)", "true");
 wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilMaskSeparate(gl.BACK, 1)");
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
-
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFunc(gl.ALWAYS, 0, 255)");
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.drawArrays(gl.TRIANGLES, 0, 0)");
 wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.stencilFuncSeparate(gl.BACK, gl.ALWAYS, 1, 255)");


### PR DESCRIPTION
The 1.0.3 version of webgl-specific.html should request stencil:true, and enable(STENCIL_TEST).