### PR TITLE
Check sampling from allocated compressed texture array

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
@@ -98,7 +98,7 @@ function runTexCompressedFormatsTest(texCompressedFormats)
         // Test a 2D texture.
         var tex = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, tex);
-        gl.texStorage2D(gl.TEXTURE_2D, 1, internalformat, 4, 4);
+        gl.texStorage2D(gl.TEXTURE_2D, 1, internalformat, 1, 1);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR,
                             "texStorage2D should succeed for " + enumToString(internalformat));
         gl.deleteTexture(tex);
@@ -111,14 +111,14 @@ function runTexCompressedFormatsTest(texCompressedFormats)
         // Test the 3D texture targets.
         var tex3d = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_3D, tex3d);
-        gl.texStorage3D(gl.TEXTURE_3D, 1, internalformat, 4, 4, 1);
+        gl.texStorage3D(gl.TEXTURE_3D, 1, internalformat, 1, 1, 1);
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
                             "texStorage3D(TEXTURE_3D) should fail for " + enumToString(internalformat));
         gl.deleteTexture(tex3d);
 
         var tex2dArr = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D_ARRAY, tex2dArr);
-        gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, internalformat, 4, 4, 1);
+        gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, internalformat, 1, 1, 1);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR,
                             "texStorage3D(TEXTURE_2D_ARRAY) should succeed for " + enumToString(internalformat));
         wtu.clearAndDrawUnitQuad(gl);

--- a/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
@@ -31,8 +31,8 @@ var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, null, 2);
 
 // Either of these extensions should be available on all WebGL 2.0 contexts
-var WEBGL_compressed_texture_etc = gl.getExtension("WEBGL_compressed_texture_etc");
-var WEBGL_compressed_texture_s3tc = gl.getExtension("WEBGL_compressed_texture_s3tc");
+const WEBGL_compressed_texture_etc = gl.getExtension("WEBGL_compressed_texture_etc");
+const WEBGL_compressed_texture_s3tc = gl.getExtension("WEBGL_compressed_texture_s3tc");
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -98,7 +98,7 @@ function runTexCompressedFormatsTest(texCompressedFormats)
         // Test a 2D texture.
         var tex = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, tex);
-        gl.texStorage2D(gl.TEXTURE_2D, 1, internalformat, 1, 1);
+        gl.texStorage2D(gl.TEXTURE_2D, 1, internalformat, 4, 4);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR,
                             "texStorage2D should succeed for " + enumToString(internalformat));
         gl.deleteTexture(tex);
@@ -111,14 +111,14 @@ function runTexCompressedFormatsTest(texCompressedFormats)
         // Test the 3D texture targets.
         var tex3d = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_3D, tex3d);
-        gl.texStorage3D(gl.TEXTURE_3D, 1, internalformat, 1, 1, 1);
+        gl.texStorage3D(gl.TEXTURE_3D, 1, internalformat, 4, 4, 1);
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
                             "texStorage3D(TEXTURE_3D) should fail for " + enumToString(internalformat));
         gl.deleteTexture(tex3d);
 
         var tex2dArr = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D_ARRAY, tex2dArr);
-        gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, internalformat, 1, 1, 1);
+        gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, internalformat, 4, 4, 1);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR,
                             "texStorage3D(TEXTURE_2D_ARRAY) should succeed for " + enumToString(internalformat));
         wtu.clearAndDrawUnitQuad(gl);

--- a/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
@@ -29,17 +29,48 @@ debug("");
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, null, 2);
+
+// Either of these extensions should be available on all WebGL 2.0 contexts
 var WEBGL_compressed_texture_etc = gl.getExtension("WEBGL_compressed_texture_etc");
