### PR TITLE
Renaming WEBGL_multiview to OVR_multiview2 spec and test changes

### DIFF
--- a/extensions/OVR_multiview2/extension.xml
+++ b/extensions/OVR_multiview2/extension.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0"?>
 
-<draft href="WEBGL_multiview/">
-  <name>WEBGL_multiview</name>
+<draft href="OVR_multiview2/">
+  <name>OVR_multiview2</name>
   <contact>
     <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL working group</a> (public_webgl 'at' khronos.org)
   </contact>
   <contributors>
     <contributor>Olli Etuaho, NVIDIA</contributor>
+    <contributor>Mingyu Hu, Microsoft</contributor>
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
   <number>36</number>
   <depends>
-    <api version="1.0"/>
+    <api version="2.0"/>
   </depends>
   <overview>
-    <mirrors href="https://www.opengl.org/registry/specs/OVR/multiview.txt" name="OVR_multiview">
+    <mirrors href="https://www.opengl.org/registry/specs/OVR/multiview2.txt" name="OVR_multiview2">
       <addendum>
-        Calling <code>framebufferTextureMultiviewWEBGL</code> with a non-null <code>texture</code> parameter that does not identify a 2D array texture generates an <code>INVALID_OPERATION</code> error.
+        Calling <code>framebufferTextureMultiviewOVR</code> with a non-null <code>texture</code> parameter that does not identify a 2D array texture generates an <code>INVALID_OPERATION</code> error.
       </addendum>
       <addendum>
         The values of <code>baseViewIndex</code> and <code>numViews</code> can result in an error only if the <code>texture</code> parameter is non-null.
@@ -25,50 +26,14 @@
         If <code>baseViewIndex</code> is not the same for all framebuffer attachment points where the value of <code>FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE</code> is not <code>NONE</code> the framebuffer is considered incomplete. Calling <code>getFramebufferStatus</code> for a framebuffer in this state returns <code>FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR</code>. Other rules for framebuffer completeness from the OVR_multiview specification also apply.
       </addendum>
       <addendum>
-        Other web APIs may expose <i>opaque multiview framebuffers</i>. Opaque multiview framebuffers are <code>WebGLFramebuffer</code> objects that act as if they have multi-view attachments, but their attachments are not exposed as textures or renderbuffers and can not be changed. Opaque multiview framebuffers may have any combination of color, depth and stencil attachments.
-      </addendum>
-      <addendum>
-        Calling <code>framebufferRenderbuffer</code>, <code>framebufferTexture2D</code>, <code>framebufferTextureLayer</code>, <code>framebufferTextureMultiviewWEBGL</code>, or any other call that could change framebuffer attachments with an opaque multiview framebuffer bound to <code>target</code> generates an <code>INVALID_OPERATION</code> error.
-      </addendum>
-      <addendum>
-        If an opaque framebuffer is bound to <code>target</code> when calling <code>getFramebufferAttachmentParameter</code>, then <code>attachment</code> must be <code>BACK</code>, <code>DEPTH</code>, or <code>STENCIL</code>.
-      </addendum>
-      <addendum>
-        If an opaque framebuffer is bound to <code>target</code> when calling <code>getFramebufferAttachmentParameter</code>, then <code>pname</code> must not be <code>FRAMEBUFFER_ATTACHMENT_OBJECT_NAME</code>.
-      </addendum>
-      <addendum>
-        Querying <code>FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR</code> on an opaque multiview framebuffer attachment point that has attachments must return the number of views in the opaque multiview framebuffer.
-      </addendum>
-      <addendum>
-        Querying <code>FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR</code> on an opaque multiview framebuffer must return 0.
-      </addendum>
-      <addendum>
-        Querying <code>FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE</code> on an opaque multiview framebuffer must return <code>FRAMEBUFFER_DEFAULT</code>.
-      </addendum>
-      <addendum>
-        The number of views in an opaque multiview framebuffer may be greater than the maximum number of texture array views (the value of <code>MAX_VIEWS_OVR</code>).
-      </addendum>
-      <addendum>
-        Passing an opaque multiview framebuffer to <code>deleteFramebuffer</code> generates an <code>INVALID_OPERATION</code> error.
-      </addendum>
-      <addendum>
-        Although the extension name is prefixed with WEBGL the extension must be enabled with the
-        <code>#extension GL_OVR_multiview</code> directive, as shown in the sample code, to use
+        The extension must be enabled with the
+        <code>#extension GL_OVR_multiview2</code> directive, as shown in the sample code, to use
         the extension in a shader.
 
-        Likewise the shading language preprocessor <code>#define GL_OVR_multiview</code>, will be defined to 1 if the extension is supported.
-      </addendum>
-      <addendum>
-        This extension relaxes the restriction in OVR_multiview that only <code>gl_Position</code> can depend on ViewID in the vertex shader. With this change, view-dependent outputs like reflection vectors and similar are allowed.
+        Likewise the shading language preprocessor <code>#define GL_OVR_multiview2</code>, will be defined to 1 if the extension is supported.
       </addendum>
       <addendum>
         When the number of views specified in the active program is one, <code>gl_ViewID_OVR</code> will always evaluate to zero.
