### PR TITLE
Probe for max non-OOM 3D texture size

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-3d-size-limit.html
+++ b/sdk/tests/conformance2/textures/misc/tex-3d-size-limit.html
@@ -62,22 +62,48 @@ function test3DTextureDimensions() {
         "texImage3D should fail for dimension out of range.");
 
     for (var i = 0; i < maxLevels; ++i) {
-        var size = 1 << i;
         var level = maxLevels - i - 1;
-        var badSize = size * 2;
+        var badSize = 1 << (i + 1);
 
-        gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, size, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed.");
-        gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 1, size, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed.");
-        gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 1, 1, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed.");
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, badSize, 2, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
         wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "texImage3D should fail for dimension out of range.");
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 2, badSize, 2, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
         wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "texImage3D should fail for dimension out of range.");
         gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 2, 2, badSize, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
         wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "texImage3D should fail for dimension out of range.");
+    }
+
+    // Probe to discover the max non-OOM level.
+    var numTestLevels = maxLevels;
+    while (true) {
+        gl.texImage3D(gl.TEXTURE_3D, numTestLevels-1, gl.RGBA, 1, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        var err = gl.getError();
+        if (err == gl.OUT_OF_MEMORY) {
+            debug("Probe failed for level=" + (numTestLevels-1) + ", reducing...");
+            numTestLevels -= 1;
+            if (!numTestLevels) {
+                testFailed("Failed to allocate any levels");
+                return;
+            }
+            continue;
+        }
+        if (err) {
+            testFailed("Should not hit non-OOM errors during max level probing.");
+            return;
+        }
+        break;
+    }
+
+    for (var i = 0; i < numTestLevels; ++i) {
+        var level = numTestLevels - i - 1;
+        var size = 1 << i;
+
+        gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, size, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed for level: " + level + " " + size + "x1x1.");
+        gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 1, size, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed for level: " + level + " 1x" + size + "x1.");
+        gl.texImage3D(gl.TEXTURE_3D, level, gl.RGBA, 1, 1, size, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage3D should succeed for level: " + level + " 1x1x" + size + ".");
     }
 
     // Clean up


### PR DESCRIPTION
Large image requests can trigger an out-of-memory error (#1925). In #2579, we try to probe the max non-OOM level for 2D and cube map textures. This is applied to 3D textures now.
