### PR TITLE
drawElements with a zero-byte buffer should call with count=0.

### DIFF
--- a/conformance-suites/2.0.0/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
+++ b/conformance-suites/2.0.0/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
@@ -306,13 +306,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElements(-1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(-1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElements(gl.POINTS, 1, -1, vertices);
+            gl.drawElements(gl.POINTS, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElements(gl.POINTS, 1, gl.FLOAT, vertices);
+            gl.drawElements(gl.POINTS, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -323,7 +323,7 @@ goog.scope(function() {
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElements(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -345,13 +345,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.POINTS);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElements (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElements (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -373,7 +373,7 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) was set.');
-            gl.drawElements(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_OPERATION);
 
             gl.deleteBuffer(bufElements);
@@ -392,13 +392,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElements(-1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(-1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElements(gl.TRIANGLES, 1, -1, vertices);
+            gl.drawElements(gl.TRIANGLES, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElements(gl.TRIANGLES, 1, gl.FLOAT, vertices);
+            gl.drawElements(gl.TRIANGLES, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -409,7 +409,7 @@ goog.scope(function() {
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElements(gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -431,13 +431,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.TRIANGLES);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElements (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElements (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -553,26 +553,26 @@ goog.scope(function() {
             this.expectError(gl.NO_ERROR);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElementsInstanced(-1, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(-1, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElementsInstanced(gl.POINTS, 1, -1, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, -1, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.FLOAT, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.FLOAT, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count or primcount are negative.');
-            gl.drawElementsInstanced(gl.POINTS, -1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, -1, gl.UNSIGNED_BYTE, vertices, 0);
             this.expectError(gl.INVALID_VALUE);
-            gl.drawElementsInstanced(gl.POINTS, 11, gl.UNSIGNED_BYTE, vertices, -1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, -1);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -594,13 +594,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.POINTS);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElementsInstanced (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElementsInstanced (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 // We removed the WebGL1 extension limitation after 2.0.0 snapshot.
                 // See https://github.com/KhronosGroup/WebGL/issues/2419.
                 // So both NO_ERROR and INVALID_OPERATION are allowed in the 2.0.0 snapshot,
@@ -630,7 +630,7 @@ goog.scope(function() {
             this.expectError(gl.NO_ERROR);
 
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) is set.');
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_OPERATION);
 
             gl.deleteBuffer(bufElements);
@@ -653,26 +653,26 @@ goog.scope(function() {
             this.expectError(gl.NO_ERROR);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElementsInstanced(-1, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(-1, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElementsInstanced(gl.TRIANGLES, 1, -1, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, -1, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElementsInstanced(gl.TRIANGLES, 1, gl.FLOAT, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, gl.FLOAT, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count or primcount are negative.');
-            gl.drawElementsInstanced(gl.TRIANGLES, -1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, -1, gl.UNSIGNED_BYTE, vertices, 0);
             this.expectError(gl.INVALID_VALUE);
-            gl.drawElementsInstanced(gl.TRIANGLES, 11, gl.UNSIGNED_BYTE, vertices, -1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, -1);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElementsInstanced(gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -694,13 +694,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.TRIANGLES);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElementsInstanced (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElementsInstanced (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 // We removed the WebGL1 extension limitation after 2.0.0 snapshot.
                 // See https://github.com/KhronosGroup/WebGL/issues/2419.
                 // So both NO_ERROR and INVALID_OPERATION are allowed in the 2.0.0 snapshot,
@@ -731,13 +731,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawRangeElements(-1, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(-1, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, -1, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.FLOAT, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -745,14 +745,14 @@ goog.scope(function() {
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if end < start.');
-            gl.drawRangeElements(gl.POINTS, 1, 0, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.POINTS, 1, 0, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -774,13 +774,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.POINTS);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawRangeElements (gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawRangeElements (gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -804,7 +804,7 @@ goog.scope(function() {
             gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) is set.');
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_OPERATION);
 
             gl.deleteBuffer(bufElements);
@@ -824,13 +824,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawRangeElements(-1, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(-1, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 1, -1, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 1, gl.FLOAT, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -838,14 +838,14 @@ goog.scope(function() {
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if end < start.');
-            gl.drawRangeElements(gl.TRIANGLES, 1, 0, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 1, 0, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -867,13 +867,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.TRIANGLES);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();

--- a/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fNegativeVertexArrayApiTests.js
@@ -306,13 +306,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElements(-1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(-1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElements(gl.POINTS, 1, -1, vertices);
+            gl.drawElements(gl.POINTS, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElements(gl.POINTS, 1, gl.FLOAT, vertices);
+            gl.drawElements(gl.POINTS, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -323,7 +323,7 @@ goog.scope(function() {
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElements(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -345,13 +345,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.POINTS);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElements (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElements (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -373,7 +373,7 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) was set.');
-            gl.drawElements(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_OPERATION);
 
             gl.deleteBuffer(bufElements);
@@ -392,13 +392,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElements(-1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(-1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElements(gl.TRIANGLES, 1, -1, vertices);
+            gl.drawElements(gl.TRIANGLES, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElements(gl.TRIANGLES, 1, gl.FLOAT, vertices);
+            gl.drawElements(gl.TRIANGLES, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -409,7 +409,7 @@ goog.scope(function() {
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElements(gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawElements(gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -431,13 +431,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.TRIANGLES);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElements (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElements (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawElements (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -553,26 +553,26 @@ goog.scope(function() {
             this.expectError(gl.NO_ERROR);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElementsInstanced(-1, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(-1, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElementsInstanced(gl.POINTS, 1, -1, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, -1, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.FLOAT, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.FLOAT, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count or primcount are negative.');
-            gl.drawElementsInstanced(gl.POINTS, -1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, -1, gl.UNSIGNED_BYTE, vertices, 0);
             this.expectError(gl.INVALID_VALUE);
-            gl.drawElementsInstanced(gl.POINTS, 11, gl.UNSIGNED_BYTE, vertices, -1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, -1);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -594,13 +594,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.POINTS);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElementsInstanced (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElementsInstanced (gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -626,7 +626,7 @@ goog.scope(function() {
             this.expectError(gl.NO_ERROR);
 
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) is set.');
-            gl.drawElementsInstanced(gl.POINTS, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.POINTS, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_OPERATION);
 
             gl.deleteBuffer(bufElements);
@@ -649,26 +649,26 @@ goog.scope(function() {
             this.expectError(gl.NO_ERROR);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawElementsInstanced(-1, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(-1, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawElementsInstanced(gl.TRIANGLES, 1, -1, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, -1, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawElementsInstanced(gl.TRIANGLES, 1, gl.FLOAT, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, gl.FLOAT, vertices, 1);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count or primcount are negative.');
-            gl.drawElementsInstanced(gl.TRIANGLES, -1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, -1, gl.UNSIGNED_BYTE, vertices, 0);
             this.expectError(gl.INVALID_VALUE);
-            gl.drawElementsInstanced(gl.TRIANGLES, 11, gl.UNSIGNED_BYTE, vertices, -1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, -1);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawElementsInstanced(gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices, 1);
+            gl.drawElementsInstanced(gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, 1);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -690,13 +690,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.TRIANGLES);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawElementsInstanced (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawElementsInstanced (gl.TRIANGLES, 1, gl.UNSIGNED_BYTE, vertices, 1);
+                gl.drawElementsInstanced (gl.TRIANGLES, 0, gl.UNSIGNED_BYTE, vertices, 1);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -723,13 +723,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawRangeElements(-1, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(-1, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, -1, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.FLOAT, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -737,14 +737,14 @@ goog.scope(function() {
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if end < start.');
-            gl.drawRangeElements(gl.POINTS, 1, 0, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.POINTS, 1, 0, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -766,13 +766,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.POINTS);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawRangeElements (gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawRangeElements (gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();
@@ -796,7 +796,7 @@ goog.scope(function() {
             gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
             bufferedLogToConsole('gl.INVALID_OPERATION is generated if gl.useProgram(null) is set.');
-            gl.drawRangeElements(gl.POINTS, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.POINTS, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_OPERATION);
 
             gl.deleteBuffer(bufElements);
@@ -816,13 +816,13 @@ goog.scope(function() {
             gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, bufElements);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if mode is not an accepted value.');
-            gl.drawRangeElements(-1, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(-1, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_ENUM is generated if type is not one of the accepted values.');
-            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 1, -1, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 0, -1, vertices);
             this.expectError(gl.INVALID_ENUM);
-            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 1, gl.FLOAT, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 0, gl.FLOAT, vertices);
             this.expectError(gl.INVALID_ENUM);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if count is negative.');
@@ -830,14 +830,14 @@ goog.scope(function() {
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_VALUE is generated if end < start.');
-            gl.drawRangeElements(gl.TRIANGLES, 1, 0, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 1, 0, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_VALUE);
 
             bufferedLogToConsole('gl.INVALID_FRAMEBUFFER_OPERATION is generated if the currently bound framebuffer is not framebuffer complete.');
             fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.checkFramebufferStatus(gl.FRAMEBUFFER);
-            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+            gl.drawRangeElements(gl.TRIANGLES, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
             this.expectError(gl.INVALID_FRAMEBUFFER_OPERATION);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.deleteFramebuffer(fbo);
@@ -859,13 +859,13 @@ goog.scope(function() {
                 gl.beginTransformFeedback (gl.TRIANGLES);
                 this.expectError (gl.NO_ERROR);
 
-                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.INVALID_OPERATION);
 
                 gl.bufferData (gl.ELEMENT_ARRAY_BUFFER, 32, gl.STATIC_DRAW);
 
                 gl.pauseTransformFeedback();
-                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 1, gl.UNSIGNED_BYTE, vertices);
+                gl.drawRangeElements (gl.TRIANGLES, 0, 1, 0, gl.UNSIGNED_BYTE, vertices);
                 this.expectError (gl.NO_ERROR);
 
                 gl.endTransformFeedback ();


### PR DESCRIPTION
If validating args, only the arg being validated should have an invalid
value. Thus, don't call drawElements(mode=-1, count=1) with a zero-byte
buffer, or you can get either error.