### PR TITLE
Temporarily disable requestVideoFrameCallback for some tests.

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-video.js
@@ -40,6 +40,10 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var videoNdx = 0;
         var video;
+
+        // crbug.com/1090960: createImageBitmap is failing for some
+        // videos even after requestVideoFrameCallback fires.
+        wtu.disableRequestVideoFrameCallback();
         function runNextVideo() {
             if (video) {
                 video.pause();

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -2913,12 +2913,24 @@ var requestAnimFrame = function(callback) {
   _requestAnimFrame.call(window, callback);
 };
 
+var _disableRequestVideoFrameCallback = false;
+
 /**
  * Provides video.requestVideoFrameCallback in a cross browser way.
  * Returns a property, or undefined if unsuported.
  */
 var getRequestVidFrameCallback = function() {
+  if (_disableRequestVideoFrameCallback)
+    return undefined;
   return HTMLVideoElement.prototype["requestVideoFrameCallback"];
+};
+
+/**
+ * Disables the use of requestVideoFrameCallback in order to work
+ * around bugs in implementations.
+ */
+var disableRequestVideoFrameCallback = function() {
+  _disableRequestVideoFrameCallback = true;
 };
 
 var _cancelAnimFrame;
@@ -3404,6 +3416,7 @@ var API = {
   comparePixels: comparePixels,
   destroyAllContexts: destroyAllContexts,
   destroyContext: destroyContext,
+  disableRequestVideoFrameCallback: disableRequestVideoFrameCallback,
   dispatchPromise: dispatchPromise,
   displayImageDiff: displayImageDiff,
   drawUnitQuad: drawUnitQuad,


### PR DESCRIPTION
Disable the use of this new API for the image_bitmap_from_video
conformance tests to work around crbug.com/1090960. It will be
re-enabled once the underlying bug is fixed.

Follow-on to #3065.