### PR TITLE
Add tests for query, sync and timer queries on workers.

### DIFF
--- a/sdk/tests/conformance/offscreencanvas/00_test_list.txt
+++ b/sdk/tests/conformance/offscreencanvas/00_test_list.txt
@@ -8,4 +8,5 @@ context-lost-restored-worker.html
 methods.html
 methods-worker.html
 offscreencanvas-resize.html
+--min-version 1.0.4 offscreencanvas-timer-query.html
 --min-version 1.0.4 offscreencanvas-transfer-image-bitmap.html

--- a/sdk/tests/conformance/offscreencanvas/offscreencanvas-timer-query.html
+++ b/sdk/tests/conformance/offscreencanvas/offscreencanvas-timer-query.html
@@ -1,0 +1,84 @@
+<!--
+Copyright (c) 2019 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test for Timer Query objects with OffscreenCanvas</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+  <div id="description"></div>
+  <div id="console"></div>
+  <script id='myWorker' type='text/worker'>
+  function tick(callback) {
+      function tickImpl() {
+          const res = callback();
+          if (res) {
+              if (requestAnimationFrame) {
+                  requestAnimationFrame(tickImpl);
+              } else {
+                  setTimeout(tickImpl, 10);
+              }
+          }
+      }
+
+      tickImpl();
+  }
+
+  self.onmessage = function(e) {
+      let canvas = new OffscreenCanvas(128, 128);
+      let gl = canvas.getContext("webgl");
+      let ext = gl.getExtension("EXT_disjoint_timer_query");
+      if (!ext) {
+          self.postMessage("PASSED - no EXT_disjoint_timer_query extension - this is legal");
+          return false;
+      }
+      let query = ext.createQueryEXT();
+      ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
+      ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
+      gl.clearColor(0.0, 1.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      tick(function() {
+          const status = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
+          if (status) {
+              self.postMessage("PASSED - timer query object completed successfully on worker");
+              return false;
+          } else {
+              const err = gl.getError();
+              if (err != 0) {
+                  self.postMessage("FAILED - GL error " + err);
+                  return false;
+              }
+          }
+          return true;
+      });
+  };
+  </script>
+  <script>
+    "use strict";
+    description("This test ensures that timer query objects work with the WebGL 1.0 context created via OffscreenCanvas.");
+    if (!window.OffscreenCanvas) {
+        testPassed("No OffscreenCanvas support");
+        finishTest();
+    } else {
+      var blob = new Blob([document.getElementById('myWorker').textContent]);
+      var worker = new Worker(URL.createObjectURL(blob));
+      worker.onmessage = function(msg) {
+          if (msg.data.startsWith("PASSED")) {
+              testPassed(msg.data);
+          } else {
+              testFailed(msg.data);
+          }
+          finishTest();
+      }
+      worker.postMessage("Start Worker");
+    }
+  </script>
+</body>
+</html>

--- a/sdk/tests/conformance2/offscreencanvas/00_test_list.txt
+++ b/sdk/tests/conformance2/offscreencanvas/00_test_list.txt
@@ -2,4 +2,7 @@ context-creation.html
 context-creation-worker.html
 methods-2.html
 methods-2-worker.html
+--min-version 2.0.1 offscreencanvas-query.html
+--min-version 2.0.1 offscreencanvas-sync.html
+--min-version 2.0.1 offscreencanvas-timer-query.html
 --min-version 2.0.1 offscreencanvas-transfer-image-bitmap.html

--- a/sdk/tests/conformance2/offscreencanvas/offscreencanvas-query.html
+++ b/sdk/tests/conformance2/offscreencanvas/offscreencanvas-query.html
@@ -1,0 +1,79 @@
+<!--
+Copyright (c) 2019 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test for Query objects with OffscreenCanvas</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+  <div id="description"></div>
+  <div id="console"></div>
+  <script id='myWorker' type='text/worker'>
+  function tick(callback) {
+      function tickImpl() {
+          const res = callback();
+          if (res) {
+              if (requestAnimationFrame) {
+                  requestAnimationFrame(tickImpl);
+              } else {
+                  setTimeout(tickImpl, 10);
+              }
+          }
+      }
+
+      tickImpl();
+  }
+
+  self.onmessage = function(e) {
+      let canvas = new OffscreenCanvas(128, 128);
+      let gl = canvas.getContext("webgl2");
+      let query = gl.createQuery();
+      gl.beginQuery(gl.ANY_SAMPLES_PASSED_CONSERVATIVE, query);
+      gl.endQuery(gl.ANY_SAMPLES_PASSED_CONSERVATIVE);
+      gl.clearColor(0.0, 1.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      tick(function() {
+          const status = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
+          if (status) {
+              self.postMessage("PASSED - query object completed successfully from worker");
+              return false;
+          } else {
+              const err = gl.getError();
+              if (err != 0) {
+                  self.postMessage("FAILED - GL error " + err);
+                  return false;
+              }
+          }
+          return true;
+      });
+  };
+  </script>
+  <script>
+    "use strict";
+    description("This test ensures that query objects work with the WebGL 2.0 context created via OffscreenCanvas.");
+    if (!window.OffscreenCanvas) {
+        testPassed("No OffscreenCanvas support");
+        finishTest();
+    } else {
+      var blob = new Blob([document.getElementById("myWorker").textContent]);
+      var worker = new Worker(URL.createObjectURL(blob));
+      worker.onmessage = function(msg) {
+          if (msg.data.startsWith("PASSED")) {
+              testPassed(msg.data);
+          } else {
+              testFailed(msg.data);
+          }
+          finishTest();
+      }
+      worker.postMessage("Start Worker");
+    }
+  </script>
+</body>
+</html>

--- a/sdk/tests/conformance2/offscreencanvas/offscreencanvas-sync.html
+++ b/sdk/tests/conformance2/offscreencanvas/offscreencanvas-sync.html
@@ -1,0 +1,77 @@
+<!--
+Copyright (c) 2019 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test for Sync objects with OffscreenCanvas</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+  <div id="description"></div>
+  <div id="console"></div>
+  <script id='myWorker' type='text/worker'>
+  function tick(callback) {
+      function tickImpl() {
+          const res = callback();
+          if (res) {
+              if (requestAnimationFrame) {
+                  requestAnimationFrame(tickImpl);
+              } else {
+                  setTimeout(tickImpl, 10);
+              }
+          }
+      }
+
+      tickImpl();
+  }
+
+  self.onmessage = function(e) {
+      let canvas = new OffscreenCanvas(128, 128);
+      let gl = canvas.getContext("webgl2");
+      let sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+      gl.clearColor(0.0, 1.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      tick(function() {
+          const status = gl.getSyncParameter(sync, gl.SYNC_STATUS);
+          if (status == gl.SIGNALED) {
+              self.postMessage("PASSED - Sync object signaled successfully from worker");
+              return false;
+          } else {
+              const err = gl.getError();
+              if (err != 0) {
+                  self.postMessage("FAILED - GL error " + err);
+                  return false;
+              }
+          }
+          return true;
+      });
+  };
+  </script>
+  <script>
+    "use strict";
+    description("This test ensures that sync objects work with the WebGL 2.0 context created via OffscreenCanvas.");
+    if (!window.OffscreenCanvas) {
+        testPassed("No OffscreenCanvas support");
+        finishTest();
+    } else {
+      var blob = new Blob([document.getElementById("myWorker").textContent]);
+      var worker = new Worker(URL.createObjectURL(blob));
+      worker.onmessage = function(msg) {
+          if (msg.data.startsWith("PASSED")) {
+              testPassed(msg.data);
+          } else {
+              testFailed(msg.data);
+          }
+          finishTest();
+      }
+      worker.postMessage("Start Worker");
+    }
+  </script>
+</body>
+</html>

--- a/sdk/tests/conformance2/offscreencanvas/offscreencanvas-timer-query.html
+++ b/sdk/tests/conformance2/offscreencanvas/offscreencanvas-timer-query.html
@@ -1,0 +1,84 @@
+<!--
+Copyright (c) 2019 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test for Timer Query objects with OffscreenCanvas</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+  <div id="description"></div>
+  <div id="console"></div>
+  <script id='myWorker' type='text/worker'>
+  function tick(callback) {
+      function tickImpl() {
+          const res = callback();
+          if (res) {
+              if (requestAnimationFrame) {
+                  requestAnimationFrame(tickImpl);
+              } else {
+                  setTimeout(tickImpl, 10);
+              }
+          }
+      }
+
+      tickImpl();
+  }
+
+  self.onmessage = function(e) {
+      let canvas = new OffscreenCanvas(128, 128);
+      let gl = canvas.getContext("webgl2");
+      let ext = gl.getExtension("EXT_disjoint_timer_query_webgl2");
+      if (!ext) {
+          self.postMessage("PASSED - no EXT_disjoint_timer_query_webgl2 extension - this is legal");
+          return false;
+      }
+      let query = gl.createQuery();
+      gl.beginQuery(ext.TIME_ELAPSED_EXT, query);
+      gl.endQuery(ext.TIME_ELAPSED_EXT);
+      gl.clearColor(0.0, 1.0, 0.0, 1.0);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      tick(function() {
+          const status = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
+          if (status) {
+              self.postMessage("PASSED - timer query object completed successfully on worker");
+              return false;
+          } else {
+              const err = gl.getError();
+              if (err != 0) {
+                  self.postMessage("FAILED - GL error " + err);
+                  return false;
+              }
+          }
+          return true;
+      });
+  };
+  </script>
+  <script>
+    "use strict";
+    description("This test ensures that timer query objects work with the WebGL 2.0 context created via OffscreenCanvas.");
+    if (!window.OffscreenCanvas) {
+        testPassed("No OffscreenCanvas support");
+        finishTest();
+    } else {
+      var blob = new Blob([document.getElementById('myWorker').textContent]);
+      var worker = new Worker(URL.createObjectURL(blob));
+      worker.onmessage = function(msg) {
+          if (msg.data.startsWith("PASSED")) {
+              testPassed(msg.data);
+          } else {
+              testFailed(msg.data);
+          }
+          finishTest();
+      }
+      worker.postMessage("Start Worker");
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Test the following scenarios with OffscreenCanvas on workers:

 - Query objects with WebGL 2.0 contexts
 - Sync objects with WebGL 2.0 contexts
 - Timer queries with WebGL 1.0 and 2.0 contexts

Regression test for http://crbug.com/1010877 .