### PR TITLE
Fix function signatures in multi-draw extensions.

### DIFF
--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -94,6 +94,47 @@ interface WEBGL_multi_draw {
 
   </idl>
 
+  <newfun>
+    <function name="multiDrawArraysWEBGL" type="void">
+      <param name="mode" type="GLenum"/>
+      <param name="firstsList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
+      <param name="firstsOffset" type="GLuint"/>
+      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsOffset" type="GLuint"/>
+      <param name="drawCount" type="GLsizei"/>
+    </function>
+    <function name="multiDrawElementsWEBGL" type="void">
+      <param name="mode" type="GLenum"/>
+      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsOffset" type="GLuint"/>
+      <param name="type" type="GLenum"/>
+      <param name="offsetsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="offsetsOffset" type="GLuint"/>
+      <param name="drawCount" type="GLsizei"/>
+    </function>
+    <function name="multiDrawArraysInstancedWEBGL" type="void">
+      <param name="mode" type="GLenum"/>
+      <param name="firstsList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
+      <param name="firstsOffset" type="GLuint"/>
+      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsOffset" type="GLuint"/>
+      <param name="instanceCountsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="instanceCountsOffset" type="GLuint"/>
+      <param name="drawCount" type="GLsizei"/>
+    </function>
+    <function name="multiDrawElementsInstancedWEBGL" type="void">
+      <param name="mode" type="GLenum"/>
+      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsOffset" type="GLuint"/>
+      <param name="type" type="GLenum"/>
+      <param name="offsetsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="offsetsOffset" type="GLuint"/>
+      <param name="instanceCountsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="instanceCountsOffset" type="GLuint"/>
+      <param name="drawCount" type="GLsizei"/>
+    </function>
+  </newfun>
+
   <security>
     The multi-draw APIs are subject to all of the same rules regarding <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/#4.5">out-of-range array accesses</a> as the core WebGL APIs.
   </security>
@@ -165,6 +206,9 @@ void main() {
     </revision>
     <revision date="2020/06/26">
       <change>Implicitly enable ANGLE_instanced_arrays</change>
+    </revision>
+    <revision date="2020/07/28">
+      <change>Add new function section</change>
     </revision>
   </history>
 </draft>

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -91,20 +91,20 @@
 interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   void multiDrawArraysInstancedBaseInstanceWEBGL(
       GLenum mode,
-      Int32Array or sequence&lt;GLint&gt; firstsList, GLuint firstsOffset,
-      Int32Array or sequence&lt;GLsizei&gt; countsList, GLuint countsOffset,
-      Int32Array or sequence&lt;GLsizei&gt; instanceCountsList, GLuint instanceCountsOffset,
-      Uint32Array or sequence&lt;GLuint&gt; baseInstancesList, GLuint baseInstancesOffset,
+      (Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
+      (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      (Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      (Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
       GLsizei drawCount
   );
   void multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
       GLenum mode,
-      Int32Array or sequence&lt;GLsizei&gt; countsList, GLuint countsOffset,
+      (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       GLenum type,
-      Int32Array or sequence&lt;GLsizei&gt; offsetsList, GLuint offsetsOffset,
-      Int32Array or sequence&lt;GLsizei&gt; instanceCountsList, GLuint instanceCountsOffset,
-      Int32Array or sequence&lt;GLint&gt; baseVerticesList, GLuint baseVerticesOffset,
-      Uint32Array or sequence&lt;GLuint&gt; baseInstancesList, GLuint baseInstancesOffset,
+      (Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
+      (Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      (Int32Array or sequence&lt;GLint&gt;) baseVerticesList, GLuint baseVerticesOffset,
+      (Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
       GLsizei drawCount
   );
 };
@@ -113,26 +113,26 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   <newfun>
     <function name="multiDrawArraysInstancedBaseInstanceWEBGL" type="void">
       <param name="mode" type="GLenum"/>
-      <param name="firstsList" type="Int32Array or sequence&lt;GLint&gt;"/>
+      <param name="firstsList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
       <param name="firstsOffset" type="GLuint"/>
-      <param name="countsList" type="Int32Array or sequence&lt;GLsizei&gt;"/>
+      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
-      <param name="baseInstancesList" type="Int32Array or sequence&lt;GLsizei&gt;"/>
+      <param name="baseInstancesList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="baseInstancesOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL" type="void">
       <param name="mode" type="GLenum"/>
-      <param name="countsList" type="Int32Array or sequence&lt;GLsizei&gt;"/>
+      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
       <param name="type" type="GLenum"/>
-      <param name="offsetsList" type="Int32Array or sequence&lt;GLsizei&gt;"/>
+      <param name="offsetsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="offsetsOffset" type="GLuint"/>
-      <param name="instanceCountsList" type="Int32Array or sequence&lt;GLsizei&gt;"/>
+      <param name="instanceCountsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="instanceCountsOffset" type="GLuint"/>
-      <param name="baseVerticesList" type="Int32Array or sequence&lt;GLint&gt;"/>
+      <param name="baseVerticesList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
       <param name="baseVerticesOffset" type="GLuint"/>
-      <param name="baseInstancesList" type="Uint32Array or sequence&lt;GLuint&gt;"/>
+      <param name="baseInstancesList" type="(Uint32Array or sequence&lt;GLuint&gt;)"/>
       <param name="baseInstancesOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
@@ -205,6 +205,9 @@ void main() {
     <revision date="2020/07/14">
       <change>Change types of countsList, offsetsList, and instanceCountsList from sequence&lt;GLint&gt; to sequence&lt;GLsizei&gt;</change>
       <change>Change type of baseInstances from Int32Array to Uint32Array and sequence&lt;GLint&gt; to sequence&lt;GLuint&gt;</change>
+    </revision>
+    <revision date="2020/07/28">
+      <change>Add parentheses around union types in IDL</change>
     </revision>
   </history>
 </draft>


### PR DESCRIPTION
Add "new functions" section to WEBGL_multi_draw.

Add needed parentheses to union types in the Web IDL in
WEBGL_multi_draw_instanced_base_vertex_base_instance.