### PR TITLE
Use high precision float and sampler2D for ext-texture-norm16.html

### DIFF
--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -153,7 +153,7 @@ function runTestExtension() {
 
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture and framebuffer setup succeed");
 
-  wtu.setupTexturedQuad(gl);
+  wtu.setupTexturedQuad(gl, 0, 1, wtu.simpleHighPrecisionTextureFragmentShader);
 
   testNorm16Texture(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT);
   testNorm16Texture(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT);

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -125,6 +125,18 @@ var simpleTextureFragmentShader = [
   '}'].join('\n');
 
 /**
+ * A fragment shader for a single texture with high precision.
+ * @type {string}
+ */
+var simpleHighPrecisionTextureFragmentShader = [
+  'precision highp float;',
+  'uniform highp sampler2D tex;',
+  'varying vec2 texCoord;',
+  'void main() {',
+  '    gl_FragData[0] = texture2D(tex, texCoord);',
+  '}'].join('\n');
+
+/**
  * A fragment shader for a single cube map texture.
  * @type {string}
  */
@@ -3386,6 +3398,7 @@ Object.defineProperties(API, {
   simpleVertexShader: { value: simpleVertexShader, writable: false },
   simpleVertexShaderESSL300: { value: simpleVertexShaderESSL300, writable: false },
   simpleTextureFragmentShader: { value: simpleTextureFragmentShader, writable: false },
+  simpleHighPrecisionTextureFragmentShader: { value: simpleHighPrecisionTextureFragmentShader, writable: false },
   simpleCubeMapTextureFragmentShader: { value: simpleCubeMapTextureFragmentShader, writable: false },
   simpleVertexColorFragmentShader: { value: simpleVertexColorFragmentShader, writable: false },
   simpleVertexColorVertexShader: { value: simpleVertexColorVertexShader, writable: false }


### PR DESCRIPTION
By default the fragment shader uses `lowp` for `sampler2D`. It is not enough for RGBA16 UNSIGNED_SHORT normalized value which has 16 bit for each channel. Use an override shader with `precision highp float; uniform highp sampler2D tex;` declared instead.

This should probably be generalized, since this is effectively needed for all tests with >8 bits per channel, including all float/half-float tests.

Previous discussion could be found in #2999

