### PR TITLE
Change invariance rule for #pragma STDGL invariant(all).

### DIFF
--- a/conformance-suites/1.0.3/conformance/glsl/misc/shaders-with-invariance.html
+++ b/conformance-suites/1.0.3/conformance/glsl/misc/shaders-with-invariance.html
@@ -216,6 +216,9 @@ GLSLConformanceTester.runTests([
     linkSuccess: false,
     passMsg: "vertex shader with invariant varying and fragment shader with variant varying must fail",
   },
+  // The following test has been removed as it was enforcing a rule contradictory to the ESSL 1.0
+  // specification.
+  /*
   {
     vShaderId: "vertexShaderVariant",
     vShaderSuccess: true,
@@ -224,6 +227,7 @@ GLSLConformanceTester.runTests([
     linkSuccess: false,
     passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
   },
+  */
   {
     vShaderId: "vertexShaderGlobalInvariant",
     vShaderSuccess: true,

--- a/conformance-suites/2.0.0/conformance/glsl/misc/shaders-with-invariance.html
+++ b/conformance-suites/2.0.0/conformance/glsl/misc/shaders-with-invariance.html
@@ -328,6 +328,9 @@ var cases = [
     linkSuccess: false,
     passMsg: "fragment shader with invariant gl_FrontFacing must fail compilation",
   },
+  // The following test has been removed as it was enforcing a rule contradictory to the ESSL 1.0
+  // specification.
+  /*
   {
     vShaderId: "vertexShaderVariant",
     vShaderSuccess: true,
@@ -336,6 +339,7 @@ var cases = [
     linkSuccess: false,
     passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
   },
+  */
   {
     vShaderId: "vertexShaderInvariant",
     vShaderSuccess: true,

--- a/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
+++ b/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
@@ -333,8 +333,8 @@ var cases = [
     vShaderSuccess: true,
     fShaderId: "fragmentShaderGlobalInvariant",
     fShaderSuccess: true,
-    linkSuccess: false,
-    passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must fail",
+    linkSuccess: true,
+    passMsg: "vertex shader with variant varying and fragment shader with invariant (global setting) varying must succeed",
   },
   {
     vShaderId: "vertexShaderInvariant",


### PR DESCRIPTION
The ESSL 1.0 specification states that the global invariance pragma
applies only to output variables. During the most recent work on this
test in #1924, the assumption was that this pragma applied essentially
to all variables, because ESSL 1.0 also mandates that the invariant
qualifier must match between vertex shader outputs and fragment shader
inputs.

ANGLE's shader translator is relaxing the validation in this area in
order to both support a Vulkan backend and pass the ES 2.0
drawElements test suite. The best understanding of the intent of the
ES 2.0 and ESSL 1.0 specifications has been applied in coming to this
decision.

The associated WebGL conformance test in shaders-with-invariance.html,
which asserts a link failure with a variant output variable in the
vertex shader and an "invariant" input variable in the fragment shader
via the pragma, is being changed to conform to the ES 2.0 spec. The
test is being removed from earlier snapshots.

For more background please see:

https://chromium-review.googlesource.com/1558678
https://bugs.chromium.org/p/angleproject/issues/detail?id=1293
https://bugs.chromium.org/p/angleproject/issues/detail?id=3285