### PR TITLE
Clarify texImage2D for RGTC and BPTC

### DIFF
--- a/extensions/EXT_texture_compression_bptc/extension.xml
+++ b/extensions/EXT_texture_compression_bptc/extension.xml
@@ -26,6 +26,9 @@
       <a href="https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_sRGB.txt">EXT_sRGB</a> OpenGL ES
       extension.
     </p>
+    <p>
+      Unlike the OpenGL ES extension, this WebGL extension does not extend <code>texImage2D</code> entry point.
+    </p>
     <features>
       <feature>
         Compression format <code>COMPRESSED_RGBA_BPTC_UNORM_EXT</code>,
@@ -108,6 +111,9 @@ interface EXT_texture_compression_bptc {
     </revision>
     <revision date="2018/11/05">
       <change>Moved to Community Approved status.</change>
+    </revision>
+    <revision date="2020/06/25">
+      <change>Clarified <code>texImage2D</code> entry point.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_texture_compression_rgtc/extension.xml
+++ b/extensions/EXT_texture_compression_rgtc/extension.xml
@@ -25,6 +25,9 @@
       EXT_texture_compression_rgtc specification must be supported in an implementation of this
       WebGL extension.
     </p>
+    <p>
+      Unlike the OpenGL ES extension, this WebGL extension does not extend <code>texImage2D</code> entry point.
+    </p>
     <features>
       <feature>
         Compression formats <code>COMPRESSED_RED_RGTC1_EXT</code>,
@@ -124,6 +127,9 @@ interface EXT_texture_compression_rgtc {
     </revision>
     <revision date="2018/11/05">
       <change>Moved to Community Approved status.</change>
+    </revision>
+    <revision date="2020/06/25">
+      <change>Clarified <code>texImage2D</code> entry point.</change>
     </revision>
   </history>
 </extension>

--- a/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
@@ -73,6 +73,28 @@ function runTestExtension() {
       { xoffset: 12, yoffset: 12, width: 4, height: 4,
         expectation: gl.NO_ERROR, message: "is valid" },
   ]);
+
+  // Test that BPTC enums are not accepted by texImage2D
+  {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_BPTC_UNORM_EXT, 4, 4, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RGBA_BPTC_UNORM_EXT fails with texImage2D");
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT, 4, 4, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT fails with texImage2D");
+
+    if (contextVersion >= 2) {
+      gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT, 4, 4, 0, gl.RGB, gl.FLOAT, null);
+      wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT fails with texImage2D");
+
+      gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT, 4, 4, 0, gl.RGB, gl.FLOAT, null);
+      wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT fails with texImage2D");
+    }
+
+    gl.deleteTexture(tex);
+  }
 };
 
 function runTest() {

--- a/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
@@ -78,6 +78,26 @@ function runTestExtension() {
       { xoffset: 12, yoffset: 12, width: 4, height: 4,
         expectation: gl.NO_ERROR, message: "is valid" },
   ]);
+
+  // Test that RGTC enums are not accepted by texImage2D
+  if (contextVersion >= 2) {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RED_RGTC1_EXT, 4, 4, 0, gl.RED, gl.UNSIGNED_BYTE, null);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RED_RGTC1_EXT fails with texImage2D");
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_SIGNED_RED_RGTC1_EXT, 4, 4, 0, gl.RED, gl.BYTE, null);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_SIGNED_RED_RGTC1_EXT fails with texImage2D");
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RED_GREEN_RGTC2_EXT, 4, 4, 0, gl.RG, gl.UNSIGNED_BYTE, null);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RED_GREEN_RGTC2_EXT fails with texImage2D");
+
+    gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT, 4, 4, 0, gl.RG, gl.BYTE, null);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT fails with texImage2D");
+
+    gl.deleteTexture(tex);
+  }
 };
 
 function runTest() {


### PR DESCRIPTION
Chromium (ANGLE?) responds with `INVALID_VALUE` instead of `INVALID_OPERATION`.