### PR TITLE
Fix typo in depth renderbuffer initialization tests

### DIFF
--- a/sdk/tests/conformance/renderbuffers/depth-renderbuffer-initialization.html
+++ b/sdk/tests/conformance/renderbuffers/depth-renderbuffer-initialization.html
@@ -19,7 +19,7 @@ found in the LICENSE.txt file.
 <script>
 "use strict";
 var wtu = WebGLTestUtils;
-description('Verify depth renderbuffers are initialized to 0 before being read in WebGL');
+description('Verify depth renderbuffers are initialized to 1.0 before being read in WebGL');
 
 var gl = wtu.create3DContext("testbed");
 

--- a/sdk/tests/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html
+++ b/sdk/tests/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html
@@ -19,7 +19,7 @@ found in the LICENSE.txt file.
 <script>
 "use strict";
 var wtu = WebGLTestUtils;
-description('Verify multisampled depth renderbuffers are initialized to 0 before being read in WebGL');
+description('Verify multisampled depth renderbuffers are initialized to 1.0 before being read in WebGL');
 
 var gl = wtu.create3DContext("testbed", null, 2);
 


### PR DESCRIPTION
This patch fixes a typo in the depth renderbuffer initialization
tests that the depth renderbuffer should be initialized to 1.0
according to WebGL SPEC (WebGL 1.0, Chapter 4.1) instead of 0.