### PR TITLE
Ext float blend test for WebGL 1

### DIFF
--- a/sdk/tests/conformance/extensions/ext-float-blend.html
+++ b/sdk/tests/conformance/extensions/ext-float-blend.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL EXT_float_blend Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/ext-float-blend.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("This test verifies the functionality of the EXT_float_blend extension, if it is available.");
+
+var wtu = WebGLTestUtils;
+var canvas = document.getElementById("canvas");
+var gl = wtu.create3DContext(canvas);
+var ext = null;
+
+(function(){
+    const oesTextureFloat = gl.getExtension("OES_texture_float");
+    if (!oesTextureFloat) {
+        testPassed("OES_texture_float is allowed to be missing.");
+        return;
+    }
+
+    const colorBufferFloat = gl.getExtension("WEBGL_color_buffer_float");
+    if (!colorBufferFloat) {
+        testPassed("WEBGL_color_buffer_float is allowed to be missing.");
+        return;
+    }
+
+    const drawBuffers = gl.getExtension("WEBGL_draw_buffers");
+    if (!drawBuffers) {
+        debug("WEBGL_draw_buffers is allowed to be missing. MRT tests will be skipped.");
+    }
+
+    const oesTextureHalfFloat = gl.getExtension("OES_texture_half_float");
+    const extColorBufferHalfFloat = gl.getExtension("EXT_color_buffer_half_float");
+    const testHalfFloat = !(!oesTextureHalfFloat || !extColorBufferHalfFloat);
+    if (!testHalfFloat) {
+        debug("OES_texture_half_float or EXT_color_buffer_half_float is allowed to be missing. NonFloat32Type tests will be skipped.");
+    }
+
+    debug("");
+    debug("Testing float32 blending without EXT_float_blend");
+    testExtFloatBlend(gl.RGBA);
+    if (drawBuffers) {
+        testExtFloatBlendMRTWebGL1(drawBuffers);
+    }
+    if (testHalfFloat) {
+        testExtFloatBlendNonFloat32TypeWebGL1(oesTextureHalfFloat);
+    }
+
+    const floatBlend = gl.getExtension("EXT_float_blend");
+    if (!floatBlend) {
+        testPassed("EXT_float_blend is allowed to be missing.");
+        return;
+    }
+
+    debug("");
+    debug("Testing that float32 blending is allowed with EXT_float_blend");
+    testExtFloatBlend(gl.RGBA);
+    if (drawBuffers) {
+        testExtFloatBlendMRTWebGL1(drawBuffers);
+    }
+    if (testHalfFloat) {
+        testExtFloatBlendNonFloat32TypeWebGL1(oesTextureHalfFloat);
+    }
+})();
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>
+<!--
+Copyright (c) 2019 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->

--- a/sdk/tests/conformance2/extensions/ext-float-blend.html
+++ b/sdk/tests/conformance2/extensions/ext-float-blend.html
@@ -30,8 +30,8 @@ var ext = null;
     debug("");
     debug("Testing float32 blending without EXT_float_blend");
     testExtFloatBlend(gl.RGBA32F);
-    testExtFloatBlendMRT();
-    testExtFloatBlendNonFloat32Type();
+    testExtFloatBlendMRTWebGL2();
+    testExtFloatBlendNonFloat32TypeWebGL2();
 
     const floatBlend = gl.getExtension("EXT_float_blend");
     if (!floatBlend) {
@@ -42,8 +42,8 @@ var ext = null;
     debug("");
     debug("Testing that float32 blending is allowed with EXT_float_blend");
     testExtFloatBlend(gl.RGBA32F);
-    testExtFloatBlendMRT();
-    testExtFloatBlendNonFloat32Type();
+    testExtFloatBlendMRTWebGL2();
+    testExtFloatBlendNonFloat32TypeWebGL2();
 })();
 
 debug("");

--- a/sdk/tests/js/tests/ext-float-blend.js
+++ b/sdk/tests/js/tests/ext-float-blend.js
@@ -200,8 +200,7 @@ function testExtFloatBlendNonFloat32Type(internalFormat, formats) {
 
 function testExtFloatBlendNonFloat32TypeWebGL1(ext) {
     const formats = [
-        [gl.RGBA, gl.RGBA, ext.HALF_FLOAT_OES],
-        [gl.RGB, gl.RGB, ext.HALF_FLOAT_OES]
+        [gl.RGBA, gl.RGBA, ext.HALF_FLOAT_OES]
     ];
     testExtFloatBlendNonFloat32Type(gl.RGBA, formats);
 }


### PR DESCRIPTION
Some test results:
* :heavy_check_mark: Linux Chrome 75 (OpenGL Backend)
* :heavy_check_mark: Linux Firefox Nightly
* :heavy_check_mark: Win Chromium local build with ext-float-blend enabled for D3D9 (Angle, validating cmd decoder, D3D9 Backend)
* :heavy_check_mark: Win Chrome 75 (Angle, validating cmd decoder, D3D11, OpenGL Backend)

Failing ones: RGBA float32 fbo color attachment is said to be unsupported, but it should be supported if WEBGL_color_buffer_float is available https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/ (RGB float32 is optional)

* :heavy_multiplication_x: Win Chrome 75 (Angle, passthrough cmd decoder, D3D11, OpenGL Backend)
* :heavy_multiplication_x: Win Firefox Nightly