### PR TITLE
Add `gl_PointSize = 1.0;` in vertex-id.html to make consistent result on win + angle

### DIFF
--- a/sdk/tests/conformance2/rendering/vertex-id.html
+++ b/sdk/tests/conformance2/rendering/vertex-id.html
@@ -18,6 +18,7 @@ flat out highp int vVertexID;
 
 void main() {
     vVertexID = gl_VertexID;
+    gl_PointSize = 1.0;
     gl_Position = vec4(0,0,0,1);
 }
 </script>


### PR DESCRIPTION
This test seem to fail on windows with angle back-end without explicitly declaring `gl_PointSize`