### PR TITLE
Fix crossorigin tests to default to remote-web-url, but fallback to l…

### DIFF
--- a/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
+++ b/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
@@ -11,6 +11,10 @@ found in the LICENSE.txt file.
 <script type="application/javascript" src="../unit.js"></script>
 <script type="application/javascript" src="../util.js"></script>
 <script type="application/javascript" src="../../../js/webgl-test-utils.js"></script>
+</head><body>
+<canvas id="gl" width="16" height="16"></canvas>
+<canvas id="c" width="128" height="128"></canvas>
+<img id="i">
 <script type="application/javascript">
 var wtu = WebGLTestUtils;
 var defaultImgUrl = "https://get.webgl.org/conformance-resources/opengl_logo.jpg";
@@ -92,12 +96,16 @@ Tests.testReadPixelsSOPCanvas = function(gl) {
 }
 
 Tests.endUnit = function(gl) {
-}
+};
 
-wtu.setupImageForCrossOriginTest("#i", defaultImgUrl, localImgUrl, initTests);
+(async function() {
+    const img = document.getElementById('i');
+    try {
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+    } catch (e) {
+        console.log(`Image setup failed (${e}), running tests anyway.`);
+    }
+    initTests();
+})();
 </script>
-</head><body>
-<canvas id="gl" width="16" height="16"></canvas>
-<canvas id="c" width="128" height="128"></canvas>
-<img id="i">
 </body></html>

