### PR TITLE
add more ext-float-blend tests

### DIFF
--- a/sdk/tests/conformance2/extensions/ext-float-blend.html
+++ b/sdk/tests/conformance2/extensions/ext-float-blend.html
@@ -30,6 +30,8 @@ var ext = null;
     debug("");
     debug("Testing that float32 blending is forbidden without EXT_float_blend");
     testExtFloatBlend(false, gl.RGBA32F);
+    testExtFloatBlendMRT(false);
+    testExtFloatBlendNonFloat32Type(false);
 
     const floatBlend = gl.getExtension("EXT_float_blend");
     if (!floatBlend) {
@@ -40,6 +42,8 @@ var ext = null;
     debug("");
     debug("Testing that float32 blending is allowed with EXT_float_blend");
     testExtFloatBlend(true, gl.RGBA32F);
+    testExtFloatBlendMRT(true);
+    testExtFloatBlendNonFloat32Type(true);
 })();
 
 debug("");

--- a/sdk/tests/js/tests/ext-float-blend.js
+++ b/sdk/tests/js/tests/ext-float-blend.js
@@ -19,7 +19,7 @@ void main()
 }
 `;
 const trivialFsMrtSrc = `#version 300 es
-precision lowp float;
+precision mediump float;
 layout(location = 0) out vec4 o_color0;
 layout(location = 1) out vec4 o_color1;
 void main()

