### PR TITLE
Remove skipCorner logic from texImage *_integer-unsigned_byte tests

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas-sub-rectangle.js
@@ -177,24 +177,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
               sourceSubRectangleString);
 
         var loc;
-        var skipCorner = false;
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             loc = gl.getUniformLocation(program, "face");
-            switch (gl[pixelFormat]) {
-              case gl.RED_INTEGER:
-              case gl.RG_INTEGER:
-              case gl.RGB_INTEGER:
-              case gl.RGBA_INTEGER:
-                // https://github.com/KhronosGroup/WebGL/issues/1819
-                skipCorner = true;
-                break;
-            }
-        }
-
-        if (skipCorner && sourceSubRectangle &&
-                sourceSubRectangle[2] == 1 && sourceSubRectangle[3] == 1) {
-            debug("Test skipped, see WebGL#1819");
-            return;
         }
 
         // Initialize the contents of the source canvas.
@@ -258,12 +242,6 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         // out of the canvas.
         var outputCanvasWidth = gl.drawingBufferWidth;
         var outputCanvasHeight = gl.drawingBufferHeight;
-        var outputCanvasHalfWidth = Math.floor(outputCanvasWidth / 2);
-        var outputCanvasHalfHeight = Math.floor(outputCanvasHeight / 2);
-        var top = 0;
-        var bottom = outputCanvasHeight - outputCanvasHalfHeight;
-        var left = 0;
-        var right = outputCanvasWidth - outputCanvasHalfWidth;
 
         for (var tt = 0; tt < targets.length; ++tt) {
             if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
@@ -272,17 +250,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             // Draw the triangles
             wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
 
-            // Check the four quadrants and make sure they have the right color.
-            // This is split up into four tests only because of the driver bug above.
             var msg = 'should be ' + expected;
-            wtu.checkCanvasRect(gl, left, top, outputCanvasHalfWidth, outputCanvasHalfHeight, expected, msg);
-            if (!skipCorner) {
-                wtu.checkCanvasRect(gl, right, top, outputCanvasHalfWidth, outputCanvasHalfHeight, expected, msg);
-            }
-            wtu.checkCanvasRect(gl, left, bottom, outputCanvasHalfWidth, outputCanvasHalfHeight, expected, msg);
-            if (!skipCorner) {
-                wtu.checkCanvasRect(gl, right, bottom, outputCanvasHalfWidth, outputCanvasHalfHeight, expected, msg);
-            }
+            wtu.checkCanvasRect(gl, 0, 0, outputCanvasWidth, outputCanvasHeight, expected, msg);
         }
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-canvas.js
@@ -291,18 +291,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var bottom = flipY ? (height - halfHeight) : 0;
 
         var loc;
-        var skipCorner = false;
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             loc = gl.getUniformLocation(program, "face");
-            switch (gl[pixelFormat]) {
-              case gl.RED_INTEGER:
-              case gl.RG_INTEGER:
-              case gl.RGB_INTEGER:
-              case gl.RGBA_INTEGER:
-                // https://github.com/KhronosGroup/WebGL/issues/1819
-                skipCorner = true;
-                break;
-            }
         }
 
         for (var tt = 0; tt < targets.length; ++tt) {
@@ -359,10 +349,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
                 // Check the top and bottom halves and make sure they have the right color.
                 debug("Checking " + (flipY ? "top" : "bottom"));
-                wtu.checkCanvasRect(gl, 0, bottom, (skipCorner && flipY) ? halfWidth : width, halfHeight, localRed,
+                wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, localRed,
                                     "shouldBe " + localRed, tolerance);
                 debug("Checking " + (flipY ? "bottom" : "top"));
-                wtu.checkCanvasRect(gl, 0, top, (skipCorner && !flipY) ? halfWidth : width, halfHeight, localGreen,
+                wtu.checkCanvasRect(gl, 0, top, width, halfHeight, localGreen,
                                     "shouldBe " + localGreen, tolerance);
             }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-data.js
@@ -105,23 +105,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
               sourceSubRectangleString);
 
         var loc;
