### PR TITLE
Add tests to verify toDataURL images are the correct orientation for premultiplyAlpha=false

### DIFF
--- a/sdk/tests/conformance/canvas/to-data-url-test.html
+++ b/sdk/tests/conformance/canvas/to-data-url-test.html
@@ -42,7 +42,7 @@ var main = function() {
 
     canvas.width = width;
     canvas.height = height;
-    
+
     if (!gl) {
       gl = wtu.create3DContext(canvas, attributes);
     }

--- a/sdk/tests/conformance/canvas/to-data-url-test.html
+++ b/sdk/tests/conformance/canvas/to-data-url-test.html
@@ -21,7 +21,6 @@ found in the LICENSE.txt file.
 var wtu = WebGLTestUtils;
 var numTests = 10;
 var gl;
-var glAttributes;
 var ctx;
 
 var main = function() {
@@ -31,12 +30,11 @@ var main = function() {
   var updateCanvas = function(width, height, attributes) {
     var canvas = document.getElementById("c3d");
 
-    if (gl && (glAttributes !== attributes)) {
+    if (gl && (gl.attributes !== attributes)) {
       // Attributes changed, recreate the canvas
       var newCanvas = canvas.cloneNode();
       canvas.parentNode.replaceChild(newCanvas, canvas);
       canvas = newCanvas;
-      glAttributes = attributes;
       gl = undefined;
     }
 
@@ -45,11 +43,13 @@ var main = function() {
 
     if (!gl) {
       gl = wtu.create3DContext(canvas, attributes);
-    }
 
-    if (!gl) {
-      testFailed("can't create 3d context");
-      return;
+      if (!gl) {
+        testFailed("can't create 3d context");
+        return;
+      }
+
+      gl.attributes = attributes;
     }
 
     return gl;
@@ -62,7 +62,10 @@ var main = function() {
   };
 
   var testSize = function(width, height, attributes, callback) {
-    var attributesDebugMessage = (attributes ? " attributes: " + JSON.stringify(attributes) : "");
+    let attributesDebugMessage = "";
+    if (attributes) {
+      attributesDebugMessage = " attributes: " + JSON.stringify(attributes);
+    }
     debug("testing " + width + " by " + height + attributesDebugMessage);
     var gl = updateCanvas(width, height, attributes);
     if (!gl) {
@@ -97,7 +100,7 @@ var main = function() {
     });
   };
 
-  var premultipliedAlphaAttributes =  {
+  const premultipliedAlphaAttributes =  {
     premultipliedAlpha: false,
   };
   var tests = [

--- a/sdk/tests/conformance/canvas/to-data-url-test.html
+++ b/sdk/tests/conformance/canvas/to-data-url-test.html
@@ -21,18 +21,39 @@ found in the LICENSE.txt file.
 var wtu = WebGLTestUtils;
 var numTests = 10;
 var gl;
+var glAttributes;
 var ctx;
 
 var main = function() {
   description();
   ctx = document.getElementById("c2d").getContext("2d");
-  gl = wtu.create3DContext("c3d");
 
-  if (!gl) {
-    testFailed("can't create 3d context");
-    finishTest();
-    return;
-  }
+  var updateCanvas = function(width, height, attributes) {
+    var canvas = document.getElementById("c3d");
+
+    if (gl && (glAttributes !== attributes)) {
+      // Attributes changed, recreate the canvas
+      var newCanvas = canvas.cloneNode();
+      canvas.parentNode.replaceChild(newCanvas, canvas);
+      canvas = newCanvas;
+      glAttributes = attributes;
+      gl = undefined;
+    }
+
+    canvas.width = width;
+    canvas.height = height;
+    
+    if (!gl) {
+      gl = wtu.create3DContext(canvas, attributes);
+    }
+
+    if (!gl) {
+      testFailed("can't create 3d context");
+      return;
+    }
+
+    return gl;
+  };
 
   var clearRect = function(gl, x, y, width, height, color) {
     gl.clearColor(color[0] / 255, color[1] / 255, color[2] / 255, color[3] / 255);
@@ -40,10 +61,15 @@ var main = function() {
     gl.clear(gl.COLOR_BUFFER_BIT);
   };
 
-  var testSize = function(gl, width, height, callback) {
-    debug("testing " + width + " by " + height);
-    gl.canvas.width = width;
-    gl.canvas.height = height;
+  var testSize = function(width, height, attributes, callback) {
+    var attributesDebugMessage = (attributes ? " attributes: " + JSON.stringify(attributes) : "");
+    debug("testing " + width + " by " + height + attributesDebugMessage);
+    var gl = updateCanvas(width, height, attributes);
+    if (!gl) {
+      callback();
+      return;
+    }
+
     gl.viewport(0, 0, width, height);
     gl.enable(gl.SCISSOR_TEST);
 
@@ -71,6 +97,9 @@ var main = function() {
     });
   };
 
+  var premultipliedAlphaAttributes =  {
+    premultipliedAlpha: false,
+  };
   var tests = [
     { width:  16    , height:  16    , },
     { width:  16 - 1, height:  16    , },
@@ -87,6 +116,7 @@ var main = function() {
     { width: 512 - 1, height: 512 - 1, },
     { width: 512 + 1, height: 512 - 1, },
     { width: 512 - 1, height: 512 + 1, },
+    { width:  16    , height:  16    , attributes: premultipliedAlphaAttributes},
   ];
   var testIndex = 0;
   var runNextTest = function() {
@@ -95,7 +125,7 @@ var main = function() {
       return;
     }
     var test = tests[testIndex++];
-    testSize(gl, test.width, test.height, function() {
+    testSize(test.width, test.height, test.attributes, function() {
       setTimeout(runNextTest, 0);
     })
   };


### PR DESCRIPTION
This adds a test to verify the image returned by toDataURL with a premultipliedAlpha=false canvas is the correct orientation.

This was suggested by:
https://bugs.webkit.org/show_bug.cgi?id=156129

I ran the test on Chrome/FireFox and got:

    testing 16 by 16 attributes: {"premultipliedAlpha":false}
    PASS should be 0,255,0,255
    PASS should be 255,0,0,255
    PASS should be 0,0,255,255

And got this on Safari:

    testing 16 by 16 attributes: {"premultipliedAlpha":false}
    FAIL should be 0,255,0,255
    at (0, 0) expected: 0,255,0,255 was 255,0,0,255
    FAIL should be 255,0,0,255
    at (0, 8) expected: 255,0,0,255 was 0,255,0,255
    PASS should be 0,0,255,255
