### PR TITLE
Add conformance test for row_major matrices

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -22,6 +22,7 @@ frag-depth.html
 invalid-default-precision.html
 invalid-invariant.html
 loops-with-side-effects.html
+--min-version 2.0.1 matrix-row-major.html
 misplaced-version-directive.html
 --min-version 2.0.1 no-attribute-vertex-shader.html
 sampler-no-precision.html

--- a/sdk/tests/conformance2/glsl3/matrix-row-major.html
+++ b/sdk/tests/conformance2/glsl3/matrix-row-major.html
@@ -1,0 +1,72 @@
+<!--
+
+/*
+** Copyright (c) 2019 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL array assignment test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderUniformMatrixRowMajor" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+out highp vec4 my_FragColor;
+layout(std140, row_major) uniform b {
+    mat4x3 m;
+};
+void main() {
+    // If the matrix is interpreted as row-major, then the translation components will be 0,1,0, or solid green.
+    my_FragColor = mat4(m) * vec4(0.0, 0.0, 0.0, 1.0);
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description("Row-major matrix layouts should work.");
+
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderUniformMatrixRowMajor',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: '',
+  uniformBlocks: [{name: "b", value: new Float32Array([
+    0, 0, 0, 0, // Red
+    0, 0, 0, 1, // Green
+    0, 0, 0, 0, // Blue
+  ])}]
+}
+], 2);
+</script>
+</body>
+</html>
+

--- a/sdk/tests/js/glsl-conformance-test.js
+++ b/sdk/tests/js/glsl-conformance-test.js
@@ -279,6 +279,22 @@ function runOneTest(gl, info) {
     }
   }
 
+  if (info.uniformBlocks !== undefined) {
+    for (var i = 0; i < info.uniformBlocks.length; ++i) {
+      var uniformBlockIndex = gl.getUniformBlockIndex(program, info.uniformBlocks[i].name);
+      if (uniformBlockIndex !== null) {
+        gl.uniformBlockBinding(program, uniformBlockIndex, i);
+        debug(info.uniformBlocks[i].name + ' (index ' + uniformBlockIndex + ') bound to slot ' + i);
+
+        var uboValueBuffer = gl.createBuffer();
+        gl.bindBufferBase(gl.UNIFORM_BUFFER, i, uboValueBuffer);
+        gl.bufferData(gl.UNIFORM_BUFFER, info.uniformBlocks[i].value, info.uniformBlocks[i].usage || gl.STATIC_DRAW);
+      } else {
+        debug('uniform block' + info.uniformBlocks[i].name + ' had null block index and was not set');
+      }
+    }
+  }
+
   wtu.setupUnitQuad(gl);
   wtu.clearAndDrawUnitQuad(gl);
 


### PR DESCRIPTION
Requires adding some simple support for uniform blocks.

Currently breaks on some Apple platforms.

Fixes issue #2882.