### PR TITLE
Test WebGL 2's new vertex attribute types

### DIFF
--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer-offsets.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer-offsets.html
@@ -52,12 +52,7 @@ There is supposed to be an example drawing here, but it's not important.
                 componentSize: 4,
                 normalize: false,
               },
-              { data: new Float32Array([ 0, 1, 0, 1, 0, 0, 0, 0, 0 ]),
-                type: gl.FLOAT,
-                componentSize: 4,
-                normalize: false,
-              },
-              { data: new Uint16Array([ 0, 32767, 0, 32767, 0, 0, 0, 0, 0 ]),
+              { data: new Uint16Array([ 0, 32767, 0, 32767, 0, 0, 0, 0, 0]),
                 type: gl.SHORT,
                 componentSize: 2,
                 normalize: true,
@@ -98,6 +93,41 @@ There is supposed to be an example drawing here, but it's not important.
                 normalize: false,
               }
             ];
+
+            if (wtu.getDefault3DContextVersion() >= 2) {
+              tests.push(...[
+                  { data: new Int32Array([ 0, 1, 0, 1, 0, 0, 0, 0, 0]),
+                    type: gl.INT,
+                    componentSize: 4,
+                    normalize: false,
+                  },
+                  { data: new Int32Array([ 0, 2147483647, 0, 2147483647, 0, 0, 0, 0, 0]),
+                    type: gl.INT,
+                    componentSize: 4,
+                    normalize: true,
+                  },
+                  { data: new Uint32Array([ 0, 1, 0, 1, 0, 0, 0, 0, 0]),
+                    type: gl.UNSIGNED_INT,
+                    componentSize: 4,
+                    normalize: false,
+                  },
+                  { data: new Uint32Array([ 0, 4294967295, 0, 4294967295, 0, 0, 0, 0, 0]),
+                    type: gl.UNSIGNED_INT,
+                    componentSize: 4,
+                    normalize: true,
+                  },
+                  { data: new Uint16Array([ 0, 0b11110000000000, 0, 0b11110000000000, 0, 0, 0, 0, 0]),
+                    type: gl.HALF_FLOAT,
+                    componentSize: 2,
+                    normalize: false,
+                  },
+                  { data: new Uint16Array([ 0, 0b11110000000000, 0, 0b11110000000000, 0, 0, 0, 0, 0]),
+                    type: gl.HALF_FLOAT,
+                    componentSize: 2,
+                    normalize: false,
+                  }
+                ]);
+            }
 
             var vertexObject = gl.createBuffer();
             gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);

--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
@@ -67,10 +67,10 @@ if (!gl) {
     gl.vertexAttribPointer(0, 1, gl.UNSIGNED_INT, 0, 0, 0);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
             "vertexAttribPointer should not support UNSIGNED_INT");
-    gl.vertexAttribPointer(0, 1, gl.FIXED, 0, 0, 0);
-    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
-            "vertexAttribPointer should not support FIXED");
   }
+  gl.vertexAttribPointer(0, 1, gl.FIXED, 0, 0, 0);
+  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
+          "vertexAttribPointer should not support FIXED");
 
   var checkVertexAttribPointer = function(
       gl, err, reason, size, type, normalize, stride, offset) {
@@ -100,6 +100,16 @@ if (!gl) {
     { type:gl.FLOAT,          bytesPerComponent: 4 },
   ];
 
+  if (wtu.getDefault3DContextVersion() >= 2) {
+    types.push(...[
+        { type:gl.INT,                         bytesPerComponent: 4 },
+        { type:gl.UNSIGNED_INT,                bytesPerComponent: 4 },
+        { type:gl.HALF_FLOAT,                  bytesPerComponent: 2 },
+        { type:gl.INT_2_10_10_10_REV,          bytesPerComponent: 4, minSize: 4 },
+        { type:gl.UNSIGNED_INT_2_10_10_10_REV, bytesPerComponent: 4, minSize: 4 },
+      ]);
+  }
+
   for (var ii = 0; ii < types.length; ++ii) {
     var info = types[ii];
     debug("");
@@ -128,6 +138,10 @@ if (!gl) {
             reason = "because stride is bad";
             err = gl.INVALID_OPERATION;
           }
+          if (size < info.minSize) {
+            reason = "because size < minSize";
+            err = gl.INVALID_OPERATION;
+          }
           checkVertexAttribPointer(
               gl, err, reason, size, info.type, false, stride, offset);
         }
@@ -135,10 +149,10 @@ if (!gl) {
 
         if (offset == 0) {
           checkVertexAttribPointer(
-              gl, gl.NO_ERROR, "at stride limit",
+              gl, size < info.minSize ? gl.INVALID_OPERATION : gl.NO_ERROR, "at stride limit",
               size, info.type, false, stride, offset);
           checkVertexAttribPointer(
-              gl, gl.INVALID_VALUE, "over stride limit",
+              gl, size < info.minSize ? gl.INVALID_OPERATION : gl.INVALID_VALUE, "over stride limit",
               size, info.type, false,
               stride + info.bytesPerComponent, offset);
         }


### PR DESCRIPTION
INT, UNSIGNED_INT, HALF_FLOAT, INT_2_10_10_10_REV, and UNSIGNED_INT_2_10_10_10_REV.

Also test that FIXED is not supported in WebGL 2, as the restriction from WebGL 1 was not lifted. Firefox seems to currently support FIXED in WebGL 2.