-      </addendum>
-      <addendum>
-        When a shader written in OpenGL ES shading language version 1.00 enables or requires <code>GL_OVR_multiview</code> with an extension directive, <code>layout</code> is treated as a keyword rather than an identifier, and using a layout qualifier to specify <code>num_views</code> is allowed. Other uses of layout qualifiers are not allowed in OpenGL ES shading language 1.00.
-      </addendum>
-      <addendum>
-        In OpenGL ES shading language version 1.00 <code>gl_ViewID_OVR</code> has the type <code>int</code> as opposed to <code>uint</code>.
       </addendum>
       <addendum>
         When a timer query is active and the number of views in the current draw framebuffer is greater than one, attempting to draw or calling <code>clear</code> generates an <code>INVALID_OPERATION</code> error.
@@ -79,32 +44,32 @@
     </mirrors>
     <features>
       <feature>
-        Adds support for rendering into multiple views simultaneously. This is supported for opaque multiview framebuffers starting from WebGL 1.0, and 2D texture arrays starting from WebGL 2.0.
+        Adds support for rendering into multiple views simultaneously. This is supported for 2D texture arrays starting from WebGL 2.0.
       </feature>
       <feature>
-        When a shader enables, requires, or warns <code>GL_OVR_multiview</code> with an extension directive:
+        When a shader enables, requires, or warns <code>GL_OVR_multiview2</code> with an extension directive:
         <ul>
           <li><code>gl_ViewID_OVR</code> is a built-in input of the type uint.</li>
         </ul>
       </feature>
       <feature>
-        The GLSL macro <code>GL_OVR_multiview</code> is defined as 1.
+        The GLSL macro <code>GL_OVR_multiview2</code> is defined as 1.
       </feature>
     </features>
   </overview>
   <idl xml:space="preserve">
 [NoInterfaceObject]
-interface WEBGL_multiview {
+interface OVR_multiview2 {
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630;
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632;
     const GLenum MAX_VIEWS_OVR = 0x9631;
     const GLenum FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR = 0x9633;
 
-    void framebufferTextureMultiviewWEBGL(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level, GLint baseViewIndex, GLsizei numViews);
+    void framebufferTextureMultiviewOVR(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level, GLint baseViewIndex, GLsizei numViews);
 };
   </idl>
   <newfun>
-    <function name="framebufferTextureMultiviewWEBGL" type="void">
+    <function name="framebufferTextureMultiviewOVR" type="void">
       <param name="target" type="GLenum"/>
       <param name="attachment" type="GLenum"/>
       <param name="texture" type="GLuint"/>
@@ -145,22 +110,10 @@ interface WEBGL_multiview {
   </newtok>
   <errors>
     <error>
-      The error <code>INVALID_OPERATION</code> is generated by calling <code>framebufferTextureMultiviewWEBGL</code> with a <code>texture</code> parameter that does not identify a 2D array texture.
+      The error <code>INVALID_OPERATION</code> is generated by calling <code>framebufferTextureMultiviewOVR</code> with a <code>texture</code> parameter that does not identify a 2D array texture.
     </error>
     <error>
-      The error <code>INVALID_OPERATION</code> is generated by calling <code>framebufferRenderbuffer</code>, <code>framebufferTexture2D</code>, <code>framebufferTextureLayer</code>, or <code>framebufferTextureMultiviewWEBGL</code> with a <code>target</code> parameter that identifies an opaque multiview framebuffer.
-    </error>
-    <error>
-      The error <code>INVALID_OPERATION</code> is generated by calling <code>deleteFramebuffer</code> with a <code>buffer</code> parameter that identifies an opaque multiview framebuffer.
-    </error>
-    <error>
-      The error <code>INVALID_ENUM</code> is generated by calling <code>getFramebufferAttachmentParameter</code> with an <code>attachment</code> parameter other than <code>BACK</code>, <code>DEPTH</code> or <code>STENCIL</code> when the <code>target</code> parameter identifies an opaque multiview framebuffer.
-    </error>
-    <error>
-      The error <code>INVALID_ENUM</code> is generated by calling <code>getFramebufferAttachmentParameter</code> with the <code>pname</code> parameter set to <code>FRAMEBUFFER_ATTACHMENT_OBJECT_NAME</code> when the <code>target</code> parameter identifies an opaque multiview framebuffer.
-    </error>
-    <error>
-      The error <code>INVALID_VALUE</code> is generated by calling <code>framebufferTextureMultiviewWEBGL</code> with a non-null <code>texture</code> in the following cases:
+      The error <code>INVALID_VALUE</code> is generated by calling <code>framebufferTextureMultiviewOVR</code> with a non-null <code>texture</code> in the following cases:
       <ul>
         <li>if <code>numViews</code> is less than one</li>
         <li>if <code>numViews</code> is more than <code>MAX_VIEWS_OVR</code></li>
@@ -187,34 +140,24 @@ interface WEBGL_multiview {
   <samplecode xml:space="preserve">
     <pre>
     var gl = document.createElement('canvas').getContext('webgl2');
-    var ext = gl.getExtension('WEBGL_multiview');
+    var ext = gl.getExtension('OVR_multiview2');
     var fb = gl.createFramebuffer();
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
     var colorTex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D_ARRAY, colorTex);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, 512, 512, 2);
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
     var depthStencilTex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D_ARRAY, depthStencilTex);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.DEPTH32F_STENCIL8, 512, 512, 2);
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, depthStencilTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, depthStencilTex, 0, 0, 2);
     gl.drawElements(...);  // draw will be broadcasted to the layers of colorTex and depthStencilTex.
     </pre>
   </samplecode>
   <samplecode xml:space="preserve">
     <pre>
