### PR TITLE
Add conformance test for dynamic indexing of row_major matrix arrays

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -52,3 +52,4 @@ valid-invariant.html
 vector-dynamic-indexing.html
 --min-version 2.0.1 vector-dynamic-indexing-nv-driver-bug.html
 --min-version 2.0.1 vector-dynamic-indexing-swizzled-lvalue.html
+--min-version 2.0.1 matrix-row-major-dynamic-indexing.html

--- a/sdk/tests/conformance2/glsl3/matrix-row-major-dynamic-indexing.html
+++ b/sdk/tests/conformance2/glsl3/matrix-row-major-dynamic-indexing.html
@@ -1,0 +1,78 @@
+<!--
+
+/*
+** Copyright (c) 2019 The Khronos Group Inc.
+**
+** Permission is hereby granted, free of charge, to any person obtaining a
+** copy of this software and/or associated documentation files (the
+** "Materials"), to deal in the Materials without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Materials, and to
+** permit persons to whom the Materials are furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be included
+** in all copies or substantial portions of the Materials.
+**
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+*/
+
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>GLSL array assignment test</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="fshaderIndexMatrixArrayInUniformBlock" type="x-shader/x-fragment">#version 300 es
+precision mediump float;
+
+out vec4 my_FragColor;
+
+uniform int u_zero;
+
+layout(row_major) uniform a {
+    mat4 u_mats[1];
+};
+
+void main() {
+    float f = u_mats[u_zero + 0][1][1];
+    my_FragColor = vec4(1.0 - f, f, 0.0, 1.0);
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description("Indexing matrices within a uniform block should work");
+
+GLSLConformanceTester.runRenderTests([
+{
+  fShaderId: 'fshaderIndexMatrixArrayInUniformBlock',
+  fShaderSuccess: true,
+  linkSuccess: true,
+  passMsg: '',
+  uniformBlocks: [{name: "a", value: new Float32Array([
+    0, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+  ])}],
+}
+], 2);
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
This is failing on OSX Chrome. A bug will also be filed with Chrome.

I'm seeing this issue on a personal project. In my environment, with `layout(row_major)` the test fails, `layout(column_major)` test succeeds.

Edit: ANGLE bug filed at https://bugs.chromium.org/p/angleproject/issues/detail?id=4242