### PR TITLE
Fix conformance/ogles after breakage from #2885.

### DIFF
--- a/sdk/tests/conformance/ogles/GL/abs/abs_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/abs/abs_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/acos/acos_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/acos/acos_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/all/all_001_to_004.html
+++ b/sdk/tests/conformance/ogles/GL/all/all_001_to_004.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/any/any_001_to_004.html
+++ b/sdk/tests/conformance/ogles/GL/any/any_001_to_004.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/array/array_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/array/array_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/asin/asin_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/asin/asin_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/atan/atan_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/atan/atan_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/atan/atan_009_to_012.html
+++ b/sdk/tests/conformance/ogles/GL/atan/atan_009_to_012.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/biConstants/biConstants_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/biConstants/biConstants_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/biConstants/biConstants_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/biConstants/biConstants_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
+++ b/sdk/tests/conformance/ogles/GL/biuDepthRange/biuDepthRange_001_to_002.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_017_to_024.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_017_to_024.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_025_to_032.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_025_to_032.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_033_to_040.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_033_to_040.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_041_to_048.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_041_to_048.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_049_to_056.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_049_to_056.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_057_to_064.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_057_to_064.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_065_to_072.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_065_to_072.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_073_to_080.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_073_to_080.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_081_to_088.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_081_to_088.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_089_to_096.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_089_to_096.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_097_to_104.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_097_to_104.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_105_to_112.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_105_to_112.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_113_to_120.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_113_to_120.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_121_to_128.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_121_to_128.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_129_to_136.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_129_to_136.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_137_to_144.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_137_to_144.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_145_to_152.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_145_to_152.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_153_to_160.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_153_to_160.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_161_to_168.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_161_to_168.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_169_to_176.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_169_to_176.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/build/build_177_to_178.html
+++ b/sdk/tests/conformance/ogles/GL/build/build_177_to_178.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html
+++ b/sdk/tests/conformance/ogles/GL/built_in_varying_array_out_of_bounds/built_in_varying_array_out_of_bounds_001_to_001.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/ceil/ceil_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/ceil/ceil_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/clamp/clamp_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/clamp/clamp_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/control_flow/control_flow_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/control_flow/control_flow_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/control_flow/control_flow_009_to_010.html
+++ b/sdk/tests/conformance/ogles/GL/control_flow/control_flow_009_to_010.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/cos/cos_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/cos/cos_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/cross/cross_001_to_002.html
+++ b/sdk/tests/conformance/ogles/GL/cross/cross_001_to_002.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/default/default_001_to_001.html
+++ b/sdk/tests/conformance/ogles/GL/default/default_001_to_001.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/degrees/degrees_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/degrees/degrees_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/discard/discard_001_to_002.html
+++ b/sdk/tests/conformance/ogles/GL/discard/discard_001_to_002.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/distance/distance_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/distance/distance_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/dot/dot_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/dot/dot_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/equal/equal_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/equal/equal_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/equal/equal_009_to_012.html
+++ b/sdk/tests/conformance/ogles/GL/equal/equal_009_to_012.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/exp/exp_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/exp/exp_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/exp/exp_009_to_012.html
+++ b/sdk/tests/conformance/ogles/GL/exp/exp_009_to_012.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/exp2/exp2_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/exp2/exp2_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/exp2/exp2_009_to_012.html
+++ b/sdk/tests/conformance/ogles/GL/exp2/exp2_009_to_012.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/faceforward/faceforward_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/faceforward/faceforward_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/floor/floor_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/floor/floor_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/fract/fract_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/fract/fract_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_017_to_024.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_017_to_024.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_025_to_032.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_025_to_032.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_033_to_040.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_033_to_040.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_041_to_048.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_041_to_048.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_049_to_056.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_049_to_056.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_057_to_064.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_057_to_064.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_065_to_072.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_065_to_072.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_073_to_080.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_073_to_080.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_081_to_088.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_081_to_088.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_089_to_096.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_089_to_096.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_097_to_104.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_097_to_104.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_105_to_112.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_105_to_112.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_113_to_120.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_113_to_120.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/functions/functions_121_to_126.html
+++ b/sdk/tests/conformance/ogles/GL/functions/functions_121_to_126.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
+++ b/sdk/tests/conformance/ogles/GL/gl_FragCoord/gl_FragCoord_001_to_003.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html
+++ b/sdk/tests/conformance/ogles/GL/gl_FrontFacing/gl_FrontFacing_001_to_001.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/greaterThan/greaterThan_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/greaterThanEqual/greaterThanEqual_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/inversesqrt/inversesqrt_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/length/length_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/length/length_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/lessThan/lessThan_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/lessThan/lessThan_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/lessThanEqual/lessThanEqual_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/log/log_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/log/log_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/log/log_009_to_012.html
+++ b/sdk/tests/conformance/ogles/GL/log/log_009_to_012.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/log2/log2_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/log2/log2_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/log2/log2_009_to_012.html
+++ b/sdk/tests/conformance/ogles/GL/log2/log2_009_to_012.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mat/mat_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/mat/mat_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mat/mat_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/mat/mat_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mat/mat_017_to_024.html
+++ b/sdk/tests/conformance/ogles/GL/mat/mat_017_to_024.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mat/mat_025_to_032.html
+++ b/sdk/tests/conformance/ogles/GL/mat/mat_025_to_032.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mat/mat_033_to_040.html
+++ b/sdk/tests/conformance/ogles/GL/mat/mat_033_to_040.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mat/mat_041_to_046.html
+++ b/sdk/tests/conformance/ogles/GL/mat/mat_041_to_046.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mat3/mat3_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/mat3/mat3_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html
+++ b/sdk/tests/conformance/ogles/GL/matrixCompMult/matrixCompMult_001_to_004.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/max/max_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/max/max_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/min/min_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/min/min_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mix/mix_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/mix/mix_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/mod/mod_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/mod/mod_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/normalize/normalize_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/normalize/normalize_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/not/not_001_to_004.html
+++ b/sdk/tests/conformance/ogles/GL/not/not_001_to_004.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/notEqual/notEqual_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/notEqual/notEqual_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/notEqual/notEqual_009_to_012.html
+++ b/sdk/tests/conformance/ogles/GL/notEqual/notEqual_009_to_012.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/operators/operators_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/operators/operators_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/operators/operators_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/operators/operators_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/operators/operators_017_to_024.html
+++ b/sdk/tests/conformance/ogles/GL/operators/operators_017_to_024.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/operators/operators_025_to_026.html
+++ b/sdk/tests/conformance/ogles/GL/operators/operators_025_to_026.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/pow/pow_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/pow/pow_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/pow/pow_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/pow/pow_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/pow/pow_017_to_024.html
+++ b/sdk/tests/conformance/ogles/GL/pow/pow_017_to_024.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/radians/radians_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/radians/radians_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/reflect/reflect_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/reflect/reflect_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/refract/refract_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/refract/refract_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/sign/sign_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/sign/sign_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/sin/sin_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/sin/sin_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/smoothstep/smoothstep_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/sqrt/sqrt_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/sqrt/sqrt_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/step/step_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/step/step_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/struct/struct_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/struct/struct_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/struct/struct_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/struct/struct_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/struct/struct_017_to_024.html
+++ b/sdk/tests/conformance/ogles/GL/struct/struct_017_to_024.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/struct/struct_025_to_032.html
+++ b/sdk/tests/conformance/ogles/GL/struct/struct_025_to_032.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/struct/struct_033_to_040.html
+++ b/sdk/tests/conformance/ogles/GL/struct/struct_033_to_040.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/struct/struct_041_to_048.html
+++ b/sdk/tests/conformance/ogles/GL/struct/struct_041_to_048.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/struct/struct_049_to_056.html
+++ b/sdk/tests/conformance/ogles/GL/struct/struct_049_to_056.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_017_to_024.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_025_to_032.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_033_to_040.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_041_to_048.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_049_to_056.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_057_to_064.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_065_to_072.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_073_to_080.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_081_to_088.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_089_to_096.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_097_to_104.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_105_to_112.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html
+++ b/sdk/tests/conformance/ogles/GL/swizzlers/swizzlers_113_to_120.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/tan/tan_001_to_006.html
+++ b/sdk/tests/conformance/ogles/GL/tan/tan_001_to_006.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/vec/vec_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/vec/vec_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/vec/vec_009_to_016.html
+++ b/sdk/tests/conformance/ogles/GL/vec/vec_009_to_016.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/vec/vec_017_to_018.html
+++ b/sdk/tests/conformance/ogles/GL/vec/vec_017_to_018.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/GL/vec3/vec3_001_to_008.html
+++ b/sdk/tests/conformance/ogles/GL/vec3/vec3_001_to_008.html
@@ -1,11 +1,10 @@
 <!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
