### PR TITLE
glEnumToString allow glOrExt arg.

### DIFF
--- a/sdk/tests/js/tests/gl-object-get-calls.js
+++ b/sdk/tests/js/tests/gl-object-get-calls.js
@@ -53,8 +53,8 @@ for (var bb = 0; bb < bufferTypes.length; ++bb) {
   var buffer = gl.createBuffer();
   gl.bindBuffer(bufferType, buffer);
   gl.bufferData(bufferType, 16, gl.DYNAMIC_DRAW);
-  var expression1 = "gl.getBufferParameter(gl." + wtu.glEnumToString(gl, bufferType) + ", gl.BUFFER_SIZE)";
-  var expression2 = "gl.getBufferParameter(gl." + wtu.glEnumToString(gl, bufferType) + ", gl.BUFFER_USAGE)";
+  var expression1 = "gl.getBufferParameter(" + bufferType + ", gl.BUFFER_SIZE)";
+  var expression2 = "gl.getBufferParameter(" + bufferType + ", gl.BUFFER_USAGE)";
   shouldBe(expression1, '16');
   shouldBe(expression2, 'gl.DYNAMIC_DRAW');
   testInvalidArgument("getBufferParameter", "parameter", [gl.BUFFER_SIZE, gl.BUFFER_USAGE], function(bufferType) {

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -33,6 +33,10 @@ var loggingOff = function() {
   error = function() {};
 };
 
+const ENUM_NAME_REGEX = RegExp('[A-Z][A-Z0-9_]*');
+const ENUM_NAME_BY_VALUE = {};
+const ENUM_NAME_PROTOTYPES = new Map();
+
 /**
  * Converts a WebGL enum to a string.
  * @param {!WebGLRenderingContext} gl The WebGLRenderingContext to use.
@@ -43,24 +47,23 @@ var glEnumToString = function(glOrExt, value) {
   if (value === undefined)
     throw new Error('glEnumToString: `value` must not be undefined');
 
-  if (glOrExt.keyByValue === undefined) {
-    const keyByValue = glOrExt.keyByValue = {};
+  const proto = glOrExt.__proto__;
+  if (!ENUM_NAME_PROTOTYPES.has(proto)) {
+    ENUM_NAME_PROTOTYPES.set(proto, true);
 
-    for (const k in glOrExt) {
-      if (k == 'drawingBufferWidth' ||
-          k == 'drawingBufferHeight') {
-        continue;
-      }
+    for (const k in proto) {
+      if (!ENUM_NAME_REGEX.test(k)) continue;
+
       const v = glOrExt[k];
-      if (keyByValue[v] === undefined) {
-        keyByValue[v] = k;
+      if (ENUM_NAME_BY_VALUE[v] === undefined) {
+        ENUM_NAME_BY_VALUE[v] = k;
       } else {
-        keyByValue[v] += '/' + k;
+        ENUM_NAME_BY_VALUE[v] += '/' + k;
       }
     }
   }
 
-  const key = glOrExt.keyByValue[value];
+  const key = ENUM_NAME_BY_VALUE[value];
   if (key !== undefined) return key;
 
   return "0x" + Number(value).toString(16);


### PR DESCRIPTION
* Caches the value->enum unmappings, instead of linearly searching.
* Combine same-valued enum names: 0 -> NONE/ZERO/POINTS/NO_ERROR.
* glErrorShouldBeImpl still maps 0 -> NO_ERROR though.