### PR TITLE
Allow Uint8ClampedArray in readPixels and tex{Sub}Image.

### DIFF
--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -307,9 +307,36 @@ function runTest(canvas, antialias) {
       shouldBe("actual", "expected");
     }
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no GL errors");
+
+    debug("");
+    debug("check readback into Uint8ClampedArray");
+    continueTestFunc = continueTestPart4;
+    const kSize = 32;
+    canvas.width = kSize;
+    canvas.height = kSize;
+    if (gl.getError() != gl.CONTEXT_LOST_WEBGL) {
+      continueTestPart4();
+    }
+  }
+
+  function continueTestPart4() {
+    const kSize = 32;
+    gl.viewport(0, 0, kSize, kSize);
+    gl.clearColor(0.0, 1.0, 0.0, 1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+
+    var buf = new Uint8ClampedArray(4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no GL errors reading back into a Uint8ClampedArray");
+    if (buf[0] == 0 && buf[1] == 255 && buf[2] == 0 && buf[3] == 255) {
+      testPassed("Readback into Uint8ClampedArray worked successfully");
+    } else {
+      assertMsg(false,
+                "color pixel at 0, 0 should be [0, 255, 0, 255], was " +
+                [buf[0], buf[1], buf[2], buf[3]]);
+    }
   }
 }
 </script>
 </body>
 </html>
-

--- a/sdk/tests/conformance/textures/misc/texture-formats-test.html
+++ b/sdk/tests/conformance/textures/misc/texture-formats-test.html
@@ -182,7 +182,8 @@ if (!gl) {
       var formatName = wtu.glEnumToString(gl, format);
       var desc = "format: " + formatName + ", type: " + typeName;
       debug("");
-      debug("checking gl.texImage2D with " + desc);
+      debug("checking gl.texImage2D with " + desc + " and buffer type " +
+            buf.constructor.name);
       gl.texImage2D(gl.TEXTURE_2D,
                     0,                 // level
                     format,            // internalFormat
@@ -205,6 +206,13 @@ if (!gl) {
    checkType(
        0, 255, 0, 255, gl.UNSIGNED_BYTE, gl.RGBA,
        new Uint8Array(
+         [ 0, 255, 0, 255,
+           0, 255, 0, 255,
+           0, 255, 0, 255,
+           0, 255, 0, 255]));
+   checkType(
+       0, 255, 0, 255, gl.UNSIGNED_BYTE, gl.RGBA,
+       new Uint8ClampedArray(
          [ 0, 255, 0, 255,
            0, 255, 0, 255,
            0, 255, 0, 255,

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -2612,9 +2612,10 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             passed. <br><br>
 
             If <code>pixels</code> is non-null, the type of <code>pixels</code> must match the type
-            of the data to be read. If it is UNSIGNED_BYTE, a Uint8Array must be supplied; if it is
-            UNSIGNED_SHORT_5_6_5, UNSIGNED_SHORT_4_4_4_4, or UNSIGNED_SHORT_5_5_5_1, a Uint16Array
-            must be supplied. If the types do not match, an INVALID_OPERATION error is generated.
+            of the data to be read. If it is UNSIGNED_BYTE, a Uint8Array or Uint8ClampedArray must
+            be supplied; if it is UNSIGNED_SHORT_5_6_5, UNSIGNED_SHORT_4_4_4_4, or
+            UNSIGNED_SHORT_5_5_5_1, a Uint16Array must be supplied. If the types do not match, an
+            INVALID_OPERATION error is generated.
             <br><br>
 
             If an attempt is made to call this function with no WebGLTexture bound (see above), an
@@ -3308,10 +3309,10 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             <br><br>
 
             The type of <code>pixels</code> must match the type of the data to be read. For example,
-            if it is UNSIGNED_BYTE, a Uint8Array must be supplied; if it is UNSIGNED_SHORT_5_6_5,
-            UNSIGNED_SHORT_4_4_4_4, or UNSIGNED_SHORT_5_5_5_1, a Uint16Array must be supplied; if it
-            is FLOAT, a Float32Array must be supplied. If the types do not match, an
-            INVALID_OPERATION error is generated.
+            if it is UNSIGNED_BYTE, a Uint8Array or Uint8ClampedArray must be supplied; if it is
+            UNSIGNED_SHORT_5_6_5, UNSIGNED_SHORT_4_4_4_4, or UNSIGNED_SHORT_5_5_5_1, a Uint16Array
+            must be supplied; if it is FLOAT, a Float32Array must be supplied. If the types do not
+            match, an INVALID_OPERATION error is generated.
             <br><br>
 
             Only two combinations of <code>format</code> and <code>type</code> are accepted. The

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1663,6 +1663,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           <tr><th>type of <em>srcData</em></th><th><em>type</em></th></tr>
           <tr><td>Int8Array</td><td>BYTE</td></tr>
           <tr><td>Uint8Array</td><td>UNSIGNED_BYTE</td></tr>
+          <tr><td>Uint8ClampedArray</td><td>UNSIGNED_BYTE</td></tr>
           <tr><td>Int16Array</td><td>SHORT</td></tr>
           <tr><td>Uint16Array</td><td>UNSIGNED_SHORT</td></tr>
           <tr><td>Uint16Array</td><td>UNSIGNED_SHORT_5_6_5</td></tr>


### PR DESCRIPTION
Where Uint8Array is allowed per spec, also allow Uint8ClampedArray.
This makes interaction with ImageData easier.

Firefox already allows Uint8ClampedArray in texImage2D where
Uint8Array is allowed, so this is a difference in behavior between
implementations that's now being clarified.

Reported in http://crbug.com/961658 .