-    var gl = document.createElement('canvas').getContext('webgl');
-    var ext = gl.getExtension('WEBGL_multiview');
-    // ... obtain opaque multiview framebuffer "fb" from another web API here ...
-    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
-    gl.drawElements(...);  // draw will be broadcasted to the views of the opaque multiview framebuffer.
-    // You can not call framebufferTextureMultiviewWEBGL to change the attachments of "fb", only draw to it.
-    </pre>
-  </samplecode>
-  <samplecode xml:space="preserve">
-    <pre>
     #version 300 es
-    #extension GL_OVR_multiview : require
+    #extension GL_OVR_multiview2 : require
     precision mediump float;
     layout (num_views = 2) in;
     in vec4 inPos;
@@ -280,6 +223,10 @@ interface WEBGL_multiview {
 
     <revision date="2018/07/26">
       <change>Fixed off-by-one issue in validating baseViewIndex + numViews.</change>
+    </revision>
+
+    <revision date="2019/03/06">
+      <change>Removing opaque framebuffer references, renaming extension to OVR_multiview2, and updating extension to only apply to WebGL 2.</change>
     </revision>
   </history>
 </draft>

--- a/sdk/tests/conformance2/extensions/ovr_multiview2.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2.html
@@ -29,20 +29,20 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 <script id="macroFragmentShader" type="x-shader/x-fragment">#version 300 es
 precision highp float;
 out vec4 my_FragColor;
 void main() {
-#ifdef GL_OVR_multiview
+#ifdef GL_OVR_multiview2
     my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
 #else
     // Error expected
-    #error no GL_OVR_multiview;
+    #error no GL_OVR_multiview2;
 #endif
 }
 </script>
@@ -63,12 +63,12 @@ function runExtensionDisabledTest()
     debug("Testing queries with extension disabled");
 
     let maxViews = gl.getParameter(0x9631);
-    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Can't query MAX_VIEWS_OVR without enabling WEBGL_multiview");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Can't query MAX_VIEWS_OVR without enabling OVR_multiview2");
 
     let baseViewIndex = gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, 0x9630);
-    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR without enabling WEBGL_multiview");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR without enabling OVR_multiview2");
     let numViews = gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.BACK, 0x9632);
-    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR without enabling WEBGL_multiview");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Can't query FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR without enabling OVR_multiview2");
 }
 
 function runQueryTest()
@@ -112,17 +112,17 @@ function runInvalidTextureTypeTest()
     debug("Testing invalid texture types");
     let tex2D = createTextureWithNearestFiltering(gl.TEXTURE_2D);
     gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, 128, 128);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, tex2D, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, tex2D, 0, 0, 1);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should not be possible to create a multiview framebuffer against a 2D texture");
 
     let texCube = createTextureWithNearestFiltering(gl.TEXTURE_CUBE_MAP);
     gl.texStorage2D(gl.TEXTURE_CUBE_MAP, 1, gl.RGBA8, 128, 128);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, texCube, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, texCube, 0, 0, 1);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should not be possible to create a multiview framebuffer against a cube map texture");
 
     let tex3D = createTextureWithNearestFiltering(gl.TEXTURE_3D);
     gl.texStorage3D(gl.TEXTURE_3D, 1, gl.RGBA8, 128, 128, 2);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, tex3D, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, tex3D, 0, 0, 2);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should not be possible to create a multiview framebuffer against a 3D texture");
 }
 
@@ -143,7 +143,7 @@ function runFramebufferQueryTest(allocateStorage)
     }
 
     let setupAndQuery = function(colorTex, levelSet, baseViewIndexSet, numViewsSet) {
-        ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, levelSet, baseViewIndexSet, numViewsSet);
+        ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, levelSet, baseViewIndexSet, numViewsSet);
         let objectType = gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
         if (objectType != gl.TEXTURE) {
             testFailed('Unexpected FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE ' + wtu.glEnumToString(gl, objectType) + ', should be TEXTURE');
@@ -168,7 +168,7 @@ function runFramebufferQueryTest(allocateStorage)
     }
 
     let setupSecondAttachmentAndQueryStatus = function(colorTex2, baseViewIndex, numViews, expectedStatus, msg) {
-        ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, colorTex2, 0, baseViewIndex, numViews);
+        ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, colorTex2, 0, baseViewIndex, numViews);
         let status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
         if (status != expectedStatus) {
             testFailed('Framebuffer status: ' + wtu.glEnumToString(gl, status) + ' did not match with the expected value: ' + wtu.glEnumToString(gl, expectedStatus) + ' - ' + msg);
@@ -212,7 +212,7 @@ function runFramebufferQueryTest(allocateStorage)
     setupSecondAttachmentAndQueryStatus(colorTex2, 1, maxViews - 1, allocateStorage ? gl.FRAMEBUFFER_COMPLETE : gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT, 'matching baseViewIndex and numViews on different attachments');
     if (allocateStorage) {
         setupSecondAttachmentAndQueryStatus(colorTex2, 0, maxViews - 1, ext.FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR, 'baseViewIndex mismatch');
-        ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews);
+        ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews);
         setupSecondAttachmentAndQueryStatus(colorTex2, 0, maxViews - 1, ext.FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR, 'numViews mismatch');
     }
 