-        var skipCorner = false;
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             loc = gl.getUniformLocation(program, "face");
-            switch (gl[pixelFormat]) {
-              case gl.RED_INTEGER:
-              case gl.RG_INTEGER:
-              case gl.RGB_INTEGER:
-              case gl.RGBA_INTEGER:
-                // https://github.com/KhronosGroup/WebGL/issues/1819
-                skipCorner = true;
-                break;
-            }
-        }
-
-        if (skipCorner && expected.length == 1 && (flipY ^ sourceSubRectangle[1] == 0)) {
-            debug("Test skipped, see WebGL#1819");
-            return;
         }
 
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -213,13 +198,9 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             // Check the top pixel and bottom pixel and make sure they have
             // the right color.
             wtu.checkCanvasRect(gl, left, top, halfWidth, halfHeight, tl, "shouldBe " + tl);
-            if (!skipCorner) {
-                wtu.checkCanvasRect(gl, right, top, halfWidth, halfHeight, tr, "shouldBe " + tr);
-            }
+            wtu.checkCanvasRect(gl, right, top, halfWidth, halfHeight, tr, "shouldBe " + tr);
             wtu.checkCanvasRect(gl, left, bottom, halfWidth, halfHeight, bl, "shouldBe " + bl);
-            if (!skipCorner) {
-                wtu.checkCanvasRect(gl, right, bottom, halfWidth, halfHeight, br, "shouldBe " + br);
-            }
+            wtu.checkCanvasRect(gl, right, bottom, halfWidth, halfHeight, br, "shouldBe " + br);
         }
     }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-webgl-canvas.js
@@ -176,18 +176,8 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         var bottom = flipY ? 0 : (height - halfHeight);
 
         var loc;
-        var skipCorner = false;
         if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
             loc = gl.getUniformLocation(program, "face");
