### PR TITLE
Add test cases to non-ascii-comments test

### DIFF
--- a/sdk/tests/conformance/glsl/misc/non-ascii-comments.vert.html
+++ b/sdk/tests/conformance/glsl/misc/non-ascii-comments.vert.html
@@ -25,9 +25,10 @@ found in the LICENSE.txt file.
 /*
  * ‚s‚ˆ‚‰‚“@‚h‚“@‚m‚‚”@‚`‚r‚b‚h‚h
  */
+#define TEST 1 // ‚s‚ˆ‚‰‚“@‚h‚“@‚m‚‚”@‚`‚r‚b‚h‚h
 void main() {
-  gl_Position = vec4(1,1,1,1);
-}
+  gl_Position = vec4(1,1,1,1); // ‚s‚ˆ‚‰‚“@‚h‚“@‚m‚‚”@‚`‚r‚b‚h‚h
+} // ‚s‚ˆ‚‰‚“@‚h‚“@‚m‚‚”@‚`‚r‚b‚h‚h
 </script>
 <script>
 "use strict";


### PR DESCRIPTION
As noted in
https://bugs.chromium.org/p/chromium/issues/detail?id=940865, comments
were not stripped by WebGL in some cases. Added a test to prevent this
from happening again.