### PR TITLE
Implicitly enable EXT_float_blend and promote it to Community Approved.

### DIFF
--- a/extensions/EXT_float_blend/extension.xml
+++ b/extensions/EXT_float_blend/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_float_blend/">
+<extension href="EXT_float_blend/">
   <name>EXT_float_blend</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list">WebGL
@@ -34,6 +34,20 @@
         WEBGL_color_buffer_float</a> extensions must be enabled.</p>
       </feature>
     </features>
+    <features>
+      On supported systems, this extension is implicitly enabled when any of the
+      following extensions are enabled:
+      <ul>
+        <li><a href="http://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float">
+        EXT_color_buffer_float</a>
+        <li><a href="http://www.khronos.org/registry/webgl/extensions/OES_texture_float">
+        OES_texture_float</a>
+        <li><a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float">
+        WEBGL_color_buffer_float</a>
+      </ul>
+      <p>
+      This preserves functionality for content written before this extension was exposed.
+    </features>
   </overview>
 
   <idl xml:space="preserve">
@@ -51,8 +65,13 @@ interface EXT_float_blend {
       <change>Promoted to draft status after discussion on public_webgl.</change>
     </revision>
 
-    <revision date="2018/02/01">
+    <revision date="2019/02/01">
       <change>Backport to WebGL 1.</change>
     </revision>
+
+    <revision date="2019/03/15">
+      <change>Implicitly enable to preserve existing content.</change>
+      <change>Promote to Community Approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/sdk/tests/conformance/extensions/oes-texture-float.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float.html
@@ -131,8 +131,8 @@ if (!gl) {
                 runFramebufferTest();
 
                 debug("");
-                debug("Testing that float32 blending fails with EXT_float_blend.");
-                testExtFloatBlend(false, gl.RGBA);
+                debug("Test float32 blending without EXT_float_blend.");
+                testExtFloatBlend(gl.RGBA);
 
                 debug("");
                 debug("Testing that float32 blending succeeds with EXT_float_blend.");
@@ -140,7 +140,7 @@ if (!gl) {
                     testPassed("No EXT_float_blend support -- this is legal");
                     return;
                 }
-                testExtFloatBlend(true, gl.RGBA);
+                testExtFloatBlend(gl.RGBA);
             }
         })();
 

--- a/sdk/tests/conformance2/extensions/ext-float-blend.html
+++ b/sdk/tests/conformance2/extensions/ext-float-blend.html
@@ -28,10 +28,10 @@ var ext = null;
     }
 
     debug("");
-    debug("Testing that float32 blending is forbidden without EXT_float_blend");
-    testExtFloatBlend(false, gl.RGBA32F);
-    testExtFloatBlendMRT(false);
-    testExtFloatBlendNonFloat32Type(false);
+    debug("Testing float32 blending without EXT_float_blend");
+    testExtFloatBlend(gl.RGBA32F);
+    testExtFloatBlendMRT();
+    testExtFloatBlendNonFloat32Type();
 
     const floatBlend = gl.getExtension("EXT_float_blend");
     if (!floatBlend) {
@@ -41,9 +41,9 @@ var ext = null;
 
     debug("");
     debug("Testing that float32 blending is allowed with EXT_float_blend");
-    testExtFloatBlend(true, gl.RGBA32F);
-    testExtFloatBlendMRT(true);
-    testExtFloatBlendNonFloat32Type(true);
+    testExtFloatBlend(gl.RGBA32F);
+    testExtFloatBlendMRT();
+    testExtFloatBlendNonFloat32Type();
 })();
 
 debug("");

--- a/sdk/tests/js/tests/ext-float-blend.js
+++ b/sdk/tests/js/tests/ext-float-blend.js
@@ -29,7 +29,9 @@ void main()
 }
 `;
 
-function testExtFloatBlend(shouldBlend, internalFormat) {
+function testExtFloatBlend(internalFormat) {
+    const shouldBlend = gl.getSupportedExtensions().indexOf('EXT_float_blend') != -1;
+
     const prog = wtu.setupProgram(gl, [trivialVsSrc, trivialFsSrc]);
     gl.useProgram(prog);
 
@@ -55,7 +57,9 @@ function testExtFloatBlend(shouldBlend, internalFormat) {
     gl.deleteTexture(tex);
 }
 
-function testExtFloatBlendMRT(shouldBlend) {
+function testExtFloatBlendMRT() {
+    const shouldBlend = gl.getSupportedExtensions().indexOf('EXT_float_blend') != -1;
+
     const prog = wtu.setupProgram(gl, [trivialVsMrtSrc, trivialFsMrtSrc]);
     gl.useProgram(prog);
 
@@ -123,7 +127,9 @@ function testExtFloatBlendMRT(shouldBlend) {
     gl.deleteTexture(texF2);
 }
 
-function testExtFloatBlendNonFloat32Type(shouldBlend) {
+function testExtFloatBlendNonFloat32Type() {
+    const shouldBlend = gl.getSupportedExtensions().indexOf('EXT_float_blend') != -1;
+
     const prog = wtu.setupProgram(gl, [trivialVsSrc, trivialFsSrc]);
     gl.useProgram(prog);
 


### PR DESCRIPTION
Update tests to require implicit activation accordingly.