### PR TITLE
Fix missing parameter to shader log display in re-compile-relink glsl/misc tests

### DIFF
--- a/sdk/tests/conformance/glsl/misc/re-compile-re-link.html
+++ b/sdk/tests/conformance/glsl/misc/re-compile-re-link.html
@@ -91,7 +91,7 @@ function checkShaderStatus(s) {
   shader = s;
   shouldBeTrue("success = gl.getShaderParameter(shader, gl.COMPILE_STATUS)");
   if (!success) {
-    debug("error: " + gl.getShaderInfoLog());
+    debug("error: " + gl.getShaderInfoLog(shader));
   }
 }
 


### PR DESCRIPTION
Missing parameter in gl.getShaderInfoLog