@@ -231,18 +231,18 @@ function runInvalidViewsTest()
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     // Don't allocate storage since it's not needed for the validation.
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews + 1);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews + 1);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Specified too many views");
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 0);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 0);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Specified zero views");
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, -1, 2);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, -1, 2);
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Specified negative baseViewIndex");
 
     let colorTex2 = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex2, 0, maxLayers - maxViews + 1, maxViews);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex2, 0, maxLayers - maxViews + 1, maxViews);
     // baseViewIndex + numViews  =  (maxLayers - maxViews + 1) + maxViews  =  maxLayers + 1
     wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "Specified so many views that baseViewIndex + numViews is greater than MAX_ARRAY_TEXTURE_LAYERS");
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex2, 0, maxLayers - maxViews, maxViews);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex2, 0, maxLayers - maxViews, maxViews);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "baseViewIndex + numViews is exactly MAX_ARRAY_TEXTURE_LAYERS");
 }
 
@@ -257,8 +257,8 @@ function runDetachTest()
     let fb = gl.createFramebuffer();
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews);
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, null, 0, maxLayers + 1, 0);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, null, 0, maxLayers + 1, 0);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "baseViewIndex and numViews are not validated when detaching");
     let objectType = gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
     if (objectType != gl.NONE) {
@@ -267,7 +267,7 @@ function runDetachTest()
         testPassed('FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE was NONE after detach');
     }
 
-    ext.framebufferTextureMultiviewWEBGL(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews);
+    ext.framebufferTextureMultiviewOVR(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, maxViews);
     gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, null, 0);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Can detach with framebufferTexture2D as well.");
     objectType = gl.getFramebufferAttachmentParameter(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE);
@@ -286,15 +286,15 @@ function runShaderCompileTest(extensionEnabled)
     var macroFragmentProgram = wtu.setupProgram(gl, [wtu.simpleVertexShaderESSL300, "macroFragmentShader"], undefined, undefined, true);
     if (extensionEnabled) {
         if (macroFragmentProgram) {
-            testPassed("GL_OVR_multiview defined in shaders when extension is enabled");
+            testPassed("GL_OVR_multiview2 defined in shaders when extension is enabled");
         } else {
-            testFailed("GL_OVR_multiview not defined in shaders when extension is enabled");
+            testFailed("GL_OVR_multiview2 not defined in shaders when extension is enabled");
         }
     } else {
         if (macroFragmentProgram) {
-            testFailed("GL_OVR_multiview defined in shaders when extension is disabled");
+            testFailed("GL_OVR_multiview2 defined in shaders when extension is disabled");
         } else {
-            testPassed("GL_OVR_multiview not defined in shaders when extension disabled");
+            testPassed("GL_OVR_multiview2 not defined in shaders when extension disabled");
         }
     }
 
@@ -326,7 +326,7 @@ function runClearTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
 
@@ -367,7 +367,7 @@ function runFragmentShaderRenderTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
     wtu.drawUnitQuad(gl);
@@ -407,7 +407,7 @@ function runVertexShaderRenderTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
     wtu.drawUnitQuad(gl);
@@ -448,7 +448,7 @@ function runRealisticUseCaseRenderTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
 
@@ -480,12 +480,12 @@ function runUniqueObjectTest()
 {
     debug("");
     debug("Testing that getExtension() returns the same object each time");
-    gl.getExtension("WEBGL_multiview").myProperty = 2;
+    gl.getExtension("OVR_multiview2").myProperty = 2;
     webglHarnessCollectGarbage();
-    shouldBe('gl.getExtension("WEBGL_multiview").myProperty', '2');
+    shouldBe('gl.getExtension("OVR_multiview2").myProperty', '2');
 }
 
-description("This test verifies the functionality of the WEBGL_multiview extension, if it is available.");
+description("This test verifies the functionality of the OVR_multiview2 extension, if it is available.");
 
 debug("");
 
@@ -500,11 +500,11 @@ if (!gl) {
 
   debug("");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       runShaderCompileTest(true);
 

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_depth.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_depth.html
@@ -29,20 +29,20 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 <script id="macroFragmentShader" type="x-shader/x-fragment">#version 300 es
 precision highp float;
 out vec4 my_FragColor;
 void main() {
-#ifdef GL_OVR_multiview
+#ifdef GL_OVR_multiview2
     my_FragColor = vec4(0.0, 1.0, 0.0, 1.0);
 #else
     // Error expected
-    #error no GL_OVR_multiview;
+    #error no GL_OVR_multiview2;
 #endif
 }
 </script>
@@ -81,11 +81,11 @@ function runDepthRenderTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     let depthTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.DEPTH32F_STENCIL8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, depthTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, depthTex, 0, 0, views);
 
     let expectedStatus = gl.FRAMEBUFFER_COMPLETE;
     let status = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
