### PR TITLE
Add test for GL error during resize

### DIFF
--- a/sdk/tests/conformance/canvas/render-after-resize-test.html
+++ b/sdk/tests/conformance/canvas/render-after-resize-test.html
@@ -60,6 +60,19 @@ wtu.drawUnitQuad(gl);
 
 wtu.checkCanvasRect(gl, 0, 0, 1, 1, [ 0, 255, 0, 255 ]);
 
+debug('\nCause a GL error, then resize and render.');
+gl.depthFunc(0); // Causes INVALID_ENUM
+gl.canvas.width = gl.canvas.height = LARGE;
+gl.clear(gl.COLOR_BUFFER_BIT);
+gl.canvas.width = gl.canvas.height = SMALL;
+
+gl.clear(gl.COLOR_BUFFER_BIT);
+wtu.drawUnitQuad(gl);
+
+wtu.checkCanvasRect(gl, 0, 0, 1, 1, [ 0, 255, 0, 255 ]);
+wtu.glErrorShouldBe(gl, gl.INVALID_ENUM);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
 // -
 
 debug('\nRender, no-op resize, then depth-fail render.');


### PR DESCRIPTION
Tests for a WebKit bug that lost the context if there was an existing GL error in the context during a resize.