### PR TITLE
readBuffer of out of range color attachment should cause INVALID_OPERATION

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/readbuffer.html
+++ b/sdk/tests/conformance2/renderbuffers/readbuffer.html
@@ -78,8 +78,8 @@ var testReadBufferOnFBO = function() {
 
   var maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
   gl.readBuffer(gl.COLOR_ATTACHMENT0 + maxColorAttachments);
-  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
-      "calling readBuffer with GL_COLOR_ATTACHMENTi that exceeds MAX_COLOR_ATTACHMENT on fbo should generate INVALID_ENUM.");
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
+      "calling readBuffer with GL_COLOR_ATTACHMENTi that exceeds MAX_COLOR_ATTACHMENT on fbo should generate INVALID_OPERATION.");
   gl.readBuffer(gl.COLOR_ATTACHMENT1);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,
       "calling readBuffer with GL_COLOR_ATTACHMENT1 on the fbo should succeed.");


### PR DESCRIPTION
Looks like the test was written to the man page, but the man page disagrees with the spec and with dEQP. The spec should win.