@@ -127,7 +127,7 @@ function runDepthRenderTest()
     }
 }
 
-description("This test verifies drawing to depth buffers with the WEBGL_multiview extension, if it is available.");
+description("This test verifies drawing to depth buffers with the OVR_multiview2 extension, if it is available.");
 
 debug("");
 
@@ -138,11 +138,11 @@ if (!gl) {
 
   debug("");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       wtu.setupUnitQuad(gl, 0, 1);
 

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_draw_buffers.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_draw_buffers.html
@@ -29,11 +29,11 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -62,7 +62,7 @@ function runDrawBuffersClearTest()
     for (let texIndex = 0; texIndex < colorTex.length; ++texIndex) {
         colorTex[texIndex] = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
         gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-        ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + texIndex, colorTex[texIndex], 0, 0, views);
+        ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + texIndex, colorTex[texIndex], 0, 0, views);
         drawBuffers[texIndex] = gl.COLOR_ATTACHMENT0 + texIndex;
     }
 
@@ -102,7 +102,7 @@ function runDrawBuffersRenderTest()
     for (let texIndex = 0; texIndex < colorTex.length; ++texIndex) {
         colorTex[texIndex] = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
         gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-        ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + texIndex, colorTex[texIndex], 0, 0, views);
+        ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0 + texIndex, colorTex[texIndex], 0, 0, views);
         drawBuffers[texIndex] = gl.COLOR_ATTACHMENT0 + texIndex;
     }
 
@@ -147,7 +147,7 @@ function runDrawBuffersRenderTest()
     }
 }
 
-description("This test verifies the functionality of the WEBGL_multiview extension when used with multiple draw buffers, if it is available.");
+description("This test verifies the functionality of the OVR_multiview2 extension when used with multiple draw buffers, if it is available.");
 
 debug("");
 
@@ -156,11 +156,11 @@ if (!gl) {
 } else {
   testPassed("WebGL context exists");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       runDrawBuffersClearTest();
 

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_flat_varying.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_flat_varying.html
@@ -29,11 +29,11 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -45,10 +45,10 @@ let wtu = WebGLTestUtils;
 let gl = wtu.create3DContext(null, null, 2);
 let ext = null;
 
-function runInstancedDrawTest()
+function runFlatVaryingTest()
 {
     debug("");
-    debug("Testing instanced rendering");
+    debug("Testing rendering with different colors in fragment shader");
 
     let width = 256;
     let height = 256;
@@ -56,10 +56,9 @@ function runInstancedDrawTest()
     let views = gl.getParameter(ext.MAX_VIEWS_OVR);
 
     let multiviewShaders = [
-      getMultiviewInstancedVertexShader(views),
-      getInstanceColorFragmentShader()
+      getMultiviewFlatVaryingVertexShader(views),
+      getMultiviewFlatVaryingFragmentShader()
     ];
-
     let testProgram = wtu.setupProgram(gl, multiviewShaders, ['a_position'], [0], true);
     if (!testProgram) {
         testFailed("Compilation with extension enabled failed.");
@@ -70,33 +69,22 @@ function runInstancedDrawTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
-    gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, 2);
+    wtu.drawUnitQuad(gl);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from draw");
 
     let readFb = gl.createFramebuffer();
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFb);
     for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
         gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, viewIndex);
-        let colorRegionLeftEdge = (width / (views * 2)) * viewIndex;
-        let colorRegionRightEdge = (width / (views * 2)) * (viewIndex + 2);
-        let stripWidth = (colorRegionRightEdge - colorRegionLeftEdge) / 2;
-        if (colorRegionLeftEdge > 0) {
-            wtu.checkCanvasRect(gl, 0, 0, Math.floor(colorRegionLeftEdge) - 1, height, [0, 0, 0, 0], 'the left edge of view ' + viewIndex + ' should be untouched');
-        }
-        if (colorRegionRightEdge < width) {
-            wtu.checkCanvasRect(gl, colorRegionRightEdge + 1, 0, width - colorRegionRightEdge - 1, height, [0, 0, 0, 0], 'the right edge of view ' + viewIndex + ' should be untouched');
-        }
-        let expectedColor = getExpectedColor(0);
-        wtu.checkCanvasRect(gl, colorRegionLeftEdge + 1, 0, stripWidth - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' drawn by instance 0 should be colored ' + expectedColor);
-        expectedColor = getExpectedColor(1);
-        wtu.checkCanvasRect(gl, colorRegionLeftEdge + stripWidth + 1, 0, stripWidth - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' drawn by instance 1 should be colored ' + expectedColor);
+        let expectedColor = getExpectedColor(viewIndex);
+        wtu.checkCanvasRect(gl, 0, 0, width, height, expectedColor, 'view ' + viewIndex + ' should be colored ' + expectedColor);
     }
 }
 
