### PR TITLE
Fix typo in WebGL2 sync test

### DIFF
--- a/sdk/tests/conformance2/sync/sync-webgl-specific.html
+++ b/sdk/tests/conformance2/sync/sync-webgl-specific.html
@@ -79,7 +79,7 @@ function runGetSyncParameterTest() {
   var iter = numRetries;
   while (--iter > 0) {
     syncWithGLServer();
-    if (gl.getSyncParameter(sync, gl.SYNC_STATUS) == gl.SYNC_SIGNALED) {
+    if (gl.getSyncParameter(sync, gl.SYNC_STATUS) == gl.SIGNALED) {
       testFailed("Sync object was signaled too early");
       finishTest();
       return;


### PR DESCRIPTION
There was a wrong check on the `gl.getSyncParameter` return value, which results that the test always pass.