### PR TITLE
Port greggman new program handling test

### DIFF
--- a/sdk/tests/conformance/programs/00_test_list.txt
+++ b/sdk/tests/conformance/programs/00_test_list.txt
@@ -6,7 +6,7 @@ gl-get-active-uniform.html
 gl-getshadersource.html
 gl-shader-test.html
 invalid-UTF-16.html
-program-handling.html
+--min-version 1.0.4 program-handling.html
 --min-version 1.0.4 program-infolog.html
 program-test.html
 --min-version 1.0.2 use-program-crash-with-discard-in-fragment-shader.html

--- a/sdk/tests/conformance/programs/00_test_list.txt
+++ b/sdk/tests/conformance/programs/00_test_list.txt
@@ -6,6 +6,7 @@ gl-get-active-uniform.html
 gl-getshadersource.html
 gl-shader-test.html
 invalid-UTF-16.html
+program-handling.html
 --min-version 1.0.4 program-infolog.html
 program-test.html
 --min-version 1.0.2 use-program-crash-with-discard-in-fragment-shader.html

--- a/sdk/tests/conformance/programs/program-handling.html
+++ b/sdk/tests/conformance/programs/program-handling.html
@@ -1,28 +1,7 @@
 <!--
-
-/*
-** Copyright (c) 2019 The Khronos Group Inc.
-**
-** Permission is hereby granted, free of charge, to any person obtaining a
-** copy of this software and/or associated documentation files (the
-** "Materials"), to deal in the Materials without restriction, including
-** without limitation the rights to use, copy, modify, merge, publish,
-** distribute, sublicense, and/or sell copies of the Materials, and to
-** permit persons to whom the Materials are furnished to do so, subject to
-** the following conditions:
-**
-** The above copyright notice and this permission notice shall be included
-** in all copies or substantial portions of the Materials.
-**
-** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
-*/
-
+Copyright (c) 2019 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
 -->
 <!DOCTYPE html>
 <html>

--- a/sdk/tests/conformance/programs/program-handling.html
+++ b/sdk/tests/conformance/programs/program-handling.html
@@ -1,0 +1,143 @@
+<!--
+
+/*
+** Copyright (c) 2019 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL Program Handling Conformance Test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/desktop-gl-constants.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<script id="vshader" type="x-shader/x-vertex">
+    attribute vec4 a_position;
+    uniform vec4 u_color;
+    varying vec4 v_color;
+    void main()
+    {
+        v_color = u_color;
+        gl_Position = a_position;
+    }
+</script>
+<script id="fshader" type="x-shader/x-fragment">
+    precision mediump float;
+    varying vec4 v_color;
+    void main()
+    {
+        gl_FragColor = v_color;
+    }
+</script>
+<script id="fshader-not-link" type="x-shader/x-fragment">
+    precision mediump float;
+    varying vec4 foo;
+    void main()
+    {
+        gl_FragColor = foo;
+    }
+</script>
+
+<canvas id="canvas" width="16" height="16"> </canvas>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+"use strict";
+
+function compile(gl, shader, src) {
+    var shaderSource = document.getElementById(src).text;
+    gl.shaderSource(shader, shaderSource);
+    gl.compileShader(shader);
+}
+
+debug("");
+debug("Canvas.getContext");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+if (!gl) {
+    testFailed("context does not exist");
+}
+
+var vs = wtu.loadShaderFromScript(gl, "vshader");
+var fs = wtu.loadShaderFromScript(gl, "fshader");
+var prg = wtu.createProgram(gl, vs, fs);
+gl.useProgram(prg);
+const positionLoc = gl.getAttribLocation(prg, 'a_position');
+const colorLoc = gl.getUniformLocation(prg, 'u_color');
+
+wtu.setupUnitQuad(gl, positionLoc);
+
+debug("Draw red with valid program");
+gl.uniform4fv(colorLoc, [1, 0, 0, 1]);
+wtu.drawUnitQuad(gl);
+wtu.checkCanvas(gl, [255, 0, 0, 255], "should be red");
+
+debug("Change fragment shader to one that will not link");
+compile(gl, fs, "fshader-not-link");
+debug("Draw orange");
+gl.uniform4fv(colorLoc, [1, 0.5, 0, 1]);
+wtu.drawUnitQuad(gl);
+wtu.checkCanvas(gl, [255, 127, 0, 255], "should be orange");
+
+debug("Try linking");
+gl.linkProgram(prg);
+assertMsg(gl.getProgramParameter(prg, gl.LINK_STATUS) == false, "link should fail");
+debug("Draw green to show even though link failed old program is still valid");
+gl.uniform4fv(colorLoc, [0, 1, 0, 1]);
+wtu.drawUnitQuad(gl);
+wtu.checkCanvas(gl, [0, 255, 0, 255], "should be green");
+
+debug("Detach and delete shaders");
+gl.detachShader(prg, vs);
+gl.detachShader(prg, fs);
+gl.deleteShader(vs);
+gl.deleteShader(fs);
+
+debug("Draw blue to show even though shaders are gone program is still valid");
+gl.uniform4fv(colorLoc, [0, 0, 1, 1]);
+wtu.drawUnitQuad(gl);
+wtu.checkCanvas(gl, [0, 0, 255, 255], "should be blue");
+
+debug("Call useProgram to show old program can not be made current again");
+gl.useProgram(prg);
+wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should be invalid");
+
+debug("Draw purple to show the original program is still usable");
+gl.uniform4fv(colorLoc, [1, 0, 1, 1]);
+wtu.drawUnitQuad(gl);
+wtu.checkCanvas(gl, [255, 0, 255, 255], "should be purple");
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+
+var successfullyParsed = true;
+</script>
+
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance/programs/program-test.html
+++ b/sdk/tests/conformance/programs/program-test.html
@@ -331,10 +331,6 @@ function go() {
     assertMsg(gl.getProgramParameter(progGood2, gl.LINK_STATUS) == false,
               "linking should fail with in-use formerly good program, with new bad shader attached");
 
-    // Invalid link leaves previous valid program intact.
-    gl.drawArrays(gl.TRIANGLES, 0, 3);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing with a valid program shouldn't generate a GL error");
-
     gl.useProgram(progGood1);
     gl.drawArrays(gl.TRIANGLES, 0, 4);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing with a valid when last used program shouldn't generate a GL error");

--- a/sdk/tests/conformance/programs/program-test.html
+++ b/sdk/tests/conformance/programs/program-test.html
@@ -331,6 +331,10 @@ function go() {
     assertMsg(gl.getProgramParameter(progGood2, gl.LINK_STATUS) == false,
               "linking should fail with in-use formerly good program, with new bad shader attached");
 
+    // Invalid link leaves previous valid program intact.
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing with a valid program shouldn't generate a GL error");
+
     gl.useProgram(progGood1);
     gl.drawArrays(gl.TRIANGLES, 0, 4);
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing with a valid when last used program shouldn't generate a GL error");


### PR DESCRIPTION
Mostly a port from @greggman 's program handling test https://github.com/KhronosGroup/WebGL/issues/2842

There is a section doing similar tests in `program-test.html`. But since it only detects gl errors without actually drawing something, it couldn't really expose problems. I removed that one test case from there. The new `program-handling.html` tests covers better for the topic of program handling for various linking situation.