-            switch (gl[pixelFormat]) {
-              case gl.RED_INTEGER:
-              case gl.RG_INTEGER:
-              case gl.RGB_INTEGER:
-              case gl.RGBA_INTEGER:
-                // https://github.com/KhronosGroup/WebGL/issues/1819
-                skipCorner = true;
-                break;
-            }
         }
 
         for (var tt = 0; tt < targets.length; ++tt) {
@@ -199,10 +189,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
             // Check the top and bottom halves and make sure they have the right color.
             debug("Checking " + (flipY ? "top" : "bottom"));
-            wtu.checkCanvasRect(gl, 0, bottom, (skipCorner && !flipY) ? halfWidth : width, halfHeight, redColor,
+            wtu.checkCanvasRect(gl, 0, bottom, width, halfHeight, redColor,
                     "shouldBe " + redColor);
             debug("Checking " + (flipY ? "bottom" : "top"));
-            wtu.checkCanvasRect(gl, 0, top, (skipCorner && flipY) ? halfWidth : width, halfHeight, greenColor,
+            wtu.checkCanvasRect(gl, 0, top, width, halfHeight, greenColor,
                     "shouldBe " + greenColor);
         }
 

--- a/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-with-image-bitmap-utils.js
@@ -122,13 +122,15 @@ function runOneIterationImageBitmapTest(useTexSubImage, bindingTarget, program, 
 
     var width = gl.canvas.width;
     var halfWidth = Math.floor(width / 2);
-    var quaterWidth = Math.floor(halfWidth / 2);
+    var quarterWidth = Math.floor(halfWidth / 2);
     var height = gl.canvas.height;
     var halfHeight = Math.floor(height / 2);
-    var quaterHeight = Math.floor(halfHeight / 2);
+    var quarterHeight = Math.floor(halfHeight / 2);
 
-    var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-    var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
+    var top = flipY ? quarterHeight : (height - halfHeight + quarterHeight);
+    var bottom = flipY ? (height - halfHeight + quarterHeight) : quarterHeight;
+    var left = quarterWidth;
+    var right = halfWidth + quarterWidth / 2;
 
     var tl = redColor;
     var tr = premultiplyAlpha ? ((optionsVal.alpha == 0.5) ? halfRed : (optionsVal.alpha == 1) ? redColor : blackColor) : redColor;
@@ -136,18 +138,8 @@ function runOneIterationImageBitmapTest(useTexSubImage, bindingTarget, program, 
     var br = premultiplyAlpha ? ((optionsVal.alpha == 0.5) ? halfGreen : (optionsVal.alpha == 1) ? greenColor : blackColor) : greenColor;
 
     var loc;
-    var skipCorner = false;
     if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
         loc = gl.getUniformLocation(program, "face");
-        switch (pixelFormat) {
-          case gl.RED_INTEGER:
-          case gl.RG_INTEGER:
-          case gl.RGB_INTEGER:
-          case gl.RGBA_INTEGER:
-            // https://github.com/KhronosGroup/WebGL/issues/1819
-            skipCorner = true;
-            break;
-        }
     }
 
     var tolerance = 10;
@@ -161,15 +153,11 @@ function runOneIterationImageBitmapTest(useTexSubImage, bindingTarget, program, 
         // Check the top pixel and bottom pixel and make sure they have
         // the right color.
         bufferedLogToConsole("Checking " + (flipY ? "top" : "bottom"));
-        wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl, tolerance);
-        if (!skipCorner && !flipY) {
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
-        }
+        wtu.checkCanvasRect(gl, left, bottom, 2, 2, tl, "shouldBe " + tl, tolerance);
+        wtu.checkCanvasRect(gl, right, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
         bufferedLogToConsole("Checking " + (flipY ? "bottom" : "top"));
-        wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl, tolerance);
-        if (!skipCorner && flipY) {
-            wtu.checkCanvasRect(gl, halfWidth + quaterWidth, top, 2, 2, br, "shouldBe " + br, tolerance);
-        }
+        wtu.checkCanvasRect(gl, left, top, 2, 2, bl, "shouldBe " + bl, tolerance);
+        wtu.checkCanvasRect(gl, right, top, 2, 2, br, "shouldBe " + br, tolerance);
     }
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
 }
@@ -331,13 +319,13 @@ function runOneIterationImageBitmapTestSubSource(useTexSubImage, bindingTarget, 
 
     var width = gl.canvas.width;
     var halfWidth = Math.floor(width / 2);
-    var quaterWidth = Math.floor(halfWidth / 2);
+    var quarterWidth = Math.floor(halfWidth / 2);
     var height = gl.canvas.height;
     var halfHeight = Math.floor(height / 2);
-    var quaterHeight = Math.floor(halfHeight / 2);
+    var quarterHeight = Math.floor(halfHeight / 2);
 
-    var top = flipY ? quaterHeight : (height - halfHeight + quaterHeight);
-    var bottom = flipY ? (height - halfHeight + quaterHeight) : quaterHeight;
+    var top = flipY ? quarterHeight : (height - halfHeight + quarterHeight);
+    var bottom = flipY ? (height - halfHeight + quarterHeight) : quarterHeight;
 
 
     var tolerance = 10;
@@ -348,11 +336,11 @@ function runOneIterationImageBitmapTestSubSource(useTexSubImage, bindingTarget, 
     // the right color.
     // For right side, check pixels closer to left to avoid border in the video tests.
     bufferedLogToConsole("Checking " + (flipY ? "top" : "bottom"));
-    wtu.checkCanvasRect(gl, quaterWidth, bottom, 2, 2, tl, "shouldBe " + tl, tolerance);
-    wtu.checkCanvasRect(gl, halfWidth + quaterWidth / 2, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
+    wtu.checkCanvasRect(gl, quarterWidth, bottom, 2, 2, tl, "shouldBe " + tl, tolerance);
+    wtu.checkCanvasRect(gl, halfWidth + quarterWidth / 2, bottom, 2, 2, tr, "shouldBe " + tr, tolerance);
     bufferedLogToConsole("Checking " + (flipY ? "bottom" : "top"));
-    wtu.checkCanvasRect(gl, quaterWidth, top, 2, 2, bl, "shouldBe " + bl, tolerance);
-    wtu.checkCanvasRect(gl, halfWidth + quaterWidth / 2, top, 2, 2, br, "shouldBe " + br, tolerance);
+    wtu.checkCanvasRect(gl, quarterWidth, top, 2, 2, bl, "shouldBe " + bl, tolerance);
+    wtu.checkCanvasRect(gl, halfWidth + quarterWidth / 2, top, 2, 2, br, "shouldBe " + br, tolerance);
 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
 }


### PR DESCRIPTION
Seems to no longer be necessary to skip these cases/checks!
Tested on 10.13.6 (Chrome, Firefox) and 10.12.6 (Chrome).

crbug.com/665197