### PR TITLE
Spec zero-sized canvas behavior and test.

### DIFF
--- a/sdk/tests/conformance/context/00_test_list.txt
+++ b/sdk/tests/conformance/context/00_test_list.txt
@@ -16,3 +16,4 @@ incorrect-context-object-behaviour.html
 --max-version 1.9.9 methods.html
 premultiplyalpha-test.html
 --min-version 1.0.4 user-defined-properties-on-context.html
+--min-version 1.0.4 zero-sized-canvas.html

--- a/sdk/tests/conformance/context/zero-sized-canvas.html
+++ b/sdk/tests/conformance/context/zero-sized-canvas.html
@@ -1,0 +1,59 @@
+<!--
+Copyright (c) 2020 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+// Global declarations so that "shouldBe" can eval with them:
+let gl;
+
+(function() {
+    description('Check that zero-sized canvases work with WebGL.');
+
+    testZero();
+
+    finishTest();
+})();
+
+function testZero() {
+    const canvas = document.createElement('canvas');
+    canvas.width = 0;
+    canvas.height = 0;
+    gl = WebGLTestUtils.create3DContext(canvas);
+
+    expectTrue(gl, `Context creation with ${canvas.width}x${canvas.height} canvas should succeed.`);
+    shouldBe('gl.drawingBufferWidth', '1');
+    shouldBe('gl.drawingBufferHeight', '1');
+    shouldBeFalse('gl.isContextLost()');
+
+    const version = gl.getParameter(gl.VERSION);
+    expectTrue(version && version.length, `getParameter() should return something.`);
+
+    debug('canvas.width = 2');
+    canvas.width = 2;
+    shouldBe('gl.drawingBufferWidth', '2');
+    shouldBeFalse('gl.isContextLost()');
+
+    debug('canvas.width = 0');
+    canvas.width = 0;
+    shouldBe('gl.drawingBufferWidth', '1');
+    shouldBeFalse('gl.isContextLost()');
+}
+
+</script>
+</body>
+</html>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -288,6 +288,10 @@
     </table>
     <br>
     <p>
+        <code>HTMLCanvasElement.width</code> and <code>.height</code> values less than 1 are treated as 1.
+        A 0x0 canvas will yield a 1x1 drawingBufferWidth/Height.
+    </p>
+    <p>
         If the requested width or height cannot be satisfied, either when the drawing buffer is first
         created or when the <code>width</code> and <code>height</code> attributes of the
         <code>HTMLCanvasElement</code> or <code>OffscreenCanvas</code> are changed, a drawing buffer


### PR DESCRIPTION
0x0 canvas yields 1x1 WebGL context.