### PR TITLE
Increase logging in OffscreenCanvas preserveDrawingBuffer test.

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/offscreencanvas/context-attribute-preserve-drawing-buffer.html
@@ -15,6 +15,7 @@ found in the LICENSE.txt file.
 </head>
 <body>
 <div id="description"></div>
+<div id="canvases"></div>
 <div id="console"></div>
 <script>
 "use strict";
@@ -33,6 +34,7 @@ const nextFrame = () => new Promise(r => requestAnimationFrame(r));
 
 async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
   const canvas = document.createElement("canvas");
+  document.getElementById("canvases").appendChild(canvas);
   const offscreenCanvas = transferredOffscreenCanvasCreation(canvas, 10, 10);
   const gl = offscreenCanvas.getContext("webgl", {preserveDrawingBuffer: preserveFlag});
 
@@ -42,6 +44,7 @@ async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
 
   let t;
   const t0 = await nextFrame();
+  const timeDuration = preserveFlag ? 500 : 2000;
   for (;;) {
     t = await nextFrame();
 
@@ -58,8 +61,9 @@ async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
       }
     }
 
-    // Keep checking until it takes up to a certain time
-    if (t > t0 + 500) {
+    // Keep checking until it takes up to a certain time.
+    // preserveDrawingBuffer:false seems flaky on Chrome's test bots; run that test for longer.
+    if (t > t0 + timeDuration) {
       break;
     }
   }
@@ -67,7 +71,7 @@ async function getPixelsFromOffscreenWebgl(preserveFlag, color, msg) {
   if (preserveFlag) {
     testPassed(msg);
   } else {
-    testFailed(msg + '\nexpected: ' + color.toString() + ' was ' + pixels.toString());
+    testFailed(msg + '\nafter ' + timeDuration + ' ms, expected: ' + color.toString() + ' was ' + pixels.toString());
   }
 }
 


### PR DESCRIPTION
Display the canvases that are being tested in the web page, in case
their eventual display is affecting the browser's composition paths.

Increase the timeout for the preserveDrawingBuffer:false test to 2000
ms in order to see whether that eliminates flakiness seen on automated
testing machines.

Related to http://crbug.com/979843 .