### PR TITLE
Create webgl2 context with antialias=false for OVR_multiview

### DIFF
--- a/extensions/OVR_multiview2/extension.xml
+++ b/extensions/OVR_multiview2/extension.xml
@@ -152,7 +152,7 @@ interface OVR_multiview2 {
   </errors>
   <samplecode xml:space="preserve">
     <pre>
-    var gl = document.createElement('canvas').getContext('webgl2');
+    var gl = document.createElement('canvas').getContext('webgl2', {antialias: false});
     var ext = gl.getExtension('OVR_multiview2');
     var fb = gl.createFramebuffer();
     gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);


### PR DESCRIPTION
The OVR_multiview2 extension only supports non-multisampled contexts, so it could be nice to reflect that in the example as `antialias` is true by default when creating a webgl context