### PR TITLE
Fix context-attribute-preserve-drawing-buffer.html

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -40,8 +40,8 @@
 <script>
 "use strict";
 description("This test checks whether OffscreenCanvas webgl context honors the preserveDrawingBuffer flag.");
-var wtu = WebGLTestUtils;
-var pixels = new Uint8Array(4);
+const wtu = WebGLTestUtils;
+const pixels = new Uint8Array(4);
 
 function checkPixels(color) {
   return (color[0] === pixels[0]) &&
@@ -53,15 +53,16 @@ function checkPixels(color) {
 const nextFrame = () => new Promise(r => requestAnimationFrame(r));
 
 async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
-  var canvas = document.createElement("canvas");
-  var offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
-  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: preserveFlag});
+  const canvas = document.createElement("canvas");
+  const offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
+  const gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: preserveFlag});
 
   // Draw some color on gl
   gl.clearColor(1, 0, 1, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
-  var t, t0 = await nextFrame();
+  let t;
+  const t0 = await nextFrame();
   for (;;) {
     t = await nextFrame();
     

--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -52,10 +52,38 @@ function checkPixels(color) {
 
 const nextFrame = () => new Promise(r => requestAnimationFrame(r));
 
-async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
+async function getPixelsFromOffscreenWebglPreserveFlagTrue(color, msg) {
   var canvas = document.createElement("canvas");
   var offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
-  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: preserveFlag});
+  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: true});
+
+  // Draw some color on gl
+  gl.clearColor(1, 0, 1, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  var t, t0 = await nextFrame();
+  for (;;) {
+    t = await nextFrame();
+    
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    if (!checkPixels(color)) {
+      testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
+      return;
+    }
+
+    // Keep checking until it takes up to a certain time
+    if (t > t0 + 500) {
+      break;
+    }
+  }
+
+  testPassed(msg);
+}
+
+async function getPixelsFromOffscreenWebglPreserveFlagFalse(color, msg) {
+  var canvas = document.createElement("canvas");
+  var offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
+  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: false});
 
   // Draw some color on gl
   gl.clearColor(1, 0, 1, 1);
@@ -66,16 +94,9 @@ async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
     t = await nextFrame();
     
     gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-    if (preserveFlag) {
-      if (!checkPixels(color)) {
-        testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
-        return;
-      }
-    } else {
-      if (checkPixels(color)) {
-        testPassed(msg);
-        return;
-      }
+    if (checkPixels(color)) {
+      testPassed(msg);
+      return;
     }
 
     // Keep checking until it takes up to a certain time
@@ -83,25 +104,20 @@ async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
       break;
     }
   }
-  
-  if (preserveFlag) {
-    testPassed(msg);
-  } else {
-    // testFailed(msg);
-    testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
-  }
+
+  testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
 }
 
 (async () => {
   if (!window.OffscreenCanvas) {
-      testPassed("No OffscreenCanvas support");
+    testPassed("No OffscreenCanvas support");
   } else {
-      // Test if OffscreenCanvas.webgl retains contents if preserveDrawingBuffer is true.
-      await getPixelsFromOffscreenWebgl(true, [255,0,255,255], "should be preserved");
+    // Test if OffscreenCanvas.webgl retains contents if preserveDrawingBuffer is true.
+    await getPixelsFromOffscreenWebglPreserveFlagTrue([255,0,255,255], "should be preserved");
 
-      // Test if OffscreenCanvas.webgl loses contents if preserveDrawingBuffer is false.
-      await getPixelsFromOffscreenWebgl(false, [0, 0, 0, 0], "should not be preserved");
-      finishTest();
+    // Test if OffscreenCanvas.webgl loses contents if preserveDrawingBuffer is false.
+    await getPixelsFromOffscreenWebglPreserveFlagFalse([0, 0, 0, 0], "should not be preserved");
+    finishTest();
   }
 })();
 

--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -52,10 +52,10 @@ function checkPixels(color) {
 
 const nextFrame = () => new Promise(r => requestAnimationFrame(r));
 
-async function getPixelsFromOffscreenWebglPreserveFlagTrue(color, msg) {
+async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
   var canvas = document.createElement("canvas");
   var offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
-  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: true});
+  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: preserveFlag});
 
   // Draw some color on gl
   gl.clearColor(1, 0, 1, 1);
