### PR TITLE
Workload simulator: OffscreenCanvas and context creation params

### DIFF
--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -497,7 +497,7 @@ function render(fromRaf, fromPostMessage) {
         gl_Position = vec4(position * size + offset + vec2(size - 1., 1. - size), 0, 1);
         texCoord = vec2(position.x, 1. - position.y);
       }`,`
-      precision highp float;
+      precision mediump float;
       varying vec2 texCoord;
       uniform vec4 colorAddition;
       uniform sampler2D tex;
@@ -526,7 +526,7 @@ function render(fromRaf, fromPostMessage) {
             texCoord = vec2(position.x, 1. - position.y);
           }`, `#version 300 es
           #extension GL_OVR_multiview2 : enable
-          precision highp float;
+          precision mediump float;
           in vec2 texCoord;
           out vec4 my_FragColor;
           uniform sampler2D tex;

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -11,26 +11,21 @@ body {
   margin: 0;
   font-family: monospace;
   user-select: none;
+  -moz-user-select: -moz-none;
+  -webkit-user-select: none;
   font-size: 22px;
   text-size-adjust: none;
 }
 
 .square {
-  width: 512px;
-  height: 512px;
   overflow: hidden;
   border-bottom: 20px solid black;
   border-right: 20px solid black;
   display: block;
-  user-select: none;
-  -moz-user-select: -moz-none;
-  -webkit-user-select: none;
 }
 
 .square img {
   position: relative;
-  left: 128;
-  top: 128;
 }
 
 #fpsPanel {
@@ -41,10 +36,15 @@ body {
   width: 300px;
   font-size: 12px;
   margin: 10px;
+  pointer-events: none;
+}
+
+#showFps, label[for='showFps'], #showStats, label[for='showStats'] {
+  pointer-events: auto;
 }
 
 #fpsSpan {
