### PR TITLE
Add DYNAMIC_DRAW bufferUsage to multi draw and base vertex base instance test

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-multi-draw.html
+++ b/sdk/tests/conformance/extensions/webgl-multi-draw.html
@@ -146,6 +146,7 @@ const wtu = WebGLTestUtils;
 const canvas = document.getElementById("canvas");
 const gl = wtu.create3DContext(canvas);
 const instancedExt = gl && gl.getExtension('ANGLE_instanced_arrays');
+const bufferUsageSet = [ gl.STATIC_DRAW, gl.DYNAMIC_DRAW ];
 
 // Check if the extension is either both enabled and supported or
 // not enabled and not supported.
@@ -187,18 +188,18 @@ function runTest() {
 
 function doTest(ext, instanced) {
 
-  function runValidationTests() {
+  function runValidationTests(bufferUsage) {
     const vertexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0.2,0.2, 0.8,0.2, 0.5,0.8 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0.2,0.2, 0.8,0.2, 0.5,0.8 ]), bufferUsage);
 
     const indexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array([ 0, 1, 2, 0]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array([ 0, 1, 2, 0]), bufferUsage);
 
     const instanceBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0, 1, 2, 3 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0, 1, 2, 3 ]), bufferUsage);
 
     const program = wtu.setupProgram(gl, ["vshaderNoDrawID", "fshader"], ["vPosition", "vInstance"], [0, 1]);
     expectTrue(program != null, "can compile simple program");
@@ -354,7 +355,7 @@ function doTest(ext, instanced) {
     }
   }
 
-  function runShaderTests() {
+  function runShaderTests(bufferUsage) {
     const illegalProgram = wtu.setupProgram(gl, ["vshaderIllegalDrawID", "fshader"], ["vPosition"], [0]);
     expectTrue(illegalProgram == null, "cannot compile program with gl_DrawID but no extension directive");
 
@@ -363,14 +364,14 @@ function doTest(ext, instanced) {
     expectTrue(drawIDProgram !== null, "can compile program with gl_DrawID");
     gl.useProgram(drawIDProgram);
     gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0, 1,0, 0,1, 0,1, 1,0, 1,1 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0, 1,0, 0,1, 0,1, 1,0, 1,1 ]), bufferUsage);
     gl.enableVertexAttribArray(0);
     gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
     wtu.checkCanvas(gl, [0, 255, 0, 255], "gl_DrawID is 0 for non-Multi* draw calls", 0);
   }
 
-  function runPixelTests() {
+  function runPixelTests(bufferUsage) {
     // An array of quads is tiled across the screen.
     // gl_DrawID is checked by using it to select the color of the draw.
     // Instanced entrypoints are tested here scaling and then instancing the
@@ -438,16 +439,16 @@ function doTest(ext, instanced) {
     const instanceBuffer = gl.createBuffer();
 
     gl.bindBuffer(gl.ARRAY_BUFFER, nonIndexedVertexBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, nonIndexedVertices, gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, nonIndexedVertices, bufferUsage);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, vertices, bufferUsage);
 
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, bufferUsage);
 
     gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 2, 3, 4]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([1, 2, 3, 4]), bufferUsage);
 
     function checkResult(config, msg) {
       const rects = [];
@@ -821,9 +822,13 @@ function doTest(ext, instanced) {
     }
   }
 
-  runValidationTests();
-  runShaderTests();
-  runPixelTests();
+  for (let i = 0; i < bufferUsageSet.length; i++) {
+    let bufferUsage = bufferUsageSet[i];
+    debug("Testing with BufferUsage = " + bufferUsage);
+    runValidationTests(bufferUsage);
+    runShaderTests(bufferUsage);
+    runPixelTests(bufferUsage);
+  }
 }
 
 runTest();

--- a/sdk/tests/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html
+++ b/sdk/tests/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html
@@ -133,6 +133,7 @@ const tileSize = [ 1/x_count, 1/y_count ];
 const tilePixelSize = [ Math.floor(width / x_count), Math.floor(height / y_count) ];
 const quadRadius = [ 0.25 * tileSize[0], 0.25 * tileSize[1] ];
 const pixelCheckSize = [ Math.floor(quadRadius[0] * width), Math.floor(quadRadius[1] * height) ];