--- a/sdk/tests/js/tests/ext-float-blend.js
+++ b/sdk/tests/js/tests/ext-float-blend.js
@@ -12,6 +12,22 @@ void main()
     gl_FragColor = vec4(0,1,0,1);
 }
 `;
+const trivialVsMrtSrc = `#version 300 es
+void main()
+{
+    gl_Position = vec4(0,0,0,1);
+}
+`;
+const trivialFsMrtSrc = `#version 300 es
+precision lowp float;
+layout(location = 0) out vec4 o_color0;
+layout(location = 1) out vec4 o_color1;
+void main()
+{
+    o_color0 = vec4(1, 0, 0, 1);
+    o_color1 = vec4(0, 1, 0, 1);
+}
+`;
 
 function testExtFloatBlend(shouldBlend, internalFormat) {
     const prog = wtu.setupProgram(gl, [trivialVsSrc, trivialFsSrc]);
@@ -34,6 +50,118 @@ function testExtFloatBlend(shouldBlend, internalFormat) {
     gl.drawArrays(gl.POINTS, 0, 1);
     wtu.glErrorShouldBe(gl, shouldBlend ? 0 : gl.INVALID_OPERATION,
                         'Float32 blending is ' + (shouldBlend ? '' : 'not ') + 'allowed ');
+    
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(tex);
+}
+
+function testExtFloatBlendMRT(shouldBlend) {
+    const prog = wtu.setupProgram(gl, [trivialVsMrtSrc, trivialFsMrtSrc]);
+    gl.useProgram(prog);
+
+    const tex1 = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex1);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    
+    const tex2 = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex2);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+    const texF1 = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texF1);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, 1, 1, 0, gl.RGBA, gl.FLOAT, null);
+    
+    const texF2 = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texF2);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, 1, 1, 0, gl.RGBA, gl.FLOAT, null);
+
+    const fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex1, 0);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, tex2, 0);
+    shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1]);
+
+    gl.enable(gl.BLEND);
+    
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, 0, 'No Float32 color attachment');
+
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texF1, 0);
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, shouldBlend ? 0 : gl.INVALID_OPERATION,
+                        'Float32 blending is ' + (shouldBlend ? '' : 'not ') + 'allowed ');
+
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, texF2, 0);
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, shouldBlend ? 0 : gl.INVALID_OPERATION,
+                        'Float32 blending is ' + (shouldBlend ? '' : 'not ') + 'allowed ');
+
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex1, 0);
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, shouldBlend ? 0 : gl.INVALID_OPERATION,
+                        'Float32 blending is ' + (shouldBlend ? '' : 'not ') + 'allowed ');
+
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0]);
+    shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, 0, 'Float32 color attachment draw buffer is not enabled');
+
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1]);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, tex2, 0);
+    shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, 0, 'No Float32 color attachment');
+
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(tex1);
+    gl.deleteTexture(tex2);
+    gl.deleteTexture(texF1);
+    gl.deleteTexture(texF2);
+}
+
+function testExtFloatBlendNonFloat32Type(shouldBlend) {
+    const prog = wtu.setupProgram(gl, [trivialVsSrc, trivialFsSrc]);
+    gl.useProgram(prog);
+
+    gl.enable(gl.BLEND);
+
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, 1, 1, 0, gl.RGBA, gl.FLOAT, null);
+
+    const fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+    shouldBe('gl.checkFramebufferStatus(gl.FRAMEBUFFER)', 'gl.FRAMEBUFFER_COMPLETE');
+
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, shouldBlend ? 0 : gl.INVALID_OPERATION,
+                        'Float32 blending is ' + (shouldBlend ? '' : 'not ') + 'allowed ');
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.drawArrays(gl.POINTS, 0, 1);
+    wtu.glErrorShouldBe(gl, 0, 'UNSIGNED_BYTE should blend anyway');
+
+    const formats = [
+        [gl.RGBA16F, gl.RGBA, gl.HALF_FLOAT],
+        [gl.RGBA16F, gl.RGBA, gl.FLOAT],
+        [gl.RG16F, gl.RG, gl.FLOAT],
+        [gl.R16F, gl.RED, gl.FLOAT],
+        [gl.R11F_G11F_B10F, gl.RGB, gl.FLOAT]
+    ];
+
+    for (let i = 0, len = formats.length; i < len; i++) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, formats[i][0], 1, 1, 0, formats[i][1], formats[i][2], null);
+        gl.drawArrays(gl.POINTS, 0, 1);
+        wtu.glErrorShouldBe(gl, 0, 'Any other float type which is not 32-bit-Float should blend anyway');
+    }
+
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(tex);
 }
 
 /*

--- a/sdk/tests/js/tests/ext-float-blend.js
+++ b/sdk/tests/js/tests/ext-float-blend.js
@@ -50,7 +50,7 @@ function testExtFloatBlend(shouldBlend, internalFormat) {
     gl.drawArrays(gl.POINTS, 0, 1);
     wtu.glErrorShouldBe(gl, shouldBlend ? 0 : gl.INVALID_OPERATION,
                         'Float32 blending is ' + (shouldBlend ? '' : 'not ') + 'allowed ');
-    
+
     gl.deleteFramebuffer(fb);
     gl.deleteTexture(tex);
 }
@@ -62,7 +62,7 @@ function testExtFloatBlendMRT(shouldBlend) {
     const tex1 = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex1);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-    
+
     const tex2 = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex2);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
@@ -70,7 +70,7 @@ function testExtFloatBlendMRT(shouldBlend) {
     const texF1 = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texF1);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, 1, 1, 0, gl.RGBA, gl.FLOAT, null);
-    
+
     const texF2 = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texF2);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, 1, 1, 0, gl.RGBA, gl.FLOAT, null);
@@ -84,7 +84,7 @@ function testExtFloatBlendMRT(shouldBlend) {
     gl.drawBuffers([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1]);
 
     gl.enable(gl.BLEND);
-    
+
     gl.drawArrays(gl.POINTS, 0, 1);
     wtu.glErrorShouldBe(gl, 0, 'No Float32 color attachment');
 


### PR DESCRIPTION
Added more ext-float-blend tests, similar to those new tests added to angle.
- testExtFloatBlendMRT
- testExtFloatBlendNonFloat32Type

Follow up work for this one: https://github.com/khronosgroup/webgl/pull/2779