### PR TITLE
Revert antialias cases

### DIFF
--- a/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.0/conformance/context-attributes-alpha-depth-stencil-antialias.html
@@ -200,7 +200,6 @@ function testAntialias(antialias)
 
     shouldBeTrue("webGL.canvas.width == webGL.canvas.height");
     // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
     var N = webGL.canvas.width;
     var buf = new Uint8Array(N * N * 4);
     webGL.readPixels(0, 0, N, N, webGL.RGBA, webGL.UNSIGNED_BYTE, buf);
@@ -235,8 +234,8 @@ function runTest()
 <canvas id="depthOff" width="1px" height="1px"></canvas>
 <canvas id="stencilOn" width="1px" height="1px"></canvas>
 <canvas id="stencilOff" width="1px" height="1px"></canvas>
-<canvas id="antialiasOn" width="3px" height="3px"></canvas>
-<canvas id="antialiasOff" width="3px" height="3px"></canvas>
+<canvas id="antialiasOn" width="2px" height="2px"></canvas>
+<canvas id="antialiasOff" width="2px" height="2px"></canvas>
 <div id="description"></div>
 <div id="console"></div>
 </body>

--- a/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.1/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -204,8 +204,7 @@ function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
     // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
+    var N = 2;
     if (antialias)
         shouldBeNonNull("webGL = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else

--- a/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.2/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -297,8 +297,7 @@ function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
     // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
+    var N = 2;
     if (antialias)
         shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else

--- a/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/1.0.3/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -302,8 +302,7 @@ function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
     // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
+    var N = 2;
     if (antialias)
         shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else

--- a/conformance-suites/2.0.0/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/conformance-suites/2.0.0/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -302,8 +302,7 @@ function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
     // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
+    var N = 2;
     if (antialias)
         shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else

--- a/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -281,8 +281,7 @@ function testAntialias(antialias)
 {
     debug("Testing antialias = " + antialias);
     // Both the width and height of canvas are N.
-    // Note that "N = 2" doesn't work for some post processing AA per the discussion at https://github.com/KhronosGroup/WebGL/pull/1977.
-    var N = 3;
+    var N = 2;
     if (antialias)
         shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
     else


### PR DESCRIPTION
Previously modified canvas size to 3\*3 for CMAA
algorithm, but CMAA had been removed from chromium,
revert canvas size to 2\*2.