### PR TITLE
Rename multi_draw and base_vertex_base_instance ext prefix to ANGLE

### DIFF
--- a/extensions/ANGLE_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/ANGLE_draw_instanced_base_vertex_base_instance/extension.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="WEBGL_draw_instanced_base_vertex_base_instance/">
+<draft href="ANGLE_draw_instanced_base_vertex_base_instance/">
 
-  <name>WEBGL_draw_instanced_base_vertex_base_instance</name>
+  <name>ANGLE_draw_instanced_base_vertex_base_instance</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
@@ -21,14 +21,14 @@
       <addendum>
         This extension exposes the <code>DrawArraysInstancedBaseInstanceANGLE</code> and
         <code>DrawElementsInstancedBaseVertexBaseInstanceANGLE</code> entrypoints as
-        <code>drawArraysInstancedBaseInstanceWEBGL</code> and
-        <code>drawElementsInstancedBaseVertexBaseInstanceWEBGL</code>. In addition the vertex
+        <code>drawArraysInstancedBaseInstanceANGLE</code> and
+        <code>drawElementsInstancedBaseVertexBaseInstanceANGLE</code>. In addition the vertex
         shader builtin <code>gl_BaseVertex</code> and <code>gl_BaseInstance</code> are added.
       </addendum>
       <addendum>
         The implementation must validate the arrays and indices referenced by
-        <code>drawArraysInstancedBaseInstanceWEBGL</code> and
-        <code>drawElementsInstancedBaseVertexBaseInstanceWEBGL</code>, similarly to how indices
+        <code>drawArraysInstancedBaseInstanceANGLE</code> and
+        <code>drawElementsInstancedBaseVertexBaseInstanceANGLE</code>, similarly to how indices
         referenced by <code>drawArrays</code> and <code>drawElements</code> are validated according
         to section
         <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/index.html#6.6">
@@ -39,7 +39,7 @@
         </a> of the WebGL specification.
       </addendum>
       <addendum>
-        Although the extension name is named WEBGL_draw_instanced_base_vertex_base_instance, the
+        Although the extension name is named ANGLE_draw_instanced_base_vertex_base_instance, the
         extension must be enabled with the
         <code>#extension GL_ANGLE_base_vertex_base_instance</code> directive, as shown in the
         sample code, to use the extension in a shader.
@@ -62,13 +62,13 @@
 
     <features>
       <feature>
-        The <code>drawArraysInstancedBaseInstanceWEBGL</code>
-        and <code>drawElementsInstancedBaseVertexBaseInstanceWEBGL</code> entry points are added.
+        The <code>drawArraysInstancedBaseInstanceANGLE</code>
+        and <code>drawElementsInstancedBaseVertexBaseInstanceANGLE</code> entry points are added.
         These provide a counterpoint to instanced rendering and are more flexible for certain
-        scenarios. <code>drawArraysInstancedBaseInstanceWEBGL</code> behaves identically to
+        scenarios. <code>drawArraysInstancedBaseInstanceANGLE</code> behaves identically to
         <code>drawArraysInstanced</code> except that the first element within those instanced
         vertex attributes is specified in <code>baseInstance</code>.
-        <code>drawElementsInstancedBaseVertexBaseInstanceWEBGL</code> is equivalent to
+        <code>drawElementsInstancedBaseVertexBaseInstanceANGLE</code> is equivalent to
         <code>drawElementsInstanced</code> except that the value of the base vertex passed into
         driver is <code>baseVertex</code> instead of zero, and that the first element within those
         instanced vertex attributes is specified in <code>baseInstance</code>.
@@ -101,12 +101,12 @@
   <idl xml:space="preserve">
 
 [NoInterfaceObject]
