### PR TITLE
Choose which cross-origin URL to use up front.

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3222,19 +3222,19 @@ var getRelativePath = function(path) {
 }
 
 async function loadCrossOriginImage(img, webUrl, localUrl) {
-  img.src = getUrlOptions().imgUrl || webUrl;
-  try {
-    console.log('[loadCrossOriginImage]', 'trying', img.src);
-    await img.decode();
-    return;
-  } catch {}
-
   if (runningOnLocalhost()) {
     img.src = getLocalCrossOrigin() + getRelativePath(localUrl);
     console.log('[loadCrossOriginImage]', '  trying', img.src);
     await img.decode();
     return;
   }
+
+  try {
+    img.src = getUrlOptions().imgUrl || webUrl;
+    console.log('[loadCrossOriginImage]', 'trying', img.src);
+    await img.decode();
+    return;
+  } catch {}
 
   throw 'createCrossOriginImage failed';
 }

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3184,9 +3184,9 @@ var getBaseDomain = function(host) {
 
 var runningOnLocalhost = function() {
   let hostname = window.location.hostname;
-  return hostname.indexOf("localhost") != -1 ||
-    hostname.indexOf("127.0.0.1") != -1 ||
-    hostname.indexOf("::1") != -1;
+  return hostname == "localhost" ||
+    hostname == "127.0.0.1" ||
+    hostname == "::1";
 }
 
 var getLocalCrossOrigin = function() {

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3183,13 +3183,16 @@ var getBaseDomain = function(host) {
 }
 
 var runningOnLocalhost = function() {
-  return window.location.hostname.indexOf("localhost") != -1 ||
-      window.location.hostname.indexOf("127.0.0.1") != -1;
+  let hostname = window.location.hostname;
+  return hostname.indexOf("localhost") != -1 ||
+    hostname.indexOf("127.0.0.1") != -1 ||
+    hostname.indexOf("::1") != -1;
 }
 
 var getLocalCrossOrigin = function() {
   var domain;
   if (window.location.host.indexOf("localhost") != -1) {
+    // TODO(kbr): figure out whether to use an IPv6 loopback address.
     domain = "127.0.0.1";
   } else {
     domain = "localhost";


### PR DESCRIPTION
The earliest version of this code, which was seemingly stable, made the
determination of whether to use a local or remote URL cor cross-origin
images up front.  Network timeouts from machines that deliberately
aren't connected to the open Internet can't be relied upon as a fallback
mechanism. Change the code back to examine the test's URL and choose
whether to load local or remote images based on that. Also attempt to
make runningOnLocalhost more robust to IPv6 loopback addresses.

Follow-on to #3052 and #3077. See http://crbug.com/1082525 for more
background.

Should fix #3076 conclusively.

Note that #3097 was proposed as an alternative solution for this problem
and may still be considered in the future if this change destabilizes some
browsers' CI systems.