### PR TITLE
Modify OVR_multiview2 example to use array of matrices

### DIFF
--- a/extensions/OVR_multiview2/extension.xml
+++ b/extensions/OVR_multiview2/extension.xml
@@ -168,14 +168,9 @@ interface OVR_multiview2 {
     precision mediump float;
     layout (num_views = 2) in;
     in vec4 inPos;
-    uniform mat4 u_viewMatrix0;
-    uniform mat4 u_viewMatrix1;
+    uniform mat4 u_viewMatrices[2];
     void main() {
-      if (gl_ViewID_OVR == 0u) {
-        gl_Position = u_viewMatrix0 * inPos;
-      } else {
-        gl_Position = u_viewMatrix1 * inPos;
-      }
+      gl_Position = u_viewMatrices[gl_ViewID_OVR] * inPos;
     }
     </pre>
   </samplecode>


### PR DESCRIPTION
I just did a small change on the example shader replacing both view matrices with an array of matrices as I have found most implementations I have seen so far on js engines tend to implement it as in the original example with custom uniforms for each matrix.
Maybe it's quite obvious but even if currently most of the use case for multiview are WebVR with 2 views, eventually we could increase that number as new devices appears, and we won't need to adapt the code to support new uniforms `u_viewMatrix2`, `u_viewMatrix3`,... just increase the number of views, simplifying the engine a bit.


```glsl
uniform mat4 u_viewMatrix0;
uniform mat4 u_viewMatrix1;
void main() {
  if (gl_ViewID_OVR == 0u) {
    gl_Position = u_viewMatrix0 * inPos;
  } else {
    gl_Position = u_viewMatrix1 * inPos;
  }
}
```

```glsl
uniform mat4 u_viewMatrices[2];
void main() {
  gl_Position = u_viewMatrices[gl_ViewID_OVR] * inPos;
}
```