-interface WEBGL_draw_instanced_base_vertex_base_instance {
-  void drawArraysInstancedBaseInstanceWEBGL(
+interface ANGLE_draw_instanced_base_vertex_base_instance {
+  void drawArraysInstancedBaseInstanceANGLE(
       GLenum mode, GLint first, GLsizei count,
       GLsizei instanceCount, GLuint baseInstance
   );
-  void drawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  void drawElementsInstancedBaseVertexBaseInstanceANGLE(
       GLenum mode, GLsizei count, GLenum type, GLintptr offset,
       GLsizei instanceCount, GLint baseVertex, GLuint baseinstance
   );
@@ -114,14 +114,14 @@ interface WEBGL_draw_instanced_base_vertex_base_instance {
   </idl>
 
   <newfun>
-    <function name="drawArraysInstancedBaseInstanceWEBGL" type="void">
+    <function name="drawArraysInstancedBaseInstanceANGLE" type="void">
       <param name="mode" type="GLenum"/>
       <param name="first" type="GLint"/>
       <param name="count" type="GLsizei"/>
       <param name="instanceCount" type="GLsizei"/>
       <param name="baseInstance" type="GLuint"/>
     </function>
-    <function name="drawElementsInstancedBaseVertexBaseInstanceWEBGL" type="void">
+    <function name="drawElementsInstancedBaseVertexBaseInstanceANGLE" type="void">
       <param name="mode" type="GLenum"/>
       <param name="count" type="GLsizei"/>
       <param name="type" type="GLenum"/>
@@ -140,7 +140,7 @@ interface WEBGL_draw_instanced_base_vertex_base_instance {
 
   <samplecode xml:space="preserve">
     <pre>
-var ext = gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
+var ext = gl.getExtension("ANGLE_draw_instanced_base_vertex_base_instance");
 
 {
   // drawArraysInstancedBaseInstance variant.
@@ -148,7 +148,7 @@ var ext = gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
   let count = 3;
   let instanceCount = 2;
   let baseInstance = 1;
-  ext.drawArraysInstancedBaseInstanceWEBGL(
+  ext.drawArraysInstancedBaseInstanceANGLE(
       gl.TRIANGLES, first, count, instanceCount, baseInstance);
 }
 
@@ -161,7 +161,7 @@ var ext = gl.getExtension("WEBGL_draw_instanced_base_vertex_base_instance");
   let instanceCount = 2;
   let baseVertice = 3;
   let baseInstance = 1;
-  ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  ext.drawElementsInstancedBaseVertexBaseInstanceANGLE(
       gl.TRIANGLES, count, gl.UNSIGHNED_SHORT, offset, instanceCount, baseVertex, baseInstance);
 }
     </pre>
@@ -184,6 +184,9 @@ void main() {
     </revision>
     <revision date="2019/09/25">
       <change>Move to draft.</change>
+    </revision>
+    <revision date="2019/11/04">
+      <change>Rename prefix from WEBGL_ to ANGLE_.</change>
     </revision>
   </history>
 </draft>

--- a/extensions/ANGLE_multi_draw/extension.xml
+++ b/extensions/ANGLE_multi_draw/extension.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="WEBGL_multi_draw/">
-  <name>WEBGL_multi_draw</name>
+<draft href="ANGLE_multi_draw/">
+  <name>ANGLE_multi_draw</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
@@ -19,15 +19,15 @@
   <overview>
     <mirrors href="https://chromium.googlesource.com/angle/angle/+/master/extensions/ANGLE_multi_draw.txt" name="ANGLE_multi_draw">
       <addendum>
-        This extension only exposes the <code>MultiDrawArraysANGLE</code>, <code>MultiDrawElementsANGLE</code>, <code>MultiDrawArraysInstancedANGLE</code>, and <code>MultiDrawElementsInstancedANGLE</code> entrypoints as <code>multiDrawArraysWEBGL</code>, <code>multiDrawElementsWEBGL</code>, <code>multiDrawArraysInstancedWEBGL</code>, and <code>multiDrawElementsInstancedWEBGL</code>.
+        This extension only exposes the <code>MultiDrawArraysANGLE</code>, <code>MultiDrawElementsANGLE</code>, <code>MultiDrawArraysInstancedANGLE</code>, and <code>MultiDrawElementsInstancedANGLE</code> entrypoints as <code>multiDrawArraysANGLE</code>, <code>multiDrawElementsANGLE</code>, <code>multiDrawArraysInstancedANGLE</code>, and <code>multiDrawElementsInstancedANGLE</code>.
       </addendum>
       <addendum>
-        The implementation must validate the arrays and indices referenced by <code>multiDrawArraysWEBGL</code>, <code>multiDrawElementsWEBGL</code>, <code>multiDrawArraysInstancedWEBGL</code>, and <code>multiDrawElementsInstancedWEBGL</code>, similarly to how indices referenced by <code>drawArrays</code> and <code>drawElements</code> are validated according to section
+        The implementation must validate the arrays and indices referenced by <code>multiDrawArraysANGLE</code>, <code>multiDrawElementsANGLE</code>, <code>multiDrawArraysInstancedANGLE</code>, and <code>multiDrawElementsInstancedANGLE</code>, similarly to how indices referenced by <code>drawArrays</code> and <code>drawElements</code> are validated according to section
         <a href="http://www.khronos.org/registry/webgl/specs/1.0/#ATTRIBS_AND_RANGE_CHECKING">Enabled Vertex Attributes and Range Checking</a> of the
         WebGL specification.
       </addendum>
       <addendum>
-        Although the extension name is named WEBGL_multi_draw, the extension must be enabled with the
+        Although the extension name is named ANGLE_multi_draw, the extension must be enabled with the
         <code>#extension GL_ANGLE_multi_draw</code> directive, as shown in the sample code, to use
         the extension in a shader.
 
@@ -42,7 +42,7 @@
     </div>
 
     <features>
-      <feature>The <code>multiDrawArraysWEBGL</code>, <code>multiDrawElementsWEBGL</code>, <code>multiDrawArraysInstancedWEBGL</code>, and <code>multiDrawElementsInstancedWEBGL</code> entry points are added. These provide a counterpoint to instanced rendering and are more flexible for certain scenarios. They behave identically to multiple calls to <code>drawArrays</code>, <code>drawElements</code>, <code>drawArraysInstanced</code>, and <code>drawElementsInstanced</code> except they handle multiple lists of arguments in one call.</feature>
+      <feature>The <code>multiDrawArraysANGLE</code>, <code>multiDrawElementsANGLE</code>, <code>multiDrawArraysInstancedANGLE</code>, and <code>multiDrawElementsInstancedANGLE</code> entry points are added. These provide a counterpoint to instanced rendering and are more flexible for certain scenarios. They behave identically to multiple calls to <code>drawArrays</code>, <code>drawElements</code>, <code>drawArraysInstanced</code>, and <code>drawElementsInstanced</code> except they handle multiple lists of arguments in one call.</feature>
 
       <feature>The <code>gl_DrawID</code> builtin is added to the shading language. For any Multi* draw call variant, the index of the draw <code>i</code> may be read by the vertex shader as <code>gl_DrawID</code>. For non Multi* calls, the value of gl_DrawID is 0.</feature>
       <glsl extname="GL_ANGLE_multi_draw">
@@ -55,25 +55,25 @@
   <idl xml:space="preserve">
 
 [NoInterfaceObject]
-interface WEBGL_multi_draw {
-  void multiDrawArraysWEBGL(
+interface ANGLE_multi_draw {
+  void multiDrawArraysANGLE(
       GLenum mode,
       (Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
       (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       GLsizei drawcount);
-  void multiDrawElementsWEBGL(
+  void multiDrawElementsANGLE(
       GLenum mode,
       (Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
       GLenum type,
       (Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
       GLsizei drawcount);
-  void multiDrawArraysInstancedWEBGL(
+  void multiDrawArraysInstancedANGLE(
       GLenum mode,
       (Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
       (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       (Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
       GLsizei drawcount);
-  void multiDrawElementsInstancedWEBGL(
+  void multiDrawElementsInstancedANGLE(
       GLenum mode,
       (Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
       GLenum type,
@@ -90,13 +90,13 @@ interface WEBGL_multi_draw {
 
   <samplecode xml:space="preserve">
     <pre>
-var ext = gl.getExtension("WEBGL_multi_draw");
+var ext = gl.getExtension("ANGLE_multi_draw");
 
 {
   // multiDrawArrays variant.
   let firsts = new Int32Array(...);
   let counts = new Int32Array(...);
-  ext.multiDrawArraysWEBGL(gl.TRIANGLES, firsts, 0, counts, 0, firsts.length);
+  ext.multiDrawArraysANGLE(gl.TRIANGLES, firsts, 0, counts, 0, firsts.length);
 }
 
 {
@@ -105,7 +105,7 @@ var ext = gl.getExtension("WEBGL_multi_draw");
   // ELEMENT_ARRAY_BUFFER are to be treated as UNSIGNED_SHORT.
   let counts = new Int32Array(...);
   let offsets = new Int32Array(...);
-  ext.multiDrawElementsWEBGL(
+  ext.multiDrawElementsANGLE(
       gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, counts.length);
 }
 
@@ -114,7 +114,7 @@ var ext = gl.getExtension("WEBGL_multi_draw");
   let firsts = new Int32Array(...);
   let counts = new Int32Array(...);
   let instanceCounts = new Int32Array(...);
-  ext.multiDrawArraysInstancedWEBGL(
+  ext.multiDrawArraysInstancedANGLE(
       gl.TRIANGLES, firsts, 0, counts, 0, instanceCounts, 0, firsts.length);
 }
 
@@ -125,7 +125,7 @@ var ext = gl.getExtension("WEBGL_multi_draw");
   let counts = new Int32Array(...);
   let offsets = new Int32Array(...);
   let instanceCounts = new Int32Array(...);
-  ext.multiDrawElementsInstancedWEBGL(
+  ext.multiDrawElementsInstancedANGLE(
       gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, instanceCounts, 0,
       counts.length);
 }
@@ -151,7 +151,10 @@ void main() {
       <change>Moved to draft.</change>
     </revision>
     <revision date="2019/10/23">
-      <change>Merged features with WEBGL_multi_draw_instanced.</change>
+      <change>Merged features with ANGLE_multi_draw_instanced.</change>
+    </revision>
+    <revision date="2019/11/04">
+      <change>Rename prefix from WEBGL_ to ANGLE_.</change>
     </revision>
   </history>
 </draft>

--- a/extensions/ANGLE_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/ANGLE_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="WEBGL_multi_draw_instanced_base_vertex_base_instance/">
+<draft href="ANGLE_multi_draw_instanced_base_vertex_base_instance/">
 
-  <name>WEBGL_multi_draw_instanced_base_vertex_base_instance</name>
+  <name>ANGLE_multi_draw_instanced_base_vertex_base_instance</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
 
   <contributors>
     <contributor>Contributors to the ANGLE_base_vertex_base_instance specification</contributor>
-    <contributor>Contributors to the WEBGL_multi_draw specification</contributor>
+    <contributor>Contributors to the ANGLE_multi_draw specification</contributor>
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
@@ -16,22 +16,22 @@
 
   <depends>
     <api version="2.0"/>
-    <ext name="WEBGL_multi_draw" require="true"/>
-    <ext name="WEBGL_draw_instanced_base_vertex_base_instance" require="true"/>
+    <ext name="ANGLE_multi_draw" require="true"/>
+    <ext name="ANGLE_draw_instanced_base_vertex_base_instance" require="true"/>
   </depends>
 
   <overview>
     <addendum>
       This extension exposes the <code>MultiDrawArraysInstancedBaseInstanceANGLE</code> and
       <code>MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE</code> entrypoints as
-      <code>multiDrawArraysInstancedBaseInstanceWEBGL</code> and
-      <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code>. In addition the vertex
+      <code>multiDrawArraysInstancedBaseInstanceANGLE</code> and
+      <code>multiDrawElementsInstancedBaseVertexBaseInstanceANGLE</code>. In addition the vertex
       shader builtins <code>gl_BaseVertex</code> and <code>gl_BaseInstance</code> are added.
     </addendum>
     <addendum>
       The implementation must validate the arrays and indices referenced by
-      <code>multiDrawArraysInstancedBaseInstanceWEBGL</code> and
-      <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code>, similarly to how indices
+      <code>multiDrawArraysInstancedBaseInstanceANGLE</code> and
+      <code>multiDrawElementsInstancedBaseVertexBaseInstanceANGLE</code>, similarly to how indices
       referenced by <code>drawArrays</code> and <code>drawElements</code> are validated according
       to section
       <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/index.html#6.6">
@@ -43,7 +43,7 @@
       </a> of the WebGL specification.
     </addendum>
     <addendum>
-      Although the extension is named WEBGL_multi_draw_instanced_base_vertex_base_instance, the
+      Although the extension is named ANGLE_multi_draw_instanced_base_vertex_base_instance, the
       extension must be enabled with the
       <code>#extension GL_ANGLE_base_vertex_base_instance</code> directive, as shown in the sample
       code, to use the extension in a shader.
@@ -64,13 +64,13 @@
 
     <features>
       <feature>
-        The <code>multiDrawArraysInstancedBaseInstanceWEBGL</code> and
-        <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code> entry points are added.
+        The <code>multiDrawArraysInstancedBaseInstanceANGLE</code> and
+        <code>multiDrawElementsInstancedBaseVertexBaseInstanceANGLE</code> entry points are added.
         They behave identically to multiple calls to <code>drawArraysInstanced</code> and
         <code>drawElementsInstanced</code> except they handle multiple lists of arguments in one
         call, plus that the first element within those instanced vertex attributes is specified in
         <code>baseInstancesList</code>. The
-        <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code> in addition specifies the
+        <code>multiDrawElementsInstancedBaseVertexBaseInstanceANGLE</code> in addition specifies the
         value of base vertex of each draw call to be values in<code>baseVerticesList</code> instead
         of zero.
       </feature>
@@ -79,8 +79,8 @@
 
   <idl xml:space="preserve">
 [NoInterfaceObject]
-interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
-  void multiDrawArraysInstancedBaseInstanceWEBGL(
+interface ANGLE_multi_draw_instanced_base_vertex_base_instance {
+  void multiDrawArraysInstancedBaseInstanceANGLE(
       GLenum mode,
       Int32array or sequence&lt;GLint&gt; firstsList, GLuint firstsOffset,
       Int32array or sequence&lt;GLint&gt; countsList, GLuint countsOffset,
@@ -88,7 +88,7 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
       Int32array or sequence&lt;GLint&gt; baseInstancesList, GLuint baseInstancesOffset,
       GLsizei drawCount
   );
-  void multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  void multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(
       GLenum mode,
       Int32array or sequence&lt;GLint&gt; countsList, GLuint countsOffset,
       GLenum type,
@@ -102,7 +102,7 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   </idl>
 
   <newfun>
-    <function name="multiDrawArraysInstancedBaseInstanceWEBGL" type="void">
+    <function name="multiDrawArraysInstancedBaseInstanceANGLE" type="void">
       <param name="mode" type="GLenum"/>
       <param name="firstsList" type="sequence&lt;GLint&gt;"/>
       <param name="firstsOffset" type="GLuint"/>
@@ -112,7 +112,7 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
       <param name="baseInstancesOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
-    <function name="multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL" type="void">
+    <function name="multiDrawElementsInstancedBaseVertexBaseInstanceANGLE" type="void">
       <param name="mode" type="GLenum"/>
       <param name="countsList" type="sequence&lt;GLint&gt;"/>
       <param name="countsOffset" type="GLuint"/>
@@ -142,7 +142,7 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
 
   <samplecode xml:space="preserve">
     <pre>
-var ext = gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance");
+var ext = gl.getExtension("ANGLE_multi_draw_instanced_base_vertex_base_instance");
 
 {
   // multiDrawArraysInstancedBaseInstance variant.
@@ -150,7 +150,7 @@ var ext = gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance"
   let counts = new Int32Array(...);
   let instanceCounts = new Int32Array(...);
   let baseInstances = new Int32Array(...);
-  ext.multiDrawArraysInstancedBaseInstanceWEBGL(
+  ext.multiDrawArraysInstancedBaseInstanceANGLE(
       gl.TRIANGLES, first, 0, counts, 0, instanceCounts, 0, baseInstances, 0, counts.length);
 }
 
@@ -163,7 +163,7 @@ var ext = gl.getExtension("WEBGL_multi_draw_instanced_base_vertex_base_instance"
   let instanceCounts = new Int32Array(...);
   let baseVertices = new Int32Array(...);
   let baseInstances = new Int32Array(...);
-  ext.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  ext.multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(
       gl.TRIANGLES, counts, 0, gl.UNSIGHNED_SHORT,
       offsets, 0, instanceCounts, 0, baseVertices, 0, baseInstances, 0,
       counts.length);
@@ -189,6 +189,9 @@ void main() {
     <revision date="2019/09/25">
       <change>Change parameters order.</change>
       <change>Move to draft.</change>
+    </revision>
+    <revision date="2019/11/04">
+      <change>Rename prefix from WEBGL_ to ANGLE_.</change>
     </revision>
   </history>
 </draft>

--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -41,4 +41,4 @@ webgl-debug-shaders.html
 --min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-broadcast-return.html
 --min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-framebuffer-unsupported.html
 --min-version 1.0.4 --max-version 1.9.9 webgl-draw-buffers-max-draw-buffers.html
---min-version 1.0.4 webgl-multi-draw.html
+--min-version 1.0.4 angle-multi-draw.html

--- a/sdk/tests/conformance/extensions/angle-multi-draw.html
+++ b/sdk/tests/conformance/extensions/angle-multi-draw.html
@@ -175,7 +175,7 @@ function runTest() {
     }
   }
 
-  const extensionName = 'WEBGL_multi_draw';
+  const extensionName = 'ANGLE_multi_draw';
   const ext = gl.getExtension(extensionName);
   if (!runSupportedTest(extensionName, ext)) {
     return;
@@ -255,13 +255,13 @@ function doTest(ext, instanced) {
     }
 
     const checkMultiDrawArrays = makeDrawCheck(
-        ext.multiDrawArraysWEBGL, setupDrawArrays);
+        ext.multiDrawArraysANGLE, setupDrawArrays);
     const checkMultiDrawElements = makeDrawCheck(
-        ext.multiDrawElementsWEBGL, setupDrawElements);
+        ext.multiDrawElementsANGLE, setupDrawElements);
     const checkMultiDrawArraysInstanced = makeDrawCheck(
-        ext.multiDrawArraysInstancedWEBGL, setupDrawArraysInstanced);
+        ext.multiDrawArraysInstancedANGLE, setupDrawArraysInstanced);
     const checkMultiDrawElementsInstanced = makeDrawCheck(
-        ext.multiDrawElementsInstancedWEBGL, setupDrawElementsInstanced);
+        ext.multiDrawElementsInstancedANGLE, setupDrawElementsInstanced);
 
     gl.useProgram(program);
 
@@ -529,35 +529,35 @@ function doTest(ext, instanced) {
     let drawIDLocation;
 
     const multiDrawArrays = function() {
-      ext.multiDrawArraysWEBGL(gl.TRIANGLES, firsts, 0, counts, 0, tri_count);
+      ext.multiDrawArraysANGLE(gl.TRIANGLES, firsts, 0, counts, 0, tri_count);
     }
 
     const multiDrawArraysWithNonzeroOffsets = function() {
-      ext.multiDrawArraysWEBGL(gl.TRIANGLES, buffer, firstsOffset, buffer, countsOffset, tri_count);
+      ext.multiDrawArraysANGLE(gl.TRIANGLES, buffer, firstsOffset, buffer, countsOffset, tri_count);
     }
 
     const multiDrawElements = function() {
-      ext.multiDrawElementsWEBGL(gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, tri_count);
+      ext.multiDrawElementsANGLE(gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, tri_count);
     }
 
     const multiDrawElementsWithNonzeroOffsets = function() {
-      ext.multiDrawElementsWEBGL(gl.TRIANGLES, buffer, countsOffset, gl.UNSIGNED_SHORT, buffer, offsetsOffset, tri_count);
+      ext.multiDrawElementsANGLE(gl.TRIANGLES, buffer, countsOffset, gl.UNSIGNED_SHORT, buffer, offsetsOffset, tri_count);
     }
 
     const multiDrawArraysInstanced = function() {
-      ext.multiDrawArraysInstancedWEBGL(gl.TRIANGLES, firsts, 0, counts, 0, instances, 0, tri_count);
+      ext.multiDrawArraysInstancedANGLE(gl.TRIANGLES, firsts, 0, counts, 0, instances, 0, tri_count);
     }
 
     const multiDrawArraysInstancedWithNonzeroOffsets = function() {
-      ext.multiDrawArraysInstancedWEBGL(gl.TRIANGLES, buffer, firstsOffset, buffer, countsOffset, buffer, instancesOffset, tri_count);
+      ext.multiDrawArraysInstancedANGLE(gl.TRIANGLES, buffer, firstsOffset, buffer, countsOffset, buffer, instancesOffset, tri_count);
     }
 
     const multiDrawElementsInstanced = function() {
-      ext.multiDrawElementsInstancedWEBGL(gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, instances, 0, tri_count);
+      ext.multiDrawElementsInstancedANGLE(gl.TRIANGLES, counts, 0, gl.UNSIGNED_SHORT, offsets, 0, instances, 0, tri_count);
     }
 
     const multiDrawElementsInstancedWithNonzeroOffsets = function() {
-      ext.multiDrawElementsInstancedWEBGL(gl.TRIANGLES, buffer, countsOffset, gl.UNSIGNED_SHORT, buffer, offsetsOffset, buffer, instancesOffset, tri_count);
+      ext.multiDrawElementsInstancedANGLE(gl.TRIANGLES, buffer, countsOffset, gl.UNSIGNED_SHORT, buffer, offsetsOffset, buffer, instancesOffset, tri_count);
     }
 
     const manyDrawArrays = function() {

--- a/sdk/tests/conformance2/extensions/00_test_list.txt
+++ b/sdk/tests/conformance2/extensions/00_test_list.txt
@@ -12,4 +12,4 @@ promoted-extensions-in-shaders.html
 --min-version 2.0.1 ovr_multiview2_single_view_operations.html
 --min-version 2.0.1 ovr_multiview2_timer_query.html
 --min-version 2.0.1 ovr_multiview2_transform_feedback.html
---min-version 2.0.1 webgl-multi-draw-instanced-base-vertex-base-instance.html
+--min-version 2.0.1 angle-multi-draw-instanced-base-vertex-base-instance.html

--- a/sdk/tests/conformance2/extensions/angle-multi-draw-instanced-base-vertex-base-instance.html
+++ b/sdk/tests/conformance2/extensions/angle-multi-draw-instanced-base-vertex-base-instance.html
@@ -117,7 +117,7 @@ void main()
 
 <script>
 "use strict";
-description("This test verifies the functionality of the WEBGL_[multi]_draw_basevertex_base_instance extension, if it is available.");
+description("This test verifies the functionality of the ANGLE_[multi]_draw_basevertex_base_instance extension, if it is available.");
 
 const wtu = WebGLTestUtils;
 const canvas = document.getElementById("canvas");
@@ -265,8 +265,8 @@ function runTest() {
     }
   }
 
-  doTest('WEBGL_draw_instanced_base_vertex_base_instance', false);
-  doTest('WEBGL_multi_draw_instanced_base_vertex_base_instance', true);
+  doTest('ANGLE_draw_instanced_base_vertex_base_instance', false);
+  doTest('ANGLE_multi_draw_instanced_base_vertex_base_instance', true);
 }
 
 function doTest(extensionName, multiDraw) {
@@ -359,9 +359,9 @@ function doTest(extensionName, multiDraw) {
 
     if (!multiDraw) {
       const checkDrawArraysInstancedBaseInstance = makeDrawValidationCheck(
-        ext.drawArraysInstancedBaseInstanceWEBGL, setupDrawArrays);
+        ext.drawArraysInstancedBaseInstanceANGLE, setupDrawArrays);
       const checkDrawElementsInstancedBaseVertexBaseInstance = makeDrawValidationCheck(
-        ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL, setupDrawElements);
+        ext.drawElementsInstancedBaseVertexBaseInstanceANGLE, setupDrawElements);
       checkDrawArraysInstancedBaseInstance(
         [gl.TRIANGLES, 0, 3, 1, 1],
         gl.NO_ERROR, "with gl.TRIANGLES"
@@ -393,9 +393,9 @@ function doTest(extensionName, multiDraw) {
       );
     } else {
       const checkMultiDrawArraysInstancedBaseInstance = makeDrawValidationCheck(
-        ext.multiDrawArraysInstancedBaseInstanceWEBGL, setupDrawArrays);
+        ext.multiDrawArraysInstancedBaseInstanceANGLE, setupDrawArrays);
       const checkMultiDrawElementsInstancedBaseVertexBaseInstance = makeDrawValidationCheck(
-        ext.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL, setupDrawElements);
+        ext.multiDrawElementsInstancedBaseVertexBaseInstanceANGLE, setupDrawElements);
 
       // Check that drawing a single triangle works
       checkMultiDrawArraysInstancedBaseInstance(
@@ -509,9 +509,9 @@ function doTest(extensionName, multiDraw) {
 
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     if (!multiDraw) {
-      ext.drawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, 0, 6, 1, 5);
+      ext.drawArraysInstancedBaseInstanceANGLE(gl.TRIANGLES, 0, 6, 1, 5);
     } else {
-      ext.multiDrawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, [0], 0, [6], 0, [1], 0, [5], 0, 1);
+      ext.multiDrawArraysInstancedBaseInstanceANGLE(gl.TRIANGLES, [0], 0, [6], 0, [1], 0, [5], 0, 1);
     }
 
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -525,9 +525,9 @@ function doTest(extensionName, multiDraw) {
 
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     if (!multiDraw) {
-      ext.drawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, 0, 6, 1, 5);
+      ext.drawArraysInstancedBaseInstanceANGLE(gl.TRIANGLES, 0, 6, 1, 5);
     } else {
-      ext.multiDrawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, [0], 0, [6], 0, [1], 0, [5], 0, 1);
+      ext.multiDrawArraysInstancedBaseInstanceANGLE(gl.TRIANGLES, [0], 0, [6], 0, [1], 0, [5], 0, 1);
     }
 
     wtu.checkCanvasRect(gl, x, y, xSize, ySize, [0, 255, 0, 255], "gl_InstanceID should always starts from 0");
@@ -546,9 +546,9 @@ function doTest(extensionName, multiDraw) {
 
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     if (!multiDraw) {
-      ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1, 3, 0);
+      ext.drawElementsInstancedBaseVertexBaseInstanceANGLE(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1, 3, 0);
     } else {
-      ext.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, [6], 0, gl.UNSIGNED_BYTE, [0], 0, [1], 0, [3], 0, [0], 0, 1);
+      ext.multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(gl.TRIANGLES, [6], 0, gl.UNSIGNED_BYTE, [0], 0, [1], 0, [3], 0, [0], 0, 1);
     }
 
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
@@ -562,9 +562,9 @@ function doTest(extensionName, multiDraw) {
 
     gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     if (!multiDraw) {
-      ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1, 3, 0);
+      ext.drawElementsInstancedBaseVertexBaseInstanceANGLE(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1, 3, 0);
     } else {
-      ext.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, [6], 0, gl.UNSIGNED_BYTE, [0], 0, [1], 0, [3], 0, [0], 0, 1);
+      ext.multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(gl.TRIANGLES, [6], 0, gl.UNSIGNED_BYTE, [0], 0, [1], 0, [3], 0, [0], 0, 1);
     }
 
     wtu.checkCanvasRect(gl, x, y, xSize, ySize, [0, 255, 0, 255], "gl_VertexID should always starts from 0");
@@ -612,25 +612,25 @@ function doTest(extensionName, multiDraw) {
     function drawArraysInstancedBaseInstance() {
       const countPerDraw = y_count * 6;
       for (let x = 0; x < x_count; x += 2) {
-        ext.drawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, 0, countPerDraw, 2, x);
+        ext.drawArraysInstancedBaseInstanceANGLE(gl.TRIANGLES, 0, countPerDraw, 2, x);
       }
     }
 
     function multiDrawArraysInstancedBaseInstance() {
-      ext.multiDrawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, drawArraysParams.firsts, 0, drawArraysParams.counts, 0, drawArraysParams.instances, 0, drawArraysParams.baseInstances, 0, drawArraysParams.drawCount);
+      ext.multiDrawArraysInstancedBaseInstanceANGLE(gl.TRIANGLES, drawArraysParams.firsts, 0, drawArraysParams.counts, 0, drawArraysParams.instances, 0, drawArraysParams.baseInstances, 0, drawArraysParams.drawCount);
     }
 
     function drawElementsInstancedBaseVertexBaseInstance() {
       const countPerDraw = 6;
       for (let v = 0; v < y_count; ++v) {
         for (let x = 0; x < x_count; x += 2) {
-          ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, countPerDraw, gl.UNSIGNED_SHORT, 0, 2, v * 4, x);
+          ext.drawElementsInstancedBaseVertexBaseInstanceANGLE(gl.TRIANGLES, countPerDraw, gl.UNSIGNED_SHORT, 0, 2, v * 4, x);
         }
       }
     }
 
     function multiDrawElementsInstancedBaseVertexBaseInstance() {
-      ext.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, drawElementsParams.counts, 0, gl.UNSIGNED_SHORT, drawElementsParams.offsets, 0, drawElementsParams.instances, 0, drawElementsParams.baseVertices, 0, drawElementsParams.baseInstances, 0, drawElementsParams.drawCount);
+      ext.multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(gl.TRIANGLES, drawElementsParams.counts, 0, gl.UNSIGNED_SHORT, drawElementsParams.offsets, 0, drawElementsParams.instances, 0, drawElementsParams.baseVertices, 0, drawElementsParams.baseInstances, 0, drawElementsParams.drawCount);
     }
 
     function checkDraw(config) {


### PR DESCRIPTION
Since the multi_draw and base_vertex_base_instance extensions directly exposes their corresponding entry points from Angle as is (I've made a recent change to make sure the entrypoints are the same with the webgl extensions), changing the prefix from WEBGL_ to ANGLE_ might clear any confusions.

Links to corresponding ANGLE extension docs:
* https://chromium.googlesource.com/angle/angle/+/refs/heads/master/extensions/ANGLE_multi_draw.txt
* https://chromium.googlesource.com/angle/angle/+/refs/heads/master/extensions/ANGLE_base_vertex_base_instance.txt