--- a/sdk/tests/conformance/more/functions/texImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texImage2DHTML.html
@@ -133,21 +133,10 @@ Tests.testTexImage2DNonSOP = function(gl) {
 Tests.endUnit = function(gl) {
 };
 
-async function setupNonSOPImage() {
-    const img = document.getElementById('i2');
-    const url = wtu.chooseUrlForCrossOriginImage(defaultImgUrl, localImgUrl);
-    img.src = url;
-    await img.decode();
-}
-
-async function throwOnTimeout(ms) {
-    await wtu.awaitTimeout(ms);
-    throw 'timeout';
-}
-
 (async function() {
+    const img = document.getElementById('i2');
     try {
-        await Promise.race([setupNonSOPImage(), throwOnTimeout(1000)]);
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
     } catch (e) {
         console.log(`Image setup failed (${e}), running tests anyway.`);
     }

--- a/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
@@ -143,23 +143,12 @@ Tests.testTexImage2DNonSOP = function(gl) {
 }
 
 Tests.endUnit = function(gl) {
-}
-
-async function setupNonSOPImage() {
-    const img = document.getElementById('i2');
-    const url = wtu.chooseUrlForCrossOriginImage(defaultImgUrl, localImgUrl);
-    img.src = url;
-    await img.decode();
-}
-
-async function throwOnTimeout(ms) {
-    await wtu.awaitTimeout(ms);
-    throw 'timeout';
-}
+};
 
 (async function() {
+    const img = document.getElementById('i2');
     try {
-        await Promise.race([setupNonSOPImage(), throwOnTimeout(1000)]);
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
     } catch (e) {
         console.log(`Image setup failed (${e}), running tests anyway.`);
     }

--- a/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
+++ b/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
@@ -12,6 +12,12 @@ found in the LICENSE.txt file.
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas"></canvas>
+<img id="img" style="display:none;">
 <script>
 "use strict";
 var wtu = WebGLTestUtils;
@@ -33,7 +39,7 @@ var localImgUrl = "../../../resources/opengl_logo.jpg";
 var imgDomain;
 var pageDomain;
 
-function imageLoaded() {
+function imageLoaded(img) {
   description("This test ensures WebGL implementations for OffscreenCanvas follow proper same-origin restrictions.");
 
   if (!window.OffscreenCanvas) {
@@ -41,8 +47,6 @@ function imageLoaded() {
     finishTest();
     return;
   }
-
-  var img = this;
 
   assertMsg(img.width > 0 && img.height > 0, "img was loaded");
   imgDomain = wtu.getBaseDomain(wtu.getHost(img.src));
@@ -105,13 +109,15 @@ function imageLoaded() {
   finishTest();
 }
 
-wtu.setupImageForCrossOriginTest("#img", defaultImgUrl, localImgUrl, imageLoaded);
+(async function() {
+    const img = document.getElementById('img');
+    try {
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+    } catch (e) {
+        console.log(`Image setup failed (${e}), running tests anyway.`);
+    }
+    imageLoaded(img);
+})();
 </script>
-</head>
-<body>
-<div id="description"></div>
-<div id="console"></div>
-<canvas id="canvas"></canvas>
-<img id="img" style="display:none;">
 </body>
 </html>

--- a/sdk/tests/conformance/textures/misc/origin-clean-conformance.html
+++ b/sdk/tests/conformance/textures/misc/origin-clean-conformance.html
@@ -12,6 +12,13 @@ found in the LICENSE.txt file.
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas1"></canvas>
+<canvas id="canvas2"></canvas>
+<img id="img" style="display:none;">
 <script>
 "use strict";
 var wtu = WebGLTestUtils;
@@ -34,9 +41,8 @@ var imgDomain;
 var pageDomain;
 var successfullyParsed;
 
-function imageLoaded() {
+function imageLoaded(img) {
   description("This test ensures WebGL implementations follow proper same-origin restrictions.");
-  var img = this;
 
   assertMsg(img.width > 0 && img.height > 0, "img was loaded");
   imgDomain = wtu.getBaseDomain(wtu.getHost(img.src));
@@ -115,14 +121,15 @@ function imageLoaded() {
   notifyFinishedToHarness();
 }
 
-wtu.setupImageForCrossOriginTest("#img", defaultImgUrl, localImgUrl, imageLoaded);
+(async function() {
+    const img = document.getElementById('img');
+    try {
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+    } catch (e) {
+        console.log(`Image setup failed (${e}), running tests anyway.`);
+    }
+    imageLoaded(img);
+})();
 </script>
-</head>
-<body>
-<div id="description"></div>
-<div id="console"></div>
-<canvas id="canvas1"></canvas>
-<canvas id="canvas2"></canvas>
-<img id="img" style="display:none;">
 </body>
 </html>

--- a/sdk/tests/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html
+++ b/sdk/tests/conformance2/textures/misc/origin-clean-conformance-offscreencanvas.html
@@ -12,6 +12,12 @@ found in the LICENSE.txt file.
 <link rel="stylesheet" href="../../../resources/js-test-style.css"/>
 <script src="../../../js/js-test-pre.js"></script>
 <script src="../../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas"></canvas>
+<img id="img" style="display:none;">
 <script>
 "use strict";
 var wtu = WebGLTestUtils;
@@ -33,7 +39,7 @@ var localImgUrl = "../../../resources/opengl_logo.jpg";
 var imgDomain;
 var pageDomain;
 
-function imageLoaded() {
+function imageLoaded(img) {
   description("This test ensures WebGL2 implementations for OffscreenCanvas follow proper same-origin restrictions.");
 
   if (!window.OffscreenCanvas) {
@@ -41,8 +47,6 @@ function imageLoaded() {
     finishTest();
     return;
   }
-
-  var img = this;
 
   assertMsg(img.width > 0 && img.height > 0, "img was loaded");
   imgDomain = wtu.getBaseDomain(wtu.getHost(img.src));
@@ -126,13 +130,15 @@ function imageLoaded() {
   finishTest();
 }
 
-wtu.setupImageForCrossOriginTest("#img", defaultImgUrl, localImgUrl, imageLoaded);
+(async function() {
+    const img = document.getElementById('img');
+    try {
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+    } catch (e) {
+        console.log(`Image setup failed (${e}), running tests anyway.`);
+    }
+    imageLoaded(img);
+})();
 </script>
-</head>
-<body>
-<div id="description"></div>
-<div id="console"></div>
-<canvas id="canvas"></canvas>
-<img id="img" style="display:none;">
 </body>
 </html>

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3194,25 +3194,22 @@ var getRelativePath = function(path) {
   return relparts.join("/");
 }
 
-function chooseUrlForCrossOriginImage(imgUrl, localUrl) {
-    if (runningOnLocalhost())
-      return getLocalCrossOrigin() + getRelativePath(localUrl);
+async function loadCrossOriginImage(img, webUrl, localUrl) {
+  img.src = getUrlOptions().imgUrl || webUrl;
+  try {
+    console.log('[loadCrossOriginImage]', 'trying', img.src);
+    await img.decode();
+    return;
+  } catch {}
 
-    return img.src = getUrlOptions().imgUrl || imgUrl;
-}
+  if (runningOnLocalhost()) {
+    img.src = getLocalCrossOrigin() + getRelativePath(localUrl);
+    console.log('[loadCrossOriginImage]', '  trying', img.src);
+    await img.decode();
+    return;
+  }
 
-var setupImageForCrossOriginTest = function(img, imgUrl, localUrl, callback) {
-  window.addEventListener("load", function() {
-    if (typeof(img) == "string")
-      img = document.querySelector(img);
-    if (!img)
-      img = new Image();
-
-    img.addEventListener("load", callback, false);
-    img.addEventListener("error", callback, false);
-
-    img.src = chooseUrlForCrossOriginImage(imgUrl, localUrl);
-  }, false);
+  throw 'createCrossOriginImage failed';
 }
 
 /**
@@ -3357,6 +3354,15 @@ async function awaitTimeout(ms) {
   });
 }
 
+async function awaitOrTimeout(promise, timeout_ms) {
+  async function throwOnTimeout(ms) {
+    await awaitTimeout(ms);
+    throw 'timeout';
+  }
+
+  await Promise.race([promise, throwOnTimeout(timeout_ms)]);
+}
+
 var API = {
   addShaderSource: addShaderSource,
   addShaderSources: addShaderSources,
@@ -3412,6 +3418,7 @@ var API = {
   insertImage: insertImage,
   isWebGL2: isWebGL2,
   linkProgram: linkProgram,
+  loadCrossOriginImage: loadCrossOriginImage,
   loadImageAsync: loadImageAsync,
   loadImagesAsync: loadImagesAsync,
   loadProgram: loadProgram,
@@ -3484,8 +3491,7 @@ var API = {
   runningOnLocalhost: runningOnLocalhost,
   getLocalCrossOrigin: getLocalCrossOrigin,
   getRelativePath: getRelativePath,
-  chooseUrlForCrossOriginImage: chooseUrlForCrossOriginImage,
-  setupImageForCrossOriginTest: setupImageForCrossOriginTest,
+  awaitOrTimeout: awaitOrTimeout,
   awaitTimeout: awaitTimeout,
 
   none: false


### PR DESCRIPTION
…ocal on localhost.

Fixes regressions from #3032:
> all/conformance/more/functions (Passed: 90/93 Failed: 2/93 Timeout: 1/93 in 26.81 seconds)
> 
> readPixelsBadArgs.html(*timeout*)
> 
> texImage2DHTML.html (Passed: 1/2 Failed: 1/2 in 170.0 ms)
> 
>     failed: testTexImage2DNonSOP
> 
> texSubImage2DHTML.html (Passed: 1/2 Failed: 1/2 in 251.0 ms)
> 
>     failed: testTexImage2DNonSOP