### PR TITLE
Remove invalid RGB10_A2 tests from 2.0.0 conformance snapshot.

### DIFF
--- a/conformance-suites/2.0.0/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
+++ b/conformance-suites/2.0.0/conformance2/textures/misc/tex-image-with-bad-args-from-dom-elements.html
@@ -49,8 +49,9 @@ var gl = wtu.create3DContext("c", undefined, 2);
 var doTexImage = function(domElement) {
     var tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, domElement);
-    wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM, gl.INVALID_OPERATION], "TexImage2D taking RGB10_A2/RGBA/UNSIGNED_INT_2_10_10_10_REV should fail");
+    // The following test was invalidated in https://github.com/KhronosGroup/WebGL/pull/2386 .
+    // gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, domElement);
+    // wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM, gl.INVALID_OPERATION], "TexImage2D taking RGB10_A2/RGBA/UNSIGNED_INT_2_10_10_10_REV should fail");
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RG8, gl.RG, gl.FLOAT, domElement);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "TexImage2D taking RG8/RG/FLOAT should fail");
     gl.deleteTexture(tex);

--- a/conformance-suites/2.0.0/conformance2/textures/misc/tex-image-with-different-data-source.html
+++ b/conformance-suites/2.0.0/conformance2/textures/misc/tex-image-with-different-data-source.html
@@ -61,8 +61,9 @@ tex = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex);
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, 16, 16, 0, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, null);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Teximage2D taking a null array buffer should succeed");
-gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, c);
-wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "TexImage2D taking RGB10_A2 internalformat and a canvas source should fail");
+// The following test was invalidated in https://github.com/KhronosGroup/WebGL/pull/2386 .
+// gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2, gl.RGBA, gl.UNSIGNED_INT_2_10_10_10_REV, c);
+// wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "TexImage2D taking RGB10_A2 internalformat and a canvas source should fail");
 gl.deleteTexture(tex);
 
 var successfullyParsed = true;


### PR DESCRIPTION
These tests were invalidated in #2386. In order to allow both old and
new implementations to pass these tests, and to minimize complexity in
the 2.0.0 conformance snapshot, simply remove the now-invalid tests.