### PR TITLE
Promote EXT_texture_norm16 to community approved

### DIFF
--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_texture_norm16/">
+<extension href="EXT_texture_norm16/">
   <name>EXT_texture_norm16</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -78,5 +78,8 @@ interface EXT_texture_norm16 {
       extension refers to sized internal formats unavailable in WebGL
       1.0.</change>
     </revision>
+    <revision date="2020/08/13">
+      <change>Promoted to Community Approved.</change>
+    </revision>
   </history>
-</draft>
+</extension>


### PR DESCRIPTION
Per discussion at WebGL WG on Aug 13 2020.

We still need to expand conformance test to test uploading DOM elements / ImageBitmaps / etc.