### PR TITLE
Update test utils to use video.rVFC

### DIFF
--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -2407,20 +2407,12 @@ var cancelAnimFrame = function(request) {
   _cancelAnimFrame.call(window, request);
 };
 
-var _requestVidFrameCallback = null;
-
 /**
  * Provides video.requestVideoFrameCallback in a cross browser way.
  * Returns a property, or undefined if unsuported.
  */
 var getRequestVidFrameCallback = function() {
-  if (_requestVidFrameCallback === null) {
-    var vid = document.createElement('video');
-    _requestVidFrameCallback =
-      getPrefixedProperty(vid, "requestVideoFrameCallback");
-  }
-
-  return _requestVidFrameCallback;
+  return HTMLVideoElement.prototype["requestVideoFrameCallback"];
 };
 
 /**

--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -2407,6 +2407,22 @@ var cancelAnimFrame = function(request) {
   _cancelAnimFrame.call(window, request);
 };
 
+var _requestVidFrameCallback = null;
+
+/**
+ * Provides video.requestVideoFrameCallback in a cross browser way.
+ * Returns a property, or undefined if unsuported.
+ */
+var getRequestVidFrameCallback = function() {
+  if (_requestVidFrameCallback === null) {
+    var vid = document.createElement('video');
+    _requestVidFrameCallback =
+      getPrefixedProperty(vid, "requestVideoFrameCallback");
+  }
+
+  return _requestVidFrameCallback;
+};
+
 /**
  * Provides requestFullScreen in a cross browser way.
  */
@@ -2586,35 +2602,42 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  var gotPlaying = false;
-  var gotTimeUpdate = false;
+  var rvfc = getRequestVidFrameCallback();
+  if (rvfc === undefined) {
+    var gotPlaying = false;
+    var gotTimeUpdate = false;
 
-  var maybeCallCallback = function() {
-    if (gotPlaying && gotTimeUpdate && callback) {
-      callback(video);
-      callback = undefined;
-      video.removeEventListener('playing', playingListener, true);
-      video.removeEventListener('timeupdate', timeupdateListener, true);
-    }
-  };
+    var maybeCallCallback = function() {
+      if (gotPlaying && gotTimeUpdate && callback) {
+        callback(video);
+        callback = undefined;
+        video.removeEventListener('playing', playingListener, true);
+        video.removeEventListener('timeupdate', timeupdateListener, true);
+      }
+    };
 
-  var playingListener = function() {
-    gotPlaying = true;
-    maybeCallCallback();
-  };
-
-  var timeupdateListener = function() {
-    // Checking to make sure the current time has advanced beyond
-    // the start time seems to be a reliable heuristic that the
-    // video element has data that can be consumed.
-    if (video.currentTime > 0.0) {
-      gotTimeUpdate = true;
+    var playingListener = function() {
+      gotPlaying = true;
       maybeCallCallback();
-    }
-  };
+    };
 
-  video.addEventListener('playing', playingListener, true);
-  video.addEventListener('timeupdate', timeupdateListener, true);
+    var timeupdateListener = function() {
+      // Checking to make sure the current time has advanced beyond
+      // the start time seems to be a reliable heuristic that the
+      // video element has data that can be consumed.
+      if (video.currentTime > 0.0) {
+        gotTimeUpdate = true;
+        maybeCallCallback();
+      }
+    };
+
+    video.addEventListener('playing', playingListener, true);
+    video.addEventListener('timeupdate', timeupdateListener, true);
+  } else {
+    // Calls video.requestVideoFrameCallback(_ => { callback(video) })
+    rvfc.call(video, _ => { callback(video) });
+  }
+
   video.loop = true;
   video.muted = true;
   video.play();

--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -2694,20 +2694,12 @@ var cancelAnimFrame = function(request) {
   _cancelAnimFrame.call(window, request);
 };
 
