### PR TITLE
EXT_texture_norm16 test copyTex/ReadPixels RGBA only

### DIFF
--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -108,7 +108,7 @@ function testNorm16Render(interalFormat, format, type) {
 
   gl.drawArrays(gl.TRIANGLES, 0, 6);
 
-  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, expectedValue, 0), undefined, undefined, readbackBuf, type, format);
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, expectedValue, 0xffff), undefined, undefined, readbackBuf, type);
 
   // Renderbuffer test
   gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[1]);
@@ -123,16 +123,19 @@ function testNorm16Render(interalFormat, format, type) {
   gl.clearColor(1, 1, 1, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
-  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0), undefined, undefined, readbackBuf, type, format);
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0xffff), undefined, undefined, readbackBuf, type);
 
-  // Copy from renderbuffer to textures[1] test
-  gl.bindTexture(gl.TEXTURE_2D, textures[1]);
-  gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1);
+  if (format === gl.RGBA) {
+    // ReadPixels and copyTex* are limited to RGBA
+    // Copy from renderbuffer to textures[1] test
+    gl.bindTexture(gl.TEXTURE_2D, textures[1]);
+    gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1);
 
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copy succeed");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copy succeed");
 
-  gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
-  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0), undefined, undefined, readbackBuf, type, format);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
+    wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0xffff), undefined, undefined, readbackBuf, type);
+  }
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   gl.bindTexture(gl.TEXTURE_2D, null);

--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -125,17 +125,13 @@ function testNorm16Render(interalFormat, format, type) {
 
   wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0xffff), undefined, undefined, readbackBuf, type);
 
-  if (format === gl.RGBA) {
-    // ReadPixels and copyTex* are limited to RGBA
-    // Copy from renderbuffer to textures[1] test
-    gl.bindTexture(gl.TEXTURE_2D, textures[1]);
-    gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1);
+  gl.bindTexture(gl.TEXTURE_2D, textures[1]);
+  gl.copyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, 1, 1);
 
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copy succeed");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copy succeed");
 
-    gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
-    wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0xffff), undefined, undefined, readbackBuf, type);
-  }
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0xffff), undefined, undefined, readbackBuf, type);
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   gl.bindTexture(gl.TEXTURE_2D, null);
@@ -167,8 +163,6 @@ function runTestExtension() {
   testNorm16Texture(ext.RGB16_SNORM_EXT, gl.RGB, gl.SHORT);
   testNorm16Texture(ext.RGBA16_SNORM_EXT, gl.RGBA, gl.SHORT);
 
-  testNorm16Render(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT);
-  testNorm16Render(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT);
   testNorm16Render(ext.RGBA16_EXT, gl.RGBA, gl.UNSIGNED_SHORT);
 };
 


### PR DESCRIPTION
According to https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_norm16.txt

"ReadPixels format and type used during CopyTex*." is limited to RGBA.

 