### PR TITLE
Test for EXT_texture_norm16 extension

### DIFF
--- a/sdk/tests/conformance2/extensions/00_test_list.txt
+++ b/sdk/tests/conformance2/extensions/00_test_list.txt
@@ -1,6 +1,7 @@
 ext-color-buffer-float.html
 ext-disjoint-timer-query-webgl2.html
 --min-version 2.0.1 ext-texture-filter-anisotropic.html
+--min-version 2.0.1 ext-texture-norm16.html
 promoted-extensions.html
 promoted-extensions-in-shaders.html
 --min-version 2.0.1 ovr_multiview2.html

--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -1,0 +1,197 @@
+<!--
+Copyright (c) 2019 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL EXT_texture_norm16 Conformance Tests</title>
+<LINK rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<!-- <script src="../../js/tests/compressed-texture-utils.js"></script> -->
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("This test verifies the functionality of the EXT_texture_compression_rgtc extension, if it is available.");
+
+debug("");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext();
+var ext;
+
+var formats = null;
+var textures;
+var fbos;
+var renderbuffer;
+var readbackBuf = new Uint16Array(4);
+
+function generateFormatColor(format, value, alpha) {
+  alpha = alpha !== undefined ? alpha : 255;
+  switch(format) {
+    case gl.RED:
+      return [value, 0, 0, alpha];
+    case gl.RG:
+      return [value, value, 0, alpha];
+    case gl.RGB:
+      return [value, value, value, alpha];
+    case gl.RGBA:
+      return [value, value, value, value];
+    default:
+      wtu.error("Unreachable: Unknown format.");
+      return null;
+  }
+}
+
+function testNorm16Texture(internalFormat, format, type) {
+  let pixelValue;
+  let expectedValue;
+  let imageData;
+
+  switch(type) {
+    case gl.SHORT:
+      pixelValue = 0x7fff;
+      expectedValue = 0xff;
+      imageData = new Int16Array(4).fill(pixelValue);
+      break;
+    case gl.UNSIGNED_SHORT:
+      pixelValue = 0x6a35;
+      expectedValue = pixelValue >> 8;
+      imageData = new Uint16Array(4).fill(pixelValue);
+      break;
+    default:
+      wtu.error("Unreachable: Unknown texture type.");
+      break;
+  }
+
+  // Texture sampled from
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, textures[0]);
+  gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 1, 1, 0, format, type, imageData);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture bindings succeed");
+
+  gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+  // Read back as gl.UNSIGNED_BYTE
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, expectedValue));
+}
+
+function testNorm16Render(interalFormat, format, type) {
+  // Only UNSIGNED_SHORT are renderable
+  let pixelValue = 0x6a35;
+  let expectedValue = pixelValue;
+  let imageData = new Uint16Array(4).fill(pixelValue);
+
+  // Render to fbo texture attachment test
+  gl.bindTexture(gl.TEXTURE_2D, textures[1]);
+  gl.texImage2D(gl.TEXTURE_2D, 0, interalFormat, 1, 1, 0, format, type, null);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "rtt bindings succeed");
+
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, textures[1], 0);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fbo bindings succeed");
+
+  gl.activeTexture(gl.TEXTURE0);
+  gl.bindTexture(gl.TEXTURE_2D, textures[0]);
+  gl.texImage2D(gl.TEXTURE_2D, 0, interalFormat, 1, 1, 0, format, type, imageData);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture bindings succeed");
+
+  gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, expectedValue, 0), undefined, undefined, readbackBuf, type, format);
+
+  // Renderbuffer test
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[1]);
+  gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
+  gl.renderbufferStorage(gl.RENDERBUFFER, interalFormat, 1, 1);
+  gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER,
+                            renderbuffer);
+  gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "renderbuffer bindings succeed");
+
+  gl.clearColor(1, 1, 1, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0), undefined, undefined, readbackBuf, type, format);
+
+  // Copy from renderbuffer to textures[1] test
+  gl.bindTexture(gl.TEXTURE_2D, textures[1]);
+  gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copy succeed");
+
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0), undefined, undefined, readbackBuf, type, format);
+
+  gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+  gl.bindTexture(gl.TEXTURE_2D, null);
+}
+
+function runTestExtension() {
+  textures = [gl.createTexture(), gl.createTexture()];
+  fbos = [gl.createFramebuffer(), gl.createFramebuffer()];
+  renderbuffer = gl.createRenderbuffer();
+
+  for (let i = 0; i < 2; i++) {
+    gl.bindTexture(gl.TEXTURE_2D, textures[i]);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+  }
+
+  gl.bindTexture(gl.TEXTURE_2D, null);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture and framebuffer setup succeed");
+
+  wtu.setupTexturedQuad(gl);
+
+  testNorm16Texture(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT);
+  testNorm16Texture(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT);
+  testNorm16Texture(ext.RGB16_EXT, gl.RGB, gl.UNSIGNED_SHORT);
+  testNorm16Texture(ext.RGBA16_EXT, gl.RGBA, gl.UNSIGNED_SHORT);
+  testNorm16Texture(ext.R16_SNORM_EXT, gl.RED, gl.SHORT);
+  testNorm16Texture(ext.RG16_SNORM_EXT, gl.RG, gl.SHORT);
+  testNorm16Texture(ext.RGB16_SNORM_EXT, gl.RGB, gl.SHORT);
+  testNorm16Texture(ext.RGBA16_SNORM_EXT, gl.RGBA, gl.SHORT);
+
+  testNorm16Render(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT);
+  testNorm16Render(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT);
+  testNorm16Render(ext.RGBA16_EXT, gl.RGBA, gl.UNSIGNED_SHORT);
+};
+
+function runTest() {
+  if (!gl) {
+    testFailed("context does not exist");
+  } else {
+    testPassed("context exists");
+
+    ext = gl.getExtension("EXT_texture_norm16");
+
+    wtu.runExtensionSupportedTest(gl, "EXT_texture_norm16", ext !== null);
+
+    if (ext !== null) {
+      runTestExtension();
+    } else {
+      testPassed("No EXT_texture_norm16 support -- this is legal");
+    }
+  }
+}
+
+runTest();
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -19,7 +19,7 @@ found in the LICENSE.txt file.
 <div id="console"></div>
 <script>
 "use strict";
