### PR TITLE
Fix a typo in the WebGL2 buffer data tests

### DIFF
--- a/conformance-suites/2.0.0/conformance2/buffers/buffer-data-and-buffer-sub-data-sub-source.html
+++ b/conformance-suites/2.0.0/conformance2/buffers/buffer-data-and-buffer-sub-data-sub-source.html
@@ -52,7 +52,7 @@ function verifyBufferData(testCase, sourceByteOffset, size, data) {
     var offset = sourceByteOffset / testCase.size;
     for (var ii = 0; ii < size; ++ii) {
         if (readbackView[ii] != data[ii]) {
-            testFailed("expected data at " + ii + ": " + data[iit] + ", got " + readbackView[ii]);
+            testFailed("expected data at " + ii + ": " + data[ii] + ", got " + readbackView[ii]);
             pass = false;
         }
     }

--- a/sdk/tests/conformance2/buffers/buffer-data-and-buffer-sub-data-sub-source.html
+++ b/sdk/tests/conformance2/buffers/buffer-data-and-buffer-sub-data-sub-source.html
@@ -31,7 +31,7 @@ function verifyBufferData(testCase, sourceByteOffset, size, data) {
     var offset = sourceByteOffset / testCase.size;
     for (var ii = 0; ii < size; ++ii) {
         if (readbackView[ii] != data[ii]) {
-            testFailed("expected data at " + ii + ": " + data[iit] + ", got " + readbackView[ii]);
+            testFailed("expected data at " + ii + ": " + data[ii] + ", got " + readbackView[ii]);
             pass = false;
         }
     }


### PR DESCRIPTION
Fixes a bug where the code inside a loop tries to use a variable that does not exist, likely due to a typo.