### PR TITLE
Fix rendering-sampling-feedback-loop test for old drivers

### DIFF
--- a/sdk/tests/conformance/rendering/rendering-sampling-feedback-loop.html
+++ b/sdk/tests/conformance/rendering/rendering-sampling-feedback-loop.html
@@ -181,12 +181,12 @@ function rendering_sampling_feedback_loop(draw_buffers) {
 
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Feedback loop detection ignores drawBuffers settings.");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Feedback loop detection should ignore drawBuffers settings.");
 
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_NEAREST);
     // The texture will be mipmap incomplete, so feedback cannot occur nor be consistently evaluated.
     wtu.clearAndDrawUnitQuad(gl);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Feedback loop detection ignores sampled incomplete textures.");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Feedback loop detection should ignore sampled incomplete textures.");
 
     if (draw_buffers) {
         drawBuffers([gl.COLOR_ATTACHMENT0]);

--- a/sdk/tests/conformance/rendering/rendering-sampling-feedback-loop.html
+++ b/sdk/tests/conformance/rendering/rendering-sampling-feedback-loop.html
@@ -119,7 +119,7 @@ if (!gl) {
         }
     }
 
-    init(drawBuffers);
+    init();
 
     // The sampling texture is bound to COLOR_ATTACHMENT1 during resource allocation
     allocate_resource();
@@ -134,7 +134,7 @@ if (!gl) {
     }
 }
 
-function init(drawBuffers) {
+function init() {
     let shaders = ["vs100", "fs100"];
     if (gl.texStorage2D) {
         shaders = ["vs300", "fs300"];

--- a/sdk/tests/conformance/rendering/rendering-sampling-feedback-loop.html
+++ b/sdk/tests/conformance/rendering/rendering-sampling-feedback-loop.html
@@ -60,6 +60,15 @@ void main() {
 }
 </script>
 
+<script id="fs100-no-ext-draw-buffers" type="x-shader/x-fragment">
+precision mediump float;
+uniform sampler2D tex;
+varying vec2 texCoord;
+void main() {
+    gl_FragData[0] = texture2D(tex, texCoord);
+}
+</script>
+
 <script id="vs300" type="x-shader/x-vertex">#version 300 es
 in highp vec4 aPosition;
 in vec2 aTexCoord;
@@ -110,7 +119,7 @@ if (!gl) {
         }
     }
 
-    init();
+    init(drawBuffers);
 
     // The sampling texture is bound to COLOR_ATTACHMENT1 during resource allocation
     allocate_resource();
@@ -125,10 +134,12 @@ if (!gl) {
     }
 }
 
-function init() {
+function init(drawBuffers) {
     let shaders = ["vs100", "fs100"];
     if (gl.texStorage2D) {
         shaders = ["vs300", "fs300"];
+    } else if (!drawBuffers) {
+        shaders = ["vs100", "fs100-no-ext-draw-buffers"];
     }
     const program = wtu.setupProgram(gl, shaders, ["aPosition", "aTexCoord"], [0, 1]);
     const positionLoc = gl.getAttribLocation(program, "aPosition");


### PR DESCRIPTION
This test also works for old driver not supporting `#extension GL_EXT_draw_buffers : require` for shaders. (d3d9 and some old android devices)