### PR TITLE
Fix incorrect test html name in test list

### DIFF
--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -26,7 +26,7 @@
 --min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float-with-image.html
 --min-version 1.0.3 --max-version 1.9.9 oes-texture-half-float-with-video.html
 --min-version 1.0.2 --max-version 1.9.9 oes-element-index-uint.html
---min-version 1.0.4 --max-version 1.9.9 oes-fbo-mipmap-renderer.html
+--min-version 1.0.4 --max-version 1.9.9 oes-fbo-render-mipmap.html
 webgl-debug-renderer-info.html
 webgl-debug-shaders.html
 --min-version 1.0.4 webgl-compressed-texture-astc.html


### PR DESCRIPTION
Tests added in `00_test_list.txt` should be `oes-fbo-render-mipmap.html`.
Thanks @kenrussell for pointing this out.