### PR TITLE
Empty glsl fragment shader fixes

### DIFF
--- a/sdk/tests/conformance/attribs/gl-vertex-attrib-unconsumed-out-of-bounds.html
+++ b/sdk/tests/conformance/attribs/gl-vertex-attrib-unconsumed-out-of-bounds.html
@@ -51,7 +51,9 @@
 </script>
 
 <script id="fshader" type="x-shader/x-fragment">
-    void main() { }
+    void main() {
+      gl_FragColor = vec4(1);
+    }
 </script>
 
 <script>

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -531,7 +531,7 @@ function runDrawTests() {
   } else {
     gl.useProgram(noWriteProgram);
     wtu.drawUnitQuad(gl);
-
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Active draw buffers with missing frag outputs.");
     drawBuffersUtils.checkAttachmentsForColor(attachments, [0, 255, 0, 255]);
     gl.deleteProgram(noWriteProgram);
   }

--- a/sdk/tests/conformance2/buffers/get-buffer-sub-data-validity.html
+++ b/sdk/tests/conformance2/buffers/get-buffer-sub-data-validity.html
@@ -130,6 +130,8 @@ function copyBufferUsingTransformFeedback(src, dst) {
     gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, tf);
     gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, dst);
 
+    gl.drawBuffers([gl.NONE]);
+
     gl.enable(gl.RASTERIZER_DISCARD);
     gl.beginTransformFeedback(gl.POINTS);
     // treats the input and output data as two uint32s

--- a/sdk/tests/deqp/modules/shared/glsShaderExecUtil.js
+++ b/sdk/tests/deqp/modules/shared/glsShaderExecUtil.js
@@ -198,16 +198,12 @@ goog.scope(function() {
      * @return {string}
      */
     glsShaderExecUtil.generateEmptyFragmentSource = function() {
-        /** @type {boolean} */ var customOut = true;
         /** @type {string} */ var src;
 
         src = '#version 300 es\n';
-
-        // \todo [2013-08-05 pyry] Do we need one dummy output?
-
+        src += 'out lowp vec4 color;\n';
         src += 'void main (void)\n{\n';
-        if (!customOut)
-            src += ' gl.FragColor = vec4(0.0);\n';
+        src += ' color = vec4(0.0);\n';
         src += '}\n';
 
         return src;


### PR DESCRIPTION
Based on the discussion here: https://github.com/KhronosGroup/WebGL/pull/2780, and finalization here: https://github.com/KhronosGroup/WebGL/issues/2845

Fix a test case to avoid `gl.INVALID_OPERATION` error generated;

FYI: By doing a quick search for `void main() {}`, there's another appearance in https://github.com/KhronosGroup/WebGL/blob/master/sdk/tests/conformance2/context/incorrect-context-object-behaviour.html
However it doesn't cause any error since there's no gl.draw(Arrays*/Elements*) call. Leave it unmodified.