### PR TITLE
Remove OffscreenCanvas commit() requirement

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -40,37 +40,37 @@
 <script>
 "use strict";
 description("This test checks whether OffscreenCanvas webgl context honors the preserveDrawingBuffer flag.");
+var wtu = WebGLTestUtils;
 
-function getPixelsFromOffscreenWebgl(preserveFlag) {
+const nextFrame = async () => new Promise(r => requestAnimationFrame(r));
+
+async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
   var canvas = document.createElement("canvas");
   var offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
   var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: preserveFlag});
 
-  // Draw some color on gl and commit
+  // Draw some color on gl
   gl.clearColor(1, 0, 1, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
-  gl.commit();
 
+  await nextFrame();
   var pixels = new Uint8Array(4);
-  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-  return pixels;
+  wtu.checkCanvas(gl, color, msg);
 }
 
-if (!window.OffscreenCanvas) {
-    testPassed("No OffscreenCanvas support");
-} else {
-    // Test if OffscreenCanvas.webgl retains context if preserveDrawingBuffer is true.
-    var pixelsPreserve = getPixelsFromOffscreenWebgl(true);
-    shouldBe(pixelsPreserve, [255,0,255,255]);
+(async () => {
+  if (!window.OffscreenCanvas) {
+      testPassed("No OffscreenCanvas support");
+  } else {
+      // Test if OffscreenCanvas.webgl retains context if preserveDrawingBuffer is true.
+      await getPixelsFromOffscreenWebgl(true, [255,0,255,255], "should be preserved");
 
-    // Test if OffscreenCanvas.webgl loses context if presereDrawingbuffer is false.
-    var pixelsNoPreserve = getPixelsFromOffscreenWebgl(false);
-    shouldBe(pixelsNoPreserve, [0,0,0,0]);
-}
-
-var successfullyParsed = true;
+      // Test if OffscreenCanvas.webgl loses context if presereDrawingbuffer is false.
+      await getPixelsFromOffscreenWebgl(false, [0, 0, 0, 0], "should not be preserved");
+      finishTest();
+  }
+})();
 
 </script>
-<script src="../../js/js-test-post.js"></script>
 </body>
 </html>

--- a/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
+++ b/sdk/tests/conformance/offscreencanvas/offscreencanvas-resize.html
@@ -28,7 +28,7 @@
 <html>
 <head>
 <meta charset="utf-8">
-<title>Resizing Test for OffscreenCanvas</title>
+<title>Resizing Test for OffscreenCanvas commit()</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
@@ -39,7 +39,7 @@
 <div id="console"></div>
 <script>
 "use strict";
-description("This test ensures that the OffscreenCanvas context returns the correct image size after resizing.");
+description("This test ensures that the OffscreenCanvas context returns the correct image size after resizing and calling commit().");
 
 function testResizeOnNewOffscreenCanvas() {
   var canvas = new OffscreenCanvas(10, 20);
@@ -101,6 +101,9 @@ function testResizeOnTransferredOffscreenCanvas() {
 
 if (!window.OffscreenCanvas) {
   testPassed("No OffscreenCanvas support");
+  finishTest();
+} else if (!new OffscreenCanvas(10, 20).getContext("webgl").commit) {
+  testPassed("commit() not supported");
   finishTest();
 } else {
   testResizeOnNewOffscreenCanvas();

--- a/sdk/tests/js/tests/canvas-tests-utils.js
+++ b/sdk/tests/js/tests/canvas-tests-utils.js
@@ -238,7 +238,6 @@ var webgl1Methods = [
   "vertexAttrib4fv",
   "vertexAttribPointer",
   "viewport",
-  "commit"
 ];
 
 var webgl2Methods = [


### PR DESCRIPTION
The commit() method of OffscreenCanvas contexts was controversial and has not been shipped by any browser. Rewrite the OffscreenCanvas tests to not require it.

For background, see:
https://github.com/w3ctag/design-reviews/issues/288
https://groups.google.com/a/chromium.org/d/topic/blink-dev/hRZ_P2o-aEk/discussion