### PR TITLE
Fix polygon-offset tests

### DIFF
--- a/conformance-suites/1.0.3/conformance/rendering/polygon-offset.html
+++ b/conformance-suites/1.0.3/conformance/rendering/polygon-offset.html
@@ -147,6 +147,7 @@
 
                 debug('Polygon offset factor of 0.1 should alter order of slanted polygons');
                 clear(gl, red, 1.0);
+                gl.polygonOffset(0, 0);
                 draw(gl, slantedSquare, colLoc, green);
                 gl.polygonOffset(0.1, 0);
                 draw(gl, slantedSquare, colLoc, blue);
@@ -154,6 +155,7 @@
 
                 debug('Polygon offset factor of 0.1 should not alter order of flat polygons');
                 clear(gl, red, 1.0);
+                gl.polygonOffset(0, 0);
                 draw(gl, flatSquare, colLoc, blue);
                 gl.polygonOffset(0.1, 0);
                 draw(gl, flatSquare, colLoc, green);

--- a/conformance-suites/2.0.0/conformance/rendering/polygon-offset.html
+++ b/conformance-suites/2.0.0/conformance/rendering/polygon-offset.html
@@ -147,6 +147,7 @@ function runTest()
 
     debug('Polygon offset factor of 0.1 should alter order of slanted polygons');
     clear(gl, red, 1.0);
+    gl.polygonOffset(0, 0);
     draw(gl, slantedSquare, colLoc, green);
     gl.polygonOffset(0.1, 0);
     draw(gl, slantedSquare, colLoc, blue);
@@ -154,6 +155,7 @@ function runTest()
 
     debug('Polygon offset factor of 0.1 should not alter order of flat polygons');
     clear(gl, red, 1.0);
+    gl.polygonOffset(0, 0);
     draw(gl, flatSquare, colLoc, blue);
     gl.polygonOffset(0.1, 0);
     draw(gl, flatSquare, colLoc, green);

--- a/sdk/tests/conformance/rendering/polygon-offset.html
+++ b/sdk/tests/conformance/rendering/polygon-offset.html
@@ -126,6 +126,7 @@ function runTest()
 
     debug('Polygon offset factor of 0.1 should alter order of slanted polygons');
     clear(gl, red, 1.0);
+    gl.polygonOffset(0, 0);
     draw(gl, slantedSquare, colLoc, green);
     gl.polygonOffset(0.1, 0);
     draw(gl, slantedSquare, colLoc, blue);
@@ -133,6 +134,7 @@ function runTest()
 
     debug('Polygon offset factor of 0.1 should not alter order of flat polygons');
     clear(gl, red, 1.0);
+    gl.polygonOffset(0, 0);
     draw(gl, flatSquare, colLoc, blue);
     gl.polygonOffset(0.1, 0);
     draw(gl, flatSquare, colLoc, green);


### PR DESCRIPTION
Two tests in the polygon-offset.html files were incorrectly
testing glPolygonOffset by comparing to the wrong base value.

The section entitled:
'Polygon offset factor of 0.1 should alter order of slanted polygons'
Was comparing gl.polygonOffset(0, 2) to gl.polygonOffset(0.1, 0)
while the goal was to compare it with a baseline of gl.polygonOffset(0, 0)

The section entitled:
'Polygon offset factor of 0.1 should not alter order of flat polygons'
Was comparing gl.polygonOffset(0.1, 0) to gl.polygonOffset(0.1, 0)
(effectively not performing the test at all)
while the goal was to compare it with a baseline of gl.polygonOffset(0, 0)

Fixed the baseline comparison polygon offsets in both cases to fix the test.