### PR TITLE
Fix vertex-array-object-and-disabled-attributes test.

### DIFF
--- a/sdk/tests/conformance2/vertex_arrays/vertex-array-object-and-disabled-attributes.html
+++ b/sdk/tests/conformance2/vertex_arrays/vertex-array-object-and-disabled-attributes.html
@@ -57,8 +57,9 @@ description();
 
 var gl = wtu.create3DContext("example", undefined, 2);
 
-var singleProgram = wtu.setupProgram(gl, ['singlevshader', 'singlefshader']);
-var dualProgram = wtu.setupProgram(gl, ['dualvshader', 'dualfshader']);
+// Location of "position" attribute must match between shaders.
+var singleProgram = wtu.setupProgram(gl, ['singlevshader', 'singlefshader'], ['position'], [0]);
+var dualProgram = wtu.setupProgram(gl, ['dualvshader', 'dualfshader'], ['position'], [0]);
 
 var positionLocation = gl.getAttribLocation(dualProgram, "position");
 var colorLocation = gl.getAttribLocation(dualProgram, "color");


### PR DESCRIPTION
conformance2/vertex_arrays/
vertex-array-object-and-disabled-attributes.html was assuming that the
"position" attribute location would match between two separately
compiled and linked programs. This must be enforced via
bindAttribLocation.

Associated with ANGLE test bug: http://crbug.com/angleproject/4049

Fixes #2949 .