### PR TITLE
update depth stencil feedbackloop test behavior

### DIFF
--- a/sdk/tests/conformance2/rendering/depth-stencil-feedback-loop.html
+++ b/sdk/tests/conformance2/rendering/depth-stencil-feedback-loop.html
@@ -133,12 +133,12 @@ function detect_depth_stencil_feedback_loop() {
 
     gl.depthMask(gl.FALSE);
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test sampls from a image. The same image is used as depth buffer. But depth mask is false.");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "The test samples from a image. The same image is used as depth buffer. A feedback loop is formed regardless of the status of depth mask.");
 
     gl.depthMask(gl.TRUE);
     gl.disable(gl.DEPTH_TEST);
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test samples from a image. The same image is used as depth buffer. But depth test is not enabled during rendering.");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "The test samples from a image. The same image is used as depth buffer. A feedback loop is formed regardless of whether the depth test is enabled.");
 
     // Test rendering and sampling feedback loop for stencil buffer
     gl.bindTexture(gl.TEXTURE_2D, tex2);
@@ -155,12 +155,12 @@ function detect_depth_stencil_feedback_loop() {
 
     gl.stencilMask(0x0);
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test sampls from a image. The same image is used as stencil buffer. But stencil mask is zero.");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "The test sampls from a image. The same image is used as stencil buffer. A feedback loop is formed regardless of the status of stencil mask.");
 
     gl.stencilMask(0xffff);
     gl.disable(gl.STENCIL_TEST);
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "The test samples from a image. The same image is used as stencil buffer. But stencil test is not enabled during rendering.");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "The test samples from a image. The same image is used as stencil buffer. A feedback loop is formed regardless of whether the stencil test is enabled.");
 }
 
 function deinit() {


### PR DESCRIPTION
A feedback loop is formed regardless of the status of depth or stencil mask, and if depth or stencil test is turned on or not.

Related discussion could be found: https://bugs.chromium.org/p/chromium/issues/detail?id=763695

> I'm not sure whether it's feasible to require that if depth writes are disabled, that it's legal to sample a depth texture that's also attached to the FBO. The OpenGL ES 3.0.5 spec section 4.4.3.1 "Rendering Feedback Loops" and section 3.8.10.3 "Rendering Feedback Loops" don't say anything about depth textures and disabling depth writes, so I suspect that at least some OpenGL ES drivers will give undefined results in this scenario. This informs making this pattern illegal in WebGL, requiring copying the texture if it's desired to both have it bound as a sampled texture as well as the current FBO's depth attachment.
