### PR TITLE
 Make renderbufferStorageMultisample with DEPTH_STENCIL and samples>0 generate INVALID_OPERATION.

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html
+++ b/sdk/tests/conformance2/renderbuffers/multisampled-depth-renderbuffer-initialization.html
@@ -29,6 +29,19 @@ if (!gl) {
     // Set the clear color to green. It should never show up.
     gl.clearColor(0, 1, 0, 1);
 
+    debug("Test renderbufferStorageMultisample with webgl1's DEPTH_STENCIL.");
+    {
+        const rb = gl.createRenderbuffer();
+        gl.bindRenderbuffer(gl.RENDERBUFFER, rb);
+        wtu.shouldGenerateGLError(gl, 0,
+            "gl.renderbufferStorageMultisample(gl.RENDERBUFFER, 0, gl.DEPTH_STENCIL, 1, 1)");
+        wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION,
+            "gl.renderbufferStorageMultisample(gl.RENDERBUFFER, 1, gl.DEPTH_STENCIL, 1, 1)");
+        wtu.shouldGenerateGLError(gl, gl.INVALID_OPERATION,
+            "gl.renderbufferStorageMultisample(gl.RENDERBUFFER, 2, gl.DEPTH_STENCIL, 1, 1)");
+        gl.deleteRenderbuffer(rb);
+    }
+
     let c = gl.canvas;
     var maxSamples = gl.getInternalformatParameter(
         gl.RENDERBUFFER, gl.RGBA8, gl.SAMPLES)[0];
@@ -52,6 +65,7 @@ if (!gl) {
 }
 
 function runTest(gl, params) {
+    debug("");
     debug("Test for depth buffer: " + JSON.stringify(params));
     let resolve = params.alloc2 ? params.alloc2 : params.alloc1;
     gl.viewport(0, 0, resolve.w, resolve.h);

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -1533,6 +1533,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glRenderbufferStorageMultisample.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
+        <p>Generates <code>INVALID_OPERATION</code> when `internalFormat == DEPTH_STENCIL && samples > 0`.</p>
       </dt>
     </dl>
 


### PR DESCRIPTION
Firefox allows DEPTH_STENCIL with samples >= 0.
Chrome allows samples==0, but INVALID_ENUM for samples >= 1.