### PR TITLE
Remove temp_externs/html5.js's references to 'mozHidden' and 'mozVisibilityState'

### DIFF
--- a/conformance-suites/2.0.0/deqp/temp_externs/html5.js
+++ b/conformance-suites/2.0.0/deqp/temp_externs/html5.js
@@ -2818,11 +2818,6 @@ Document.prototype.visibilityState;
 /**
  * @type {string}
  */
-Document.prototype.mozVisibilityState;
-
-/**
- * @type {string}
- */
 Document.prototype.webkitVisibilityState;
 
 /**
@@ -2835,11 +2830,6 @@ Document.prototype.msVisibilityState;
  * @type {boolean}
  */
 Document.prototype.hidden;
-
-/**
- * @type {boolean}
- */
-Document.prototype.mozHidden;
 
 /**
  * @type {boolean}

--- a/sdk/tests/deqp/temp_externs/html5.js
+++ b/sdk/tests/deqp/temp_externs/html5.js
@@ -2818,11 +2818,6 @@ Document.prototype.visibilityState;
 /**
  * @type {string}
  */
-Document.prototype.mozVisibilityState;
-
-/**
- * @type {string}
- */
 Document.prototype.webkitVisibilityState;
 
 /**
@@ -2835,11 +2830,6 @@ Document.prototype.msVisibilityState;
  * @type {boolean}
  */
 Document.prototype.hidden;
-
-/**
- * @type {boolean}
- */
-Document.prototype.mozHidden;
 
 /**
  * @type {boolean}


### PR DESCRIPTION
fixes #2825