### PR TITLE
Not requiring compile error report at compiling stage.

### DIFF
--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -722,7 +722,7 @@ function runBuildTest(test, callback) {
       compileSuccess = (success[0] && success[1]);
       if (!test.compstat) {
         if (compileSuccess) {
-          testFailed("expected compile failure but was successful");
+          testPassed("expected compile failure but was successful (spec doesn't require reporting errors at compile time)");
         } else {
           testPassed("expected compile failure and it failed");
         }
@@ -736,8 +736,9 @@ function runBuildTest(test, callback) {
         var program = wtu.createProgram(gl, shaders[0], shaders[1], function() {
           linkSuccess = false;
         });
-        if (linkSuccess !== test.linkstat) {
-          testFailed("expected link to " + (test.linkstat ? "succeed" : "fail"));
+        var linkstatAdjusted = test.linkstat && test.compstat;
+        if (linkSuccess !== linkstatAdjusted) {
+          testFailed("expected link to " + (linkstatAdjusted ? "succeed" : "fail"));
         } else {
           testPassed("shaders compiled and linked as expected.");
         }

--- a/sdk/tests/conformance/ogles/ogles-utils.js
+++ b/sdk/tests/conformance/ogles/ogles-utils.js
@@ -732,17 +732,19 @@ function runBuildTest(test, callback) {
         } else {
           testFailed("expected compile success but it failed");
         }
-        var linkSuccess = true;
-        var program = wtu.createProgram(gl, shaders[0], shaders[1], function() {
-          linkSuccess = false;
-        });
-        var linkstatAdjusted = test.linkstat && test.compstat;
-        if (linkSuccess !== linkstatAdjusted) {
-          testFailed("expected link to " + (linkstatAdjusted ? "succeed" : "fail"));
-        } else {
-          testPassed("shaders compiled and linked as expected.");
-        }
       }
+
+      var linkSuccess = true;
+      var program = wtu.createProgram(gl, shaders[0], shaders[1], function() {
+        linkSuccess = false;
+      });
+      var linkstatAdjusted = test.linkstat && test.compstat;
+      if (linkSuccess !== linkstatAdjusted) {
+        testFailed("expected link to " + (linkstatAdjusted ? "succeed" : "fail"));
+      } else {
+        testPassed("shaders compiled and linked as expected.");
+      }
+
       callback();
     }
   }


### PR DESCRIPTION
Change the behavior of a series of shaders compiling and linking test to the following:
* Test won't fail if compile status is success but is expected to be failure.
* GLSL es 100 spec section 10.27: 
> Should compilers be required to report any errors at compile time or can errors be deferred until link
time?
RESOLUTION: If a program cannot be compiled, on-target compilers are only required to report that an error has occurred. This error may be reported at compile time or link time or both. Development systems must generate grammar errors at compile time.

* GLSL es 300 spec section 12.32:

> Should compilers be required to report any errors at compile time or can errors be deferred until link
time?
RESOLUTION: If a program cannot be compiled, on-target compilers are only required to report that an error has occurred. This error may be reported at compile time or link time or both. Development systems must generate grammar errors at compile time.

* `linkstatAdjusted = test.linkstat && test.compstat`