### PR TITLE
Reject WEBGL_security_sensitive_resources.

### DIFF
--- a/extensions/rejected/WEBGL_security_sensitive_resources/extension.xml
+++ b/extensions/rejected/WEBGL_security_sensitive_resources/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="WEBGL_security_sensitive_resources/">
+<rejected href="rejected/WEBGL_security_sensitive_resources/">
 
   <name>WEBGL_security_sensitive_resources</name>
 
@@ -196,5 +196,10 @@ dictionary WebGLContextAttributes {
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
     </revision>
+    <revision date="2019/05/14">
+      <change>Moved to rejected state. No champion of the extension,
+      and there have been demonstrations that even these restrictions
+      are insufficient to guard against attacks.</change>
+    </revision>
   </history>
-</draft>
+</rejected>


### PR DESCRIPTION
Olli Etuaho, formerly of NVIDIA, demonstrated that it's possible to
infer textures' contents despite defenses such as these. No current
champion of this spec. Per discussion in WebGL WG, reject it.