### PR TITLE
Fix integer-cubemap-specification-order-bug.html in 2.0.0 snapshot.

### DIFF
--- a/conformance-suites/2.0.0/conformance2/textures/misc/integer-cubemap-specification-order-bug.html
+++ b/conformance-suites/2.0.0/conformance2/textures/misc/integer-cubemap-specification-order-bug.html
@@ -100,7 +100,7 @@ function createTextureCube(layers, maxLevel) {
         gl.texImage2D(face + gl.TEXTURE_CUBE_MAP_POSITIVE_X, level, gl.RG8I, levelSize, levelSize, 0, gl.RG_INTEGER, gl.BYTE, new Int8Array(backingBuffer));
     });
 
-    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_LINEAR);
+    gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_NEAREST);
     gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);


### PR DESCRIPTION
Incorporate fix from #2327, which never made it into the 2.0.0
snapshot. This test was substantially rewritten on top-of-tree in #2806.
