### PR TITLE
Fix flakiness of context-attribute-preserve-drawing-buffer.html.

### DIFF
--- a/sdk/tests/conformance/context/context-attribute-preserve-drawing-buffer.html
+++ b/sdk/tests/conformance/context/context-attribute-preserve-drawing-buffer.html
@@ -17,13 +17,13 @@ found in the LICENSE.txt file.
   display: inline-block;
 }
 canvas {
-  width:50px;
-  height:50px;
+  width:10px;
+  height:10px;
 }
 .square {
   display:inline-block;
-  width:50px;
-  height:50px;
+  width:10px;
+  height:10px;
   background-color:red;
 }
 </style>

--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -90,7 +90,7 @@ found in the LICENSE.txt file.
     width: 90%;
     height: calc(100% - 170px);
     bottom: 0px;
-    left: calc(91% - 15px);
+    left: calc(91% - 50px);
     transition: left 0.15s;
   }
   #iframe-container.iframe-shown {


### PR DESCRIPTION
Previously, at smaller window sizes, the preserveDrawingBuffer:false
test canvas was off the visible region of the page, and thus not cleared
since it was not Painted.

The fix:
* Increase the min-width of the test-runner test iframe.
* Decrease the size of canvases in context-attribute-preserve-drawing-buffer.html.