-var vao = null;
+var WEBGL_compressed_texture_s3tc = gl.getExtension("WEBGL_compressed_texture_s3tc");
 
 if (!gl) {
     testFailed("WebGL context does not exist");
-} else if (!WEBGL_compressed_texture_etc) {
-    testPassed("No WEBGL_compressed_texture_etc support -- this is legal");
 } else {
     testPassed("WebGL context exists");
 
-    runTexCompressedFormatsTest();
+    if (WEBGL_compressed_texture_etc) {
+        debug("Testing WEBGL_compressed_texture_etc formats");
+
+        // These compressed formats are in Table 3.19 from the OpenGL ES 3.0.4 spec.
+        runTexCompressedFormatsTest([
+            WEBGL_compressed_texture_etc.COMPRESSED_R11_EAC,
+            WEBGL_compressed_texture_etc.COMPRESSED_SIGNED_R11_EAC,
+            WEBGL_compressed_texture_etc.COMPRESSED_RG11_EAC,
+            WEBGL_compressed_texture_etc.COMPRESSED_SIGNED_RG11_EAC,
+            WEBGL_compressed_texture_etc.COMPRESSED_RGB8_ETC2,
+            WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_ETC2,
+            WEBGL_compressed_texture_etc.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2,
+            WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2,
+            WEBGL_compressed_texture_etc.COMPRESSED_RGBA8_ETC2_EAC,
+            WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC,
+        ]);
+    } else {
+        testPassed("No WEBGL_compressed_texture_etc support -- this is legal");
+    }
+
+    if (WEBGL_compressed_texture_s3tc) {
+        debug("Testing WEBGL_compressed_texture_s3tc formats");
+
+        runTexCompressedFormatsTest([
+            WEBGL_compressed_texture_s3tc.COMPRESSED_RGB_S3TC_DXT1_EXT,
+            WEBGL_compressed_texture_s3tc.COMPRESSED_RGBA_S3TC_DXT1_EXT,
+            WEBGL_compressed_texture_s3tc.COMPRESSED_RGBA_S3TC_DXT3_EXT,
+            WEBGL_compressed_texture_s3tc.COMPRESSED_RGBA_S3TC_DXT5_EXT,
+        ]);
+    } else {
+        testPassed("No WEBGL_compressed_texture_s3tc support -- this is legal");
+    }
 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
@@ -48,22 +79,8 @@ function enumToString(value) {
   return wtu.glEnumToString(gl, value);
 }
 
-function runTexCompressedFormatsTest()
+function runTexCompressedFormatsTest(texCompressedFormats)
 {
-    // These compressed formats are in Table 3.19 from the OpenGL ES 3.0.4 spec.
-    var texCompressedFormats = [
-        WEBGL_compressed_texture_etc.COMPRESSED_R11_EAC,
-        WEBGL_compressed_texture_etc.COMPRESSED_SIGNED_R11_EAC,
-        WEBGL_compressed_texture_etc.COMPRESSED_RG11_EAC,
-        WEBGL_compressed_texture_etc.COMPRESSED_SIGNED_RG11_EAC,
-        WEBGL_compressed_texture_etc.COMPRESSED_RGB8_ETC2,
-        WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_ETC2,
-        WEBGL_compressed_texture_etc.COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2,
-        WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2,
-        WEBGL_compressed_texture_etc.COMPRESSED_RGBA8_ETC2_EAC,
-        WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC,
-    ];
-
     wtu.setupUnitQuad(gl);
 
     gl.useProgram(wtu.setupSimpleTextureProgramESSL300(gl, undefined, undefined,
@@ -86,9 +103,10 @@ function runTexCompressedFormatsTest()
                             "texStorage2D should succeed for " + enumToString(internalformat));
         gl.deleteTexture(tex);
 
-        // GLES 3.0.4 p147:
-        // "If internalformat is an ETC2/EAC format, CompressedTexImage3D will generate an
-        //  INVALID_OPERATION error if target is not TEXTURE_2D_ARRAY."
+        // GLES 3.0.4 p147: + EXT_texture_compression_s3tc:
+        // If internalformat is an ETC2/EAC/DXT1/DXT3/DXT5
+        // format, CompressedTexImage3D will generate an INVALID_OPERATION error if
+        // target is not TEXTURE_2D_ARRAY.
 
         // Test the 3D texture targets.
         var tex3d = gl.createTexture();

--- a/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
+++ b/sdk/tests/conformance2/textures/misc/tex-storage-compressed-formats.html
@@ -64,6 +64,19 @@ function runTexCompressedFormatsTest()
         WEBGL_compressed_texture_etc.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC,
     ];
 
+    wtu.setupUnitQuad(gl);
+
+    gl.useProgram(wtu.setupSimpleTextureProgramESSL300(gl, undefined, undefined,
+           `#version 300 es
+            precision mediump float;
+            uniform mediump sampler2DArray tex;
+            in vec2 texCoord;
+            out vec4 out_color;
+            void main() {
+              out_color = texture(tex, vec3(texCoord, 0));
+            }`
+        ));
+
     texCompressedFormats.forEach(function(internalformat){
         // Test a 2D texture.
         var tex = gl.createTexture();
@@ -90,6 +103,8 @@ function runTexCompressedFormatsTest()
         gl.texStorage3D(gl.TEXTURE_2D_ARRAY, 1, internalformat, 1, 1, 1);
         wtu.glErrorShouldBe(gl, gl.NO_ERROR,
                             "texStorage3D(TEXTURE_2D_ARRAY) should succeed for " + enumToString(internalformat));
+        wtu.clearAndDrawUnitQuad(gl);
+        wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing unit quad from empty texture");
         gl.deleteTexture(tex2dArr);
     });
 }


### PR DESCRIPTION
In Chrome (80-82), sampling from freshly-allocated compressed 2D texture array results in `INVALID_ENUM` error on `drawArrays` call.

https://crbug.com/1051217