### PR TITLE
Increase timeout for cross-origin image loading tests.

### DIFF
--- a/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
+++ b/sdk/tests/conformance/more/functions/readPixelsBadArgs.html
@@ -101,7 +101,7 @@ Tests.endUnit = function(gl) {
 (async function() {
   const img = document.getElementById('i');
   try {
-    await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+    await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl));
   } catch (e) {
     testFailed(`Image setup failed (${e}).`);
     finishTest();

--- a/sdk/tests/conformance/more/functions/texImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texImage2DHTML.html
@@ -136,7 +136,7 @@ Tests.endUnit = function(gl) {
 (async function() {
     const img = document.getElementById('i2');
     try {
-        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl));
     } catch (e) {
         testFailed(`Image setup failed (${e}).`);
         finishTest();

--- a/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
+++ b/sdk/tests/conformance/more/functions/texSubImage2DHTML.html
@@ -148,7 +148,7 @@ Tests.endUnit = function(gl) {
 (async function() {
     const img = document.getElementById('i2');
     try {
-        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+        await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl));
     } catch (e) {
         testFailed(`Image setup failed (${e}).`);
         finishTest();

--- a/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
+++ b/sdk/tests/conformance/textures/misc/origin-clean-conformance-offscreencanvas.html
@@ -112,7 +112,7 @@ function imageLoaded(img) {
 (async function() {
   const img = document.getElementById('img');
   try {
-    await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+    await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl));
   } catch (e) {
     testFailed(`Image setup failed (${e}).`);
     finishTest();

--- a/sdk/tests/conformance/textures/misc/origin-clean-conformance.html
+++ b/sdk/tests/conformance/textures/misc/origin-clean-conformance.html
@@ -124,7 +124,7 @@ function imageLoaded(img) {
 (async function() {
   const img = document.getElementById('img');
   try {
-    await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl), 1000);
+    await wtu.awaitOrTimeout(wtu.loadCrossOriginImage(img, defaultImgUrl, localImgUrl));
   } catch (e) {
     testFailed(`Image setup failed (${e}).`);
     finishTest();

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3355,11 +3355,15 @@ async function awaitTimeout(ms) {
   });
 }
 
-async function awaitOrTimeout(promise, timeout_ms) {
+async function awaitOrTimeout(promise, opt_timeout_ms) {
   async function throwOnTimeout(ms) {
     await awaitTimeout(ms);
     throw 'timeout';
   }
+
+  let timeout_ms = opt_timeout_ms;
+  if (timeout_ms === undefined)
+    timeout_ms = 5000;
 
   await Promise.race([promise, throwOnTimeout(timeout_ms)]);
 }


### PR DESCRIPTION
Change WebGLTestUtils.awaitOrTimeout to offer a default timeout of
5000 ms, and all tests currently using it to use the default.

Tested both manually and in Chromium's automated WebGL test harness.
Unclear whether this will fix the problems seen on Chromium's bots,
but need to try.

Follow-on to #3052. Addresses #3076.