### PR TITLE
Support WebKit's MiniBrowser in webglHarnessCollectGarbage().

### DIFF
--- a/conformance-suites/2.0.0/js/js-test-pre.js
+++ b/conformance-suites/2.0.0/js/js-test-pre.js
@@ -708,6 +708,14 @@ function webglHarnessCollectGarbage() {
         return;
     }
 
+    // WebKit's MiniBrowser with the following environment variables set:
+    //   export JSC_useDollarVM=1
+    //   export __XPC_JSC_useDollarVM=1
+    if (window.$vm) {
+        window.$vm.gc();
+        return;
+    }
+
     function gcRec(n) {
         if (n < 1)
             return {};

--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -737,6 +737,14 @@ function webglHarnessCollectGarbage() {
         return;
     }
 
+    // WebKit's MiniBrowser with the following environment variables set:
+    //   export JSC_useDollarVM=1
+    //   export __XPC_JSC_useDollarVM=1
+    if (window.$vm) {
+        window.$vm.gc();
+        return;
+    }
+
     function gcRec(n) {
         if (n < 1)
             return {};


### PR DESCRIPTION
This allows the expando-loss.html and expando-loss-2.html tests to be
run correctly in the MiniBrowser with the following two environment
variables set:
  export JSC_useDollarVM=1
  export __XPC_JSC_useDollarVM=1

Thanks to Yusuke Suzuki from Apple for this tip.