### PR TITLE
Fix invariance rule for FS #pragma STDGL invariant(all)

### DIFF
--- a/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
+++ b/sdk/tests/conformance/glsl/misc/shaders-with-invariance.html
@@ -320,8 +320,8 @@ var cases = [
     vShaderSuccess: true,
     fShaderId: "fragmentShaderGlobalInvariant",
     fShaderSuccess: true,
-    linkSuccess: true,
-    passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must succeed",
+    linkSuccess: false,
+    passMsg: "vertex shader with invariant varying and fragment shader with invariant (global setting) varying must fail",
   }
 ];
 


### PR DESCRIPTION
Previous change "Change invariance rule for #pragma STDGL invariant(all)."
incorrectly updated fragmentShaderGlobalInvariant test to expect to pass.
That test uses "#pragma STDGL invariant(all)" in the FS which only affects
outputs and therefore does NOT cause the input varying to match the VS output
invariant varying, thus causing a link fail.

Therefore restoring this test to correctly expect the link to fail. The
change to expect it to pass was made during an intermediate ANGLE fix that
can be referenced for more info:
https://chromium-review.googlesource.com/c/angle/angle/+/1558678

New bug relevant to this current fix is:
https://bugs.chromium.org/p/chromium/issues/detail?id=980675