### PR TITLE
Handle Bad Implementations

### DIFF
--- a/other/get.webgl.org/webgl2/index.html
+++ b/other/get.webgl.org/webgl2/index.html
@@ -1,6 +1,6 @@
 <!--
 NOTE: If you need/want this page changed to include
-other browsers see https://github.com/KhronosGroup/WebGL/tree/master/other/get.webgl.org
+other browsers see https://github.com/KhronosGroup/WebGL/tree/master/other/get.webgl.org/webgl2/
 -->
 <!doctype html>
 <html>

--- a/other/get.webgl.org/webgl2/index.html
+++ b/other/get.webgl.org/webgl2/index.html
@@ -128,10 +128,10 @@ other browsers see https://github.com/KhronosGroup/WebGL/tree/master/other/get.w
       }
 
     </style>
-<script type="text/javascript" src="troubleshooting/DoNotCopyOrLinkThisFileElseYouWillNotGetAutoUpdatedHelpForYourUsers.js"></script>
-<script type="text/javascript" src="twgl-full.min.js"></script>
-<script type="text/javascript" src="cube.js"></script>
-<script type="text/javascript">
+<script src="troubleshooting/DoNotCopyOrLinkThisFileElseYouWillNotGetAutoUpdatedHelpForYourUsers.js"></script>
+<script src="twgl-full.min.js"></script>
+<script src="cube.js"></script>
+<script>
 /**/
 
 function $$(x) {

--- a/other/get.webgl.org/webgl2/index.html
+++ b/other/get.webgl.org/webgl2/index.html
@@ -182,9 +182,35 @@ function pageLoaded() {
     addClass($$("no-javascript"), "webgl-hidden");
     b = BrowserDetect;
     b.init();
+    var badImpl = false;
     var canvas = document.getElementById("webgl-logo");
     try { gl = canvas.getContext("webgl2"); }
     catch (x) { gl = null; }
+
+    if (gl) {
+        // check if it really supports WebGL2. Issues, Some browers claim to support WebGL2
+        // but in reality pass less than 20% of the conformance tests. Add a few simple
+        // tests to fail so as not to mislead users.
+        var params = [
+            { pname: 'MAX_3D_TEXTURE_SIZE', min: 256, },
+            { pname: 'MAX_DRAW_BUFFERS', min:4, },
+            { pname: 'MAX_COLOR_ATTACHMENTS', min:4, },
+            { pname: 'MAX_VERTEX_UNIFORM_BLOCKS', min:12, },
+            { pname: 'MAX_VERTEX_TEXTURE_IMAGE_UNITS', min:16, },
+            { pname: 'MAX_FRAGMENT_INPUT_COMPONENTS', min:60, },
+            { pname: 'MAX_UNIFORM_BUFFER_BINDINGS', min:24, },
+            { pname: 'MAX_COMBINED_UNIFORM_BLOCKS', min:24, },
+        ];
+        for (var i = 0; i < params.length; ++i) {
+            var param = params[i];
+            var value = gl.getParameter(gl[param.pname]);
+            if (typeof value !== 'number' || Number.isNaN(value) || value < params.min) {
+                gl = null;
+                badImpl = true;
+                break;
+            }
+        }
+    }
 
     if (gl) {
         // Set the support link to the correct URL for the browser.
@@ -193,7 +219,7 @@ function pageLoaded() {
         // show webgl supported div, and launch webgl demo
         removeClass($$("webgl-yes"), "webgl-hidden");
         launchLogo(gl);
-    } else if (window.WebGL2RenderingContext) {
+    } else if (!badImpl && window.WebGL2RenderingContext) {
         // not a foolproof way to check if the browser
         // might actually support WebGL, but better than nothing
         removeClass($$("webgl-disabled"), "webgl-hidden");


### PR DESCRIPTION
Some browsers pass less than 20% of the WebGL2 conformance tests
yet turning on support would make it appear WebGL2 is supported
leading to improper reporting all around the net.

Here's a minor test to try to weed out such implementations
from reporting support.