### PR TITLE
Fix BaseVertexBaseInstance extensions number

### DIFF
--- a/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
@@ -11,7 +11,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>NN</number>
+  <number>46</number>
 
   <depends>
     <api version="2.0"/>

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -12,7 +12,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>NN</number>
+  <number>47</number>
 
   <depends>
     <api version="2.0"/>


### PR DESCRIPTION
Didn't assign an extension number when promoted to draft.
Thanks for Ken for pointing this out.