### PR TITLE
Update for Web IDL extended attribute changes

### DIFF
--- a/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.2/conformance/typedarrays/array-unit-tests.html
@@ -186,9 +186,9 @@ function testInheritanceHierarchy() {
 
   try {
     var foo = ArrayBufferView;
-    testFailed('ArrayBufferView has [NoInterfaceObject] extended attribute and should not be defined');
+    testFailed('ArrayBufferView is a typedef and should not be defined');
   } catch (e) {
-    testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
+    testPassed('ArrayBufferView is a typedef and was (correctly) not defined');
   }
 }
 

--- a/conformance-suites/1.0.3/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/1.0.3/conformance/typedarrays/array-unit-tests.html
@@ -185,9 +185,9 @@ function testInheritanceHierarchy() {
 
   try {
     var foo = ArrayBufferView;
-    testFailed('ArrayBufferView has [NoInterfaceObject] extended attribute and should not be defined');
+    testFailed('ArrayBufferView is a typedef and should not be defined');
   } catch (e) {
-    testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
+    testPassed('ArrayBufferView is a typedef and was (correctly) not defined');
   }
 
   // Uint8ClampedArray inherited from Uint8Array in earlier versions

--- a/conformance-suites/2.0.0/conformance/typedarrays/array-unit-tests.html
+++ b/conformance-suites/2.0.0/conformance/typedarrays/array-unit-tests.html
@@ -185,9 +185,9 @@ function testInheritanceHierarchy() {
 
   try {
     var foo = ArrayBufferView;
-    testFailed('ArrayBufferView has [NoInterfaceObject] extended attribute and should not be defined');
+    testFailed('ArrayBufferView is a typedef and should not be defined');
   } catch (e) {
-    testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
+    testPassed('ArrayBufferView is a typedef and was (correctly) not defined');
   }
 
   // Uint8ClampedArray inherited from Uint8Array in earlier versions

--- a/extensions/ANGLE_instanced_arrays/extension.xml
+++ b/extensions/ANGLE_instanced_arrays/extension.xml
@@ -27,7 +27,7 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface ANGLE_instanced_arrays {
     const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
     void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);

--- a/extensions/EXT_blend_minmax/extension.xml
+++ b/extensions/EXT_blend_minmax/extension.xml
@@ -31,7 +31,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_blend_minmax {
   const GLenum MIN_EXT = 0x8007;
   const GLenum MAX_EXT = 0x8008;

--- a/extensions/EXT_clip_cull_distance/extension.xml
+++ b/extensions/EXT_clip_cull_distance/extension.xml
@@ -36,7 +36,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [NoInterfaceObject]
+    [LegacyNoInterfaceObject]
     interface EXT_clip_cull_distance {
       const GLenum MAX_CLIP_DISTANCES_EXT                       = 0x0D32;
       const GLenum MAX_CULL_DISTANCES_EXT                       = 0x82F9;

--- a/extensions/EXT_color_buffer_float/extension.xml
+++ b/extensions/EXT_color_buffer_float/extension.xml
@@ -72,7 +72,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_color_buffer_float {
 }; // interface EXT_color_buffer_float
 </idl>

--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -72,7 +72,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_color_buffer_half_float {
   const GLenum RGBA16F_EXT = 0x881A;
   const GLenum RGB16F_EXT = 0x881B;

--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -48,11 +48,11 @@
   <idl xml:space="preserve">
 typedef unsigned long long GLuint64EXT;
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WebGLTimerQueryEXT : WebGLObject {
 };
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_disjoint_timer_query {
   const GLenum QUERY_COUNTER_BITS_EXT      = 0x8864;
   const GLenum CURRENT_QUERY_EXT           = 0x8865;

--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -42,7 +42,7 @@
   <idl xml:space="preserve">
 typedef unsigned long long GLuint64EXT;
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_disjoint_timer_query_webgl2 {
   const GLenum QUERY_COUNTER_BITS_EXT      = 0x8864;
   const GLenum TIME_ELAPSED_EXT            = 0x88BF;

--- a/extensions/EXT_float_blend/extension.xml
+++ b/extensions/EXT_float_blend/extension.xml
@@ -52,7 +52,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_float_blend {
 }; // interface EXT_float_blend
 </idl>

--- a/extensions/EXT_frag_depth/extension.xml
+++ b/extensions/EXT_frag_depth/extension.xml
@@ -36,7 +36,7 @@
   </overview>
   
   <idl xml:space="preserve">
-    [NoInterfaceObject]
+    [LegacyNoInterfaceObject]
     interface EXT_frag_depth {
     };
   </idl>

--- a/extensions/EXT_sRGB/extension.xml
+++ b/extensions/EXT_sRGB/extension.xml
@@ -32,7 +32,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [NoInterfaceObject]
+    [LegacyNoInterfaceObject]
     interface EXT_sRGB {
       const GLenum SRGB_EXT                                     = 0x8C40;
       const GLenum SRGB_ALPHA_EXT                               = 0x8C42;

--- a/extensions/EXT_shader_texture_lod/extension.xml
+++ b/extensions/EXT_shader_texture_lod/extension.xml
@@ -81,7 +81,7 @@
   </overview>
   
   <idl xml:space="preserve">
-    [NoInterfaceObject]
+    [LegacyNoInterfaceObject]
     interface EXT_shader_texture_lod {
     };
   </idl>

--- a/extensions/EXT_texture_filter_anisotropic/extension.xml
+++ b/extensions/EXT_texture_filter_anisotropic/extension.xml
@@ -26,7 +26,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_texture_filter_anisotropic {
   const GLenum TEXTURE_MAX_ANISOTROPY_EXT       = 0x84FE;
   const GLenum MAX_TEXTURE_MAX_ANISOTROPY_EXT   = 0x84FF;

--- a/extensions/OES_element_index_uint/extension.xml
+++ b/extensions/OES_element_index_uint/extension.xml
@@ -23,7 +23,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_element_index_uint {
 };
   </idl>

--- a/extensions/OES_fbo_render_mipmap/extension.xml
+++ b/extensions/OES_fbo_render_mipmap/extension.xml
@@ -30,7 +30,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_fbo_render_mipmap {
 };
   </idl>

--- a/extensions/OES_standard_derivatives/extension.xml
+++ b/extensions/OES_standard_derivatives/extension.xml
@@ -37,7 +37,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_standard_derivatives {
     const GLenum FRAGMENT_SHADER_DERIVATIVE_HINT_OES = 0x8B8B;
 };

--- a/extensions/OES_texture_float/extension.xml
+++ b/extensions/OES_texture_float/extension.xml
@@ -44,7 +44,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_texture_float { }; </idl>
 
   <history>

--- a/extensions/OES_texture_float_linear/extension.xml
+++ b/extensions/OES_texture_float_linear/extension.xml
@@ -28,7 +28,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_texture_float_linear { };</idl>
 
   <history>

--- a/extensions/OES_texture_half_float/extension.xml
+++ b/extensions/OES_texture_half_float/extension.xml
@@ -44,7 +44,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_texture_half_float {
   const GLenum HALF_FLOAT_OES = 0x8D61;
 };

--- a/extensions/OES_texture_half_float_linear/extension.xml
+++ b/extensions/OES_texture_half_float_linear/extension.xml
@@ -29,7 +29,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_texture_half_float_linear { };</idl>
 
   <history>

--- a/extensions/OES_vertex_array_object/extension.xml
+++ b/extensions/OES_vertex_array_object/extension.xml
@@ -17,11 +17,11 @@
     <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_vertex_array_object.txt" name="OES_vertex_array_object" />
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WebGLVertexArrayObjectOES : WebGLObject {
 };
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_vertex_array_object {
     const GLenum VERTEX_ARRAY_BINDING_OES = 0x85B5;
 

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -73,7 +73,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_color_buffer_float {
   const GLenum RGBA32F_EXT = 0x8814;
   const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;

--- a/extensions/WEBGL_compressed_texture_astc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_astc/extension.xml
@@ -304,7 +304,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_astc {
     /* Compressed Texture Format */
     const GLenum COMPRESSED_RGBA_ASTC_4x4_KHR = 0x93B0;

--- a/extensions/WEBGL_compressed_texture_etc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_etc/extension.xml
@@ -92,7 +92,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_etc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_R11_EAC                        = 0x9270;

--- a/extensions/WEBGL_compressed_texture_etc1/extension.xml
+++ b/extensions/WEBGL_compressed_texture_etc1/extension.xml
@@ -59,7 +59,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_etc1 {
     /* Compressed Texture Format */
     const GLenum COMPRESSED_RGB_ETC1_WEBGL = 0x8D64; 

--- a/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
@@ -74,7 +74,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_pvrtc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_PVRTC_4BPPV1_IMG      = 0x8C00;

--- a/extensions/WEBGL_compressed_texture_s3tc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_s3tc/extension.xml
@@ -100,7 +100,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_s3tc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_S3TC_DXT1_EXT        = 0x83F0;

--- a/extensions/WEBGL_compressed_texture_s3tc_srgb/extension.xml
+++ b/extensions/WEBGL_compressed_texture_s3tc_srgb/extension.xml
@@ -100,7 +100,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_s3tc_srgb {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_SRGB_S3TC_DXT1_EXT        = 0x8C4C;

--- a/extensions/WEBGL_debug_renderer_info/extension.xml
+++ b/extensions/WEBGL_debug_renderer_info/extension.xml
@@ -14,7 +14,7 @@
     <p>WebGL implementations might mask the <code>RENDERER</code> and <code>VENDOR</code> strings of the underlying graphics driver for privacy reasons. This extension exposes new tokens to query this information in a guaranteed manner for debugging purposes.</p>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_debug_renderer_info {
 
       const GLenum UNMASKED_VENDOR_WEBGL            = 0x9245;

--- a/extensions/WEBGL_debug_shaders/extension.xml
+++ b/extensions/WEBGL_debug_shaders/extension.xml
@@ -16,7 +16,7 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_debug_shaders {
 
       DOMString getTranslatedShaderSource(WebGLShader shader);

--- a/extensions/WEBGL_depth_texture/extension.xml
+++ b/extensions/WEBGL_depth_texture/extension.xml
@@ -125,7 +125,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_depth_texture {
   const GLenum UNSIGNED_INT_24_8_WEBGL = 0x84FA;
 };

--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -100,7 +100,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_draw_buffers {
     const GLenum COLOR_ATTACHMENT0_WEBGL     = 0x8CE0;
     const GLenum COLOR_ATTACHMENT1_WEBGL     = 0x8CE1;

--- a/extensions/WEBGL_lose_context/extension.xml
+++ b/extensions/WEBGL_lose_context/extension.xml
@@ -29,7 +29,7 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_lose_context {
       void loseContext();
       void restoreContext();

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -411,7 +411,7 @@
 <xsl:template match="interface" mode="newfun">
   <dt class="idl-code">
 	<xsl:if test="@noobject = 'true'">
-	  <xsl:text>[LegacyLegacyNoInterfaceObject]</xsl:text><br/>
+	  <xsl:text>[LegacyNoInterfaceObject]</xsl:text><br/>
 	</xsl:if>
     <xsl:text>interface </xsl:text>
     <em><xsl:value-of select="@name" /></em>

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -411,7 +411,7 @@
 <xsl:template match="interface" mode="newfun">
   <dt class="idl-code">
 	<xsl:if test="@noobject = 'true'">
-	  <xsl:text>[NoInterfaceObject]</xsl:text><br/>
+	  <xsl:text>[LegacyLegacyNoInterfaceObject]</xsl:text><br/>
 	</xsl:if>
     <xsl:text>interface </xsl:text>
     <em><xsl:value-of select="@name" /></em>

--- a/extensions/proposals/WEBGL_debug/extension.xml
+++ b/extensions/proposals/WEBGL_debug/extension.xml
@@ -112,7 +112,7 @@
   </overview>
 
   <idl xml:space="preserve"><![CDATA[
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_debug : EventTarget {
   const GLenum MAX_DEBUG_MESSAGE_LENGTH_KHR = 0x9143;
   const GLenum MAX_DEBUG_GROUP_STACK_DEPTH_KHR = 0x826C;
@@ -155,7 +155,7 @@ interface WEBGL_debug : EventTarget {
   DOMString getObjectLabelKHR(WebGLObject? object);
 }; // interface WEBGL_debug
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WebGLDebugMessage : Event {
   readonly attribute GLenum source;
   readonly attribute GLenum type;

--- a/extensions/proposals/WEBGL_dynamic_texture/extension.xml
+++ b/extensions/proposals/WEBGL_dynamic_texture/extension.xml
@@ -192,7 +192,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_dynamic_texture {
   typedef double WDTNanoTime;
 
@@ -501,7 +501,7 @@ WDTNanoTime ustnow();</pre></li></p>
       <p>The <code>WDTStreamFrameInfo</code> interface represents information
       about a frame acquired from a WDTStream.</p>
 
-      <pre class="idl" xml:space="preserve">[NoInterfaceObject] interface WDTStreamFrameInfo {
+      <pre class="idl" xml:space="preserve">[LegacyNoInterfaceObject] interface WDTStreamFrameInfo {
   readonly attribute double frameTime;
   readonly attribute WDTNanoTime presentTime;
 };</pre>
@@ -531,7 +531,7 @@ WDTNanoTime ustnow();</pre></li></p>
       for controlling an image stream being fed to a dynamic texture
       object.</p>
 
-      <pre class="idl" xml:space="preserve">[NoInterfaceObject] interface WDTStream {
+      <pre class="idl" xml:space="preserve">[LegacyNoInterfaceObject] interface WDTStream {
   typedef (HTMLCanvasElement or
            HTMLImageElement or
            HTMLVideoElement) StreamSource;

--- a/extensions/proposals/WEBGL_subarray_uploads/extension.xml
+++ b/extensions/proposals/WEBGL_subarray_uploads/extension.xml
@@ -26,7 +26,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_subarray_uploads {
     void bufferSubData(GLenum target, GLsizeiptr bufferOffset, GLsizeiptr subarrayOffset,
                        GLsizeiptr subarraySize, (ArrayBuffer or SharedArrayBuffer) data);

--- a/extensions/rejected/OES_depth24/extension.xml
+++ b/extensions/rejected/OES_depth24/extension.xml
@@ -30,7 +30,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_depth24 {
   const GLenum DEPTH_COMPONENT24_OES = 0x81A6;
 };

--- a/extensions/rejected/WEBGL_compressed_texture_atc/extension.xml
+++ b/extensions/rejected/WEBGL_compressed_texture_atc/extension.xml
@@ -81,7 +81,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_atc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_ATC_WEBGL                     = 0x8C92;

--- a/extensions/rejected/WEBGL_debug_shader_precision/extension.xml
+++ b/extensions/rejected/WEBGL_debug_shader_precision/extension.xml
@@ -85,7 +85,7 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_debug_shader_precision {
 };
   </idl>

--- a/extensions/rejected/WEBGL_draw_elements_no_range_check/extension.xml
+++ b/extensions/rejected/WEBGL_draw_elements_no_range_check/extension.xml
@@ -62,7 +62,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_draw_elements_no_range_check {
 };
   </idl>

--- a/extensions/rejected/WEBGL_get_buffer_sub_data_async/extension.xml
+++ b/extensions/rejected/WEBGL_get_buffer_sub_data_async/extension.xml
@@ -28,7 +28,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_get_buffer_sub_data_async {
   // Asynchronous version of getBufferSubData which fulfills the returned promise when the data becomes available.
   Promise&lt;ArrayBuffer&gt; getBufferSubDataAsync(GLenum target, GLintptr srcByteOffset, ArrayBufferView dstBuffer,

--- a/extensions/rejected/WEBGL_security_sensitive_resources/extension.xml
+++ b/extensions/rejected/WEBGL_security_sensitive_resources/extension.xml
@@ -92,7 +92,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_security_sensitive_resources {
   WebGLFramebuffer? createSecuritySensitiveFramebuffer();
   WebGLTexture? createSecuritySensitiveTexture();

--- a/extensions/rejected/WEBGL_shared_resources/extension.xml
+++ b/extensions/rejected/WEBGL_shared_resources/extension.xml
@@ -317,7 +317,7 @@ var ctx2 = canvas2.getContext("webgl", {
     </ul>
   </issues>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_shared_resources {
      const GLenum READ_ONLY  = 0x0001;
      const GLenum EXCLUSIVE  = 0x0004;
@@ -338,7 +338,7 @@ interface WEBGL_shared_resources {
 
 callback AcquireSharedResourcesCallback = void ();
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WebGLShareGroup {
 };
 

--- a/extensions/rejected/WEBGL_subscribe_uniform/extension.xml
+++ b/extensions/rejected/WEBGL_subscribe_uniform/extension.xml
@@ -44,7 +44,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_subscribe_uniform {
   const GLenum SUBSCRIBED_VALUES_BUFFER = 0x924B;
 

--- a/extensions/rejected/WEBGL_texture_from_depth_video/extension.xml
+++ b/extensions/rejected/WEBGL_texture_from_depth_video/extension.xml
@@ -41,7 +41,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_texture_from_depth_video {
 };
   </idl>

--- a/sdk/tests/conformance/typedarrays/array-unit-tests.html
+++ b/sdk/tests/conformance/typedarrays/array-unit-tests.html
@@ -164,9 +164,9 @@ function testInheritanceHierarchy() {
 
   try {
     var foo = ArrayBufferView;
-    testFailed('ArrayBufferView has [NoInterfaceObject] extended attribute and should not be defined');
+    testFailed('ArrayBufferView is a typedef and should not be defined');
   } catch (e) {
-    testPassed('ArrayBufferView has [NoInterfaceObject] extended attribute and was (correctly) not defined');
+    testPassed('ArrayBufferView is a typedef and was (correctly) not defined');
   }
 
   // Uint8ClampedArray inherited from Uint8Array in earlier versions

--- a/specs/1.0.3/index.html
+++ b/specs/1.0.3/index.html
@@ -1131,8 +1131,7 @@ for (var i = 0; i < numVertices; i++) {
     See <a href="#CONTEXT_LOST">the context lost event</a> for further details.
     </p>
     <pre class="idl">
-[NoInterfaceObject]
-interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
+interface mixin <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 {
 
     /* ClearBufferMask */
@@ -1786,7 +1785,7 @@ interface <dfn id="WebGLRenderingContextBase">WebGLRenderingContextBase</dfn>
 interface <dfn id="WebGLRenderingContext">WebGLRenderingContext</dfn>
 {
 };
-WebGLRenderingContext implements WebGLRenderingContextBase;
+WebGLRenderingContext includes WebGLRenderingContextBase;
 </pre>
 
 <!-- ======================================================================================================= -->

--- a/specs/1.0.3/webgl.idl
+++ b/specs/1.0.3/webgl.idl
@@ -70,8 +70,7 @@ interface WebGLShaderPrecisionFormat {
     readonly attribute GLint precision;
 };
 
-[NoInterfaceObject]
-interface WebGLRenderingContextBase
+interface mixin WebGLRenderingContextBase
 {
 
     /* ClearBufferMask */
@@ -725,7 +724,7 @@ interface WebGLRenderingContextBase
 interface WebGLRenderingContext
 {
 };
-WebGLRenderingContext implements WebGLRenderingContextBase;
+WebGLRenderingContext includes WebGLRenderingContextBase;
 
 
 [Constructor(DOMString type, optional WebGLContextEventInit eventInit)]

--- a/specs/2.0.0/index.html
+++ b/specs/2.0.0/index.html
@@ -416,8 +416,7 @@ typedef (Float32Array or sequence&lt;GLfloat&gt;) Float32List;
 typedef (Int32Array or sequence&lt;GLint&gt;) Int32List;
 typedef (Uint32Array or sequence&lt;GLuint&gt;) Uint32List;
 
-[NoInterfaceObject]
-interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
+interface mixin <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
 {
   const GLenum READ_BUFFER                                   = 0x0C02;
   const GLenum UNPACK_ROW_LENGTH                             = 0x0CF2;
@@ -961,12 +960,12 @@ interface <dfn id="WebGL2RenderingContextBase">WebGL2RenderingContextBase</dfn>
   [WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
-WebGL2RenderingContextBase implements WebGLRenderingContextBase;
 
 interface <dfn id="WebGL2RenderingContext">WebGL2RenderingContext</dfn>
 {
 };
-WebGL2RenderingContext implements WebGL2RenderingContextBase;
+WebGL2RenderingContext includes WebGLRenderingContextBase;
+WebGL2RenderingContext includes WebGL2RenderingContextBase;
 
 </pre>
 

--- a/specs/2.0.0/webgl2.idl
+++ b/specs/2.0.0/webgl2.idl
@@ -29,8 +29,7 @@ typedef (Float32Array or sequence<GLfloat>) Float32List;
 typedef (Int32Array or sequence<GLint>) Int32List;
 typedef (Uint32Array or sequence<GLuint>) Uint32List;
 
-[NoInterfaceObject]
-interface WebGL2RenderingContextBase
+interface mixin WebGL2RenderingContextBase
 {
   const GLenum READ_BUFFER                                   = 0x0C02;
   const GLenum UNPACK_ROW_LENGTH                             = 0x0CF2;
@@ -574,11 +573,9 @@ interface WebGL2RenderingContextBase
   [WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
   void bindVertexArray(WebGLVertexArrayObject? array);
 };
-WebGL2RenderingContextBase implements WebGLRenderingContextBase;
 
 interface WebGL2RenderingContext
 {
 };
-WebGL2RenderingContext implements WebGL2RenderingContextBase;
-
-
+WebGL2RenderingContext includes WebGLRenderingContextBase;
+WebGL2RenderingContext includes WebGL2RenderingContextBase;


### PR DESCRIPTION
[NoInterfaceObject] → [LegacyNoInterfaceObject]. This follows https://github.com/heycam/webidl/pull/870.

This also replaces a couple instances of [NoInterfaceObject] with the interface mixin concept, as was previously done in 2df151be79b1a44d41464b149d6044fbf6bbf2f7 and a6f99093cbc1e22112b0d36ae368438d268f2376.

---

I imagine some of these changes might not be desired; it seems there are old copies of the spec in the master branch of the repo and maybe those need to stay for archival purposes. Let me know which, if any, changes to revert.