-var _requestVidFrameCallback = null;
-
 /**
  * Provides video.requestVideoFrameCallback in a cross browser way.
  * Returns a property, or undefined if unsuported.
  */
 var getRequestVidFrameCallback = function() {
-  if (_requestVidFrameCallback === null) {
-    var vid = document.createElement('video');
-    _requestVidFrameCallback =
-      getPrefixedProperty(vid, "requestVideoFrameCallback");
-  }
-
-  return _requestVidFrameCallback;
+  return HTMLVideoElement.prototype["requestVideoFrameCallback"];
 };
 
 /**

--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -2694,6 +2694,22 @@ var cancelAnimFrame = function(request) {
   _cancelAnimFrame.call(window, request);
 };
 
+var _requestVidFrameCallback = null;
+
+/**
+ * Provides video.requestVideoFrameCallback in a cross browser way.
+ * Returns a property, or undefined if unsuported.
+ */
+var getRequestVidFrameCallback = function() {
+  if (_requestVidFrameCallback === null) {
+    var vid = document.createElement('video');
+    _requestVidFrameCallback =
+      getPrefixedProperty(vid, "requestVideoFrameCallback");
+  }
+
+  return _requestVidFrameCallback;
+};
+
 /**
  * Provides requestFullScreen in a cross browser way.
  */
@@ -2875,37 +2891,46 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  var gotPlaying = false;
-  var gotTimeUpdate = false;
+  var rvfc = getRequestVidFrameCallback();
+  if (rvfc === undefined) {
+    var gotPlaying = false;
+    var gotTimeUpdate = false;
 
-  var maybeCallCallback = function() {
-    if (gotPlaying && gotTimeUpdate && callback) {
-      callback(video);
-      callback = undefined;
-      video.removeEventListener('playing', playingListener, true);
-      video.removeEventListener('timeupdate', timeupdateListener, true);
-    }
-  };
+    var maybeCallCallback = function() {
+      if (gotPlaying && gotTimeUpdate && callback) {
+        callback(video);
+        callback = undefined;
+        video.removeEventListener('playing', playingListener, true);
+        video.removeEventListener('timeupdate', timeupdateListener, true);
+      }
+    };
 
-  var playingListener = function() {
-    gotPlaying = true;
-    maybeCallCallback();
-  };
-
-  var timeupdateListener = function() {
-    // Checking to make sure the current time has advanced beyond
-    // the start time seems to be a reliable heuristic that the
-    // video element has data that can be consumed.
-    if (video.currentTime > 0.0) {
-      gotTimeUpdate = true;
+    var playingListener = function() {
+      gotPlaying = true;
       maybeCallCallback();
-    }
-  };
+    };
 
-  video.addEventListener('playing', playingListener, true);
-  video.addEventListener('timeupdate', timeupdateListener, true);
+    var timeupdateListener = function() {
+      // Checking to make sure the current time has advanced beyond
+      // the start time seems to be a reliable heuristic that the
+      // video element has data that can be consumed.
+      if (video.currentTime > 0.0) {
+        gotTimeUpdate = true;
+        maybeCallCallback();
+      }
+    };
+
+    video.addEventListener('playing', playingListener, true);
+    video.addEventListener('timeupdate', timeupdateListener, true);
+  } else {
+    // Calls video.requestVideoFrameCallback(_ => { callback(video) })
+    rvfc.call(video, _ => { callback(video) });
+  }
+
   video.loop = true;
   video.muted = true;
+  // See whether setting the preload flag de-flakes video-related tests.
+  video.preload = 'auto';
   video.play();
 };
 

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -2913,21 +2913,12 @@ var requestAnimFrame = function(callback) {
   _requestAnimFrame.call(window, callback);
 };
 
-var _requestVidFrameCallback = null;
-
-
 /**
  * Provides video.requestVideoFrameCallback in a cross browser way.
  * Returns a property, or undefined if unsuported.
  */
 var getRequestVidFrameCallback = function() {
-  if (_requestVidFrameCallback === null) {
-    var vid = document.createElement('video');
-    _requestVidFrameCallback =
-      getPrefixedProperty(vid, "requestVideoFrameCallback");
-  }
-
-  return _requestVidFrameCallback;
+  return HTMLVideoElement.prototype["requestVideoFrameCallback"];
 };
 
 var _cancelAnimFrame;


### PR DESCRIPTION
The startPlayingAndWaitForVideo function uses various heuristics to
determine whether or not a video has started playing. These heuristics
mostly rely on currentTime progress, but don't aren't necessarily
reliable when determining wether there is actually new video data to
be consumed.

This commit adds cross browser support for the
video.requestVideoFrameCallback API, which can be used to replace the
heuristics, and potentially deflake tests.