### PR TITLE
Increase timeout on long-loop-compile.html.

### DIFF
--- a/sdk/tests/conformance/glsl/misc/large-loop-compile.html
+++ b/sdk/tests/conformance/glsl/misc/large-loop-compile.html
@@ -156,10 +156,11 @@ if (!gl) {
   setTimeout(function() {
     if (!receivedContextLost) {
       testPassed("Large loop compiled and linked without terminating the WebGL context");
-      if (endTime - startTime < 5000) {
-        testPassed("Shader compilation completed in a reasonable amount of time");
+      let timeString = ": " + (endTime - startTime) + " ms";
+      if (endTime - startTime < 7500) {
+        testPassed("Shader compilation completed in a reasonable amount of time" + timeString);
       } else {
-        testFailed("Shader compilation took an unreasonably long time");
+        testFailed("Shader compilation took an unreasonably long time" + timeString);
       }
     }
     finishTest();

--- a/sdk/tests/conformance/glsl/misc/large-loop-compile.html
+++ b/sdk/tests/conformance/glsl/misc/large-loop-compile.html
@@ -156,11 +156,11 @@ if (!gl) {
   setTimeout(function() {
     if (!receivedContextLost) {
       testPassed("Large loop compiled and linked without terminating the WebGL context");
-      let timeString = ": " + (endTime - startTime) + " ms";
+      const timeString = `${endTime - startTime} ms`;
       if (endTime - startTime < 7500) {
-        testPassed("Shader compilation completed in a reasonable amount of time" + timeString);
+        testPassed("Shader compilation completed in a reasonable amount of time: " + timeString);
       } else {
-        testFailed("Shader compilation took an unreasonably long time" + timeString);
+        testFailed("Shader compilation took an unreasonably long time: " + timeString);
       }
     }
     finishTest();
@@ -170,4 +170,3 @@ var successfullyParsed = true;
 </script>
 </body>
 </html>
-


### PR DESCRIPTION
This test assumes the HLSL compiler will finish within 5000 ms for a
long loop which it apparently has to unroll. On some slower Windows
bots this timeout is occasionally being hit, so increase the timeout
50%, to 7500 ms.

Related to http://crbug.com/691951.