### PR TITLE
Add WebGL 2.0 test of pixelStorei with PACK_SKIP_PIXELS > 0.

### DIFF
--- a/sdk/tests/conformance2/reading/read-pixels-pack-parameters.html
+++ b/sdk/tests/conformance2/reading/read-pixels-pack-parameters.html
@@ -322,6 +322,7 @@ function testPackParameters(usePixelPackBuffer)
     runTestIteration(0, 0, 2, 3, {alignment:8, skipPixels:2}, usePixelPackBuffer, false);
     runTestIteration(0, 0, 2, 3, {alignment:8, skipPixels:1, skipRows:3}, usePixelPackBuffer, false);
     runTestIteration(0, 0, 2, 3, {alignment:8, skipRows:3}, usePixelPackBuffer, true);
+    runTestIteration(0, 0, 2, 3, {skipPixels:1, rowLength:4}, usePixelPackBuffer, true);
 }
 
 debug("");


### PR DESCRIPTION
All of the existing tests for this pixel pack parameter with a value
greater than 0 were assumed to fail validation. Adding a positive test
reveals an apparent OpenGL driver bug on macOS.

Test case for http://crbug.com/angleproject/4849 .

This new test passes in Chromium and Firefox on macOS, and in WebKit
on top of ANGLE with the necessary driver bug workaround.