### PR TITLE
Whitelist files containing Unicode characters.

### DIFF
--- a/sdk/tests/py/lint/lint.py
+++ b/sdk/tests/py/lint/lint.py
@@ -146,10 +146,13 @@ def check_regexp_line(path, f):
 
     applicable_regexps = [regexp for regexp in regexps if regexp.applies(path)]
 
-    for i, line in enumerate(f):
-        for regexp in applicable_regexps:
-            if regexp.search(line):
-                errors.append((regexp.error, "%s line %i" % (path, i+1), i+1))
+    try:
+        for i, line in enumerate(f):
+            for regexp in applicable_regexps:
+                if regexp.search(line):
+                    errors.append((regexp.error, "%s line %i" % (path, i+1), i+1))
+    except UnicodeDecodeError as e:
+        return [("CONTAINS UNICODE", "File %s contains Unicode characters" % path, None)]
 
     return errors
 

--- a/sdk/tests/py/lint/lint.py
+++ b/sdk/tests/py/lint/lint.py
@@ -152,7 +152,7 @@ def check_regexp_line(path, f):
                 if regexp.search(line):
                     errors.append((regexp.error, "%s line %i" % (path, i+1), i+1))
     except UnicodeDecodeError as e:
-        return [("CONTAINS UNICODE", "File %s contains Unicode characters" % path, None)]
+        return [("INVALID UNICODE", "File %s contains non-UTF-8 Unicode characters" % path, None)]
 
     return errors
 

--- a/sdk/tests/py/lint/lint.whitelist
+++ b/sdk/tests/py/lint/lint.whitelist
@@ -28,6 +28,12 @@ INDENT TABS:*.vert
 INDENT TABS:deqp/functional/gles3/*.js
 INDENT TABS:conformance-suites/2.0.0/deqp/functional/gles3/*.js
 
+## Two files in the repository deliberately contain Unicode. Skip the
+## content checks for them.
+
+CONTAINS UNICODE:sdk/tests/conformance/glsl/misc/non-ascii-comments.vert.html
+CONTAINS UNICODE:sdk/tests/conformance/glsl/misc/non-ascii.vert.html
+
 ## File types that should never be checked ##
 
 *:*.pdf

--- a/sdk/tests/py/lint/lint.whitelist
+++ b/sdk/tests/py/lint/lint.whitelist
@@ -28,11 +28,12 @@ INDENT TABS:*.vert
 INDENT TABS:deqp/functional/gles3/*.js
 INDENT TABS:conformance-suites/2.0.0/deqp/functional/gles3/*.js
 
-## Two files in the repository deliberately contain Unicode. Skip the
-## content checks for them.
+## Two files in the repository deliberately contain non-UTF-8 Unicode,
+## which Python can't decode by default. Skip the content checks for
+## them.
 
-CONTAINS UNICODE:sdk/tests/conformance/glsl/misc/non-ascii-comments.vert.html
-CONTAINS UNICODE:sdk/tests/conformance/glsl/misc/non-ascii.vert.html
+INVALID UNICODE:conformance/glsl/misc/non-ascii-comments.vert.html
+INVALID UNICODE:conformance/glsl/misc/non-ascii.vert.html
 
 ## File types that should never be checked ##
 


### PR DESCRIPTION
Two files in the repository deliberately contain non-UTF-8 Unicode
characters. Explicitly whitelist them so if other files later accidentally
add such characters, they're discovered.

Related to #2885.