@@ -66,9 +66,16 @@ async function getPixelsFromOffscreenWebglPreserveFlagTrue(color, msg) {
     t = await nextFrame();
     
     gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-    if (!checkPixels(color)) {
-      testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
-      return;
+    if (preserveFlag) {
+      if (!checkPixels(color)) {
+        testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
+        return;
+      }
+    } else {
+      if (checkPixels(color)) {
+        testPassed(msg);
+        return;
+      }
     }
 
     // Keep checking until it takes up to a certain time
@@ -77,46 +84,22 @@ async function getPixelsFromOffscreenWebglPreserveFlagTrue(color, msg) {
     }
   }
 
-  testPassed(msg);
-}
-
-async function getPixelsFromOffscreenWebglPreserveFlagFalse(color, msg) {
-  var canvas = document.createElement("canvas");
-  var offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
-  var gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: false});
-
-  // Draw some color on gl
-  gl.clearColor(1, 0, 1, 1);
-  gl.clear(gl.COLOR_BUFFER_BIT);
-
-  var t, t0 = await nextFrame();
-  for (var i = 0, len = 5; i < len; i++) {
-    t = await nextFrame();
-    
-    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
-    if (checkPixels(color)) {
-      testPassed(msg);
-      return;
-    }
-
-    // Keep checking until it takes up to a certain time
-    if (t > t0 + 500) {
-      break;
-    }
+  if (preserveFlag) {
+    testPassed(msg);
+  } else {
+    testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
   }
-
-  testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
 }
 
 (async () => {
   if (!window.OffscreenCanvas) {
-    testPassed("No OffscreenCanvas support");
+      testPassed("No OffscreenCanvas support");
   } else {
     // Test if OffscreenCanvas.webgl retains contents if preserveDrawingBuffer is true.
-    await getPixelsFromOffscreenWebglPreserveFlagTrue([255,0,255,255], "should be preserved");
+    await getPixelsFromOffscreenWebgl(true, [255,0,255,255], "should be preserved");
 
     // Test if OffscreenCanvas.webgl loses contents if preserveDrawingBuffer is false.
-    await getPixelsFromOffscreenWebglPreserveFlagFalse([0, 0, 0, 0], "should not be preserved");
+    await getPixelsFromOffscreenWebgl(false, [0, 0, 0, 0], "should not be preserved");
     finishTest();
   }
 })();

--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -41,8 +41,16 @@
 "use strict";
 description("This test checks whether OffscreenCanvas webgl context honors the preserveDrawingBuffer flag.");
 var wtu = WebGLTestUtils;
+var pixels = new Uint8Array(4);
 
-const nextFrame = async () => new Promise(r => requestAnimationFrame(r));
+function checkPixels(color) {
+  return (color[0] === pixels[0]) &&
+    (color[1] === pixels[1]) &&
+    (color[2] === pixels[2]) &&
+    (color[3] === pixels[3]);
+}
+
+const nextFrame = () => new Promise(r => requestAnimationFrame(r));
 
 async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
   var canvas = document.createElement("canvas");
@@ -53,19 +61,45 @@ async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
   gl.clearColor(1, 0, 1, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
-  await nextFrame();
-  var pixels = new Uint8Array(4);
-  wtu.checkCanvas(gl, color, msg);
+  var t, t0 = await nextFrame();
+  for (var i = 0, len = 5; i < len; i++) {
+    t = await nextFrame();
+    
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+    if (preserveFlag) {
+      if (!checkPixels(color)) {
+        testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
+        return;
+      }
+    } else {
+      if (checkPixels(color)) {
+        testPassed(msg);
+        return;
+      }
+    }
+
+    // Keep checking until it takes up to a certain time
+    if (t > t0 + 500) {
+      break;
+    }
+  }
+  
+  if (preserveFlag) {
+    testPassed(msg);
+  } else {
+    // testFailed(msg);
+    testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
+  }
 }
 
 (async () => {
   if (!window.OffscreenCanvas) {
       testPassed("No OffscreenCanvas support");
   } else {
-      // Test if OffscreenCanvas.webgl retains context if preserveDrawingBuffer is true.
+      // Test if OffscreenCanvas.webgl retains contents if preserveDrawingBuffer is true.
       await getPixelsFromOffscreenWebgl(true, [255,0,255,255], "should be preserved");
 
-      // Test if OffscreenCanvas.webgl loses context if presereDrawingbuffer is false.
+      // Test if OffscreenCanvas.webgl loses contents if preserveDrawingBuffer is false.
       await getPixelsFromOffscreenWebgl(false, [0, 0, 0, 0], "should not be preserved");
       finishTest();
   }

--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -65,7 +65,7 @@ async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
   const t0 = await nextFrame();
   for (;;) {
     t = await nextFrame();
-    
+
     gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
     if (preserveFlag) {
       if (!checkPixels(color)) {


### PR DESCRIPTION
There's no way to guarantee the compositor finished preparing the frame.

So we are gonna change the test to the following behavior: 

Do a for loop for `await nextFrame()` and keep doing readpixels and checking within the loop until we reach some time limit (say 0.5s). For testing `preserveDrawingBuffer: false` we could early terminate if the pixel data matches. And when testing `preserveDrawingBuffer: true` we could assert failure once the pixel doesn't match the expected ones.