### PR TITLE
Fix object-deletion-behaviour-2 to create WebGL 2.0 context.

### DIFF
--- a/conformance-suites/2.0.0/conformance2/misc/object-deletion-behaviour-2.html
+++ b/conformance-suites/2.0.0/conformance2/misc/object-deletion-behaviour-2.html
@@ -42,9 +42,8 @@
 description("Tests deletion behavior for WebGL2 buffer, sampler, vertexArray and transformFeedback objects.");
 
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext();
+var gl = wtu.create3DContext(undefined, undefined, 2);
 var shouldGenerateGLError = wtu.shouldGenerateGLError;
-var contextVersion = wtu.getDefault3DContextVersion();
 
 debug("");
 debug("buffer deletion");


### PR DESCRIPTION
The 2.0.0 snapshot of this test was incorrectly creating a WebGL 1.0
context.