### PR TITLE
Use an empty string for the default bind address

### DIFF
--- a/serve_localhost.py
+++ b/serve_localhost.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--bind', '-b', default='localhost', metavar='ADDRESS',
+    parser.add_argument('--bind', '-b', default='', metavar='ADDRESS',
                         help='Specify alternate bind address '
                              '[default: all interfaces]')
     parser.add_argument('--directory', '-d', default=os.getcwd(),


### PR DESCRIPTION
The comment says the default is all interfaces but then explicitly specifies localhost. By using an empty string we can bind everywhere.