### PR TITLE
Shader source character set and preprocess validation test

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/00_test_list.txt
+++ b/sdk/tests/conformance/glsl/bugs/00_test_list.txt
@@ -5,6 +5,7 @@
 --min-version 1.0.3 array-of-struct-with-int-first-position.html
 --min-version 1.0.4 assign-to-swizzled-twice-in-function.html
 --min-version 1.0.4 bool-type-cast-bug-int-float.html
+--min-version 1.0.4 character-set.html
 --min-version 1.0.3 compare-loop-index-to-uniform.html
 --min-version 1.0.3 complex-glsl-does-not-crash.html
 --min-version 1.0.4 compound-assignment-type-combination.html

--- a/sdk/tests/conformance/glsl/bugs/angle-d3d11-compiler-error.html
+++ b/sdk/tests/conformance/glsl/bugs/angle-d3d11-compiler-error.html
@@ -54,7 +54,7 @@ if (!gl) {
   debug("");
   debug("Checking shader compilation and linking.");
 
-  checkCompilation()
+  checkCompilation();
 }
 
 function checkCompilation() {

--- a/sdk/tests/conformance/glsl/bugs/character-set.html
+++ b/sdk/tests/conformance/glsl/bugs/character-set.html
@@ -32,6 +32,16 @@ void main() {
 }
 </script>
 
+<script id="fs-invalid-2" type="x-shader/x-fragment">
+precision mediump float;
+#if defined(NOT_DEFINED_FOO)
+一些注释
+#endif
+void main() {
+  gl_FragColor = vec4(1, 0, 0, 1);
+}
+</script>
+
 <script id="fs-comment-valid" type="x-shader/x-fragment">
 precision mediump float;
 // some comment: asdf1234~!@#$%^&*()-=[];',./{}:"?><_+
@@ -94,6 +104,12 @@ function runTest() {
             passMsg: 'Unallowed characters detected'
         },
         {
+            fShaderId: 'fs-invalid-2',
+            fShaderSuccess: false,
+            linkSuccess: false,
+            passMsg: 'Non ASCII characters detected that would be cleared by preprocessing step is still invalid'
+        },
+        {
             fShaderId: 'fs-comment-valid',
             fShaderSuccess: true,
             linkSuccess: true,
@@ -103,7 +119,7 @@ function runTest() {
             fShaderId: 'fs-cleared-by-preprocessing-valid',
             fShaderSuccess: true,
             linkSuccess: true,
-            passMsg: 'Unsupported shader extensions cleared by preprocessing step is valid'
+            passMsg: 'Unsupported shader extensions (with invalid ASCII characters) cleared by preprocessing step is valid'
         },
     ]);
 }

--- a/sdk/tests/conformance/glsl/bugs/character-set.html
+++ b/sdk/tests/conformance/glsl/bugs/character-set.html
@@ -1,0 +1,119 @@
+<!--
+Copyright (c) 2020 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Character Set</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"></script>
+<script src="../../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+
+<script id="fs-invalid-0" type="x-shader/x-fragment">
+precision mediump float;
+$
+void main() {
+  gl_FragColor = vec4(1, 0, 0, 1);
+}
+</script>
+
+<script id="fs-invalid-1" type="x-shader/x-fragment">
+precision mediump float;
+一些注释
+void main() {
+  gl_FragColor = vec4(1, 0, 0, 1);
+}
+</script>
+
+<script id="fs-comment-valid" type="x-shader/x-fragment">
+precision mediump float;
+// some comment: asdf1234~!@#$%^&*()-=[];',./{}:"?><_+
+// some comment: 一些注释 (╯‵□′)╯︵┻━┻
+// some comment: \\\\\\\\\
+// some comment: \n\\r\n
+void main() {
+  gl_FragColor = vec4(1, 0, 0, 1);
+}
+</script>
+
+<script id="fs-cleared-by-preprocessing-valid" type="x-shader/x-fragment">
+precision mediump float;
+#if defined(GL_GOOGLE_cpp_style_line_directive)
+#line 9 "foo.txt"
+#endif
+void main() {
+  gl_FragColor = vec4(1, 0, 0, 1);
+}
+</script>
+
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="2" height="2"> </canvas>
+<script>
+"use strict";
+// See http://crbug.com/1108588 for original failing case.
+// Check "OpenGL Registry The OpenGL ES Shading Language"
+// Section 3.2 Character Sets For more info
+description("This test checks character set validation for glsl.");
+
+debug("");
+debug("Canvas.getContext");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+if (!gl) {
+  testFailed("context does not exist");
+} else {
+  testPassed("context exists");
+
+  debug("");
+  debug("Checking shader character set validation and compilation");
+
+  runTest();
+}
+
+function runTest() {
+    GLSLConformanceTester.runTests([
+        {
+            fShaderId: 'fs-invalid-0',
+            fShaderSuccess: false,
+            linkSuccess: false,
+            passMsg: 'Unallowed characters detected'
+        },
+        {
+            fShaderId: 'fs-invalid-1',
+            fShaderSuccess: false,
+            linkSuccess: false,
+            passMsg: 'Unallowed characters detected'
+        },
+        {
+            fShaderId: 'fs-comment-valid',
+            fShaderSuccess: true,
+            linkSuccess: true,
+            passMsg: 'Unallowed characters and UTF-8 characters in comment are valid'
+        },
+        {
+            fShaderId: 'fs-cleared-by-preprocessing-valid',
+            fShaderSuccess: true,
+            linkSuccess: true,
+            passMsg: 'Unsupported shader extensions cleared by preprocessing step is valid'
+        },
+    ]);
+}
+
+debug("");
+var successfullyParsed = true;
+
+</script>
+<script src="../../../js/js-test-post.js"></script>
+
+</body>
+</html>
+    

--- a/sdk/tests/conformance/glsl/bugs/character-set.html
+++ b/sdk/tests/conformance/glsl/bugs/character-set.html
@@ -116,4 +116,3 @@ var successfullyParsed = true;
 
 </body>
 </html>
-    


### PR DESCRIPTION
Addressing issue reported at: https://bugs.chromium.org/p/chromium/issues/detail?id=1108588

The main issue is that WebGL should not validate shader string before preprocessing for cases like:
```
#if defined(GL_GOOGLE_cpp_style_line_directive)
#line 45 "foo.txt"
#endif
```
where " is not a valid character but should be cleared by preprocessing step thus not failing the validation and compilation.

(Check https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf Section 3.2)

Tested on Win 10 and fails in Chrome and Firefox. Passed for modified local Chromium build.