### PR TITLE
Revert antialias cases

### DIFF
--- a/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
@@ -39,7 +39,7 @@ var successfullyParsed = false;
 var webGL = null;
 var contextAttribs = null;
 var pixel = [0, 0, 0, 1];
-var redChannels = [0, 0, 0];
+var redChannel = 0;
 var correctColor = null;
 
 function init()
@@ -196,19 +196,9 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255,
         255, 0, 0, 255]);
-    drawAndReadPixel(webGL, vertices, colors, 0, 0);
-
-    shouldBeTrue("webGL.canvas.width == webGL.canvas.height");
-    // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = webGL.canvas.width;
-    var buf = new Uint8Array(N * N * 4);
-    webGL.readPixels(0, 0, N, N, webGL.RGBA, webGL.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
-    redChannels[1] = buf[4 * N * (N - 1)]; // left top
-    redChannels[2] = buf[4 * (N - 1)]; // right bottom
-    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
-    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
+    var buf = drawAndReadPixel(webGL, vertices, colors, 0, 0);
+    redChannel = buf[0];
+    shouldBe("redChannel != 255 && redChannel != 0", "contextAttribs.antialias");
 }
 
 function runTest()
@@ -235,8 +225,8 @@ function runTest()
 <canvas id="depthOff" width="1px" height="1px"></canvas>
 <canvas id="stencilOn" width="1px" height="1px"></canvas>
 <canvas id="stencilOff" width="1px" height="1px"></canvas>
-<canvas id="antialiasOn" width="3px" height="3px"></canvas>
-<canvas id="antialiasOff" width="3px" height="3px"></canvas>
+<canvas id="antialiasOn" width="2px" height="2px"></canvas>
+<canvas id="antialiasOff" width="2px" height="2px"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 </body>

--- a/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -40,7 +40,7 @@ var successfullyParsed = false;
 var webGL = null;
 var contextAttribs = null;
 var pixel = [0, 0, 0, 1];
-var redChannels = [0, 0, 0];
+var redChannel = 0;
 var correctColor = null;
 var value;
 
@@ -203,13 +203,10 @@ function testStencil(stencil)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
-    // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
     if (antialias)
-        shouldBeNonNull("webGL = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("webGL = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("webGL = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("webGL = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = webGL.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -220,14 +217,9 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255,
         255, 0, 0, 255]);
-    drawAndReadPixel(webGL, vertices, colors, 0, 0);
-    var buf = new Uint8Array(N * N * 4);
-    webGL.readPixels(0, 0, N, N, webGL.RGBA, webGL.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
-    redChannels[1] = buf[4 * N * (N - 1)]; // left top
-    redChannels[2] = buf[4 * (N - 1)]; // right bottom
-    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
-    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
+    var buf = drawAndReadPixel(webGL, vertices, colors, 0, 0);
+    redChannel = buf[0];
+    shouldBe("redChannel != 255 && redChannel != 0", "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -63,7 +63,7 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var redChannels = [0, 0, 0];
+var redChannel = 0;
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -296,13 +296,10 @@ function testStencilAndDepth(stencil, depth)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
-    // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -314,13 +311,10 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(N * N * 4);
-    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
-    redChannels[1] = buf[4 * N * (N - 1)]; // left top
-    redChannels[2] = buf[4 * (N - 1)]; // right bottom
-    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
-    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
+    var buf = new Uint8Array(1 * 1 *4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannel = buf[0];
+    shouldBe("redChannel != 255 && redChannel != 0", "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -62,7 +62,7 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var redChannels = [0, 0, 0];
+var redChannel = 0;
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -301,13 +301,10 @@ function testStencilAndDepth(stencil, depth)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
-    // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -319,13 +316,10 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(N * N * 4);
-    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
-    redChannels[1] = buf[4 * N * (N - 1)]; // left top
-    redChannels[2] = buf[4 * (N - 1)]; // right bottom
-    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
-    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
+    var buf = new Uint8Array(1 * 1 *4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannel = buf[0];
+    shouldBe("redChannel != 255 && redChannel != 0", "contextAttribs.antialias");
 }
 
 function runTest()

--- a/conformance-suites/2.0.0/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/2.0.0/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -62,7 +62,7 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var redChannels = [0, 0, 0];
+var redChannel = 0;
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -301,13 +301,10 @@ function testStencilAndDepth(stencil, depth)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
-    // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -319,13 +316,10 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(N * N * 4);
-    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
-    redChannels[1] = buf[4 * N * (N - 1)]; // left top
-    redChannels[2] = buf[4 * (N - 1)]; // right bottom
-    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
-    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
+    var buf = new Uint8Array(1 * 1 *4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannel = buf[0];
+    shouldBe("redChannel != 255 && redChannel != 0", "contextAttribs.antialias");
 }
 
 function runTest()

--- a/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -41,7 +41,7 @@ void main()
 var wtu = WebGLTestUtils;
 var gl;
 var contextAttribs = null;
-var redChannels = [0, 0, 0];
+var redChannel = 0;
 var correctColor = null;
 var framebuffer;
 var fbHasColor;
@@ -280,13 +280,10 @@ function testStencilAndDepth(stencil, depth)
 function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
-    // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
     if (antialias)
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
+        shouldBeNonNull("gl = getWebGL(" + 2 + ", " + 2 + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
 
     var vertices = new Float32Array([
@@ -298,13 +295,10 @@ function testAntialias(antialias)
         255, 0, 0, 255,
         255, 0, 0, 255]);
     drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(N * N * 4);
-    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
-    redChannels[1] = buf[4 * N * (N - 1)]; // left top
-    redChannels[2] = buf[4 * (N - 1)]; // right bottom
-    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
-    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
+    var buf = new Uint8Array(1 * 1 *4);
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannel = buf[0];
+    shouldBe("redChannel != 255 && redChannel != 0", "contextAttribs.antialias");
 }
 
 function runTest()


### PR DESCRIPTION
Previously modified canvas size for CMAA algorithm,
but CMAA had been removed from chromium, revert them.