### PR TITLE
Bump tolerance limit for tex-image...video.js 5=>6.

### DIFF
--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-video.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-2d-with-video.js
@@ -181,7 +181,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
             // Check a few pixels near the top and bottom and make sure they have
             // the right color.
-            var tolerance = 5;
+            const tolerance = 6;
             debug("Checking lower left corner");
             wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
                                 "shouldBe " + bottomColor, tolerance);

--- a/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-video.js
+++ b/conformance-suites/2.0.0/js/tests/tex-image-and-sub-image-3d-with-video.js
@@ -152,7 +152,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
         // Check a few pixels near the top and bottom and make sure they have
         // the right color.
-        var tolerance = 5;
+        const tolerance = 6;
         debug("Checking lower left corner");
         wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
                             "shouldBe " + bottomColor, tolerance);

--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
@@ -173,7 +173,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
             wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
             // Check a few pixels near the top and bottom and make sure they have
             // the right color.
-            var tolerance = 5;
+            const tolerance = 6;
             debug("Checking lower left corner");
             wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
                                 "shouldBe " + bottomColor, tolerance);

--- a/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-3d-with-video.js
@@ -135,7 +135,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         wtu.clearAndDrawUnitQuad(gl, [0, 0, 0, 255]);
         // Check a few pixels near the top and bottom and make sure they have
         // the right color.
-        var tolerance = 5;
+        const tolerance = 6;
         debug("Checking lower left corner");
         wtu.checkCanvasRect(gl, 4, 4, 2, 2, bottomColor,
                             "shouldBe " + bottomColor, tolerance);


### PR DESCRIPTION
Satisfies #2973.