### PR TITLE
Specialize EXT_texture_norm16 to WebGL 2.0.

### DIFF
--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -13,7 +13,7 @@
   <number>44</number>
 
   <depends>
-    <api version="1.0"/>
+    <api version="2.0"/>
   </depends>
 
   <overview>
@@ -72,6 +72,11 @@ interface EXT_texture_norm16 {
     </revision>
     <revision date="2019/09/25">
       <change>Promoted to Draft.</change>
+    </revision>
+    <revision date="2020/08/10">
+      <change>Specialized to WebGL 2.0 after WG agreement, since this
+      extension refers to sized internal formats unavailable in WebGL
+      1.0.</change>
     </revision>
   </history>
 </draft>

--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -23,7 +23,7 @@ description("This test verifies the functionality of the EXT_texture_norm16 exte
 debug("");
 
 var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext();
+var gl = wtu.create3DContext(null, null, 2);
 var ext;
 
 var formats = null;
@@ -138,6 +138,21 @@ function testNorm16Render(interalFormat, format, type, tolerance) {
   gl.bindTexture(gl.TEXTURE_2D, null);
 }
 
+function testSnorm16Unrenderable(internalFormat, format, type) {
+  gl.bindTexture(gl.TEXTURE_2D, textures[1]);
+  gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 1, 1, 0, format, type, null);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture definition succeeded");
+
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fbos[0]);
+  gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, textures[1], 0);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fbo binding succeeded");
+
+  wtu.framebufferStatusShouldBe(gl, gl.FRAMEBUFFER, [ gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT, gl.FRAMEBUFFER_UNSUPPORTED ],
+                                "framebuffer should not be complete with SNORM16 texture attached");
+}
+
 function runTestExtension() {
   textures = [gl.createTexture(), gl.createTexture()];
   fbos = [gl.createFramebuffer(), gl.createFramebuffer()];
@@ -174,6 +189,11 @@ function runTestExtension() {
   testNorm16Render(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT, 0);
   testNorm16Render(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT, 0);
   testNorm16Render(ext.RGBA16_EXT, gl.RGBA, gl.UNSIGNED_SHORT, 0);
+
+  testSnorm16Unrenderable(ext.R16_SNORM_EXT, gl.RED, gl.SHORT);
+  testSnorm16Unrenderable(ext.RG16_SNORM_EXT, gl.RG, gl.SHORT);
+  testSnorm16Unrenderable(ext.RGB16_SNORM_EXT, gl.RGB, gl.SHORT);
+  testSnorm16Unrenderable(ext.RGBA16_SNORM_EXT, gl.RGBA, gl.SHORT);
 };
 
 function runTest() {


### PR DESCRIPTION
Revise conformance2/extensions/ext-texture-norm16.html to mandate that
16-bit signed normalized textures are not color renderable. That
functionality is covered under EXT_render_snorm, not currently exposed
to WebGL.

Partially addresses #3114.