-  font-size: 40px;
+  font-size: 30px;
 }
 
 .bad {
@@ -56,16 +56,22 @@ body {
 }
 
 input {
-  margin: 20px;
-  padding: 20px;
-  transform: scale(2);
+  margin: 15px 15px;
+  transform: scale(2) translate(0px, -2px);
 }
 
+input[type="number"] {
+  width: 50px;
+}
 input[type="range"] {
     width: 100px;
-    margin: 40px 200px;
+    margin: 30px 200px;
     padding: 0px;
     transform: scale(4);
+}
+
+label {
+  white-space: pre;
 }
 
 #warning {
@@ -75,8 +81,6 @@ input[type="range"] {
   min-height: 2em;
 }
 </style>
-
-<button id=highPower>high power</button>
 
 <canvas id=webglCanvas class=square></canvas>
 <canvas id=canvas class=square style=display:none;></canvas>
@@ -92,7 +96,6 @@ input[type="range"] {
 <label for=mousemove><input type=radio name=continuous id=mousemove checked>Mouse/touch drag triggers rendering</label>
 <label for=continuous><input type=radio name=continuous id=continuous>Continuous rendering loop</label>
 <br>
-
 <div id=continuousOptions>
 Looping method:
 <label for=useRaf><input type=radio name=loop id=useRaf checked>requestAnimationFrame</label>
@@ -106,6 +109,8 @@ Target FPS: <span id=fpsLabel>60</span>
 </div>
 </div>
 <p>Do the following extra work each frame:</p>
+<input type=range id=jsWork min=0 max=100 value=0>
+<span id=jsWorkLabel>0</span> ms Javascript work
 <div id=glOptions>
 <input type=range id=pixels min=65536 max=65536000 value=65536 step=65536>
 draw <span id=pixelsLabel>64K</span> pixels per view
@@ -125,91 +130,150 @@ Multiply the above slider values by:
 <br>
 <label for=readPixels><input type=checkbox id=readPixels>glReadPixels</label>
 <br>
+<p>Context creation options:</p>
+<label for=antialias><input type=checkbox id=antialias checked>Antialias</label>
+<label for=alpha><input type=checkbox id=alpha checked>Alpha</label>
+<label for=depth><input type=checkbox id=depth checked>Depth</label>
+<label for=stencil><input type=checkbox id=stencil>Stencil</label>
+<label for=premultipliedAlpha><input type=checkbox id=premultipliedAlpha checked>Premultiplied Alpha</label>
+<label for=preserveDrawingBuffer><input type=checkbox id=preserveDrawingBuffer>Preserve Drawing Buffer</label>
+<label for=desyncrhonized><input type=checkbox id=desyncrhonized>Desynchronized</label>
+<br>
+Power preference
+<label for=ppDefault><input type=radio name=pp id=ppDefault checked>default</label>
+<label for=lowPower><input type=radio name=pp id=lowPower>low-power</label>
+<label for=highPerformance><input type=radio name=pp id=highPerformance>high-performance</label>
 </div>
+Canvas size <input type=number id=canvasSize value=512 min=1> pixels<sup>2</sup>
 <div id="multiviewOptions">
 <input type=range id=views min=1 max=4 value=0 step=1>
-using <span id=viewsLabel>1</span> views(s)
+Draw <span id=viewsLabel>1</span> views(s)
 <br>
 <label for=multiview><input type=checkbox id=multiview>Use OVR_multiview2</label>
 <label for=multiviewCopy><input type=checkbox id=multiviewCopy checked>Copy multiview draw results to main canvas</label>
 </div>
-<input type=range id=jsWork min=0 max=100 value=0>
-<span id=jsWorkLabel>0</span> ms Javascript work
-
-
 
 <div id=fpsPanel>
-<p><label for=showFps><input type=checkbox id=showFps checked>Show FPS</label>
-<p>
+<label for=showFps><input type=checkbox id=showFps checked>Show FPS</label>
 <div id=fps>
   <span id=fpsSpan></span>
   <p>
-  <label for=showStats><input type=checkbox id=showStats>Show detailed stats</label>
+  <label for=showStats><input type=checkbox id=showStats>More info</label>
   <div id=stats></div>
 </div>
-<p>FPS figures are for the last second of rendering.
 </div>
 
 <h2><center>WebGL workload simulator</center></h2>
 
-<script id=vs type=text/x-glsl>
-attribute vec2 position;
-varying vec2 texCoord;
-uniform vec2 offset;
-void main() {
-  gl_Position = vec4(position + offset, 0, 1);
-  texCoord = vec2(position.x, 1. - position.y);
-}
-</script>
-<script id=fs type=text/x-glsl>
-precision highp float;
-varying vec2 texCoord;
-uniform vec4 colorAddition;
-uniform sampler2D tex;
-void main() {
-  gl_FragColor = texture2D(tex, texCoord) + colorAddition * 0.5;
-}
-</script>
-<script id="multiviewVs" type="text/x-glsl">#version 300 es
-#extension GL_OVR_multiview2 : enable
-layout(num_views=$(num_views)) in;
-in vec2 position;
-out vec2 texCoord;
-
-uniform vec2 offset;
-
-void main() {
-  gl_Position = vec4(position + offset, 0, 1);
-  texCoord = vec2(position.x, 1. - position.y);
-}
-</script>
-<script id="multiviewFs" type="text/x-glsl">#version 300 es
-#extension GL_OVR_multiview2 : enable
-precision highp float;
-in vec2 texCoord;
-out vec4 my_FragColor;
-
-uniform sampler2D tex;
-
-void main() {
-  vec4 colorAddition = vec4(((gl_ViewID_OVR & 0x4u) != 0u) ? 1.0 : 0.0,
-                            ((gl_ViewID_OVR & 0x2u) != 0u) ? 1.0 : 0.0,
-                            ((gl_ViewID_OVR & 0x1u) != 0u) ? 1.0 : 0.0,
-                            1.0);
-  my_FragColor = texture(tex, texCoord) + colorAddition * 0.5;
-}
-</script>
 <script>
-const img = document.getElementById('img');
-// Wait for the image to load before doing anything.
-img.onload = img.onerror = function() {
-const canvas = document.getElementById('canvas');
-const webglCanvas = document.getElementById('webglCanvas');
-const dom = document.getElementById('dom');
-const imgSize = img.width || 256;
-const size = webglCanvas.clientWidth;
-let multiviewAvailable = false;
-let webglVersion;
+'use strict';
+// Add all elements with ids as global readonly variables.
+for (let element of document.documentElement.querySelectorAll('[id]'))
+  Object.defineProperty(this, element.id, {value: element, writeable: false});
+
+
+/************\
+* Options UI *
+\************/
+
+
+// Set all input elements with values from the query string.
+const controls = document.getElementsByTagName('input');
+const defaultChecked = {};
+const defaultValues = {};
+const defaultMaxes = {};
+for (const control of controls) {
+  defaultChecked[control.id] = control.checked;
+  defaultValues[control.id] = control.value;
+  defaultMaxes[control.id] = control.max;
+  const param = window.location.search.match(control.id + '(?:=([^&]*))?');
+  if (param) {
+    if (control.type == 'radio')
+      control.checked = true;
+    else if (param.length > 1) {
+      if (control.type == 'checkbox')
+        control.checked = param[1] != 'false';
+      else
+        control.value = param[1];
+    }
+  }
+  control.oninput = updateControls;
+}
+// Some controls require a page reload when changed.
+const reloadControls = ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desyncrhonized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize'].map(x=>window[x]);
+for (let control of reloadControls) {
+  control.onchange = ()=>{
+    updateControls();
+    callReplaceStateThrottled();
+    location.reload();
+  };
+}
+
+let queryString = window.location.search;
+let previousQueryString = queryString;
+let replaceStateScheduled = false;
+function callReplaceStateThrottled() {
+  replaceStateScheduled = false;
+  if (queryString == previousQueryString)
+    return;
+  previousQueryString = queryString;
+  let path = window.location.pathname;
+  history.replaceState(null, null, queryString == '?' ? path : path + queryString);
+}
+const suffixes = ['', 'K', 'M', 'G', 'E']
+const divisors = [];
+for (let i = 0; i < suffixes.length; i++)
+  divisors[i] = Math.pow(10, i * 3);
+const formatSI = (x) => {
+  const order = Math.min(Math.log10(Math.abs(x)) / 3 | 0, suffixes.length);
+  return (x / divisors[order]).toFixed(1) + suffixes[order];
+}
+var multiplier;
+function updateControls() {
+  multiplier = x1.checked ? 1 : x10.checked ? 10 : 100;
+  webglCanvas.style.display = useGl.checked ? 'block' : 'none';
+  canvas.style.display = use2D.checked ? 'block' : 'none';
+  dom.style.display = useDom.checked ? 'block' : 'none';
+  continuousOptions.style.visibility =
+      continuous.checked ? 'visible' : 'hidden';
+  glOptions.style.visibility =
+      useGl.checked ? 'visible' : 'hidden';
+  multiviewOptions.style.visibility =
+      (useGl.checked && multiviewAvailable) ? 'visible' : 'hidden';
+  fpsOptions.style.display =
+      continuous.checked && (useSetTimeout.checked || useSetInterval.checked) ?
+      'block' : 'none';
+  fps.style.visibility =
+      showFps.checked ? 'visible' : 'hidden';
+  stats.style.visibility =
+      showStats.checked ? 'visible' : 'hidden';
+  drawCallsLabel.textContent = Math.max(1, drawCalls.value * multiplier);
+  pixelsLabel.textContent = formatSI(pixels.value * multiplier);
+  jsWorkLabel.textContent = jsWork.value;
+  fpsLabel.textContent = fpsSlider.value;
+  uploadLabel.textContent =
+      parseFloat(uploads.value).toFixed(2);
+  viewsLabel.textContent = views.value;
+
+  const queryParams = [];
+  for (const control of controls) {
+    if (control.type == 'radio') {
+      if (!defaultChecked[control.id] && control.checked)
+        queryParams.push(control.id);
+    } else if (control.type == 'checkbox') {
+      if (control.checked != defaultChecked[control.id])
+        queryParams.push(control.id + '=' + control.checked);
+    } else if (control.value != defaultValues[control.id]) {
+      queryParams.push(control.id + '=' + control.value);
+    }
+  }
+  queryString = '?' + queryParams.join('&');
+  if (!replaceStateScheduled) {
+    replaceStateScheduled = true;
+    setTimeout(callReplaceStateThrottled, 200);
+  }
+  render();
+};
 
 
 /**********************\
@@ -217,15 +281,20 @@ let webglVersion;
 \**********************/
 
 
+const imgSize = 256;
+const size = parseInt(canvasSize.value);
+let multiviewAvailable = false;
+let webglVersion;
+
 let mouseDown = false;
 const lastPos = [0, 0];
-document.onmouseup = function(e) { mouseDown = false; };
-document.onmousedown = function(e) {
+document.onmouseup = (e) => mouseDown = false;
+document.onmousedown = (e) => {
   mouseDown = true;
   lastPos[0] = e.pageX;
   lastPos[1] = e.pageY;
 };
-document.ontouchstart = function(e) {
+document.ontouchstart = (e) => {
   lastPos[0] = e.touches[0].pageX;
   lastPos[1] = e.touches[0].pageY;
 }
@@ -256,107 +325,9 @@ function mouseMove(e) {
 }
 document.addEventListener("mousemove", mouseMove, true);
 document.body.addEventListener("touchmove", mouseMove, true);
-function cancel(e) { e.preventDefault(); }
-const toCancel = [dom, canvas, webglCanvas, img];
-for (const element of toCancel) {
-  element.onmousedown = cancel;
-  element.ontouchstart = cancel;
-}
+for (const element of [dom, canvas, webglCanvas, img])
+  element.onmousedown = element.ontouchstart = (e)=>e.preventDefault();
 
-
-/************\
-* Options UI *
-\************/
-
-
-// Set all input elements with values from the query string.
-const controls = document.getElementsByTagName('input');
-const defaultChecked = {};
-const defaultValues = {};
-const defaultMaxes = {};
-for (const control of controls) {
-  window[control.id] = control;
-  defaultChecked[control.id] = control.checked;
-  defaultValues[control.id] = control.value;
-  defaultMaxes[control.id] = control.max;
-  const param = window.location.search.match(control.id + '(?:=([^&]*))?');
-  if (param) {
-    if (control.type == 'radio')
-      control.checked = true;
-    else if (param.length > 1) {
-      if (control.type == 'checkbox')
-        control.checked = param[1] != 'false';
-      else
-        control.value = param[1];
-    }
-  }
-  control.oninput = updateControls;
-}
-let queryString = window.location.search;
-let previousQueryString = queryString;
-let replaceStateScheduled = false;
-function callReplaceStateThrottled() {
-  replaceStateScheduled = false;
-  if (queryString == previousQueryString)
-    return;
-  previousQueryString = queryString;
-  let path = window.location.pathname;
-  history.replaceState(null, null, queryString == '?' ? path : path + queryString);
-}
-const suffixes = ['', 'K', 'M', 'G', 'E']
-const divisors = [];
-for (let i = 0; i < suffixes.length; i++)
-  divisors[i] = Math.pow(10, i * 3);
-const formatSI = (x) => {
-  const order = Math.min(Math.log10(Math.abs(x)) / 3 | 0, suffixes.length);
-  return (x / divisors[order]).toFixed(1) + suffixes[order];
-}
-var multiplier;
-function updateControls() {
-  multiplier = x1.checked ? 1 : x10.checked ? 10 : 100;
-  webglCanvas.style.display = useGl.checked ? 'block' : 'none';
-  canvas.style.display = use2D.checked ? 'block' : 'none';
-  dom.style.display = useDom.checked ? 'block' : 'none';
-  document.getElementById('continuousOptions').style.visibility =
-      continuous.checked ? 'visible' : 'hidden';
-  document.getElementById('glOptions').style.visibility =
-      useGl.checked ? 'visible' : 'hidden';
-  document.getElementById('multiviewOptions').style.visibility =
-      (useGl.checked && multiviewAvailable) ? 'visible' : 'hidden';
-  document.getElementById('fpsOptions').style.display =
-      continuous.checked && (useSetTimeout.checked || useSetInterval.checked) ?
-      'block' : 'none';
-  document.getElementById('fps').style.visibility =
-      showFps.checked ? 'visible' : 'hidden';
-  document.getElementById('stats').style.visibility =
-      showStats.checked ? 'visible' : 'hidden';
-  document.getElementById('drawCallsLabel').textContent = Math.max(1, drawCalls.value * multiplier);
-  document.getElementById('pixelsLabel').textContent = formatSI(pixels.value * multiplier);
-  document.getElementById('jsWorkLabel').textContent = jsWork.value;
-  document.getElementById('fpsLabel').textContent = fpsSlider.value;
-  document.getElementById('uploadLabel').textContent =
-      parseFloat(uploads.value).toFixed(2);
-  document.getElementById('viewsLabel').textContent = views.value;
-
-  const queryParams = [];
-  for (const control of controls) {
-    if (control.type == 'radio') {
-      if (!defaultChecked[control.id] && control.checked)
-        queryParams.push(control.id);
-    } else if (control.type == 'checkbox') {
-      if (control.checked != defaultChecked[control.id])
-        queryParams.push(control.id + '=' + control.checked);
-    } else if (control.value != defaultValues[control.id]) {
-      queryParams.push(control.id + '=' + control.value);
-    }
-  }
-  queryString = '?' + queryParams.join('&');
-  if (!replaceStateScheduled) {
-    replaceStateScheduled = true;
-    setTimeout(callReplaceStateThrottled, 200);
-  }
-  render();
-};
 
 
 /***********\
@@ -366,8 +337,11 @@ function updateControls() {
 
 webglCanvas.width = webglCanvas.height = size;
 canvas.width = canvas.height = size;
+dom.style.width = size + 'px';
+dom.style.height = size + 'px';
 
-window.onmessage = function() { render(false, true); };
+
+window.onmessage = () => render(false, true);
 
 let ctx;
 let gl;
@@ -452,34 +426,19 @@ function render(fromRaf, fromPostMessage) {
 
   warningText = '';
 
-  if (useDom.checked) {
-    img.style.left = position[0] + 'px';
-    img.style.top = position[1] + 'px';
-    return;
-  }
-  if (use2D.checked) {
-    ctx = ctx || canvas.getContext('2d');
-    ctx.fillStyle = 'white';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    try {
-      ctx.drawImage(img, position[0], position[1]);
-    } catch (e) {
-      ctx.fillStyle = 'black';
-      ctx.fillRect(position[0], position[1], imgSize, imgSize);
-    }
-    return;
-  }
   // Initialize GL.
   if (!gl) {
-    // We're using antialias: false so that results are comparable between
-    // multiview and non-multiview rendering (multiview is never antialiased).
+    const options = {};
+    for (let option of ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desyncrhonized'])
+      options[option] = window[option].checked;
+    options.powerPreference = ppDefault.checked ? 'default' : lowPower.checked ? 'low-power' : 'high-performance';
     // We create a WebGL 2 context if available - if not, fall back to WebGL 1.
-    gl = webglCanvas.getContext('webgl2', {antialias: true});
+    gl = webglCanvas.getContext('webgl2', options);
     if (gl) {
       webglVersion = 2;
     } else {
       webglVersion = 1;
-      gl = webglCanvas.getContext('webgl', {antialias: true});
+      gl = webglCanvas.getContext('webgl', options);
       const aia = gl.getExtension('ANGLE_instanced_arrays');
       gl.drawArraysInstanced = (a, b, c, d)=>aia.drawArraysInstancedANGLE(a, b, c, d);
     }
@@ -488,41 +447,56 @@ function render(fromRaf, fromPostMessage) {
     const tex = gl.createTexture();
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, tex);
-    try {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array([0, 0, 0, 255]));
+    img.onload = ()=>{
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, tex);
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
       gl.generateMipmap(gl.TEXTURE_2D);
-    } catch (e) {}
+      render();
+    };
 
-    let setupProgram = function(vsSource, fsSource, attribs) {
-      const vs = gl.createShader(gl.VERTEX_SHADER);
-      gl.shaderSource(vs, vsSource);
-      gl.compileShader(vs);
-      //console.log(gl.getShaderInfoLog(vs));
-      const fs = gl.createShader(gl.FRAGMENT_SHADER);
-      gl.shaderSource(fs, fsSource);
-      gl.compileShader(fs);
-      //console.log(gl.getShaderInfoLog(fs));
-
+    function setupProgram(vsSource, fsSource, attribs, uniforms) {
       let prog = gl.createProgram();
-      gl.attachShader(prog, fs);
-      gl.attachShader(prog, vs);
-
-      for (let i = 0; i < attribs.length; ++i) {
-        gl.bindAttribLocation(prog, i, attribs[i]);
+      function compileShader(source, type) {
+        const shader = gl.createShader(type);
+        gl.shaderSource(shader, source);
+        gl.compileShader(shader);
+        if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS))
+          console.log(gl.getShaderInfoLog(shader));
+        gl.attachShader(prog, shader);
       }
-
+      compileShader(vsSource, gl.VERTEX_SHADER);
+      compileShader(fsSource, gl.FRAGMENT_SHADER);
+      for (let i = 0; i < attribs.length; ++i)
+        gl.bindAttribLocation(prog, i, attribs[i]);
       gl.linkProgram(prog);
-      //console.log(gl.getProgramInfoLog(prog));
+      if (!gl.getProgramParameter(prog, gl.LINK_STATUS))
+        console.log(gl.getProgramInfoLog(prog));
+      for (const attrib of attribs)
+        prog[attrib] = gl.getAttribLocation(prog, attrib);
+      for (const uniform of uniforms)
+        prog[uniform] = gl.getUniformLocation(prog, uniform);
       return prog;
     }
 
-    // Setup shaders
-    program = setupProgram(document.getElementById('vs').textContent, document.getElementById('fs').textContent, ['position', 'texCoordIn']);
-    program.position = gl.getAttribLocation(program, 'position');
-    program.texCoordIn = gl.getAttribLocation(program, 'texCoordIn');
-    program.offset = gl.getUniformLocation(program, 'offset');
-    program.tex = gl.getUniformLocation(program, 'tex');
-    program.colorAddition = gl.getUniformLocation(program, 'colorAddition');
+    program = setupProgram(`
+      attribute vec2 position;
+      varying vec2 texCoord;
+      uniform vec2 offset;
+      uniform float size;
+      void main() {
+        gl_Position = vec4(position * size + offset + vec2(size - 1., 1. - size), 0, 1);
+        texCoord = vec2(position.x, 1. - position.y);
+      }`,`
+      precision highp float;
+      varying vec2 texCoord;
+      uniform vec4 colorAddition;
+      uniform sampler2D tex;
+      void main() {
+        gl_FragColor = texture2D(tex, texCoord) + colorAddition * 0.5;
+      }`,
+      ['position', 'texCoordIn'], ['offset', 'tex', 'size', 'colorAddition']);
     gl.useProgram(program);
     gl.uniform1i(program.tex, 0);
 
@@ -532,11 +506,32 @@ function render(fromRaf, fromPostMessage) {
       maxViewsMultiview = Math.min(gl.getParameter(ext.MAX_VIEWS_OVR), 16);
       views.max = maxViewsMultiview;
       for (let i = 0; i < maxViewsMultiview; ++i) {
-        let vsSource = document.getElementById('multiviewVs').textContent;
-        vsSource = vsSource.replace('$(num_views)', (i + 1));
-        multiviewProgram[i] = setupProgram(vsSource, document.getElementById('multiviewFs').textContent, ['position', 'texCoordIn']);
-        multiviewProgram[i].offset = gl.getUniformLocation(multiviewProgram[i], 'offset');
-        multiviewProgram[i].tex = gl.getUniformLocation(multiviewProgram[i], 'tex');
+        multiviewProgram[i] = setupProgram(`
+          #version 300 es
+          #extension GL_OVR_multiview2 : enable
+          layout(num_views=${i + 1}) in;
+          in vec2 position;
+          out vec2 texCoord;
+          uniform vec2 offset;
+          uniform float size;
+          void main() {
+            gl_Position = vec4(position * size + offset + vec2(size - 1., 1. - size), 0, 1);
+            texCoord = vec2(position.x, 1. - position.y);
+          }`, `
+          #version 300 es
+          #extension GL_OVR_multiview2 : enable
+          precision highp float;
+          in vec2 texCoord;
+          out vec4 my_FragColor;
+          uniform sampler2D tex;
+          void main() {
+            vec4 colorAddition = vec4(((gl_ViewID_OVR & 0x4u) != 0u) ? 1.0 : 0.0,
+                                      ((gl_ViewID_OVR & 0x2u) != 0u) ? 1.0 : 0.0,
+                                      ((gl_ViewID_OVR & 0x1u) != 0u) ? 1.0 : 0.0,
+                                      1.0);
+            my_FragColor = texture(tex, texCoord) + colorAddition * 0.5;
+          }`,
+          ['position', 'texCoordIn'], ['offset', 'tex', 'size']);
         gl.useProgram(multiviewProgram[i]);
         gl.uniform1i(multiviewProgram[i].tex, 0);
       }
@@ -559,6 +554,24 @@ function render(fromRaf, fromPostMessage) {
     gl.disable(gl.CULL_FACE);
 
     updateControls();
+  } // End GL init
+
+  if (useDom.checked) {
+    img.style.left = position[0] + 'px';
+    img.style.top = position[1] + 'px';
+    return;
+  }
+  if (use2D.checked) {
+    ctx = ctx || canvas.getContext('2d');
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    try {
+      ctx.drawImage(img, position[0], position[1]);
+    } catch (e) {
+      ctx.fillStyle = 'black';
+      ctx.fillRect(position[0], position[1], imgSize, imgSize);
+    }
+    return;
   }
 
   // Upload some data to test the PCI bottleneck.
@@ -618,8 +631,9 @@ function render(fromRaf, fromPostMessage) {
 
   gl.useProgram(usedProgram);
   gl.uniform2f(usedProgram.offset,
-               (position[0] - imgSize) / webglCanvas.width * 2,
-               -position[1] / webglCanvas.width * 2);
+               (position[0] - imgSize) / size * 2,
+               -position[1] / size * 2);
+  gl.uniform1f(usedProgram.size, imgSize * 2 / size);
 
   if (usedProgram == program) {
     gl.uniform4f(program.colorAddition, 0.0, 0.0, 0.0, 1.0);
@@ -632,7 +646,7 @@ function render(fromRaf, fromPostMessage) {
       gl.uniform4f(program.colorAddition, (viewIndex & 4) ? 1.0 : 0.0, (viewIndex & 2) ? 1.0 : 0.0, (viewIndex & 1) ? 1.0 : 0.0, 1.0);
       gl.disable(gl.SCISSOR_TEST);
     }
-    gl.clearColor(0.9, 1, 0.9, 1);
+    gl.clearColor(1, 1, 1, 1);
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.drawArraysInstanced(gl.TRIANGLE_STRIP, 0, 4, instancesFirstCall);
     var instancesDrawn = instancesFirstCall;
@@ -744,23 +758,16 @@ function countFps(name, mouseEventsThisFrame) {
         }
         text += "<div class=light>" + counter.count + " frames</div>";
       }
-      document.getElementById('stats').innerHTML = text;
+      stats.innerHTML = text;
     }
   }
   if (warningText != displayedWarningText) {
-    document.getElementById('warning').textContent = warningText;
+    warning.textContent = warningText;
     displayedWarningText = warningText;
   }
 }
 
 updateControls();
-}; // img.onload
 
-highPower.onclick = ()=>{
-  let canvas = document.createElement('canvas');
-  document.body.appendChild(canvas);
-  canvas.getContext('webgl', {powerPreference: "high-performance"});
-}
-
-img.src = 'logo-256x256.png';
+img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAgMAAAAhHED1AAAADFBMVEUAAAA5AAByAACZAAADU26qAAAFIUlEQVR42u2ZPW7jRhTHOVQkFiwEFU4RFTwCj0Am8AG8wHIDrC8QZBH4BAGJNGkdIL7BLpCo8Q1CpkqrDRCkVWEvkKSIChVUQHLy3pshRZlDeUhVCeZf6GOt+XHmvf+8+VjLMjIyMjIyMjIyMjIyMjIyMjIyMjL6j2txEUWX45u/uueo6l04qvlUNCfE9yPaf8zbendme84fB7af8ad6O6g9SzsAfjsEcNNtz6sBuVhylR7OGsCgQXhHzf5crVaCuNftQHvgd2LkF28GdKHVgcdD4C7udbvQ6sCRg9mNZheW6vZEyHUAaW/agKDhBadurxjwNN3oh1BpvGWpb6K12uOJ7gh6Mjbb6I6gL2Ffaeag1zKzZ/Jgn4wA6uo0wJUpgI8fvaDCPrCq+wcPBegaxsthgFgANvSRAEXnNxcaE2lL4UwwJh37v+F7DOTl5SkX7AiQWdaEPgI5CltRwhFy5bxwDwBGqXCoM/gtaw0Sba4G1DbKCbBBwOYYMKuzrAaIGOYIsAngSkc0AK/uoRogfLhJCxw9/mz+FCAeUfYAZBLWcUnx3OEDs2OAHGMPQBo5FIA0R0ByBIBf7EMojoka4EgfBxWOPi7QmeERwMEA2viiBIgsFtAMR++XXYBL0ySF+CoBcxliD/7oVV6JEwJm1UsCsCtKQkEzZqsGeNLHCPBLDx4WV9YsheoCgBTt45MzPXhVAnzpkjkEKSjn8HQIp4++YvwXykpAxpr3AQICZDDSzIpzF36SFpTakPG/qUrE5Itp9FINEC5JINZrADiYrJwykzH5l7SZEycAIQHS3QTb7ea8gqAD4J8U/5UnpwCpBEwwTVubrwHg89sZ3wEgdGjkGgD025bhU9fwAV0Z51TawJqHZicBTD5+A11JIfY+hBLewJqif2i2kwCL72x06xaCgXmblwwLi18yXUAKwc8gjg5/j3lzK4ZvXjUIkJAVfsa8OZwA80p7CHGBLgoA8A3/LYquOU0msOYzgNoH0sc+vH4mSsSnCHA5pVEHIGYSvPKJADDMPwDQiSz6/DQgseRchtdqUvdAAMRcsPsAQV2zPaomUFOqJz2IaTZO+gB+vTDOqZ5BVSsn/P0CRADIQkALjdMHqAsKNMWKCnW1sMX0E1mo4BE5FbbidEmTNR1ec5sGHREA4jKnmuj3Adx61XCoH7i2kINcYSSIi0sxTvsAdVnHphtaBGACb7HvDL8HBf7hAddHBNxFEVQm5cIiKj8uVFucwzSL4A0mJlYmPD0UVrMKq5Y2ubZb2A+oywBh0C8bOyN3cQ1gGr0IO5Nhi4CMvq4hYHfXVJHgbd1sohrA7MPvWcdJtPYm5MxMZGZTF1URpipuAOzXv7LuBgOfHRIgES0SVm/+6EMetAA/Zd0tDhR1LjqU0O67hHb3MmL4jLXfAnzdBkzqLRKuz3JpXWLmGP9W7p8BWFmf/GCtSG+t76Kkm4bqKDVfiqO7fINl6er5jeatNVbeYZ84Ts7wg7Z6r7sZu92vg1COPXA0e9W+E8cXz42hPrJUYw9dzcH1QX0oDHUTybkqWkuNw7PdHH1Dxd3OWv/Uo7g6mqaVjhXcvssndq/n0NYVzOPx8znXM2jrEmh/iOSrbgnVugX6kU5bC3EzmGhOCPU91JA5qr6IGjBFZ2dehVnWtaL9flBZuDnrMk8m/YzrRAVh+LVs61J35LUue920/+NqXIVdvKZxrKJz7sYXC/MfBEZGRkZGRkZGRkZGRkZGRkZGRkb/N/0Lo92VZbHxh60AAAAASUVORK5CYII=';
 </script>

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -76,7 +76,7 @@ input[type="range"] {
 }
 </style>
 
-
+<button id=highPower>high power</button>
 
 <canvas id=webglCanvas class=square></canvas>
 <canvas id=canvas class=square style=display:none;></canvas>
@@ -474,12 +474,12 @@ function render(fromRaf, fromPostMessage) {
     // We're using antialias: false so that results are comparable between
     // multiview and non-multiview rendering (multiview is never antialiased).
     // We create a WebGL 2 context if available - if not, fall back to WebGL 1.
-    gl = webglCanvas.getContext('webgl2', {antialias: false});
+    gl = webglCanvas.getContext('webgl2', {antialias: true});
     if (gl) {
       webglVersion = 2;
     } else {
       webglVersion = 1;
-      gl = webglCanvas.getContext('webgl', {antialias: false});
+      gl = webglCanvas.getContext('webgl', {antialias: true});
       const aia = gl.getExtension('ANGLE_instanced_arrays');
       gl.drawArraysInstanced = (a, b, c, d)=>aia.drawArraysInstancedANGLE(a, b, c, d);
     }
@@ -755,6 +755,12 @@ function countFps(name, mouseEventsThisFrame) {
 
 updateControls();
 }; // img.onload
+
+highPower.onclick = ()=>{
+  let canvas = document.createElement('canvas');
+  document.body.appendChild(canvas);
+  canvas.getContext('webgl', {powerPreference: "high-performance"});
+}
 
 img.src = 'logo-256x256.png';
 </script>

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -78,7 +78,7 @@ input[type="range"] {
 <br>
 <div id=canvasOptions>
   <label for=onscreen><input type=radio name=offscreen id=onscreen checked>Regular canvas</label>
-  <label for=offscreen><input type=radio name=offscreen id=offscreen>OffscreenCanvas (still on main thread)</label>
+  <label for=offscreen><input type=radio name=offscreen id=offscreen>OffscreenCanvas (on main thread)</label>
   <!-- <label for=offscreenWorker><input type=radio name=offscreen id=offscreenWorker>OffscreenCanvas on worker</label> -->
   <br>
   <label for=transferControlToOffscreen><input type=checkbox id=transferControlToOffscreen checked>Use transferControlToOffscreen</label>
@@ -128,7 +128,7 @@ input[type="range"] {
   <label for=stencil><input type=checkbox id=stencil>Stencil</label>
   <label for=premultipliedAlpha><input type=checkbox id=premultipliedAlpha checked>Premultiplied Alpha</label>
   <label for=preserveDrawingBuffer><input type=checkbox id=preserveDrawingBuffer>Preserve Drawing Buffer</label>
-  <label for=desyncrhonized><input type=checkbox id=desyncrhonized>Desynchronized</label>
+  <label for=desynchronized><input type=checkbox id=desynchronized>Desynchronized</label>
   <br>
   Power preference
   <label for=ppDefault><input type=radio name=pp id=ppDefault checked>default</label>
@@ -190,7 +190,7 @@ for (const control of controls) {
   control.oninput = updateControls;
 }
 // Some controls require a page reload when changed.
-const reloadControls = ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desyncrhonized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize', 'onscreen', 'offscreen', 'transferControlToOffscreen'].map(x=>window[x]);
+const reloadControls = ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desynchronized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize', 'onscreen', 'offscreen', 'transferControlToOffscreen'].map(x=>window[x]);
 for (let control of reloadControls) {
   control.onchange = ()=>{
     updateControls();
@@ -421,7 +421,7 @@ function render(fromRaf, fromPostMessage) {
   // Initialize GL.
   if (!gl) {
     const options = {};
-    for (let option of ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desyncrhonized'])
+    for (let option of ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desynchronized'])
       options[option] = window[option].checked;
     options.powerPreference = ppDefault.checked ? 'default' : lowPower.checked ? 'low-power' : 'high-performance';
     let renderCanvas = webglCanvas;

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -130,7 +130,7 @@ Multiply the above slider values by:
 <input type=range id=views min=1 max=4 value=0 step=1>
 using <span id=viewsLabel>1</span> views(s)
 <br>
-<label for=multiview><input type=checkbox id=multiview>Use WEBGL_multiview</label>
+<label for=multiview><input type=checkbox id=multiview>Use OVR_multiview2</label>
 <label for=multiviewCopy><input type=checkbox id=multiviewCopy checked>Copy multiview draw results to main canvas</label>
 </div>
 <input type=range id=jsWork min=0 max=100 value=0>
@@ -171,7 +171,7 @@ void main() {
 }
 </script>
 <script id="multiviewVs" type="text/x-glsl">#version 300 es
-#extension GL_OVR_multiview : enable
+#extension GL_OVR_multiview2 : enable
 layout(num_views=$(num_views)) in;
 in vec2 position;
 out vec2 texCoord;
@@ -184,7 +184,7 @@ void main() {
 }
 </script>
 <script id="multiviewFs" type="text/x-glsl">#version 300 es
-#extension GL_OVR_multiview : enable
+#extension GL_OVR_multiview2 : enable
 precision highp float;
 in vec2 texCoord;
 out vec4 my_FragColor;
@@ -526,9 +526,9 @@ function render(fromRaf, fromPostMessage) {
     gl.useProgram(program);
     gl.uniform1i(program.tex, 0);
 
-    if (webglVersion >= 2 && gl.getExtension('WEBGL_multiview')) {
+    if (webglVersion >= 2 && gl.getExtension('OVR_multiview2')) {
       multiviewAvailable = true;
-      let ext = gl.getExtension('WEBGL_multiview')
+      let ext = gl.getExtension('OVR_multiview2')
       maxViewsMultiview = Math.min(gl.getParameter(ext.MAX_VIEWS_OVR), 16);
       views.max = maxViewsMultiview;
       for (let i = 0; i < maxViewsMultiview; ++i) {
@@ -590,10 +590,10 @@ function render(fromRaf, fromPostMessage) {
     gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, webglCanvas.width, webglCanvas.height, maxViewsMultiview);
-    multiviewExt = gl.getExtension('WEBGL_multiview');
+    multiviewExt = gl.getExtension('OVR_multiview2');
     multiviewFramebuffer = gl.createFramebuffer();
     gl.bindFramebuffer(gl.FRAMEBUFFER, multiviewFramebuffer);
-    multiviewExt.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, multiviewTexture, 0, 0, numViews);
+    multiviewExt.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, multiviewTexture, 0, 0, numViews);
     lastNumViews = numViews;
     for (let i = 0; i < maxViewsMultiview; ++i) {
       viewFramebuffer[i] = gl.createFramebuffer();
@@ -608,7 +608,7 @@ function render(fromRaf, fromPostMessage) {
   if (multiviewAvailable && multiview.checked) {
     gl.bindFramebuffer(gl.FRAMEBUFFER, multiviewFramebuffer);
     if (numViews != lastNumViews) {
-      multiviewExt.framebufferTextureMultiviewWEBGL(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, multiviewTexture, 0, 0, numViews);
+      multiviewExt.framebufferTextureMultiviewOVR(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, multiviewTexture, 0, 0, numViews);
       lastNumViews = numViews;
     }
     usedProgram = multiviewProgram[numViews - 1];

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -17,6 +17,7 @@ body {
   text-size-adjust: none;
 }
 
+.square img { position: relative; }
 .square {
   overflow: hidden;
   border-bottom: 20px solid black;
@@ -24,10 +25,7 @@ body {
   display: block;
 }
 
-.square img {
-  position: relative;
-}
-
+#fpsSpan { font-size: 30px; }
 #fpsPanel {
   position: fixed;
   text-align: right;
@@ -39,30 +37,9 @@ body {
   pointer-events: none;
 }
 
-#showFps, label[for='showFps'], #showStats, label[for='showStats'] {
-  pointer-events: auto;
-}
-
-#fpsSpan {
-  font-size: 30px;
-}
-
-.bad {
-  color: red;
-}
-
-.light {
-  color: #CCCCCC;
-}
-
-input {
-  margin: 15px 15px;
-  transform: scale(2);
-}
-
-input[type="number"] {
-  width: 50px;
-}
+input, label { white-space: pre; pointer-events: auto; }
+input { margin: 15px 15px;  transform: scale(2); }
+input[type="number"] { width: 50px; }
 input[type="range"] {
     width: 100px;
     margin: 30px 200px;
@@ -70,19 +47,14 @@ input[type="range"] {
     transform: scale(4);
 }
 
+.rotate { animation: rotating 2s linear infinite; }
 @keyframes rotating {
   from { transform: scale(2) rotate(0deg); }
   to { transform: scale(2) rotate(360deg); }
 }
 
-.rotate {
-  animation: rotating 2s linear infinite;
-}
-
-label {
-  white-space: pre;
-}
-
+.bad { color: red; }
+.light { color: #CCCCCC; }
 #warning {
   color: #FF0000;
   display: block;
@@ -96,7 +68,7 @@ label {
 <div id=dom class=square style=display:none;background:white>
   <img id=img style=width:256px;height:256px;background:black></img>
 </div>
-<div id="warning"></div>
+<div id=warning></div>
 
 <label for=animation><input type=checkbox id=animation>CSS animation</label>
 <br>
@@ -104,74 +76,82 @@ label {
 <label for=use2D><input type=radio name=renderer id=use2D>Canvas 2D</label>
 <label for=useDom><input type=radio name=renderer id=useDom>DOM</label>
 <br>
+<div id=canvasOptions>
+  <label for=onscreen><input type=radio name=offscreen id=onscreen checked>Regular canvas</label>
+  <label for=offscreen><input type=radio name=offscreen id=offscreen>OffscreenCanvas (still on main thread)</label>
+  <!-- <label for=offscreenWorker><input type=radio name=offscreen id=offscreenWorker>OffscreenCanvas on worker</label> -->
+  <br>
+  <label for=transferControlToOffscreen><input type=checkbox id=transferControlToOffscreen checked>Use transferControlToOffscreen</label>
+</div>
 <label for=mousemove><input type=radio name=continuous id=mousemove checked>Mouse/touch drag triggers rendering</label>
 <label for=continuous><input type=radio name=continuous id=continuous>Continuous rendering loop</label>
 <br>
 <div id=continuousOptions>
-Looping method:
-<label for=useRaf><input type=radio name=loop id=useRaf checked>requestAnimationFrame</label>
-<label for=usePostMessage><input type=radio name=loop id=usePostMessage>postMessage</label>
-<label for=useSetTimeout><input type=radio name=loop id=useSetTimeout>setTimeout</label>
-<label for=useSetInterval><input type=radio name=loop id=useSetInterval>setInterval</label>
-<br>
-<div id=fpsOptions>
-<input id=fpsSlider type=range min=10 max=240 step=10 value=60>
-Target FPS: <span id=fpsLabel>60</span>
-</div>
+  Looping method:
+  <label for=useRaf><input type=radio name=loop id=useRaf checked>requestAnimationFrame</label>
+  <label for=usePostMessage><input type=radio name=loop id=usePostMessage>postMessage</label>
+  <label for=useSetTimeout><input type=radio name=loop id=useSetTimeout>setTimeout</label>
+  <label for=useSetInterval><input type=radio name=loop id=useSetInterval>setInterval</label>
+  <br>
+  <div id=fpsOptions>
+    <input id=fpsSlider type=range min=10 max=240 step=10 value=60>
+    Target FPS: <span id=fpsLabel>60</span>
+  </div>
 </div>
 <p>Do the following extra work each frame:</p>
 <input type=range id=jsWork min=0 max=100 value=0>
 <span id=jsWorkLabel>0</span> ms Javascript work
 <div id=glOptions>
-<input type=range id=pixels min=65536 max=65536000 value=65536 step=65536>
-draw <span id=pixelsLabel>64K</span> pixels per view
-<br>
-<input type=range id=drawCalls min=0 max=10000 value=0 step=10>
-using <span id=drawCallsLabel>1</span> draw call(s) per view
-<br>
-Multiply the above slider values by:
-<label for=x1><input type=radio name=multiplier id=x1 checked>1 </label>
-<label for=x10><input type=radio name=multiplier id=x10>10 </label>
-<label for=x100><input type=radio name=multiplier id=x100>100 </label>
-<br>
-<input type=range id=uploads min=0 max=256 value=0 step=0.25>
-<span id=uploadLabel>0.00</span> MB glBufferData
-<br>
-<label for=finish><input type=checkbox id=finish>glFinish</label>
-<br>
-<label for=readPixels><input type=checkbox id=readPixels>glReadPixels</label>
-<br>
-<p>Context creation options:</p>
-<label for=antialias><input type=checkbox id=antialias checked>Antialias</label>
-<label for=alpha><input type=checkbox id=alpha checked>Alpha</label>
-<label for=depth><input type=checkbox id=depth checked>Depth</label>
-<label for=stencil><input type=checkbox id=stencil>Stencil</label>
-<label for=premultipliedAlpha><input type=checkbox id=premultipliedAlpha checked>Premultiplied Alpha</label>
-<label for=preserveDrawingBuffer><input type=checkbox id=preserveDrawingBuffer>Preserve Drawing Buffer</label>
-<label for=desyncrhonized><input type=checkbox id=desyncrhonized>Desynchronized</label>
-<br>
-Power preference
-<label for=ppDefault><input type=radio name=pp id=ppDefault checked>default</label>
-<label for=lowPower><input type=radio name=pp id=lowPower>low-power</label>
-<label for=highPerformance><input type=radio name=pp id=highPerformance>high-performance</label>
+  <input type=range id=pixels min=65536 max=65536000 value=65536 step=65536>
+  draw <span id=pixelsLabel>64K</span> pixels per view
+  <br>
+  <input type=range id=drawCalls min=0 max=10000 value=0 step=10>
+  using <span id=drawCallsLabel>1</span> draw call(s) per view
+  <br>
+  Multiply the above slider values by:
+  <label for=x1><input type=radio name=multiplier id=x1 checked>1 </label>
+  <label for=x10><input type=radio name=multiplier id=x10>10 </label>
+  <label for=x100><input type=radio name=multiplier id=x100>100 </label>
+  <br>
+  <input type=range id=uploads min=0 max=256 value=0 step=0.25>
+  <span id=uploadLabel>0.00</span> MB glBufferData
+  <br>
+  <label for=finish><input type=checkbox id=finish>glFinish</label>
+  <br>
+  <label for=readPixels><input type=checkbox id=readPixels>glReadPixels</label>
+  <br>
+  <p>Context creation options:</p>
+  <label for=antialias><input type=checkbox id=antialias checked>Antialias</label>
+  <label for=alpha><input type=checkbox id=alpha checked>Alpha</label>
+  <label for=depth><input type=checkbox id=depth checked>Depth</label>
+  <label for=stencil><input type=checkbox id=stencil>Stencil</label>
+  <label for=premultipliedAlpha><input type=checkbox id=premultipliedAlpha checked>Premultiplied Alpha</label>
+  <label for=preserveDrawingBuffer><input type=checkbox id=preserveDrawingBuffer>Preserve Drawing Buffer</label>
+  <label for=desyncrhonized><input type=checkbox id=desyncrhonized>Desynchronized</label>
+  <br>
+  Power preference
+  <label for=ppDefault><input type=radio name=pp id=ppDefault checked>default</label>
+  <label for=lowPower><input type=radio name=pp id=lowPower>low-power</label>
+  <label for=highPerformance><input type=radio name=pp id=highPerformance>high-performance</label>
 </div>
+<br>
 Canvas size <input type=number id=canvasSize value=512 min=1> pixels<sup>2</sup>
 <div id="multiviewOptions">
-<input type=range id=views min=1 max=4 value=0 step=1>
-Draw <span id=viewsLabel>1</span> views(s)
-<br>
-<label for=multiview><input type=checkbox id=multiview>Use OVR_multiview2</label>
-<label for=multiviewCopy><input type=checkbox id=multiviewCopy checked>Copy multiview draw results to main canvas</label>
+  <input type=range id=views min=1 max=4 value=0 step=1>
+  Draw <span id=viewsLabel>1</span> views(s)
+  <br>
+  <label for=multiview><input type=checkbox id=multiview>Use OVR_multiview2</label>
+  <label for=multiviewCopy><input type=checkbox id=multiviewCopy checked>Copy multiview draw results to main canvas</label>
 </div>
 
 <div id=fpsPanel>
-<label for=showFps><input type=checkbox id=showFps checked>Show FPS</label>
-<div id=fps>
-  <span id=fpsSpan></span>
-  <p>
-  <label for=showStats><input type=checkbox id=showStats>More info</label>
-  <div id=stats></div>
-</div>
+  <label for=showFps><input type=checkbox id=showFps checked>Show FPS</label>
+  <div id=fps>
+    <span id=fpsSpan></span>
+    <p>
+    <label for=showStats><input type=checkbox id=showStats>More info</label>
+    <div id=stats></div>
+  </div>
 </div>
 
 <h2><center>WebGL workload simulator</center></h2>
@@ -209,7 +189,7 @@ for (const control of controls) {
   control.oninput = updateControls;
 }
 // Some controls require a page reload when changed.
-const reloadControls = ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desyncrhonized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize'].map(x=>window[x]);
+const reloadControls = ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desyncrhonized', 'ppDefault', 'lowPower', 'highPerformance', 'canvasSize', 'onscreen', 'offscreen', 'transferControlToOffscreen'].map(x=>window[x]);
 for (let control of reloadControls) {
   control.onchange = ()=>{
     updateControls();
@@ -244,19 +224,16 @@ function updateControls() {
   canvas.style.display = use2D.checked ? 'block' : 'none';
   dom.style.display = useDom.checked ? 'block' : 'none';
   animation.className = animation.checked ? 'rotate' : null;
-  continuousOptions.style.visibility =
-      continuous.checked ? 'visible' : 'hidden';
-  glOptions.style.visibility =
-      useGl.checked ? 'visible' : 'hidden';
-  multiviewOptions.style.visibility =
-      (useGl.checked && multiviewAvailable) ? 'visible' : 'hidden';
+  canvasOptions.style.display = useDom.checked ? 'none' : '';
+  transferControlToOffscreen.parentElement.style.display = onscreen.checked ? 'none' : '';
+  continuousOptions.style.display = continuous.checked ? '' : 'none';
+  glOptions.style.display = useGl.checked ? '' : 'none';
+  multiviewOptions.style.display = (useGl.checked && multiviewAvailable) ? '' : 'none';
   fpsOptions.style.display =
       continuous.checked && (useSetTimeout.checked || useSetInterval.checked) ?
-      'block' : 'none';
-  fps.style.visibility =
-      showFps.checked ? 'visible' : 'hidden';
-  stats.style.visibility =
-      showStats.checked ? 'visible' : 'hidden';
+      '' : 'none';
+  fps.style.visibility = showFps.checked ? 'visible' : 'hidden';
+  stats.style.visibility = showStats.checked ? 'visible' : 'hidden';
   drawCallsLabel.textContent = Math.max(1, drawCalls.value * multiplier);
   pixelsLabel.textContent = formatSI(pixels.value * multiplier);
   jsWorkLabel.textContent = jsWork.value;
@@ -348,16 +325,15 @@ for (const element of [dom, canvas, webglCanvas, img])
 \***********/
 
 
-webglCanvas.width = webglCanvas.height = size;
-canvas.width = canvas.height = size;
-dom.style.width = size + 'px';
-dom.style.height = size + 'px';
-
+webglCanvas.width = webglCanvas.height = canvas.width = canvas.height = size;
+dom.style.width = dom.style.height = size + 'px';
 
 window.onmessage = () => render(false, true);
 
 let ctx;
 let gl;
+let bitmapRenderer;
+let offscreenCanvas;
 let program;
 let buffer;
 const borderSize = 10;
@@ -445,13 +421,23 @@ function render(fromRaf, fromPostMessage) {
     for (let option of ['antialias', 'alpha', 'depth', 'stencil', 'premultipliedAlpha', 'preserveDrawingBuffer', 'desyncrhonized'])
       options[option] = window[option].checked;
     options.powerPreference = ppDefault.checked ? 'default' : lowPower.checked ? 'low-power' : 'high-performance';
+    let renderCanvas = webglCanvas;
+    if (offscreen.checked) {
+      if (transferControlToOffscreen.checked) {
+        renderCanvas = webglCanvas.transferControlToOffscreen();
+      } else {
+        bitmapRenderer = webglCanvas.getContext('bitmaprenderer')
+        renderCanvas = offscreenCanvas = new OffscreenCanvas(size, size);
+      }
+    }
+    renderCanvas.width = renderCanvas.height = size;
     // We create a WebGL 2 context if available - if not, fall back to WebGL 1.
-    gl = webglCanvas.getContext('webgl2', options);
+    gl = renderCanvas.getContext('webgl2', options);
     if (gl) {
       webglVersion = 2;
     } else {
       webglVersion = 1;
-      gl = webglCanvas.getContext('webgl', options);
+      gl = renderCanvas.getContext('webgl', options);
       const aia = gl.getExtension('ANGLE_instanced_arrays');
       gl.drawArraysInstanced = (a, b, c, d)=>aia.drawArraysInstancedANGLE(a, b, c, d);
     }
@@ -556,7 +542,7 @@ function render(fromRaf, fromPostMessage) {
     gl.vertexAttribPointer(program.position, 2, gl.FLOAT, false, 0, 0);
 
     // Setup drawing state
-    gl.viewport(0, 0, webglCanvas.width, webglCanvas.height);
+    gl.viewport(0, 0, size, size);
     gl.clearColor(1, 1, 1, 1);
     gl.disable(gl.SCISSOR_TEST);
     gl.disable(gl.DEPTH_TEST);
@@ -573,7 +559,19 @@ function render(fromRaf, fromPostMessage) {
     return;
   }
   if (use2D.checked) {
-    ctx = ctx || canvas.getContext('2d');
+    if (!ctx) {
+      if (offscreen.checked) {
+        if (transferControlToOffscreen.checked) {
+          offscreenCanvas = canvas.transferControlToOffscreen();
+        } else {
+          bitmapRenderer = canvas.getContext('bitmaprenderer');
+          offscreenCanvas = new OffscreenCanvas(size, size);
+        }
+        ctx = offscreenCanvas.getContext('2d');
+      } else {
+        ctx = canvas.getContext('2d');
+      }
+    }
     ctx.fillStyle = 'white';
     ctx.fillRect(0, 0, canvas.width, canvas.height);
     try {
@@ -581,6 +579,9 @@ function render(fromRaf, fromPostMessage) {
     } catch (e) {
       ctx.fillStyle = 'black';
       ctx.fillRect(position[0], position[1], imgSize, imgSize);
+    }
+    if (offscreen.checked && !transferControlToOffscreen.checked && bitmapRenderer && offscreenCanvas) {
+      bitmapRenderer.transferFromImageBitmap(offscreenCanvas.transferToImageBitmap());
     }
     return;
   }
@@ -604,7 +605,7 @@ function render(fromRaf, fromPostMessage) {
   const instancesPerCall = Math.max(1, instances / numDrawCalls | 0);
   const instancesFirstCall = instancesPerCall + numDrawCalls % instancesPerCall;
   // Set up to scissor out all but one pixel of the map.
-  gl.scissor(position[0], webglCanvas.height - position[1] - 1, 1, 1);
+  gl.scissor(position[0], size - position[1] - 1, 1, 1);
 
   if (multiviewAvailable && (multiview.checked || numViews > 1) && !multiviewFramebuffer) {
     multiviewTexture = gl.createTexture();
@@ -613,7 +614,7 @@ function render(fromRaf, fromPostMessage) {
     gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, webglCanvas.width, webglCanvas.height, maxViewsMultiview);
+    gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, gl.RGBA8, size, size, maxViewsMultiview);
     multiviewExt = gl.getExtension('OVR_multiview2');
     multiviewFramebuffer = gl.createFramebuffer();
     gl.bindFramebuffer(gl.FRAMEBUFFER, multiviewFramebuffer);
@@ -687,9 +688,9 @@ function render(fromRaf, fromPostMessage) {
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, viewFramebuffer[i]);
         let x = i % gridCellsPerRow;
         let y = Math.floor(i / gridCellsPerRow);
-        x *= webglCanvas.width / gridCellsPerRow;
-        y *= webglCanvas.height / gridCellsPerRow;
-        gl.blitFramebuffer(0, 0, webglCanvas.width, webglCanvas.height, x, y, x + webglCanvas.width / gridCellsPerRow, y + webglCanvas.height / gridCellsPerRow, gl.COLOR_BUFFER_BIT, gl.NEAREST);
+        x *= size / gridCellsPerRow;
+        y *= size / gridCellsPerRow;
+        gl.blitFramebuffer(0, 0, size, size, x, y, x + size / gridCellsPerRow, y + size / gridCellsPerRow, gl.COLOR_BUFFER_BIT, gl.NEAREST);
       }
     } else {
       warningText = 'NOTE: Offscreen multiview rendering active - rendering not copied to canvas';
@@ -701,6 +702,9 @@ function render(fromRaf, fromPostMessage) {
   }
   if (readPixels.checked) {
     gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, readPixelsArray);
+  }
+  if (offscreen.checked && !transferControlToOffscreen.checked && offscreenCanvas && bitmapRenderer) {
+    bitmapRenderer.transferFromImageBitmap(offscreenCanvas.transferToImageBitmap());
   }
 }
 

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -102,9 +102,10 @@ input[type="range"] {
 <input type=range id=jsWork min=0 max=100 value=0>
 <span id=jsWorkLabel>0</span> ms Javascript work
 <div id=glOptions>
-  <input type=range id=pixels min=65536 max=65536000 value=65536 step=65536>
-  draw <span id=pixelsLabel>64K</span> pixels per view
-  <br>
+  <div id=pixelsWrapper>
+    <input type=range id=pixels min=65536 max=65536000 value=65536 step=65536>
+    draw <span id=pixelsLabel>64K</span> pixels per view
+  </div>
   <input type=range id=drawCalls min=0 max=10000 value=0 step=10>
   using <span id=drawCallsLabel>1</span> draw call(s) per view
   <br>
@@ -441,7 +442,13 @@ function render(fromRaf, fromPostMessage) {
       webglVersion = 1;
       gl = renderCanvas.getContext('webgl', options);
       const aia = gl.getExtension('ANGLE_instanced_arrays');
-      gl.drawArraysInstanced = (a, b, c, d)=>aia.drawArraysInstancedANGLE(a, b, c, d);
+      if (aia)
+        gl.drawArraysInstanced = (a, b, c, d)=>aia.drawArraysInstancedANGLE(a, b, c, d);
+      else {
+        pixels.value = pixels.min;
+        pixelsWrapper.style.display = 'none';
+        gl.drawArraysInstanced = (a, b, c, d)=>gl.drawArrays(a, b, c);
+      }
     }
 
     // Setup texture

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -57,7 +57,7 @@ body {
 
 input {
   margin: 15px 15px;
-  transform: scale(2) translate(0px, -2px);
+  transform: scale(2);
 }
 
 input[type="number"] {
@@ -68,6 +68,15 @@ input[type="range"] {
     margin: 30px 200px;
     padding: 0px;
     transform: scale(4);
+}
+
+@keyframes rotating {
+  from { transform: scale(2) rotate(0deg); }
+  to { transform: scale(2) rotate(360deg); }
+}
+
+.rotate {
+  animation: rotating 2s linear infinite;
 }
 
 label {
@@ -89,6 +98,8 @@ label {
 </div>
 <div id="warning"></div>
 
+<label for=animation><input type=checkbox id=animation>CSS animation</label>
+<br>
 <label for=useGl>Renderer: <input type=radio name=renderer id=useGl checked>WebGL</label>
 <label for=use2D><input type=radio name=renderer id=use2D>Canvas 2D</label>
 <label for=useDom><input type=radio name=renderer id=useDom>DOM</label>
@@ -190,12 +201,10 @@ for (const control of controls) {
   if (param) {
     if (control.type == 'radio')
       control.checked = true;
-    else if (param.length > 1) {
-      if (control.type == 'checkbox')
-        control.checked = param[1] != 'false';
-      else
-        control.value = param[1];
-    }
+    else if (control.type == 'checkbox')
+      control.checked = param[1] != 'false';
+    else
+      control.value = param[1];
   }
   control.oninput = updateControls;
 }
@@ -234,6 +243,7 @@ function updateControls() {
   webglCanvas.style.display = useGl.checked ? 'block' : 'none';
   canvas.style.display = use2D.checked ? 'block' : 'none';
   dom.style.display = useDom.checked ? 'block' : 'none';
+  animation.className = animation.checked ? 'rotate' : null;
   continuousOptions.style.visibility =
       continuous.checked ? 'visible' : 'hidden';
   glOptions.style.visibility =
@@ -254,6 +264,9 @@ function updateControls() {
   uploadLabel.textContent =
       parseFloat(uploads.value).toFixed(2);
   viewsLabel.textContent = views.value;
+  // Multiview is currently incompatible with multisampling.
+  if ((views.value > 1 || multiview.checked) && antialias.checked)
+    antialias.click();
 
   const queryParams = [];
   for (const control of controls) {
@@ -262,7 +275,7 @@ function updateControls() {
         queryParams.push(control.id);
     } else if (control.type == 'checkbox') {
       if (control.checked != defaultChecked[control.id])
-        queryParams.push(control.id + '=' + control.checked);
+        queryParams.push(defaultChecked[control.id] ? control.id + '=' + control.checked : control.id);
     } else if (control.value != defaultValues[control.id]) {
       queryParams.push(control.id + '=' + control.value);
     }
@@ -506,8 +519,7 @@ function render(fromRaf, fromPostMessage) {
       maxViewsMultiview = Math.min(gl.getParameter(ext.MAX_VIEWS_OVR), 16);
       views.max = maxViewsMultiview;
       for (let i = 0; i < maxViewsMultiview; ++i) {
-        multiviewProgram[i] = setupProgram(`
-          #version 300 es
+        multiviewProgram[i] = setupProgram(`#version 300 es
           #extension GL_OVR_multiview2 : enable
           layout(num_views=${i + 1}) in;
           in vec2 position;
@@ -517,8 +529,7 @@ function render(fromRaf, fromPostMessage) {
           void main() {
             gl_Position = vec4(position * size + offset + vec2(size - 1., 1. - size), 0, 1);
             texCoord = vec2(position.x, 1. - position.y);
-          }`, `
-          #version 300 es
+          }`, `#version 300 es
           #extension GL_OVR_multiview2 : enable
           precision highp float;
           in vec2 texCoord;

--- a/sdk/tests/extra/workload-simulator.html
+++ b/sdk/tests/extra/workload-simulator.html
@@ -331,9 +331,11 @@ dom.style.width = dom.style.height = size + 'px';
 window.onmessage = () => render(false, true);
 
 let ctx;
-let gl;
 let bitmapRenderer;
 let offscreenCanvas;
+let gl;
+let glBitmapRenderer;
+let glOffscreenCanvas;
 let program;
 let buffer;
 const borderSize = 10;
@@ -426,8 +428,8 @@ function render(fromRaf, fromPostMessage) {
       if (transferControlToOffscreen.checked) {
         renderCanvas = webglCanvas.transferControlToOffscreen();
       } else {
-        bitmapRenderer = webglCanvas.getContext('bitmaprenderer')
-        renderCanvas = offscreenCanvas = new OffscreenCanvas(size, size);
+        glBitmapRenderer = webglCanvas.getContext('bitmaprenderer')
+        renderCanvas = glOffscreenCanvas = new OffscreenCanvas(size, size);
       }
     }
     renderCanvas.width = renderCanvas.height = size;
@@ -703,8 +705,8 @@ function render(fromRaf, fromPostMessage) {
   if (readPixels.checked) {
     gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, readPixelsArray);
   }
-  if (offscreen.checked && !transferControlToOffscreen.checked && offscreenCanvas && bitmapRenderer) {
-    bitmapRenderer.transferFromImageBitmap(offscreenCanvas.transferToImageBitmap());
+  if (offscreen.checked && !transferControlToOffscreen.checked && glOffscreenCanvas && glBitmapRenderer) {
+    glBitmapRenderer.transferFromImageBitmap(glOffscreenCanvas.transferToImageBitmap());
   }
 }
 


### PR DESCRIPTION
This adds a bunch of options to the workload simulator. We can now test OffscreenCanvas (main thread only) and specify arbitrary context creation parameters including powerPreference.

Try it here: https://jdarpinian.github.io/WebGL/sdk/tests/extra/workload-simulator.html