### PR TITLE
 get-buffer-sub-data-validity.html: asyncify + regression test for crbug.com/941930

### DIFF
--- a/sdk/tests/conformance2/buffers/get-buffer-sub-data-validity.html
+++ b/sdk/tests/conformance2/buffers/get-buffer-sub-data-validity.html
@@ -89,23 +89,22 @@ function resolvable() {
     return promise;
 }
 
-function fence() {
-    const promise = resolvable();
+function wait() {
+    return new Promise(res => {
+        setTimeout(res, 0);
+    });
+}
 
+async function fence() {
     const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
     gl.flush();
-    function check() {
-        const status = gl.clientWaitSync(sync, 0, 0);
-        if (status == gl.ALREADY_SIGNALED || status == gl.CONDITION_SATISFIED) {
-            gl.deleteSync(sync);
-            promise.resolve();
-        } else {
-            setTimeout(check, 0);
-        }
-    }
-    setTimeout(check, 0);
 
-    return promise;
+    let status;
+    do {
+        await wait();
+        status = gl.clientWaitSync(sync, 0, 0);
+    } while (status != gl.ALREADY_SIGNALED && status != gl.CONDITION_SATISIFIED);
+    gl.deleteSync(sync);
 }
 
 function checkGetBufferSubData(err, data) {
@@ -143,120 +142,105 @@ function copyBufferUsingTransformFeedback(src, dst) {
     gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
 }
 
-Promise.resolve()
-    .then(() => {
-        debug("");
-        debug("write-read");
-        gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        checkGetBufferSubData(gl.NO_ERROR, "srcData");
-    })
-    .then(() => {
-        debug("");
-        debug("fence-wait-write-read");
-        return fence().then(() => {
-            gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-            checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-read-fence-wait");
-        gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        return fence();
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-fence-wait-read");
-        gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        fence();
-        return fence().then(() => {
-            checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-wait-read");
-        gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        return fence().then(() => {
-            checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-wait-write-read");
-        gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        return fence().then(() => {
-            gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-            checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-write-wait-read");
-        gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+(async () => {
+    debug("");
+    debug("write-read");
+    gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("fence-wait-write-read");
+    await fence();
+    gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("write-read-fence-wait");
+    gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+    await fence();
+
+    debug("");
+    debug("write-fence-fence-wait-read");
+    gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    fence(); // no await
+    await fence();
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("write-fence-wait-read");
+    gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    await fence();
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("write-fence-wait-write-read");
+    gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    await fence();
+    gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("write-fence-write-wait-read");
+    gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    {
         const p = fence();
         gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        return p.then(() => {
-            checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-transformfeedback-wait-read");
-        gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+        await p;
+    }
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("write-fence-transformfeedback-wait-read");
+    gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    {
         const p = fence();
         gl.bindBuffer(gl.COPY_WRITE_BUFFER, null);
         copyBufferUsingTransformFeedback(srcBuffer, readbackBuffer);
         gl.bindBuffer(gl.COPY_WRITE_BUFFER, readbackBuffer);
-        return p.then(() => {
-            checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-unbind-fence-wait-bind-read");
-        gl.bindBuffer(gl.COPY_WRITE_BUFFER, null);
-        gl.bindBuffer(gl.ARRAY_BUFFER, readbackBuffer);
-        gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.ARRAY_BUFFER, 0, 0, 8);
-        gl.bindBuffer(gl.ARRAY_BUFFER, badBuffer);
-        return fence().then(() => {
-            gl.bindBuffer(gl.COPY_WRITE_BUFFER, readbackBuffer);
-            checkGetBufferSubData(gl.NO_ERROR, "srcData");
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-wait-delete-read");
-        gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        return fence().then(() => {
-            deleteReadbackBuffer();
-            checkGetBufferSubData(gl.INVALID_OPERATION, "noData");
-            recreateReadbackBuffer();
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-delete-wait-read");
-        gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+        await p;
+    }
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("write-unbind-fence-wait-bind-read");
+    gl.bindBuffer(gl.COPY_WRITE_BUFFER, null);
+    gl.bindBuffer(gl.ARRAY_BUFFER, readbackBuffer);
+    gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.ARRAY_BUFFER, 0, 0, 8);
+    gl.bindBuffer(gl.ARRAY_BUFFER, badBuffer);
+    await fence();
+    gl.bindBuffer(gl.COPY_WRITE_BUFFER, readbackBuffer);
+    checkGetBufferSubData(gl.NO_ERROR, "srcData");
+
+    debug("");
+    debug("write-fence-wait-delete-read");
+    gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    await fence();
+    deleteReadbackBuffer();
+    checkGetBufferSubData(gl.INVALID_OPERATION, "noData");
+    recreateReadbackBuffer();
+
+    debug("");
+    debug("write-fence-delete-wait-read");
+    gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    {
         const p = fence();
         deleteReadbackBuffer();
-        return p.then(() => {
-            checkGetBufferSubData(gl.INVALID_OPERATION, "noData");
-            recreateReadbackBuffer();
-        });
-    })
-    .then(() => {
-        debug("");
-        debug("write-fence-delete-wait-read");
-        gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
-        deleteReadbackBuffer();
-        return fence().then(() => {
-            checkGetBufferSubData(gl.INVALID_OPERATION, "noData");
-            recreateReadbackBuffer();
-        });
-    })
-    .then(finishTest);
+        await p;
+    }
+    checkGetBufferSubData(gl.INVALID_OPERATION, "noData");
+    recreateReadbackBuffer();
+
+    debug("");
+    debug("write-fence-delete-wait-read");
+    gl.copyBufferSubData(gl.ARRAY_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+    deleteReadbackBuffer();
+    await fence();
+    checkGetBufferSubData(gl.INVALID_OPERATION, "noData");
+    recreateReadbackBuffer();
+
+    finishTest();
+})();
 
 var successfullyParsed = true;
 </script>

--- a/sdk/tests/conformance2/buffers/get-buffer-sub-data-validity.html
+++ b/sdk/tests/conformance2/buffers/get-buffer-sub-data-validity.html
@@ -239,6 +239,27 @@ function copyBufferUsingTransformFeedback(src, dst) {
     checkGetBufferSubData(gl.INVALID_OPERATION, "noData");
     recreateReadbackBuffer();
 
+    // crbug.com/941930
+    {
+        debug("");
+        debug("write-delete-recreate-fence-wait-read");
+        gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+        deleteReadbackBuffer();
+        recreateReadbackBuffer();
+        await fence();
+        checkGetBufferSubData(gl.NO_ERROR, "noData");
+
+        debug("");
+        debug("write-delete-fence-wait-read");
+        gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 8);
+        {
+            const p = fence();
+            deleteReadbackBuffer();
+            await p;
+        }
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+    }
+
     finishTest();
 })();
 


### PR DESCRIPTION
This adds a minimal regression test for crbug.com/941930, where several things were being incorrectly managed in the nonblocking readback path in Chrome's passthrough command decoder.

It also `async`ifies this test to make it more readable.

I recommend reviewing the two commits separately - the first should make no functional changes.