### PR TITLE
Specialize EXT_texture_norm16 to WebGL 2.0; promote to community appr…

### DIFF
--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_texture_norm16/">
+<extension href="EXT_texture_norm16/">
   <name>EXT_texture_norm16</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -13,7 +13,7 @@
   <number>44</number>
 
   <depends>
-    <api version="1.0"/>
+    <api version="2.0"/>
   </depends>
 
   <overview>
@@ -73,5 +73,9 @@ interface EXT_texture_norm16 {
     <revision date="2019/09/25">
       <change>Promoted to Draft.</change>
     </revision>
+    <revision date="2020/07/14">
+      <change>Specialized to WebGL 2.0 after WG agreement, since this extension refers to sized
+      internal formats unavailable in WebGL 1.0. Promoted to Community Approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>


### PR DESCRIPTION
…oved.

This extension refers to sized internal formats that are unavailable
in the WebGL 1.0 specification. Per agreement in the WebGL WG,
restrict it to being exposed on WebGL 2.0 contexts.

Promote to community approved.

Addresses #3114.