### PR TITLE
Do is-webgl2 checks by duck-typing, not instanceof.

### DIFF
--- a/sdk/tests/conformance/extensions/oes-texture-float-linear.html
+++ b/sdk/tests/conformance/extensions/oes-texture-float-linear.html
@@ -25,7 +25,7 @@ const wtu = WebGLTestUtils;
 const gl = wtu.create3DContext();
 
 (function() {
-    if (!(gl instanceof WebGL2RenderingContext)) {
+    if (!(gl.drawArraysInstanced)) {
         if (!gl.getExtension("OES_texture_float")) {
             testPassed("No OES_texture_float support -- this is legal");
             return;

--- a/sdk/tests/conformance/extensions/oes-texture-half-float-linear.html
+++ b/sdk/tests/conformance/extensions/oes-texture-half-float-linear.html
@@ -25,7 +25,7 @@ const wtu = WebGLTestUtils;
 const gl = wtu.create3DContext();
 
 (function() {
-    if (gl instanceof WebGL2RenderingContext)
+    if (gl.drawArraysInstanced)
         throw new Error("OES_texture_half_float_linear is core in WebGL 2.");
 
     const ext = gl.getExtension("OES_texture_half_float");

--- a/sdk/tests/js/tests/oes-texture-float-and-half-float-linear.js
+++ b/sdk/tests/js/tests/oes-texture-float-and-half-float-linear.js
@@ -78,7 +78,7 @@ function testTexLinear(gl, extensionName, internalFormatWebgl2, pixelType) {
     {
         const format = gl.RGBA;
         let internalFormat = format;
-        if (gl instanceof WebGL2RenderingContext) {
+        if (gl.drawArraysInstanced) {
             internalFormat = gl[internalFormatWebgl2];
         }
         var numberOfChannels = 4;


### PR DESCRIPTION
Doing instanceof makes it hard for webgl-1on2 testing, since the rendering context there is webgl1 behavior, but instanceof WebGL2RenderingContext.