### PR TITLE
Mute videos before playing.

### DIFF
--- a/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
@@ -1357,6 +1357,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   video.addEventListener('playing', playingListener, true);
   video.addEventListener('timeupdate', timeupdateListener, true);
   video.loop = true;
+  video.muted = true;
   video.play();
 };
 

--- a/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
@@ -2022,6 +2022,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   video.addEventListener('playing', playingListener, true);
   video.addEventListener('timeupdate', timeupdateListener, true);
   video.loop = true;
+  video.muted = true;
   video.play();
 };
 

--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -2616,6 +2616,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   video.addEventListener('playing', playingListener, true);
   video.addEventListener('timeupdate', timeupdateListener, true);
   video.loop = true;
+  video.muted = true;
   video.play();
 };
 

--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -2905,6 +2905,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   video.addEventListener('playing', playingListener, true);
   video.addEventListener('timeupdate', timeupdateListener, true);
   video.loop = true;
+  video.muted = true;
   video.play();
 };
 

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3003,6 +3003,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
 
   requestAnimFrame.call(window, timeWatcher);
   video.loop = true;
+  video.muted = true;
   video.play();
 };
 


### PR DESCRIPTION
Browsers often refuse to auto-play videos without user interaction,
unless the videos are muted.