### PR TITLE
User highp for VertexID in vertex-id.html test

### DIFF
--- a/sdk/tests/conformance2/rendering/vertex-id.html
+++ b/sdk/tests/conformance2/rendering/vertex-id.html
@@ -14,7 +14,7 @@
 <!-- Shaders for testing instanced draws -->
 <script id="vs" type="text/plain">
 #version 300 es
-flat out int vVertexID;
+flat out highp int vVertexID;
 
 void main() {
     vVertexID = gl_VertexID;
@@ -23,8 +23,8 @@ void main() {
 </script>
 <script id="fs" type="text/plain">
 #version 300 es
-flat in int vVertexID;
-out int oVertexID;
+flat in highp int vVertexID;
+out highp int oVertexID;
 void main() {
     oVertexID = vVertexID;
 }


### PR DESCRIPTION
https://buganizer.corp.google.com/issues/129495560#comment3

As stated here, default precision for `int` is `mediump` which is often implemented as 16 bits on mobile parts. This would leads to the failure of this test on pixel 2 and 3 (Qualcomm)