### PR TITLE
Fix a typo in Copyright for WebGL 2 compute

### DIFF
--- a/specs/latest/2.0-compute/index.bs
+++ b/specs/latest/2.0-compute/index.bs
@@ -1,6 +1,6 @@
 <pre class='metadata'>
 Shortname: webgl2-compute
-Title: WebGL 2.0 Compute Specification
+Title: WebGL 2.0 Compute
 Level: 1
 Status: khronos/ED
 Group: WebGL


### PR DESCRIPTION
Current <Copyright> section has two "specification": https://www.khronos.org/registry/webgl/specs/latest/2.0-compute/. It's incorrect. This small change fix the tiny bug. 

PTAL. @kenrussell 