### PR TITLE
update test to sync up with spec update #2780

### DIFF
--- a/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
+++ b/sdk/tests/conformance2/rendering/fs-color-type-mismatch-color-buffer-type.html
@@ -108,7 +108,7 @@ if (!gl) {
 function check_type_match() {
     gl.useProgram(program0);
     rendering([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);
-    rendering([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.NO_ERROR);
+    rendering([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1], gl.INVALID_OPERATION);
 
     gl.useProgram(program1);
     rendering([gl.COLOR_ATTACHMENT0, gl.NONE], gl.NO_ERROR);


### PR DESCRIPTION
https://github.com/KhronosGroup/WebGL/pull/2780

Active draw buffers should have its corresponding outputs from fragment shader.