+const bufferUsageSet = [ gl.STATIC_DRAW, gl.DYNAMIC_DRAW ];
 
 function getTileCenter(x, y) {
   return [ tileSize[0] * (0.5 + x), tileSize[1] * (0.5 + y) ];
@@ -193,18 +194,6 @@ const vertexBuffer = gl.createBuffer();
 const nonIndexedVertexBuffer = gl.createBuffer();
 const instanceIDBuffer = gl.createBuffer();
 
-gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
-
-gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, gl.STATIC_DRAW);
-
-gl.bindBuffer(gl.ARRAY_BUFFER, nonIndexedVertexBuffer);
-gl.bufferData(gl.ARRAY_BUFFER, nonIndexedVertices, gl.STATIC_DRAW);
-
-gl.bindBuffer(gl.ARRAY_BUFFER, instanceIDBuffer);
-gl.bufferData(gl.ARRAY_BUFFER, instanceIDs, gl.STATIC_DRAW);
-
 const drawArraysDrawCount = x_count / 2;
 let drawArraysParams = {
   drawCount: drawArraysDrawCount,
@@ -235,6 +224,20 @@ for (let v = 0; v < y_count; ++v) {
     drawElementsParams.baseInstances[b] = i;
     ++b;
   }
+}
+
+function setupGeneralBuffers(bufferUsage) {
+  gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, vertices, bufferUsage);
+
+  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+  gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indices, bufferUsage);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, nonIndexedVertexBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, nonIndexedVertices, bufferUsage);
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, instanceIDBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, instanceIDs, bufferUsage);
 }
 
 // Check if the extension is either both enabled and supported or
@@ -306,18 +309,18 @@ function doTest(extensionName, multiDraw) {
     return [vs, fs];
   }
 
-  function runValidationTests() {
+  function runValidationTests(bufferUsage) {
     const vertexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0.2,0.2, 0.8,0.2, 0.5,0.8 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0.2,0.2, 0.8,0.2, 0.5,0.8 ]), bufferUsage);
 
     const indexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array([ 0, 1, 2 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array([ 0, 1, 2 ]), bufferUsage);
 
     const instanceBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, instanceBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0, 1, 2 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0, 1, 2 ]), bufferUsage);
 
     const program = wtu.setupProgram(gl, ['vshaderSimple', 'fshader'], ['vPosition, vInstanceID'], [0, 1]);
     expectTrue(program != null, "can compile simple program");
@@ -486,7 +489,7 @@ function doTest(extensionName, multiDraw) {
     }
   }
 
-  function runShaderTests() {
+  function runShaderTests(bufferUsage) {
     const illegalBaseInstanceProgram = wtu.setupProgram(gl, ["vshaderIllegalBaseInstance", "fshader"]);
     expectTrue(illegalBaseInstanceProgram == null, "cannot compile program with gl_BaseInstance but no extension directive");
     const illegalBaseVertexProgram = wtu.setupProgram(gl, ["vshaderIllegalBaseVertex", "fshader"]);
@@ -499,7 +502,7 @@ function doTest(extensionName, multiDraw) {
 
     // gl_BaseInstance and gl_InstanceID
     gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0, 1,0, 0.5,1, 0,1, 0.5,0, 1,1 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0, 1,0, 0.5,1, 0,1, 0.5,0, 1,1 ]), bufferUsage);
     gl.enableVertexAttribArray(0);
     gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
 
@@ -534,9 +537,9 @@ function doTest(extensionName, multiDraw) {
 
     // gl_BaseVertex and gl_VertexID
     gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0, 1,0, 0.5,1, 0,1, 0.5,0, 1,1, 0,0, 1,0, 0.5,1, 0,1 ]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0, 1,0, 0.5,1, 0,1, 0.5,0, 1,1, 0,0, 1,0, 0.5,1, 0,1 ]), bufferUsage);
     gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, gl.createBuffer());
-    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array([0, 1, 2, 3, 4, 5]), gl.STATIC_DRAW);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array([0, 1, 2, 3, 4, 5]), bufferUsage);
     gl.enableVertexAttribArray(0);
     gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
 
@@ -731,9 +734,14 @@ function doTest(extensionName, multiDraw) {
     });
   }
 
-  runValidationTests();
-  runShaderTests();
-  runPixelTests();
+  for (let i = 0; i < bufferUsageSet.length; i++) {
+    let bufferUsage = bufferUsageSet[i];
+    debug("Testing with BufferUsage = " + bufferUsage);
+    setupGeneralBuffers(bufferUsage);
+    runValidationTests(bufferUsage);
+    runShaderTests(bufferUsage);
+    runPixelTests();
+  }
 }
 
 runTest();


### PR DESCRIPTION
Now multi_draw and base_vertex_base_instance test with buffers setup with `[ gl.STATIC_DRAW, gl.DYNAMIC_DRAW ]`

Corresponds to ANGLE bugs:
http://crbug.com/angleproject/4754
http://crbug.com/1078330