### PR TITLE
Promote KHR_parallel_shader_compile to community approved.

### DIFF
--- a/extensions/KHR_parallel_shader_compile/extension.xml
+++ b/extensions/KHR_parallel_shader_compile/extension.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- vi:set sw=2 ts=4: -->
 <?xml-stylesheet href="../../extension.xsl" type="text/xsl"?>
-<draft href="KHR_parallel_shader_compile/">
+<extension href="KHR_parallel_shader_compile/">
   <name>KHR_parallel_shader_compile</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -139,5 +139,8 @@
               compilation/linking optimizations in implementations.</change>
       <change>Provide expected best-practice example code.</change>
     </revision>
+    <revision date="2019/05/10">
+      <change>Moved to community approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>


### PR DESCRIPTION
This extension significantly improves startup time and smoothness of
WebGL applications loading many shader programs.