### PR TITLE
Default to WebGL 2 conformance tests instead of WebGL 1.

### DIFF
--- a/sdk/tests/webgl-conformance-tests.html
+++ b/sdk/tests/webgl-conformance-tests.html
@@ -193,7 +193,7 @@ window.onbeforeunload = function() {
   return false;
 }
 
-var DEFAULT_CONFORMANCE_TEST_VERSION = "1.0.4 (beta)";
+var DEFAULT_CONFORMANCE_TEST_VERSION = "2.0.1 (beta)";
 
 var OPTIONS = {
   version: DEFAULT_CONFORMANCE_TEST_VERSION,


### PR DESCRIPTION
I think it's time to change the default.