### PR TITLE
Explicitly set the background color to white

### DIFF
--- a/sdk/tests/resources/js-test-style.css
+++ b/sdk/tests/resources/js-test-style.css
@@ -15,3 +15,6 @@
     white-space: pre-wrap;
     font-family: monospace;
 }
+body {
+    background-color: #ffffff;
+}


### PR DESCRIPTION
Some, especially TV-set, browsers render black or transparent by default.
Setting background explicitly to white will help many people.

An example of a non-white background requirement -- Section 5.3.3.1 of HbbTV 2.0.1 spec:
https://www.hbbtv.org/wp-content/uploads/2015/07/HbbTV-SPEC20-00023-002-HbbTV_2.0.1_specification_for_publication_clean.pdf