### PR TITLE
Fix alpha channel set to 1 in ext-texture-norm16 test

### DIFF
--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -108,7 +108,7 @@ function testNorm16Render(interalFormat, format, type) {
 
   gl.drawArrays(gl.TRIANGLES, 0, 6);
 
-  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, expectedValue, 0), undefined, undefined, readbackBuf, type, format);
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, expectedValue, 0xffff), undefined, undefined, readbackBuf, type);
 
   // Renderbuffer test
   gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[1]);
@@ -123,7 +123,7 @@ function testNorm16Render(interalFormat, format, type) {
   gl.clearColor(1, 1, 1, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
-  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0), undefined, undefined, readbackBuf, type, format);
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0xffff), undefined, undefined, readbackBuf, type);
 
   // Copy from renderbuffer to textures[1] test
   gl.bindTexture(gl.TEXTURE_2D, textures[1]);
@@ -132,7 +132,7 @@ function testNorm16Render(interalFormat, format, type) {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "copy succeed");
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
-  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0), undefined, undefined, readbackBuf, type, format);
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, 0xffff, 0xffff), undefined, undefined, readbackBuf, type);
 
   gl.bindFramebuffer(gl.FRAMEBUFFER, null);
   gl.bindTexture(gl.TEXTURE_2D, null);


### PR DESCRIPTION
Part of the fix after figuring out the root cause for the failure hasn't landed.
https://github.com/KhronosGroup/WebGL/pull/2972/files