### PR TITLE
WebKit-specific rule to stop the slide-over button from looking horrible on iOS

### DIFF
--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -71,7 +71,7 @@
 
   #testlist {
     position:fixed;
-    top:200px;
+    top:180px;
     left:0;
     right:10%;
     bottom:0px;
@@ -123,6 +123,7 @@
     width: 20px;
     height: 100%;
     padding: 0;
+    -webkit-appearance: none;
   }
   #test-iframe {
     display: inline-block;


### PR DESCRIPTION
- also tweaked the position of the test list to reduce
  the gap between it and the header