### PR TITLE
Add deleted-object-behavior.html to 00_test_list.txt

### DIFF
--- a/sdk/tests/conformance/context/00_test_list.txt
+++ b/sdk/tests/conformance/context/00_test_list.txt
@@ -12,7 +12,7 @@ context-attributes-alpha-depth-stencil-antialias.html
 context-lost-restored.html
 context-lost.html
 --max-version 1.9.9 context-type-test.html
-deleted-object-behavior.html
+--min-version 1.0.4 deleted-object-behavior.html
 incorrect-context-object-behaviour.html
 --max-version 1.9.9 methods.html
 premultiplyalpha-test.html

--- a/sdk/tests/conformance/context/00_test_list.txt
+++ b/sdk/tests/conformance/context/00_test_list.txt
@@ -12,6 +12,7 @@ context-attributes-alpha-depth-stencil-antialias.html
 context-lost-restored.html
 context-lost.html
 --max-version 1.9.9 context-type-test.html
+deleted-object-behavior.html
 incorrect-context-object-behaviour.html
 --max-version 1.9.9 methods.html
 premultiplyalpha-test.html


### PR DESCRIPTION
deleted-object-behavior was added to the conformance test but never added to any test_list.txt files.

Add deleted-object-behavior.html to 00_test_list.txt as part this change.