### PR TITLE
Validating draw buffers now also considers color mask settings

### DIFF
--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -78,7 +78,7 @@
 
         In this scenario, if there are draw buffers other than COLOR_ATTACHMENT0, because there is
         only a fragment shader output for DRAW_BUFFER0, draw commands generate
-        <code>INVALID_OPERATION</code>.
+        <code>INVALID_OPERATION</code>, unless all 4 channels of <code>colorMask</code> is set to false.
       </addendum>
       <addendum>
         If a fragment shader writes to neither <code>gl_FragColor</code> nor <code>gl_FragData</code>, the values of

--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -78,7 +78,7 @@
 
         In this scenario, if there are draw buffers other than COLOR_ATTACHMENT0, because there is
         only a fragment shader output for DRAW_BUFFER0, draw commands generate
-        <code>INVALID_OPERATION</code>, unless all 4 channels of <code>colorMask</code> is set to false.
+        <code>INVALID_OPERATION</code>, unless all 4 channels of <code>colorMask</code> are set to false.
       </addendum>
       <addendum>
         If a fragment shader writes to neither <code>gl_FragColor</code> nor <code>gl_FragData</code>, the values of

--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -551,6 +551,13 @@ function runDrawTests() {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
   wtu.drawUnitQuad(gl);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Active draw buffers with missing frag outputs.");
+  gl.colorMask(false, false, false, false);
+  wtu.drawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors when all 4 channels of color mask are disabled.");
+  gl.colorMask(false, true, false, false);
+  wtu.drawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "partially diabled color mask shall have no impact.");
+  gl.colorMask(true, true, true, true);
 
   debug("test that gl_FragColor broadcasts if extension is enabled in fragment shader");
   gl.clear(gl.COLOR_BUFFER_BIT);

--- a/sdk/tests/conformance2/rendering/draw-buffers.html
+++ b/sdk/tests/conformance2/rendering/draw-buffers.html
@@ -364,6 +364,13 @@ function runDrawTests() {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
   wtu.drawUnitQuad(gl);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Active draw buffers with missing frag outputs.");
+  gl.colorMask(false, false, false, false);
+  wtu.drawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors when all 4 channels of color mask are disabled.");
+  gl.colorMask(false, true, false, false);
+  wtu.drawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "partially diabled color mask shall have no impact.");
+  gl.colorMask(true, true, true, true);
 
   gl.drawBuffers([gl.COLOR_ATTACHMENT0]);
   wtu.drawUnitQuad(gl);

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3571,7 +3571,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <p>
         If any draw buffer with an attachment does not have a defined fragment shader output, draws
-        generate <code>INVALID_OPERATION</code>, unless all 4 channels of <code>colorMask</code> is set to false.
+        generate <code>INVALID_OPERATION</code>, unless all 4 channels of <code>colorMask</code> are set to false.
     </p>
 
     <h3>No Program Binaries</h3>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -3571,7 +3571,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <p>
         If any draw buffer with an attachment does not have a defined fragment shader output, draws
-        generate <code>INVALID_OPERATION</code>.
+        generate <code>INVALID_OPERATION</code>, unless all 4 channels of <code>colorMask</code> is set to false.
     </p>
 
     <h3>No Program Binaries</h3>


### PR DESCRIPTION
Add tests and update spec and extensions description texts.

Discussion: https://github.com/KhronosGroup/WebGL/issues/2880