### PR TITLE
Set preload='auto' flag on videos uploaded to WebGL textures.

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3004,6 +3004,8 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   requestAnimFrame.call(window, timeWatcher);
   video.loop = true;
   video.muted = true;
+  // See whether setting the preload flag de-flakes video-related tests.
+  video.preload = 'auto';
   video.play();
 };
 


### PR DESCRIPTION
This is an attempt to see whether this eliminates flakiness in
video-related WebGL tests, per suggestion from Chrome's media team in
https://crbug.com/979444#c20 .