-
-/*
+<!-- this file is auto-generated. DO NOT EDIT. -->
+<!--
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
+-->
 <html>
 <head>
 <meta charset="utf-8">

--- a/sdk/tests/conformance/ogles/process-ogles2-tests.py
+++ b/sdk/tests/conformance/ogles/process-ogles2-tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#! /usr/bin/env python2
 
 """generates tests from OpenGL ES 2.0 .run/.test files."""
 
@@ -29,12 +29,10 @@ FILTERS = [
 ]
 
 LICENSE = """
-/*
 Copyright (c) 2019 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
-*/
-"""
+""".strip()
 
 COMMENT_RE = re.compile("/\*\n\*\*\s+Copyright.*?\*/",
                         re.IGNORECASE | re.DOTALL)
@@ -222,7 +220,8 @@ def CopyShader(filename, src, dst):
     print "no matching license found:", s
     raise RuntimeError
   new_text = REMOVE_COPYRIGHT_RE.sub("", new_text)
-  new_text = new_text.replace(marker, LICENSE)
+  glsl_license = '/*\n' + LICENSE + '\n*/'
+  new_text = new_text.replace(marker, glsl_license)
   f = WriteOpen(d)
   f.write(new_text)
   f.close()
@@ -342,9 +341,8 @@ class TestReader():
   def WriteTests(self, filename, outname, tests_data):
     Log("Writing %s" % outname)
     template = """<!DOCTYPE html>
-<!-- this file is auto-generated. DO NOT EDIT.
+<!-- this file is auto-generated. DO NOT EDIT. -->
 %(license)s
--->
 <html>
 <head>
 <meta charset="utf-8">
@@ -376,9 +374,10 @@ var successfullyParsed = true;
     css_html = RelativizePaths(outname, css, '<link rel="stylesheet" href="%s" />')
     scripts_html = RelativizePaths(outname, scripts, '<script src="%s"></script>')
 
+    html_license = '<!--\n' + LICENSE + '\n-->'
     f = WriteOpen(outname)
     f.write(template % {
-        "license": LICENSE,
+        "license": html_license,
         "css": css_html,
         "scripts": scripts_html,
         "title": os.path.basename(outname),


### PR DESCRIPTION
These are generated files, and I've update the generation script.
Unfortunately, it looks like the ES conformance suite (now VK-GL-CTS)
has refactored the old mustpass.run files out of existance, so I'm not
sure we can trivially regenerate these tests. (though that's probably
ok)