-description("This test verifies instanced draws together with the WEBGL_multiview extension, if it is available.");
+description("This test verifies that flat varyings work in multiview shaders using OVR_multiview2 extension, if it is available.");
 
 debug("");
 
@@ -105,15 +93,15 @@ if (!gl) {
 } else {
   testPassed("WebGL context exists");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       wtu.setupUnitQuad(gl, 0, 1);
 
-      runInstancedDrawTest();
+      runFlatVaryingTest();
   }
 }
 

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_instanced_draw.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_instanced_draw.html
@@ -29,11 +29,11 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -45,10 +45,10 @@ let wtu = WebGLTestUtils;
 let gl = wtu.create3DContext(null, null, 2);
 let ext = null;
 
-function runFlatVaryingTest()
+function runInstancedDrawTest()
 {
     debug("");
-    debug("Testing rendering with different colors in fragment shader");
+    debug("Testing instanced rendering");
 
     let width = 256;
     let height = 256;
@@ -56,9 +56,10 @@ function runFlatVaryingTest()
     let views = gl.getParameter(ext.MAX_VIEWS_OVR);
 
     let multiviewShaders = [
-      getMultiviewFlatVaryingVertexShader(views),
-      getMultiviewFlatVaryingFragmentShader()
+      getMultiviewInstancedVertexShader(views),
+      getInstanceColorFragmentShader()
     ];
+
     let testProgram = wtu.setupProgram(gl, multiviewShaders, ['a_position'], [0], true);
     if (!testProgram) {
         testFailed("Compilation with extension enabled failed.");
@@ -69,22 +70,33 @@ function runFlatVaryingTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
-    wtu.drawUnitQuad(gl);
+    gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, 2);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from draw");
 
     let readFb = gl.createFramebuffer();
     gl.bindFramebuffer(gl.READ_FRAMEBUFFER, readFb);
     for (let viewIndex = 0; viewIndex < views; ++viewIndex) {
         gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, viewIndex);
-        let expectedColor = getExpectedColor(viewIndex);
-        wtu.checkCanvasRect(gl, 0, 0, width, height, expectedColor, 'view ' + viewIndex + ' should be colored ' + expectedColor);
+        let colorRegionLeftEdge = (width / (views * 2)) * viewIndex;
+        let colorRegionRightEdge = (width / (views * 2)) * (viewIndex + 2);
+        let stripWidth = (colorRegionRightEdge - colorRegionLeftEdge) / 2;
+        if (colorRegionLeftEdge > 0) {
+            wtu.checkCanvasRect(gl, 0, 0, Math.floor(colorRegionLeftEdge) - 1, height, [0, 0, 0, 0], 'the left edge of view ' + viewIndex + ' should be untouched');
+        }
+        if (colorRegionRightEdge < width) {
+            wtu.checkCanvasRect(gl, colorRegionRightEdge + 1, 0, width - colorRegionRightEdge - 1, height, [0, 0, 0, 0], 'the right edge of view ' + viewIndex + ' should be untouched');
+        }
+        let expectedColor = getExpectedColor(0);
+        wtu.checkCanvasRect(gl, colorRegionLeftEdge + 1, 0, stripWidth - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' drawn by instance 0 should be colored ' + expectedColor);
+        expectedColor = getExpectedColor(1);
+        wtu.checkCanvasRect(gl, colorRegionLeftEdge + stripWidth + 1, 0, stripWidth - 2, height, expectedColor, 'a thin strip in view ' + viewIndex + ' drawn by instance 1 should be colored ' + expectedColor);
     }
 }
 
-description("This test verifies that flat varyings work in multiview shaders using WEBGL_multiview extension, if it is available.");
+description("This test verifies instanced draws together with the OVR_multiview2 extension, if it is available.");
 
 debug("");
 
@@ -93,15 +105,15 @@ if (!gl) {
 } else {
   testPassed("WebGL context exists");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       wtu.setupUnitQuad(gl, 0, 1);
 
-      runFlatVaryingTest();
+      runInstancedDrawTest();
   }
 }
 

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_non_multiview_shaders.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_non_multiview_shaders.html
@@ -29,11 +29,11 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -66,7 +66,7 @@ function runNonMultiviewShaderTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, depth);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
 
     gl.viewport(0, 0, width, height);
 
@@ -79,12 +79,12 @@ function runNonMultiviewShaderTest()
     gl.framebufferTextureLayer(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0);
     wtu.checkCanvasRect(gl, 0, 0, width, height, [0, 255, 0, 255], 'view 0 should be green');
 
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
     wtu.drawUnitQuad(gl);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "draw should generate an INVALID_OPERATION error when using a non-multiview shader and the number of views is > 1");
 }
 
-description("This test verifies that non-multiview shaders work correctly with WEBGL_multiview extension, if it is available.");
+description("This test verifies that non-multiview shaders work correctly with OVR_multiview2 extension, if it is available.");
 
 debug("");
 
