### PR TITLE
Disable incorrect builtinprecision tests

### DIFF
--- a/sdk/tests/deqp/functional/gles3/00_test_list.txt
+++ b/sdk/tests/deqp/functional/gles3/00_test_list.txt
@@ -1,4 +1,8 @@
---min-version 2.0.1 builtinprecision/00_test_list.txt
+# The builtinprecision tests are not correct. Errors were introduced when
+# porting the tests from C++ to JavaScript. Tests that fail here pass in
+# the C++ version of dEQP ported to WASM. The tests are disabled here until
+# they can be fixed.
+# --min-version 2.0.1 builtinprecision/00_test_list.txt
 draw/00_test_list.txt
 fbocolorbuffer/00_test_list.txt
 fboinvalidate/00_test_list.txt


### PR DESCRIPTION
The builtinprecision tests are not correct. Errors were introduced when porting the tests from C++ to JavaScript. Tests that fail here pass in the C++ version of dEQP ported to WASM. This change disables the tests until they can be fixed.