### PR TITLE
Support EXT_color_buffer_half_float in WebGL 2.0 contexts.

### DIFF
--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -16,44 +16,55 @@
   <depends>
     <api version="1.0"/>
 
-    <ext name="OES_texture_half_float" require="true"/>
-
-    <subsumed version="2.0" by="EXT_color_buffer_float" />
+    <ext name="OES_texture_half_float" require="webgl1"/>
   </depends>
 
   <overview>
     <mirrors href="http://www.khronos.org/registry/gles/extensions/EXT/EXT_color_buffer_half_float.txt"
              name="EXT_color_buffer_half_float">
       <addendum>
-        <p>All references to <code>R16F</code> and <code>RG16F</code> types
-        are ignored.</p>
+        <p>In WebGL 1.0 contexts, references to the <code>R16F</code> and
+        <code>RG16F</code> types are ignored.</p>
       </addendum>
       <addendum>
 	<p>WebGL implementations supporting this extension are required to
-	support rendering to <code>RGBA16F</code> format.</p>
+	support rendering to the <code>RGBA16F</code> format.</p>
       </addendum>
     </mirrors>
 
     <features>
       <feature>
-        <p>The 16-bit floating-point types <code>RGB16F</code> and
-        <code>RGBA16F</code> become available as color-renderable formats.
-        Renderbuffers can be created in these formats. These and textures
-        created with <code>type = HALF_FLOAT_OES</code>, which will have one
-        of these internal formats, can be attached to framebuffer object color
-        attachments for rendering. Implementations supporting this extension are
-	required to support rendering to <code>RGBA16F</code> format.
-	Applications must check framebuffer completeness to determine if
-	<code>RGB16F</code> is supported.</p>
+        <p><b>In WebGL 1.0 contexts</b>, the 16-bit floating-point types
+        <code>RGB16F</code> and <code>RGBA16F</code> become available as
+        color-renderable formats.  Renderbuffers can be created in these
+        formats. These and textures created with <code>type =
+        HALF_FLOAT_OES</code>, which will have one of these internal formats,
+        can be attached to framebuffer object color attachments for
+        rendering. Implementations supporting this extension are required to
+        support rendering to the <code>RGBA16F</code> format.  Applications must
+        check framebuffer completeness to determine if <code>RGB16F</code> is
+        supported.</p>
       </feature>
 
       <feature>
-        <p><span style="color: red">NOTE:</span> fragment shaders outputs
-        gl_FragColor and gl_FragData[0] will only be clamped and converted
-        when the color buffer is fixed-point and <code>blendColor()</code> and
-        <code>clearColor()</code> will no longer clamp their parameter values
-        on input. Clamping will be applied as necessary at draw time according
-        to the type of color buffer in use.</p>
+        <p><b>In WebGL 2.0 contexts</b>, the 16-bit floating-point types
+        <code>RGBA16F,</code>, <code>RG16F</code> and <code>R16F</code> become
+        available as color-renderable formats.  Renderbuffers can be created in
+        these formats. These and textures created with <code>type =
+        HALF_FLOAT</code>, which will have one of these internal formats, can be
+        attached to framebuffer object color attachments for rendering.
+        Implementations supporting this extension are required to support
+        rendering to <code>RGBA16F</code> format. The <code>RGB16F</code> format
+        is not color-renderable.</p>
+      </feature>
+
+      <feature>
+        <p><span style="color: red">NOTE:</span> fragment shaders' outputs
+        gl_FragColor and gl_FragData[0] will only be clamped and converted when
+        the color buffer is fixed-point, and <code>blendColor()</code> and
+        <code>clearColor()</code> will no longer clamp their parameter values on
+        input. Clamping will be applied as necessary at draw time according to
+        the type of color buffer in use.</p>
       </feature>
 
       <feature>
@@ -150,6 +161,12 @@ interface EXT_color_buffer_half_float {
 
     <revision date="2017/09/14">
       <change>Require RGBA16F to be color-renderable and RGB16F to be optionally color-renderable.</change>
+    </revision>
+
+    <revision date="2020/08/31">
+      <change>Expose to WebGL 2.0 contexts to support devices which can render
+      only to 16-bit floating point targets, and therefore can not support
+      EXT_color_buffer_float.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -234,6 +234,12 @@
 	<xsl:when test="@require='true'">
 	  <p> Implementations must also support the <xsl:apply-templates select="."/> extension. </p>
 	</xsl:when>
+	<xsl:when test="@require='webgl1'">
+	  <p> In WebGL 1.0 contexts, implementations must also support the <xsl:apply-templates select="."/> extension. </p>
+	</xsl:when>
+	<xsl:when test="@require='webgl2'">
+	  <p> In WebGL 2.0 contexts, implementations must also support the <xsl:apply-templates select="."/> extension. </p>
+	</xsl:when>
 	<xsl:otherwise>
 	  <p> Written against the <xsl:apply-templates select="."/> specification. </p>
 	</xsl:otherwise>


### PR DESCRIPTION
Allows floating-point rendering in WebGL 2.0 on devices that only have
16-bit-per-channel floating point render targets (iOS, specifically),
so which can not support EXT_color_buffer_float.

Closes #3093.