@@ -93,11 +93,11 @@ if (!gl) {
 } else {
   testPassed("WebGL context exists");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       wtu.setupUnitQuad(gl, 0, 1);
 

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_single_view_operations.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_single_view_operations.html
@@ -29,11 +29,11 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -58,7 +58,7 @@ function runSingleViewReadTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, depth);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
 
     gl.viewport(0, 0, width, height);
     gl.clearColor(0.0, 1.0, 1.0, 1.0);
@@ -73,7 +73,7 @@ function runSingleViewReadTest()
     gl.getError();
 
     // Also test for the error case with two views
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
     gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, buf);
     wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION, "should be an error to read from a framebuffer with two views");
 }
@@ -91,7 +91,7 @@ function runSingleViewBlitTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, depth);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
 
     gl.viewport(0, 0, width, height);
     gl.clearColor(0.0, 1.0, 1.0, 1.0);
@@ -116,7 +116,7 @@ function runSingleViewBlitTest()
 
     // Also test for the error case with two views
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
     gl.blitFramebuffer(0, 0, width, height, 0, 0, width, height, gl.COLOR_BUFFER_BIT, gl.NEAREST);
     wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION, "should be an error to blit from a framebuffer with two views");
@@ -135,7 +135,7 @@ function runSingleViewCopyTexImage2DTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, depth);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
 
     gl.viewport(0, 0, width, height);
     gl.clearColor(0.0, 1.0, 1.0, 1.0);
@@ -154,7 +154,7 @@ function runSingleViewCopyTexImage2DTest()
 
     // Also test for the error case with two views
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
     gl.bindTexture(gl.TEXTURE_2D, copyTargetTex);
     gl.copyTexImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 0, 0, width, height, 0);
     wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION, "should be an error to copy from a framebuffer with two views");
@@ -173,7 +173,7 @@ function runSingleViewCopyTexSubImage2DTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, depth);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
 
     gl.viewport(0, 0, width, height);
     gl.clearColor(0.0, 1.0, 1.0, 1.0);
@@ -193,7 +193,7 @@ function runSingleViewCopyTexSubImage2DTest()
 
     // Also test for the error case with two views
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
     gl.bindTexture(gl.TEXTURE_2D, copyTargetTex);
     gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, width, height);
     wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION, "should be an error to copy from a framebuffer with two views");
@@ -212,7 +212,7 @@ function runSingleViewCopyTexSubImage3DTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, depth);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 1);
 
     gl.viewport(0, 0, width, height);
     gl.clearColor(0.0, 1.0, 1.0, 1.0);
@@ -232,13 +232,13 @@ function runSingleViewCopyTexSubImage3DTest()
 
     // Also test for the error case with two views
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, 2);
     gl.bindTexture(gl.TEXTURE_3D, copyTargetTex);
     gl.copyTexSubImage3D(gl.TEXTURE_3D, 0, 0, 0, 0, 0, 0, width, height);
     wtu.glErrorShouldBe(gl, gl.INVALID_FRAMEBUFFER_OPERATION, "should be an error to copy from a framebuffer with two views");
 }
 
-description("This test verifies that framebuffers with only one view can be read from with WEBGL_multiview extension, if it is available.");
+description("This test verifies that framebuffers with only one view can be read from with OVR_multiview2 extension, if it is available.");
 
 debug("");
 
@@ -247,11 +247,11 @@ if (!gl) {
 } else {
   testPassed("WebGL context exists");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       runSingleViewReadTest();
 

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_timer_query.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_timer_query.html
@@ -29,11 +29,11 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -60,7 +60,7 @@ function runClearTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
 
@@ -108,7 +108,7 @@ function runFragmentShaderRenderTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     gl.viewport(0, 0, width, height);
 
@@ -130,7 +130,7 @@ function runFragmentShaderRenderTest()
     }
 }
 
-description("This test verifies the functionality of the WEBGL_multiview extension and its interaction with EXT_disjoint_timer_query_webgl2, if it is available.");
+description("This test verifies the functionality of the OVR_multiview2 extension and its interaction with EXT_disjoint_timer_query_webgl2, if it is available.");
 
 debug("");
 
@@ -139,11 +139,11 @@ if (!gl) {
 } else {
   testPassed("WebGL context exists");
 
-  if (!gl.getExtension("WEBGL_multiview") || !gl.getExtension("EXT_disjoint_timer_query_webgl2")) {
-      testPassed("No WEBGL_multiview support or no EXT_disjoint_timer_query_webgl2 support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2") || !gl.getExtension("EXT_disjoint_timer_query_webgl2")) {
+      testPassed("No OVR_multiview2 support or no EXT_disjoint_timer_query_webgl2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview and EXT_disjoint_timer_query_webgl2 extensions");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 and EXT_disjoint_timer_query_webgl2 extensions");
+      ext = gl.getExtension('OVR_multiview2');
       queryExt = gl.getExtension('EXT_disjoint_timer_query_webgl2');
 
       runClearTest();

--- a/sdk/tests/conformance2/extensions/ovr_multiview2_transform_feedback.html
+++ b/sdk/tests/conformance2/extensions/ovr_multiview2_transform_feedback.html
@@ -29,11 +29,11 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>WebGL WEBGL_multiview Conformance Tests</title>
+<title>WebGL OVR_multiview2 Conformance Tests</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
-<script src="../../js/tests/webgl_multiview_util.js"></script>
+<script src="../../js/tests/ovr_multiview2_util.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -70,7 +70,7 @@ function runTransformFeedbackTest()
     gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
     let colorTex = createTextureWithNearestFiltering(gl.TEXTURE_2D_ARRAY);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, width, height, views);
-    ext.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
+    ext.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, colorTex, 0, 0, views);
 
     let xfb = gl.createTransformFeedback();
     gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, xfb);