-description("This test verifies the functionality of the EXT_texture_compression_rgtc extension, if it is available.");
+description("This test verifies the functionality of the EXT_texture_norm16 extension, if it is available.");
 
 debug("");
 

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -1166,12 +1166,15 @@ var checkCanvasRects = function(gl, rects) {
  * @param {!function()} logFn Function to call for logging.
  * @param {TypedArray} opt_readBackBuf optional buffer to read back into.
  *        Typically passed to either reuse buffer, or support readbacks from
- *        floating-point framebuffers.
+ *        floating-point/norm16 framebuffers.
  * @param {GLenum} opt_readBackType optional read back type, defaulting to
  *        gl.UNSIGNED_BYTE. Can be used to support readback from floating-point
+ *        /norm16 framebuffers.
+ * @param {GLenum} opt_readBackFormat optional read back format, defaulting to
+ *        gl.RGBA. Can be used to support readback from norm16
  *        framebuffers.
  */
-var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn, opt_readBackBuf, opt_readBackType) {
+var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRange, sameFn, differentFn, logFn, opt_readBackBuf, opt_readBackType, opt_readBackFormat) {
   if (isWebGLContext(gl) && !gl.getParameter(gl.FRAMEBUFFER_BINDING)) {
     // We're reading the backbuffer so clip.
     var xr = clipToRange(x, width, 0, gl.canvas.width);
@@ -1194,7 +1197,8 @@ var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRan
   if (isWebGLContext(gl)) {
     buf = opt_readBackBuf ? opt_readBackBuf : new Uint8Array(width * height * 4);
     var readBackType = opt_readBackType ? opt_readBackType : gl.UNSIGNED_BYTE;
-    gl.readPixels(x, y, width, height, gl.RGBA, readBackType, buf);
+    var readBackFormat = opt_readBackFormat ? opt_readBackFormat : gl.RGBA;
+    gl.readPixels(x, y, width, height, readBackFormat, readBackType, buf);
   } else {
     buf = gl.getImageData(x, y, width, height).data;
   }
@@ -1232,12 +1236,15 @@ var checkCanvasRectColor = function(gl, x, y, width, height, color, opt_errorRan
  *        color checking. 0 by default.
  * @param {TypedArray} opt_readBackBuf optional buffer to read back into.
  *        Typically passed to either reuse buffer, or support readbacks from
- *        floating-point framebuffers.
+ *        floating-point/norm16 framebuffers.
  * @param {GLenum} opt_readBackType optional read back type, defaulting to
  *        gl.UNSIGNED_BYTE. Can be used to support readback from floating-point
- *        framebuffers.
+ *        /norm16 framebuffers.
+ * @param {GLenum} opt_readBackFormat optional read back format, defaulting to
+ *        gl.RGBA. Can be used to support readback from floating-point
+ *        /norm16 framebuffers.
  */
-var checkCanvasRect = function(gl, x, y, width, height, color, opt_msg, opt_errorRange, opt_readBackBuf, opt_readBackType) {
+var checkCanvasRect = function(gl, x, y, width, height, color, opt_msg, opt_errorRange, opt_readBackBuf, opt_readBackType, opt_readBackFormat) {
   checkCanvasRectColor(
       gl, x, y, width, height, color, opt_errorRange,
       function() {
@@ -1254,7 +1261,8 @@ var checkCanvasRect = function(gl, x, y, width, height, color, opt_msg, opt_erro
       },
       debug,
       opt_readBackBuf,
-      opt_readBackType);
+      opt_readBackType,
+      opt_readBackFormat);
 };
 
 /**


### PR DESCRIPTION
Add test for EXT_texture_norm16 extension.
Refactor checkCanvasRect a bit to expose `opt_readBackFormat` to assign formats other than `gl.RGBA`