### PR TITLE
Fix samplers.html: enumToString might return multiple enums separated by slash

### DIFF
--- a/sdk/tests/conformance2/samplers/samplers.html
+++ b/sdk/tests/conformance2/samplers/samplers.html
@@ -174,7 +174,7 @@ function runParameterTest() {
         var pname = testCases[ii].pname;
         var param = testCases[ii].param;
         wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.samplerParameteri(s, " + pname + ", " + param + ")");
-        shouldBe("gl.getSamplerParameter(s, " + pname + ")", "gl['" + (enumToString(param).split('/'))[0] + "']");
+        shouldBe("gl.getSamplerParameter(s, " + pname + ")", param);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     }
 

--- a/sdk/tests/conformance2/samplers/samplers.html
+++ b/sdk/tests/conformance2/samplers/samplers.html
@@ -174,7 +174,7 @@ function runParameterTest() {
         var pname = testCases[ii].pname;
         var param = testCases[ii].param;
         wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.samplerParameteri(s, " + pname + ", " + param + ")");
-        shouldBe("gl.getSamplerParameter(s, " + pname + ")", "gl['" + enumToString(param) + "']");
+        shouldBe("gl.getSamplerParameter(s, " + pname + ")", "gl['" + (enumToString(param).split('/'))[0] + "']");
         wtu.glErrorShouldBe(gl, gl.NO_ERROR);
     }
 


### PR DESCRIPTION
Now glEnumToString might return multiple enums sharing one values #2980.

Quick fix for a test where https://github.com/KhronosGroup/WebGL/blob/master/sdk/tests/conformance2/samplers/samplers.html#L177
```
eval("gl['POINTS/ZERO/NO_ERROR/NONE']");
```
will return undefined leading to a test failure..

This is a quick fix but might not be optimal.