### PR TITLE
Fix sample code in OES_fbo_render_mimap/extension.xml

### DIFF
--- a/extensions/OES_fbo_render_mipmap/extension.xml
+++ b/extensions/OES_fbo_render_mipmap/extension.xml
@@ -43,14 +43,17 @@ interface OES_fbo_render_mipmap {
             gl.bindTexture(gl.TEXTURE_2D, texture);
             var fbos = [];
 
-            for(var level=0; level&lt;7; level++){
+            for(var level=0; level&lt;8; level++){
                 var size = 128/Math.pow(2, level);
                 gl.texImage2D(gl.TEXTURE_2D, level, gl.RGBA, size, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
                 var fbo = gl.createFramebuffer();
                 gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
                 gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, level);
                 fbos.push(fbo);
+            }
 
+            for(var level=0; level&lt;8; level++){
+                gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[level]);
                 var fboStatus = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
                 console.assert(fboStatus == gl.FRAMEBUFFER_COMPLETE, 'Framebuffer is not complete');
             }


### PR DESCRIPTION
Trivial fix for the sample code in `OES_fbo_render_mimap/extension.xml`

As discussed here: https://github.com/KhronosGroup/WebGL/pull/2952#discussion_r339275137

Status of each framebuffer is only guaranteed to be framebuffer-complete after the texture it attaches to is in a good state.

Also for a 128x128 ( = 2^7) texture it should have 8 mipmap levels to be mipmap complete. (1 (level=7), 2, 4, 8, 16, 32, 64, 128(level = 0) )