@@ -116,7 +116,7 @@ function runTransformFeedbackTest()
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors from ending transform feedback");
 }
 
-description("This test verifies interaction between transform feedback and the WEBGL_multiview extension, if it is available.");
+description("This test verifies interaction between transform feedback and the OVR_multiview2 extension, if it is available.");
 
 debug("");
 
@@ -125,11 +125,11 @@ if (!gl) {
 } else {
   testPassed("WebGL context exists");
 
-  if (!gl.getExtension("WEBGL_multiview")) {
-      testPassed("No WEBGL_multiview support -- this is legal");
+  if (!gl.getExtension("OVR_multiview2")) {
+      testPassed("No OVR_multiview2 support -- this is legal");
   } else {
-      testPassed("Successfully enabled WEBGL_multiview extension");
-      ext = gl.getExtension('WEBGL_multiview');
+      testPassed("Successfully enabled OVR_multiview2 extension");
+      ext = gl.getExtension('OVR_multiview2');
 
       wtu.setupUnitQuad(gl, 0, 1);
 

--- a/sdk/tests/js/tests/ovr_multiview2_util.js
+++ b/sdk/tests/js/tests/ovr_multiview2_util.js
@@ -83,7 +83,7 @@ function checkVerticalStrip(width, height, strips, coloredStripIndex, expectedSt
 
 function getMultiviewPassthroughVertexShader(views) {
     let shaderCode = ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
 
     'layout(num_views = $(num_views)) in;',
 
@@ -100,7 +100,7 @@ function getMultiviewPassthroughVertexShader(views) {
 // strip in each view.
 function getMultiviewOffsetVertexShader(views) {
     let shaderCode = ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
 
     'layout(num_views = $(num_views)) in;',
 
@@ -119,7 +119,7 @@ function getMultiviewOffsetVertexShader(views) {
 // view given in the uniform array "transform".
 function getMultiviewRealisticUseCaseVertexShader(views) {
     let shaderCode = ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
 
     'layout(num_views = $(num_views)) in;',
 
@@ -136,7 +136,7 @@ function getMultiviewRealisticUseCaseVertexShader(views) {
 
 function getMultiviewColorFragmentShader() {
     return ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
     'precision highp float;',
 
     'out vec4 my_FragColor;',
@@ -152,7 +152,7 @@ function getMultiviewColorFragmentShader() {
 
 function getMultiviewColorFragmentShaderForDrawBuffers(drawBuffers) {
     let shaderCode = ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
     'precision highp float;',
 
     'out vec4 my_FragColor[$(drawBuffers)];',
@@ -174,7 +174,7 @@ function getMultiviewColorFragmentShaderForDrawBuffers(drawBuffers) {
 
 function getMultiviewVaryingVertexShader(views) {
     let shaderCode = ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
 
     'layout(num_views = $(num_views)) in;',
 
@@ -190,7 +190,7 @@ function getMultiviewVaryingVertexShader(views) {
 
 function getMultiviewVaryingFragmentShader() {
     return ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
     'precision highp float;',
 
     'in float testVarying;',
@@ -207,7 +207,7 @@ function getMultiviewVaryingFragmentShader() {
 
 function getMultiviewFlatVaryingVertexShader(views) {
     let shaderCode = ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
 
     'layout(num_views = $(num_views)) in;',
 
@@ -223,7 +223,7 @@ function getMultiviewFlatVaryingVertexShader(views) {
 
 function getMultiviewFlatVaryingFragmentShader() {
     return ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
     'precision highp float;',
 
     'flat in int testVarying;',
@@ -240,7 +240,7 @@ function getMultiviewFlatVaryingFragmentShader() {
 
 function getMultiviewInstancedVertexShader(views) {
     let shaderCode = ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
 
     'layout(num_views = $(num_views)) in;',
 
@@ -263,7 +263,7 @@ function getMultiviewInstancedVertexShader(views) {
 
 function getInstanceColorFragmentShader() {
     return ['#version 300 es',
-    '#extension GL_OVR_multiview : require',
+    '#extension GL_OVR_multiview2 : require',
     'precision highp float;',
 
     'in vec4 color;',


### PR DESCRIPTION
Removed all references to opaque frame buffer. Removed support of WebGL, only WebGL2 2DTextureArrays are supported.

Function rename: framebufferTextureMultiviewWEBGL -> framebufferTextureMultiviewOVR
extension directive rename: GL_OVR_multiview -> GL_OVR_multiview2

Renamed all test files from webgl_multiview... to ovr_multiview2... 