### PR TITLE
Skip deqp derivate.dfdy highp tests on 2.0 ToT

### DIFF
--- a/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
+++ b/conformance-suites/2.0.0/deqp/framework/common/tcuSkipList.js
@@ -301,9 +301,12 @@ goog.scope(function() {
         _skip("multisample.fbo_max_samples.num_samples_line");
         _skip("multisample.fbo_max_samples.depth");
 
-        _setReason("Removed from native dEQP mustpass. Possibly non-spec-compliant.");
-        // These tests may be overly strict compared to the spec - they fail on Android/Qualcomm (Google Pixel).
-        // crbug.com/695679
+        _setReason("Removed from native dEQP mustpass. Not passable on Adreno.");
+        // These tests have been skipped in native dEQP since 2015:
+        // https://android.googlesource.com/platform/external/deqp/+/ea026b329e6bf73f109cda914c90f08d5f7a5b8d
+        // They do not pass on Android/Qualcomm (Google Pixel 1, Pixel 3).
+        // It's not clear if the tests or the hardware are out-of-spec, but there's nothing we can do about it right now.
+        // See also: crbug.com/695679
         _skip("derivate.dfdy.fbo_float.float_highp");
         _skip("derivate.dfdy.fbo_float.vec2_highp");
         _skip("derivate.dfdy.fbo_float.vec3_highp");

--- a/sdk/tests/deqp/framework/common/tcuSkipList.js
+++ b/sdk/tests/deqp/framework/common/tcuSkipList.js
@@ -206,6 +206,25 @@ goog.scope(function() {
         // Also see conformance2/rendering/blitframebuffer-stencil-only.html for 2.0.1 test.
         _skip("blit.depth_stencil.depth24_stencil8_scale");
         _skip("blit.depth_stencil.depth24_stencil8_stencil_only");
+
+        _setReason("Removed from native dEQP mustpass. Not passable on Adreno.");
+        // These tests have been skipped in native dEQP since 2015:
+        // https://android.googlesource.com/platform/external/deqp/+/ea026b329e6bf73f109cda914c90f08d5f7a5b8d
+        // They do not pass on Android/Qualcomm (Google Pixel 1, Pixel 3).
+        // It's not clear if the tests or the hardware are out-of-spec, but there's nothing we can do about it right now.
+        // See also: crbug.com/695679
+        _skip("derivate.dfdy.fbo_float.float_highp");
+        _skip("derivate.dfdy.fbo_float.vec2_highp");
+        _skip("derivate.dfdy.fbo_float.vec3_highp");
+        _skip("derivate.dfdy.fbo_float.vec4_highp");
+        _skip("derivate.dfdy.nicest.fbo_float.float_highp");
+        _skip("derivate.dfdy.nicest.fbo_float.vec2_highp");
+        _skip("derivate.dfdy.nicest.fbo_float.vec3_highp");
+        _skip("derivate.dfdy.nicest.fbo_float.vec4_highp");
+        _skip("derivate.dfdy.fastest.fbo_float.float_highp");
+        _skip("derivate.dfdy.fastest.fbo_float.vec2_highp");
+        _skip("derivate.dfdy.fastest.fbo_float.vec3_highp");
+        _skip("derivate.dfdy.fastest.fbo_float.vec4_highp");
     } // if (!runSkippedTests)
 
     /*


### PR DESCRIPTION
(These suppressions were already in 2.0.0, this just adds them to
top-of-tree 2.0 as well.)

crbug.com/695679
crbug.com/906745