### PR TITLE
Duplicate and centralize glsl-comment testcases into this file.

### DIFF
--- a/sdk/tests/conformance/glsl/preprocessor/comments.html
+++ b/sdk/tests/conformance/glsl/preprocessor/comments.html
@@ -22,6 +22,35 @@ found in the LICENSE.txt file.
 description();
 
 // Your syntax highlighter may hate this file.
+// Because this stuff is tricky, we collect all tests here, including duplicating from other tests.
+// That way, this test file is a one-stop-shop for validation testing.
+
+const nonAscii = [
+  65533,
+  65533,
+  65533,
+  65533,
+  834,
+  96,
+  65533,
+  114,
+  65533,
+  98,
+  65533,
+  104,
+  65533,
+  104,
+  65533,
+  322,
+  834,
+  514,
+  65533,
+  65533,
+  322,
+  65533,
+  65533,
+  66,
+].map(x => String.fromCodePoint(x)).join('');
 
 GLSLConformanceTester.runTests([{
     vShaderSource: `void main() {}`,
@@ -43,6 +72,11 @@ GLSLConformanceTester.runTests([{
     vShaderSuccess: true,
     linkSuccess: true,
     passMsg: 'Complete block-comment-end'
+  }, {
+    vShaderSource: `void main() {}/* **/`,
+    vShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: 'Complete block-comment-end with **/'
   }, {
     vShaderSource: `void main() {}/`,
     vShaderSuccess: false,
@@ -77,8 +111,73 @@ over the lazy dog
     vShaderSuccess: true,
     linkSuccess: true,
     passMsg: 'Line-comment with backslash-line-continuation with newline before EOF'
-  },
-]);
+  }, {
+    vShaderSource: `void main() {}//${String.fromCodePoint(0x8f)}`,
+    vShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: 'upper-ascii in line-comment'
+  }, {
+    vShaderSource: `void main() {}/*${String.fromCodePoint(0x8f)}*/`,
+    vShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: 'upper-ascii in block-comment'
+
+    // -
+    // Like comment_frag.frag from conformance/ogles/GL/build/build_049_to_056.html
+  }, {
+    vShaderSource: `
+void main()
+{
+    /******  // comment not closed
+}`,
+    vShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: 'Unclosed block-comment containing line-comment'
+
+
+    // -
+    // Like conformance/glsl/misc/non-ascii-comments.vert.html
+  }, {
+    vShaderSource: `void main() {}/*${String.fromCodePoint(0x8f)}`,
+    vShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: 'upper-ascii in unterminated block-comment'
+  }, {
+    vShaderSource: `void main() {}// ${nonAscii}`,
+    vShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: 'More non-ascii in line-comment'
+  }, {
+    vShaderSource: `void main() {}/*
+     * ${nonAscii}
+     */`,
+    vShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: 'More non-ascii in block-comment'
+  }, {
+    vShaderSource: `void main() {}/*
+     * ${nonAscii}
+     *`,
+    vShaderSuccess: false,
+    linkSuccess: false,
+    passMsg: 'More non-ascii in unterminated block-comment'
+
+
+    // -
+    // Like deqp/data/gles2/shaders/preprocessor.html | preprocessor.comments.comment_trick_2_*
+  }, {
+    vShaderSource: `void main() {
+        float out0;
+        /**/
+        out0 = 1.0;
+        /*/
+        out0 = 0.0;
+        /**/
+      }`,
+    vShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: '/**/ /*/ /**/'
+}]);
 </script>
 </body>
 </html>


### PR DESCRIPTION
It's nicer to have a one-stop-shop for validating tests for this
behavior.