### PR TITLE
Test compressed texture upload from (a subrange of) a PBO

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc.html
@@ -157,6 +157,11 @@ function runTestExtension() {
     testDXT1_RGBA();
     testDXT3_RGBA();
     testDXT5_RGBA();
+
+    // Test compressed PBOs with a single format
+    if (contextVersion >= 2) {
+        testDXT5_RGBA_PBO();
+    }
 }
 
 function testDXT1_RGB() {
@@ -607,6 +612,46 @@ function testDXTTexture(test, useTexStorage) {
             compareRect(width, height, test.channels, uncompressedData, "LINEAR");
         }
     }
+}
+
+function testDXT5_RGBA_PBO() {
+    var width = 8;
+    var height = 8;
+    var channels = 4;
+    var data = img_8x8_rgba_dxt5;
+    var format = ext.COMPRESSED_RGBA_S3TC_DXT5_EXT;
+    var uncompressedData = uncompressDXT(width, height, data, format);
+
+    var tex = gl.createTexture();
+
+    // First, PBO size = image size
+    var pbo1 = gl.createBuffer();
+    gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pbo1);
+    gl.bufferData(gl.PIXEL_UNPACK_BUFFER, data, gl.STATIC_DRAW);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uploading a PBO");
+
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texStorage2D(gl.TEXTURE_2D, 1, format, width, height);
+    gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, format, data.length, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uploading a texture from a PBO");
+
+    gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad");
+    compareRect(width, height, channels, uncompressedData, "NEAREST");
+
+    // Second, image is just a subrange of the PBO
+    var pbo2 = gl.createBuffer();
+    gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, pbo2);
+    gl.bufferData(gl.PIXEL_UNPACK_BUFFER, data.length*3, gl.STATIC_DRAW);
+    gl.bufferSubData(gl.PIXEL_UNPACK_BUFFER, data.length, data);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uploading a PBO subrange");
+    gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, format, data.length, data.length);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "uploading a texture from a PBO subrange");
+    gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, null);
+    wtu.clearAndDrawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad");
+    compareRect(width, height, channels, uncompressedData, "NEAREST");
 }
 
 function compareRect(width, height, channels, expectedData, filteringMode) {


### PR DESCRIPTION
As requested by @kenrussell in #2745 (so this should close it?).

Repeating the original issue here for clarity -- I discovered an overly restrictive checks in Firefox for compressed texture uploads from a PBO, where it allowed an image to be uploaded from a PBO with a non-zero initial offset, but always required the remaining size in the PBO to be equal to image size. This breaks for example in case a PBO contains more images and one wants to upload just one of them. The same works correctly under Chromium-based browsers.

This PR adds two tests:

- first, where the PBO size = image size, uploading the whole buffer contents to a texture (to test the common case, since there was no PBO+compression test before I think -- passes in both Chrome and Firefox)
- second, where the PBO size = 3 times image size, uploading just the middle image to a texture (passes in Chrome, fails in Firefox)

I first tried to add this PBO test to `testDXTTexture()` so it gets tested for DXT1, DXT3, etc., but that felt a bit too much, so I extracted relevant code out and testing just on a single format, assuming browser implementation sanity -- if PBOs work with one format, they should for the others as well. Hope that's okay, if you have a better idea, let me know.

**Note:** it's been a while since I wrote raw GL code and it's the first time I'm writing WebGL directly (always went through Emscripten with an engine on top before), so please point any silly mistakes I did, I'll happily correct them :)