### PR TITLE
Add compressedTexSubImage validation test for bptc and rgtc

### DIFF
--- a/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
@@ -52,6 +52,27 @@ function runTestExtension() {
   ctu.testCorrectEnumValuesInExt(ext, validFormats);
   // Test that texture upload buffer size is validated correctly.
   ctu.testFormatRestrictionsOnBufferSize(gl, validFormats, expectedByteLength, getBlockDimensions);
+  // Test TexSubImage validation on dimensions
+  // CompressedTexSubImage* will result in an
+  // INVALID_OPERATION error only if one of the following conditions occurs:
+  // * <width> is not a multiple of four, and <width> plus <xoffset> is not
+  // equal to TEXTURE_WIDTH;
+  // * <height> is not a multiple of four, and <height> plus <yoffset> is
+  //           not equal to TEXTURE_HEIGHT; or
+  // * <xoffset> or <yoffset> is not a multiple of four.
+  ctu.testTexSubImageDimensions(gl, validFormats, expectedByteLength, getBlockDimensions,
+    16, 16, [
+      { xoffset: 0, yoffset: 0, width: 4, height: 3,
+        expectation: gl.INVALID_OPERATION, message: "height is not a multiple of 4" },
+      { xoffset: 0, yoffset: 0, width: 3, height: 4,
+        expectation: gl.INVALID_OPERATION, message: "width is not a multiple of 4" },
+      { xoffset: 1, yoffset: 0, width: 4, height: 4,
+        expectation: gl.INVALID_OPERATION, message: "xoffset is not a multiple of 4" },
+      { xoffset: 0, yoffset: 1, width: 4, height: 4,
+        expectation: gl.INVALID_OPERATION, message: "yoffset is not a multiple of 4" },
+      { xoffset: 12, yoffset: 12, width: 4, height: 4,
+        expectation: gl.NO_ERROR, message: "is valid" },
+  ]);
 };
 
 function runTest() {

--- a/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
@@ -57,6 +57,27 @@ function runTestExtension() {
   ctu.testCorrectEnumValuesInExt(ext, validFormats);
   // Test that texture upload buffer size is validated correctly.
   ctu.testFormatRestrictionsOnBufferSize(gl, validFormats, expectedByteLength, getBlockDimensions);
+  // Test TexSubImage validation on dimensions
+  // CompressedTexSubImage* will result in an
+  // INVALID_OPERATION error only if one of the following conditions occurs:
+  // * <width> is not a multiple of four, and <width> plus <xoffset> is not
+  // equal to TEXTURE_WIDTH;
+  // * <height> is not a multiple of four, and <height> plus <yoffset> is
+  //           not equal to TEXTURE_HEIGHT; or
+  // * <xoffset> or <yoffset> is not a multiple of four.
+  ctu.testTexSubImageDimensions(gl, validFormats, expectedByteLength, getBlockDimensions,
+    16, 16, [
+      { xoffset: 0, yoffset: 0, width: 4, height: 3,
+        expectation: gl.INVALID_OPERATION, message: "height is not a multiple of 4" },
+      { xoffset: 0, yoffset: 0, width: 3, height: 4,
+        expectation: gl.INVALID_OPERATION, message: "width is not a multiple of 4" },
+      { xoffset: 1, yoffset: 0, width: 4, height: 4,
+        expectation: gl.INVALID_OPERATION, message: "xoffset is not a multiple of 4" },
+      { xoffset: 0, yoffset: 1, width: 4, height: 4,
+        expectation: gl.INVALID_OPERATION, message: "yoffset is not a multiple of 4" },
+      { xoffset: 12, yoffset: 12, width: 4, height: 4,
+        expectation: gl.NO_ERROR, message: "is valid" },
+  ]);
 };
 
 function runTest() {

--- a/sdk/tests/js/tests/compressed-texture-utils.js
+++ b/sdk/tests/js/tests/compressed-texture-utils.js
@@ -156,6 +156,42 @@ var testFormatRestrictionsOnBufferSize = function(gl, validFormats, expectedByte
     }
 };
 
+/**
+ * @param {WebGLRenderingContextBase} gl
+ * @param {Object} validFormats Mapping from format names to format enum values.
+ * @param expectedByteLength A function that takes in width, height and format and returns the expected buffer size in bytes.
+ * @param getBlockDimensions A function that takes in a format and returns block size in pixels.
+ * @param {number} width Width of the image in pixels.
+ * @param {number} height Height of the image in pixels.
+ * @param {Object} subImageConfigs configs for compressedTexSubImage calls
+ */
+var testTexSubImageDimensions = function(gl, validFormats, expectedByteLength, getBlockDimensions, width, height, subImageConfigs) {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+
+    for (var formatId in validFormats) {
+        if (validFormats.hasOwnProperty(formatId)) {
+            var format = validFormats[formatId];
+            var blockSize = getBlockDimensions(format);
+            var expectedSize = expectedByteLength(width, height, format);
+            var data = new Uint8Array(expectedSize);
+
+            gl.compressedTexImage2D(gl.TEXTURE_2D, 0, format, width, height, 0, data);
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "setting up compressed texture");
+
+            for (let i = 0, len = subImageConfigs.length; i < len; ++i) {
+                let c = subImageConfigs[i];
+                var subData = new Uint8Array(expectedByteLength(c.width, c.height, format));
+                gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, c.xoffset, c.yoffset, c.width, c.height, format, subData);
+                wtu.glErrorShouldBe(gl, c.expectation, c.message);
+            }
+        }
+    }
+
+    gl.bindTexture(gl.TEXTURE_2D, null);
+    gl.deleteTexture(tex);
+};
+
 return {
     formatToString: formatToString,
     insertCaptionedImg: insertCaptionedImg,
@@ -163,7 +199,8 @@ return {
     testCompressedFormatsListed: testCompressedFormatsListed,
     testCompressedFormatsUnavailableWhenExtensionDisabled: testCompressedFormatsUnavailableWhenExtensionDisabled,
     testCorrectEnumValuesInExt: testCorrectEnumValuesInExt,
-    testFormatRestrictionsOnBufferSize: testFormatRestrictionsOnBufferSize
+    testFormatRestrictionsOnBufferSize: testFormatRestrictionsOnBufferSize,
+    testTexSubImageDimensions: testTexSubImageDimensions
 };
 
 })();

--- a/sdk/tests/js/tests/compressed-texture-utils.js
+++ b/sdk/tests/js/tests/compressed-texture-utils.js
@@ -200,7 +200,7 @@ return {
     testCompressedFormatsUnavailableWhenExtensionDisabled: testCompressedFormatsUnavailableWhenExtensionDisabled,
     testCorrectEnumValuesInExt: testCorrectEnumValuesInExt,
     testFormatRestrictionsOnBufferSize: testFormatRestrictionsOnBufferSize,
-    testTexSubImageDimensions: testTexSubImageDimensions
+    testTexSubImageDimensions: testTexSubImageDimensions,
 };
 
 })();


### PR DESCRIPTION
CTS used to miss the validation test for bptc and rgtc (There are some compressedTexSubImage* tests for pvrtc, s3tc and astc). Now latest Firefox and Chromium on Linux Nvidia are tested passing these newly added tests.