### PR TITLE
Update MultiDraw and MultiDrawBaseVertexBaseInstance extension

### DIFF
--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -45,6 +45,16 @@
       <feature>The <code>multiDrawArraysWEBGL</code>, <code>multiDrawElementsWEBGL</code>, <code>multiDrawArraysInstancedWEBGL</code>, and <code>multiDrawElementsInstancedWEBGL</code> entry points are added. These provide a counterpoint to instanced rendering and are more flexible for certain scenarios. They behave identically to multiple calls to <code>drawArrays</code>, <code>drawElements</code>, <code>drawArraysInstanced</code>, and <code>drawElementsInstanced</code> except they handle multiple lists of arguments in one call.</feature>
 
       <feature>The <code>gl_DrawID</code> builtin is added to the shading language. For any Multi* draw call variant, the index of the draw <code>i</code> may be read by the vertex shader as <code>gl_DrawID</code>. For non Multi* calls, the value of gl_DrawID is 0.</feature>
+      
+      <feature>
+        When this extension is enabled, the
+        following extensions are enabled explicitly:
+        <ul>
+          <li><a href="http://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays">
+          ANGLE_instanced_arrays</a></li>
+        </ul>
+      </feature>
+      
       <glsl extname="GL_ANGLE_multi_draw">
         <stage type="vertex"/>
         <input name="gl_DrawID" type="int" />

--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -48,7 +48,7 @@
       
       <feature>
         When this extension is enabled, the
-        following extensions are enabled explicitly:
+        following extensions are enabled implicitly:
         <ul>
           <li><a href="http://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays">
           ANGLE_instanced_arrays</a></li>
@@ -162,6 +162,9 @@ void main() {
     </revision>
     <revision date="2019/10/23">
       <change>Merged features with WEBGL_multi_draw_instanced.</change>
+    </revision>
+    <revision date="2020/06/26">
+      <change>Implicitly enable ANGLE_instanced_arrays</change>
     </revision>
   </history>
 </draft>

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -74,6 +74,15 @@
         value of base vertex of each draw call to be values in<code>baseVerticesList</code> instead
         of zero.
       </feature>
+
+      <feature>
+        When this extension is enabled, the
+        following extensions are enabled explicitly:
+        <ul>
+          <li><a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw">
+          WEBGL_multi_draw</a></li>
+        </ul>
+      </feature>
     </features>
   </overview>
 

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -77,7 +77,7 @@
 
       <feature>
         When this extension is enabled, the
-        following extensions are enabled explicitly:
+        following extensions are enabled implicitly:
         <ul>
           <li><a href="http://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw">
           WEBGL_multi_draw</a></li>
@@ -198,6 +198,9 @@ void main() {
     <revision date="2019/09/25">
       <change>Change parameters order.</change>
       <change>Move to draft.</change>
+    </revision>
+    <revision date="2020/06/26">
+      <change>Implicitly enable WEBGL_multi_draw</change>
     </revision>
   </history>
 </draft>


### PR DESCRIPTION
Update as discussed at WebGL Virtual F2F. Original agreement at https://gitlab.khronos.org/webgl/member-tools/-/wikis/WebGL-F2F-Meeting-Sep-2019#extension-promotion-rejection-burndown-extension-promotion-rejection-burndown