### PR TITLE
Accept all NaNs when sampling invalid LDR ASTC non-sRGB

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
@@ -1592,29 +1592,21 @@ var program = wtu.setupTexturedQuad(gl);
 // For LDR and non-sRGB formats, the error color is magenta *or* all NaNs. To
 // make sure we accept this we create a program that transforms an all NaN
 // sampling result to magenta.
-var nanToMagentaProgram = wtu.setupTexturedQuad(gl);
-var fragmentShader = null;
-for (let shader of gl.getAttachedShaders(nanToMagentaProgram)) {
-    if (gl.getShaderParameter(shader, gl.SHADER_TYPE) == gl.FRAGMENT_SHADER) {
-        fragmentShader = shader;
-    }
-}
-gl.detachShader(nanToMagentaProgram, fragmentShader);
-fragmentShader = wtu.loadShader(gl,
-   `precision mediump float;
-    uniform sampler2D tex;
-    varying vec2 texCoord;
-    void main() {
-        vec4 c = texture2D(tex, texCoord);
-        if (all(notEqual(c, c))) {
-            gl_FragData[0] = vec4(1, 0, 1, 1);
-        } else {
-            gl_FragData[0] = texture2D(tex, texCoord);
-        }
-    }`, gl.FRAGMENT_SHADER);
-gl.attachShader(nanToMagentaProgram, fragmentShader);
-gl.linkProgram(nanToMagentaProgram);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking nan program");
+const nanToMagentaProgram = wtu.setupTexturedQuad(gl, undefined, undefined,
+    {
+        fragmentShaderOverride:
+           `precision mediump float;
+            uniform sampler2D tex;
+            varying vec2 texCoord;
+            void main() {
+                vec4 c = texture2D(tex, texCoord);
+                if (all(notEqual(c, c))) {
+                    gl_FragData[0] = vec4(1, 0, 1, 1);
+                } else {
+                    gl_FragData[0] = texture2D(tex, texCoord);
+                }
+            }`,
+    });
 gl.useProgram(program);
 
 var extFlag = "WEBGL_compressed_texture_astc";

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
@@ -1588,6 +1588,35 @@ var contextVersion = wtu.getDefault3DContextVersion();
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, {antialias: false});
 var program = wtu.setupTexturedQuad(gl);
+
+// For LDR and non-sRGB formats, the error color is magenta *or* all NaNs. To
+// make sure we accept this we create a program that transforms an all NaN
+// sampling result to magenta.
+var nanToMagentaProgram = wtu.setupTexturedQuad(gl);
+var fragmentShader = null;
+for (let shader of gl.getAttachedShaders(nanToMagentaProgram)) {
+    if (gl.getShaderParameter(shader, gl.SHADER_TYPE) == gl.FRAGMENT_SHADER) {
+        fragmentShader = shader;
+    }
+}
+gl.detachShader(nanToMagentaProgram, fragmentShader);
+fragmentShader = wtu.loadShader(gl, 
+   `precision mediump float;
+    uniform sampler2D tex;
+    varying vec2 texCoord;
+    void main() {
+        vec4 c = texture2D(tex, texCoord);
+        if (all(notEqual(c, c))) {
+            gl_FragData[0] = vec4(1, 0, 1, 1);
+        } else {
+            gl_FragData[0] = texture2D(tex, texCoord);
+        }
+    }`, gl.FRAGMENT_SHADER);
+gl.attachShader(nanToMagentaProgram, fragmentShader);
+gl.linkProgram(nanToMagentaProgram);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "linking nan program");
+gl.useProgram(program);
+
 var extFlag = "WEBGL_compressed_texture_astc";
 var ext = null;
 var vao = null;
@@ -1764,6 +1793,14 @@ function testASTCTexture(test, useTexStorage) {
     if (useTexStorage) {
         gl.texStorage2D(gl.TEXTURE_2D, 1, format, width, height);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR, "allocating compressed texture via texStorage2D");
+        if (format >= ext.COMPRESSED_RGBA_ASTC_4x4_KHR && format <= ext.COMPRESSED_RGBA_ASTC_12x12_KHR) {
+            // For LDR non-sRGB formats, we accept all NaNs as a valid result.
+            // This program transforms all NaNs to the normal error color,
+            // magenta.
+            gl.useProgram(nanToMagentaProgram);
+        } else {
+            gl.useProgram(program);
+        }
         wtu.clearAndDrawUnitQuad(gl);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad");
         var clearColor = [255, 0, 255, 255];

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-astc.html
@@ -1600,7 +1600,7 @@ for (let shader of gl.getAttachedShaders(nanToMagentaProgram)) {
     }
 }
 gl.detachShader(nanToMagentaProgram, fragmentShader);
-fragmentShader = wtu.loadShader(gl, 
+fragmentShader = wtu.loadShader(gl,
    `precision mediump float;
     uniform sampler2D tex;
     varying vec2 texCoord;

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -389,11 +389,12 @@ var setupNoTexCoordTextureProgram = function(gl) {
  * @return {WebGLProgram}
  */
 var setupSimpleTextureProgram = function(
-    gl, opt_positionLocation, opt_texcoordLocation) {
+    gl, opt_positionLocation, opt_texcoordLocation, opt_fragmentShaderOverride) {
   opt_positionLocation = opt_positionLocation || 0;
   opt_texcoordLocation = opt_texcoordLocation || 1;
+  opt_fragmentShaderOverride = opt_fragmentShaderOverride || simpleTextureFragmentShader;
   return setupProgram(gl,
-                      [simpleTextureVertexShader, simpleTextureFragmentShader],
+                      [simpleTextureVertexShader, opt_fragmentShaderOverride],
                       ['vPosition', 'texCoord0'],
                       [opt_positionLocation, opt_texcoordLocation]);
 };
@@ -555,13 +556,14 @@ var setupQuad = function(gl, options) {
  *        position. Default = 0.
  * @param {number} opt_texcoordLocation The attrib location for
  *        texture coords. Default = 1.
- * @param {!Object} various options. See setupQuad for details.
+ * @param {!Object} various options defined by setupQuad, plus an option
+          fragmentShaderOverride to specify a custom fragment shader.
  * @return {!WebGLProgram}
  */
 var setupTexturedQuad = function(
     gl, opt_positionLocation, opt_texcoordLocation, options) {
   var program = setupSimpleTextureProgram(
-      gl, opt_positionLocation, opt_texcoordLocation);
+      gl, opt_positionLocation, opt_texcoordLocation, options && options.fragmentShaderOverride);
   setupUnitQuad(gl, opt_positionLocation, opt_texcoordLocation, options);
   return program;
 };


### PR DESCRIPTION
When sampling invalid LDR ASTC textures which are not sRGB, hardware is allowed to return either the normal error color (magenta) or all NaNs. This modifies the ASTC test to accept an all NaN result in this case.

This fixes the test on some Qualcomm Android devices including Pixel phones.