### PR TITLE
Add blocklist Chrome command line parameter

### DIFF
--- a/other/test-runner/config.json
+++ b/other/test-runner/config.json
@@ -15,7 +15,7 @@
                     "paths": ["C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"]
                 },
                 "remote-android": {
-                    "pre_launch_command": "adb shell \"echo 'chrome --disable-fre --disable-gpu-driver-bug-workarounds --ignore-gpu-blacklist --disable-gesture-requirement-for-media-playback' > /data/local/chrome-command-line\"",
+                    "pre_launch_command": "adb shell \"echo 'chrome --disable-fre --disable-gpu-driver-bug-workarounds --ignore-gpu-blacklist --ignore-gpu-blocklist --disable-gesture-requirement-for-media-playback' > /data/local/chrome-command-line\"",
                     "package_name": "com.android.chrome",
                     "main_activity": "com.android.chrome/com.google.android.apps.chrome.Main",
                     "launch_intent": "android.intent.action.VIEW",
@@ -28,7 +28,8 @@
             "args": [
                 "--no-first-run",
                 "--disable-gpu-driver-bug-workarounds",
-                "--ignore-gpu-blacklist"
+                "--ignore-gpu-blacklist",
+                "--ignore-gpu-blocklist"
             ]
         },
 
@@ -46,6 +47,7 @@
                 "--no-first-run",
                 "--disable-gpu-driver-bug-workarounds",
                 "--ignore-gpu-blacklist",
+                "--ignore-gpu-blocklist",
                 "--use-gl=desktop"
             ]
         },
@@ -66,7 +68,8 @@
             "args": [
                 "--no-first-run",
                 "--disable-gpu-driver-bug-workarounds",
-                "--ignore-gpu-blacklist"
+                "--ignore-gpu-blacklist",
+                "--ignore-gpu-blocklist"
             ]
         },
 
@@ -84,6 +87,7 @@
                 "--no-first-run",
                 "--disable-gpu-driver-bug-workarounds",
                 "--ignore-gpu-blacklist",
+                "--ignore-gpu-blocklist",
                 "--use-gl=desktop"
             ]
         },
@@ -107,7 +111,8 @@
             "args": [
                 "--no-first-run",
                 "--disable-gpu-driver-bug-workarounds",
-                "--ignore-gpu-blacklist"
+                "--ignore-gpu-blacklist",
+                "--ignore-gpu-blocklist"
             ]
         },
 
@@ -125,6 +130,7 @@
                 "--no-first-run",
                 "--disable-gpu-driver-bug-workarounds",
                 "--ignore-gpu-blacklist",
+                "--ignore-gpu-blocklist",
                 "--use-gl=desktop"
             ]
         },


### PR DESCRIPTION
The name "blocklist" is more inclusive than "blacklist" while
still conveying the intention clearly.
See https://developers.google.com/style/word-list#blacklist

In order to rename Chrome's --ignore-gpu-blacklist command line
parameter we must first add the new --ignore-gpu-blocklist
everywhere it is used. Once this is done, Chrome can rename its
command line parameter and then we can remove the old references.

This PR adds the --ignore-gpu-blocklist command line parameter.