### PR TITLE
Update WEBGL_video_texture

### DIFF
--- a/extensions/proposals/WEBGL_video_texture/extension.xml
+++ b/extensions/proposals/WEBGL_video_texture/extension.xml
@@ -69,7 +69,7 @@ interface WEBGL_video_texture {
 
     [RaisesException] WebGLVideoFrameInfo shareVideoImageWEBGL(
       GLenum target, HTMLVideoElement video);
-    [RaiseException] bool releaseVideoImageWEBGL(GLenum target);
+    [RaiseException] void releaseVideoImageWEBGL(GLenum target);
 };
   </idl>
 
@@ -163,6 +163,9 @@ interface WEBGL_video_texture {
     <revision date="2019/10/29">
       <change>Allocate enums for TEXTURE_VIDEO_IMAGE_WEBGL and SAMPLER_VIDEO_IMAGE_WEBGL out of
       WebGL's current assigned enum block in the OpenGL extension registry.</change>
+    </revision>
+    <revision date="2020/05/13">
+      <change>Change return type of releaseVideoImageWEBGL from bool to void.</change>
     </revision>
   </history>
 </proposal>


### PR DESCRIPTION
In current spec, API releaseVideoImageWEBGL returns boolean.
Since it can raise exception and in the spec example the return value
doesn't been checked, void should be a better return value.