### PR TITLE
Add [Exposed] extended attribute to extensions

### DIFF
--- a/extensions/ANGLE_instanced_arrays/extension.xml
+++ b/extensions/ANGLE_instanced_arrays/extension.xml
@@ -27,12 +27,12 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface ANGLE_instanced_arrays {
     const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
     void drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
     void drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
-    void vertexAttribDivisorANGLE(GLuint index, GLuint divisor); 
+    void vertexAttribDivisorANGLE(GLuint index, GLuint divisor);
 };
   </idl>
   <issues>

--- a/extensions/EXT_blend_minmax/extension.xml
+++ b/extensions/EXT_blend_minmax/extension.xml
@@ -31,7 +31,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_blend_minmax {
   const GLenum MIN_EXT = 0x8007;
   const GLenum MAX_EXT = 0x8008;

--- a/extensions/EXT_clip_cull_distance/extension.xml
+++ b/extensions/EXT_clip_cull_distance/extension.xml
@@ -41,7 +41,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface EXT_clip_cull_distance {
       const GLenum MAX_CLIP_DISTANCES_EXT                       = 0x0D32;
       const GLenum MAX_CULL_DISTANCES_EXT                       = 0x82F9;

--- a/extensions/EXT_color_buffer_float/extension.xml
+++ b/extensions/EXT_color_buffer_float/extension.xml
@@ -72,7 +72,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_color_buffer_float {
 }; // interface EXT_color_buffer_float
 </idl>

--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -83,7 +83,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_color_buffer_half_float {
   const GLenum RGBA16F_EXT = 0x881A;
   const GLenum RGB16F_EXT = 0x881B;

--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -48,11 +48,11 @@
   <idl xml:space="preserve">
 typedef unsigned long long GLuint64EXT;
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WebGLTimerQueryEXT : WebGLObject {
 };
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_disjoint_timer_query {
   const GLenum QUERY_COUNTER_BITS_EXT      = 0x8864;
   const GLenum CURRENT_QUERY_EXT           = 0x8865;

--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -42,7 +42,7 @@
   <idl xml:space="preserve">
 typedef unsigned long long GLuint64EXT;
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_disjoint_timer_query_webgl2 {
   const GLenum QUERY_COUNTER_BITS_EXT      = 0x8864;
   const GLenum TIME_ELAPSED_EXT            = 0x88BF;
@@ -89,7 +89,7 @@ interface EXT_disjoint_timer_query_webgl2 {
       <tr><td>TIMESTAMP_EXT</td><td>CURRENT_QUERY</td><td>null</td></tr>
       <tr><td>TIME_ELAPSED_EXT</td><td>QUERY_COUNTER_BITS_EXT</td><td>GLint</td></tr>
       <tr><td>TIMESTAMP_EXT</td><td>QUERY_COUNTER_BITS_EXT</td><td>GLint</td></tr>
-      </table>      
+      </table>
     </function>
   </newtok>
 
@@ -104,7 +104,7 @@ interface EXT_disjoint_timer_query_webgl2 {
       <tr><th>pname</th><th>returned type</th></tr>
       <tr><td>TIMESTAMP_EXT</td><td>GLuint64EXT</td></tr>
       <tr><td>GPU_DISJOINT_EXT</td><td>boolean</td></tr>
-      </table>      
+      </table>
     </function>
   </newtok>
 

--- a/extensions/EXT_float_blend/extension.xml
+++ b/extensions/EXT_float_blend/extension.xml
@@ -52,7 +52,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_float_blend {
 }; // interface EXT_float_blend
 </idl>

--- a/extensions/EXT_frag_depth/extension.xml
+++ b/extensions/EXT_frag_depth/extension.xml
@@ -34,9 +34,9 @@
       </glsl>
     </features>
   </overview>
-  
+
   <idl xml:space="preserve">
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface EXT_frag_depth {
     };
   </idl>

--- a/extensions/EXT_sRGB/extension.xml
+++ b/extensions/EXT_sRGB/extension.xml
@@ -32,7 +32,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface EXT_sRGB {
       const GLenum SRGB_EXT                                     = 0x8C40;
       const GLenum SRGB_ALPHA_EXT                               = 0x8C42;

--- a/extensions/EXT_shader_texture_lod/extension.xml
+++ b/extensions/EXT_shader_texture_lod/extension.xml
@@ -79,9 +79,9 @@
       </glsl>
     </features>
   </overview>
-  
+
   <idl xml:space="preserve">
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface EXT_shader_texture_lod {
     };
   </idl>

--- a/extensions/EXT_texture_compression_bptc/extension.xml
+++ b/extensions/EXT_texture_compression_bptc/extension.xml
@@ -75,7 +75,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_texture_compression_bptc {
     const GLenum COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8E8C;
     const GLenum COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT = 0x8E8D;

--- a/extensions/EXT_texture_compression_bptc/extension.xml
+++ b/extensions/EXT_texture_compression_bptc/extension.xml
@@ -75,7 +75,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_texture_compression_bptc {
     const GLenum COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8E8C;
     const GLenum COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT = 0x8E8D;

--- a/extensions/EXT_texture_compression_rgtc/extension.xml
+++ b/extensions/EXT_texture_compression_rgtc/extension.xml
@@ -79,7 +79,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_texture_compression_rgtc {
     const GLenum COMPRESSED_RED_RGTC1_EXT = 0x8DBB;
     const GLenum COMPRESSED_SIGNED_RED_RGTC1_EXT = 0x8DBC;

--- a/extensions/EXT_texture_compression_rgtc/extension.xml
+++ b/extensions/EXT_texture_compression_rgtc/extension.xml
@@ -79,7 +79,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_texture_compression_rgtc {
     const GLenum COMPRESSED_RED_RGTC1_EXT = 0x8DBB;
     const GLenum COMPRESSED_SIGNED_RED_RGTC1_EXT = 0x8DBC;

--- a/extensions/EXT_texture_filter_anisotropic/extension.xml
+++ b/extensions/EXT_texture_filter_anisotropic/extension.xml
@@ -26,7 +26,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_texture_filter_anisotropic {
   const GLenum TEXTURE_MAX_ANISOTROPY_EXT       = 0x84FE;
   const GLenum MAX_TEXTURE_MAX_ANISOTROPY_EXT   = 0x84FF;

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -53,7 +53,7 @@
 
   <idl xml:space="preserve">
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface EXT_texture_norm16 {
   const GLenum R16_EXT = 0x822A;
   const GLenum RG16_EXT = 0x822C;

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -53,7 +53,7 @@
 
   <idl xml:space="preserve">
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface EXT_texture_norm16 {
   const GLenum R16_EXT = 0x822A;
   const GLenum RG16_EXT = 0x822C;

--- a/extensions/KHR_parallel_shader_compile/extension.xml
+++ b/extensions/KHR_parallel_shader_compile/extension.xml
@@ -43,7 +43,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface KHR_parallel_shader_compile {
       const GLenum COMPLETION_STATUS_KHR                = 0x91B1;
     };

--- a/extensions/KHR_parallel_shader_compile/extension.xml
+++ b/extensions/KHR_parallel_shader_compile/extension.xml
@@ -43,7 +43,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [NoInterfaceObject]
+    [LegacyNoInterfaceObject]
     interface KHR_parallel_shader_compile {
       const GLenum COMPLETION_STATUS_KHR                = 0x91B1;
     };

--- a/extensions/OES_draw_buffers_indexed/extension.xml
+++ b/extensions/OES_draw_buffers_indexed/extension.xml
@@ -39,7 +39,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OES_draw_buffers_indexed {
   void enableiOES(GLenum target, GLuint index);
 

--- a/extensions/OES_draw_buffers_indexed/extension.xml
+++ b/extensions/OES_draw_buffers_indexed/extension.xml
@@ -39,7 +39,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_draw_buffers_indexed {
   void enableiOES(GLenum target, GLuint index);
 

--- a/extensions/OES_element_index_uint/extension.xml
+++ b/extensions/OES_element_index_uint/extension.xml
@@ -23,7 +23,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_element_index_uint {
 };
   </idl>

--- a/extensions/OES_fbo_render_mipmap/extension.xml
+++ b/extensions/OES_fbo_render_mipmap/extension.xml
@@ -30,7 +30,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_fbo_render_mipmap {
 };
   </idl>

--- a/extensions/OES_standard_derivatives/extension.xml
+++ b/extensions/OES_standard_derivatives/extension.xml
@@ -37,7 +37,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_standard_derivatives {
     const GLenum FRAGMENT_SHADER_DERIVATIVE_HINT_OES = 0x8B8B;
 };

--- a/extensions/OES_texture_float/extension.xml
+++ b/extensions/OES_texture_float/extension.xml
@@ -44,7 +44,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_texture_float { }; </idl>
 
   <history>

--- a/extensions/OES_texture_float_linear/extension.xml
+++ b/extensions/OES_texture_float_linear/extension.xml
@@ -28,7 +28,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_texture_float_linear { };</idl>
 
   <history>

--- a/extensions/OES_texture_half_float/extension.xml
+++ b/extensions/OES_texture_half_float/extension.xml
@@ -44,7 +44,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_texture_half_float {
   const GLenum HALF_FLOAT_OES = 0x8D61;
 };

--- a/extensions/OES_texture_half_float_linear/extension.xml
+++ b/extensions/OES_texture_half_float_linear/extension.xml
@@ -29,7 +29,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_texture_half_float_linear { };</idl>
 
   <history>

--- a/extensions/OES_vertex_array_object/extension.xml
+++ b/extensions/OES_vertex_array_object/extension.xml
@@ -17,11 +17,11 @@
     <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_vertex_array_object.txt" name="OES_vertex_array_object" />
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WebGLVertexArrayObjectOES : WebGLObject {
 };
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_vertex_array_object {
     const GLenum VERTEX_ARRAY_BINDING_OES = 0x85B5;
 
@@ -78,11 +78,11 @@ interface OES_vertex_array_object {
       <li>
         <p>RESOLVED: Buffers should be reference counted when attached to
         a vertex array object. This is consistent with the OpenGL ES 3.0
-        spec's implementation of Vertex Array Objects and matches the 
+        spec's implementation of Vertex Array Objects and matches the
         behavior of other WebGL objects, such as textures that are attached
         to framebuffers.
         </p>
-        <p>This will require that most implementations do not call 
+        <p>This will require that most implementations do not call
         glDeleteBuffer when the user calls deleteBuffer on the WebGL context.
         Instead the implementation must wait for all references to be released
         before calling glDeleteBuffer to prevent undefined behavior.
@@ -91,7 +91,7 @@ interface OES_vertex_array_object {
         bound vertex array object, then it is as if BindBuffer had been called,
         with a buffer of 0, for each target to which this buffer was attached
         in the currently bound vertex array object. In other words, this buffer
-        is ﬁrst detached from all attachment points in the currently bound 
+        is ﬁrst detached from all attachment points in the currently bound
         vertex array object. Note that the buffer is speciﬁcally not detached
         from any other vertex array object. Detaching the buffer from any other
         vertex array objects is the responsibility of the application.

--- a/extensions/OVR_multiview2/extension.xml
+++ b/extensions/OVR_multiview2/extension.xml
@@ -71,7 +71,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OVR_multiview2 {
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630;
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632;

--- a/extensions/OVR_multiview2/extension.xml
+++ b/extensions/OVR_multiview2/extension.xml
@@ -71,7 +71,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface OVR_multiview2 {
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630;
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632;

--- a/extensions/WEBGL_blend_equation_advanced_coherent/extension.xml
+++ b/extensions/WEBGL_blend_equation_advanced_coherent/extension.xml
@@ -4,7 +4,7 @@
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
-  
+
   <contributors>
 	<contributor>Ashley Gullen (ashley at scirra dot com)</contributor>
     <contributor>Members of the WebGL working group</contributor>
@@ -20,12 +20,12 @@
     <mirrors href="https://www.opengl.org/registry/specs/KHR/blend_equation_advanced.txt"
              name="KHR_blend_equation_advanced_coherent">
     </mirrors>
-	
+
     <div class="nonnormative">
       <p>This extension exposes the KHR_blend_equation_advanced_coherent functionality to WebGL.</p>
 
       <p>CanvasRenderingContext2D provides a series of common blend functions with globalCompositeOperation, such as "multiply" and "screen". KHR_blend_equation_advanced_coherent provides, with the exception of "xor", exactly the same list of blend functions for WebGL, as detailed below:</p>
-	  
+
 	  <ul>
 		<li>"multiply": MULTIPLY_KHR</li>
 		<li>"screen": SCREEN_KHR</li>
@@ -43,9 +43,9 @@
 		<li>"color": HSL_COLOR_KHR</li>
 		<li>"luminosity": HSL_LUMINOSITY_KHR</li>
 	  </ul>
-	  
+
 	  <p>These effects are useful for high-quality artistic blends. They can be implemented using shaders and rendering via an intermediate texture. However this has a high performance overhead both in draw calls and GPU bandwidth. Advanced blend modes allow a much simpler, high-performance way of implementing these blends. Using shaders rendering to an intermediate texture can be used as a fallback if this extension is not supported.</p>
-	  
+
 	  <p>Note only the coherent variant of this extension is exposed in order to eliminate the possibility of undefined behavior in KHR_blend_equation_advanced. This also simplifies the extension and removes the need to insert blend barriers during rendering.</p>
     </div>
 
@@ -55,7 +55,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_blend_equation_advanced_coherent  {
   const GLenum MULTIPLY       = 0x9294;
   const GLenum SCREEN         = 0x9295;
@@ -105,23 +105,23 @@ gl.getParameter(gl.BLEND_EQUATION) == ext.MULTIPLY;
   <issues/>
 
   <history>
-  
+
     <revision date="2019/09/25">
       <change>Moved to draft after WebGL F2F of September 2019</change>
     </revision>
-	
+
     <revision date="2018/09/13">
       <change>Forked from WEBGL_blend_equation_advanced to specify only the coherent variant</change>
     </revision>
-	
+
     <revision date="2018/08/23">
       <change>Converted to extension XML format</change>
     </revision>
-	
+
 	<revision date="2018/08/21">
       <change>Revised description</change>
     </revision>
-	
+
 	<revision date="2015/05/26">
       <change>Original draft as a TXT file</change>
     </revision>

--- a/extensions/WEBGL_blend_equation_advanced_coherent/extension.xml
+++ b/extensions/WEBGL_blend_equation_advanced_coherent/extension.xml
@@ -55,7 +55,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_blend_equation_advanced_coherent  {
   const GLenum MULTIPLY       = 0x9294;
   const GLenum SCREEN         = 0x9295;

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -73,7 +73,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_color_buffer_float {
   const GLenum RGBA32F_EXT = 0x8814;
   const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;

--- a/extensions/WEBGL_compressed_texture_astc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_astc/extension.xml
@@ -15,7 +15,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture format defined in the 
+      This extension exposes the compressed texture format defined in the
       <a href="https://www.opengl.org/registry/specs/KHR/texture_compression_astc_hdr.txt">
       KHR_texture_compression_astc_hdr</a> OpenGL ES extension to WebGL. Consult that extension
       specification for behavioral definitions, including error behaviors.
@@ -70,7 +70,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -87,7 +87,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -104,7 +104,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -121,7 +121,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -138,7 +138,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -155,7 +155,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -172,7 +172,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -189,7 +189,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -206,7 +206,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -223,7 +223,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -240,7 +240,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -257,7 +257,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -274,7 +274,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -291,7 +291,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -304,7 +304,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_astc {
     /* Compressed Texture Format */
     const GLenum COMPRESSED_RGBA_ASTC_4x4_KHR = 0x93B0;
@@ -392,7 +392,7 @@ interface WEBGL_compressed_texture_astc {
       <code>COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR</code>
       <br/>
     </function>
-    
+
     <function name="compressedTexSubImage2D">
       <param name="internalformat" type="GLenum"/>
       Accepted by the <code>internalformat</code> parameter:
@@ -431,7 +431,7 @@ interface WEBGL_compressed_texture_astc {
   <errors>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_4x4_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -440,7 +440,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_5x4_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -449,7 +449,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_5x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -458,7 +458,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_6x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -467,7 +467,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_6x6_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -476,7 +476,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_8x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -485,7 +485,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_8x6_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -494,7 +494,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_8x8_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -503,7 +503,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -512,7 +512,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x6_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -521,7 +521,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x8_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -530,7 +530,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x10_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -539,7 +539,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_12x10_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -548,7 +548,7 @@ interface WEBGL_compressed_texture_astc {
      </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_12x12_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>

--- a/extensions/WEBGL_compressed_texture_etc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_etc/extension.xml
@@ -92,7 +92,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_etc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_R11_EAC                        = 0x9270;
@@ -107,7 +107,7 @@ interface WEBGL_compressed_texture_etc {
     const GLenum COMPRESSED_SRGB8_ALPHA8_ETC2_EAC          = 0x9279;
 };
   </idl>
-  
+
   <newtok>
     <function name="compressedTexImage2D">
       <param name="internalformat" type="GLenum"/>
@@ -124,7 +124,7 @@ interface WEBGL_compressed_texture_etc {
       <code>COMPRESSED_SRGB8_ALPHA8_ETC2_EAC</code>
       <br/>
     </function>
-    
+
     <function name="compressedTexSubImage2D">
       <param name="internalformat" type="GLenum"/>
       Accepted by the <code>internalformat</code> parameter:

--- a/extensions/WEBGL_compressed_texture_etc1/extension.xml
+++ b/extensions/WEBGL_compressed_texture_etc1/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture format defined in the 
+      This extension exposes the compressed texture format defined in the
       <a href="http://www.khronos.org/registry/gles/extensions/OES/OES_compressed_ETC1_RGB8_texture.txt">
       OES_compressed_ETC1_RGB8_texture</a> OpenGL ES extension to WebGL.
     </p>
@@ -59,10 +59,10 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_etc1 {
     /* Compressed Texture Format */
-    const GLenum COMPRESSED_RGB_ETC1_WEBGL = 0x8D64; 
+    const GLenum COMPRESSED_RGB_ETC1_WEBGL = 0x8D64;
 };
   </idl>
   <history>

--- a/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture formats defined in the 
+      This extension exposes the compressed texture formats defined in the
       <a href="http://www.khronos.org/registry/gles/extensions/IMG/IMG_texture_compression_pvrtc.txt">
       IMG_texture_compression_pvrtc</a> OpenGL extension to WebGL.
     </p>
@@ -74,7 +74,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_pvrtc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_PVRTC_4BPPV1_IMG      = 0x8C00;

--- a/extensions/WEBGL_compressed_texture_s3tc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_s3tc/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture formats defined in the 
+      This extension exposes the compressed texture formats defined in the
       <a href="http://www.opengl.org/registry/specs/EXT/texture_compression_s3tc.txt">
       EXT_texture_compression_s3tc</a> OpenGL extension to WebGL.
     </p>
@@ -100,7 +100,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_s3tc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_S3TC_DXT1_EXT        = 0x83F0;
@@ -126,7 +126,7 @@ interface WEBGL_compressed_texture_s3tc {
       <change>Added NoInterfaceObject extended attribute.</change>
     </revision>
     <revision date="2019/10/24">
-      <change>Added a note about <code>COMPRESSED_RGB_S3TC_DXT1_EXT</code> support.</change> 
+      <change>Added a note about <code>COMPRESSED_RGB_S3TC_DXT1_EXT</code> support.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_compressed_texture_s3tc_srgb/extension.xml
+++ b/extensions/WEBGL_compressed_texture_s3tc_srgb/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the sRGB compressed texture formats defined in the 
+      This extension exposes the sRGB compressed texture formats defined in the
       <a href="https://www.opengl.org/registry/specs/EXT/texture_sRGB.txt">
       EXT_texture_sRGB</a> OpenGL extension to WebGL.
     </p>
@@ -100,7 +100,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_s3tc_srgb {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_SRGB_S3TC_DXT1_EXT        = 0x8C4C;

--- a/extensions/WEBGL_debug_renderer_info/extension.xml
+++ b/extensions/WEBGL_debug_renderer_info/extension.xml
@@ -14,7 +14,7 @@
     <p>WebGL implementations might mask the <code>RENDERER</code> and <code>VENDOR</code> strings of the underlying graphics driver for privacy reasons. This extension exposes new tokens to query this information in a guaranteed manner for debugging purposes.</p>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_debug_renderer_info {
 
       const GLenum UNMASKED_VENDOR_WEBGL            = 0x9245;

--- a/extensions/WEBGL_debug_shaders/extension.xml
+++ b/extensions/WEBGL_debug_shaders/extension.xml
@@ -16,7 +16,7 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_debug_shaders {
 
       DOMString getTranslatedShaderSource(WebGLShader shader);

--- a/extensions/WEBGL_depth_texture/extension.xml
+++ b/extensions/WEBGL_depth_texture/extension.xml
@@ -125,7 +125,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_depth_texture {
   const GLenum UNSIGNED_INT_24_8_WEBGL = 0x84FA;
 };

--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -100,7 +100,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_draw_buffers {
     const GLenum COLOR_ATTACHMENT0_WEBGL     = 0x8CE0;
     const GLenum COLOR_ATTACHMENT1_WEBGL     = 0x8CE1;

--- a/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
@@ -43,7 +43,7 @@
         extension must be enabled with the
         <code>#extension GL_ANGLE_base_vertex_base_instance</code> directive, as shown in the
         sample code, to use the extension in a shader.
-        
+
         Likewise the shading language preprocessor
         <code>#define GL_ANGLE_base_vertex_base_instance</code> will be defined to 1 if the
         extension is supported.
@@ -100,7 +100,7 @@
 
   <idl xml:space="preserve">
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_draw_instanced_base_vertex_base_instance {
   void drawArraysInstancedBaseInstanceWEBGL(
       GLenum mode, GLint first, GLsizei count,

--- a/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
@@ -100,7 +100,7 @@
 
   <idl xml:space="preserve">
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_draw_instanced_base_vertex_base_instance {
   void drawArraysInstancedBaseInstanceWEBGL(
       GLenum mode, GLint first, GLsizei count,

--- a/extensions/WEBGL_lose_context/extension.xml
+++ b/extensions/WEBGL_lose_context/extension.xml
@@ -29,7 +29,7 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_lose_context {
       void loseContext();
       void restoreContext();

--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -45,7 +45,7 @@
       <feature>The <code>multiDrawArraysWEBGL</code>, <code>multiDrawElementsWEBGL</code>, <code>multiDrawArraysInstancedWEBGL</code>, and <code>multiDrawElementsInstancedWEBGL</code> entry points are added. These provide a counterpoint to instanced rendering and are more flexible for certain scenarios. They behave identically to multiple calls to <code>drawArrays</code>, <code>drawElements</code>, <code>drawArraysInstanced</code>, and <code>drawElementsInstanced</code> except they handle multiple lists of arguments in one call.</feature>
 
       <feature>The <code>gl_DrawID</code> builtin is added to the shading language. For any Multi* draw call variant, the index of the draw <code>i</code> may be read by the vertex shader as <code>gl_DrawID</code>. For non Multi* calls, the value of gl_DrawID is 0.</feature>
-      
+
       <feature>
         When this extension is enabled, the
         following extensions are enabled implicitly:
@@ -54,7 +54,7 @@
           ANGLE_instanced_arrays</a></li>
         </ul>
       </feature>
-      
+
       <glsl extname="GL_ANGLE_multi_draw">
         <stage type="vertex"/>
         <input name="gl_DrawID" type="int" />
@@ -64,7 +64,7 @@
 
   <idl xml:space="preserve">
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_multi_draw {
   void multiDrawArraysWEBGL(
       GLenum mode,

--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -64,7 +64,7 @@
 
   <idl xml:space="preserve">
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_multi_draw {
   void multiDrawArraysWEBGL(
       GLenum mode,

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -87,7 +87,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   void multiDrawArraysInstancedBaseInstanceWEBGL(
       GLenum mode,

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -87,7 +87,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   void multiDrawArraysInstancedBaseInstanceWEBGL(
       GLenum mode,

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -71,7 +71,7 @@
       <xsl:call-template name="logo" />
 
       <h1><xsl:value-of select="$title" /></h1>
-      
+
       <xsl:if test="$spec_status='proposal'">
       <p><strong>DO NOT IMPLEMENT!!!</strong></p>
       </xsl:if>
@@ -188,7 +188,7 @@
     </body>
   </html>
 </xsl:template>
-  
+
 <xsl:template name="logo">
   <xsl:comment>begin-logo</xsl:comment>
   <div class="left">
@@ -417,7 +417,7 @@
 <xsl:template match="interface" mode="newfun">
   <dt class="idl-code">
 	<xsl:if test="@noobject = 'true'">
-	  <xsl:text>[LegacyNoInterfaceObject]</xsl:text><br/>
+	  <xsl:text>[Exposed=(Window,Worker), LegacyNoInterfaceObject]</xsl:text><br/>
 	</xsl:if>
     <xsl:text>interface </xsl:text>
     <em><xsl:value-of select="@name" /></em>

--- a/extensions/proposals/EXT_shader_framebuffer_fetch/extension.xml
+++ b/extensions/proposals/EXT_shader_framebuffer_fetch/extension.xml
@@ -21,23 +21,23 @@
 
     <features>
       <feature>
-            It provides a mechanism whereby a fragment shader may read existing framebuffer data as input. 
+            It provides a mechanism whereby a fragment shader may read existing framebuffer data as input.
       </feature>
       <feature>
-            Prior to fragment shading, if <code>GL_EXT_shader_framebuffer_fetch</code> is enabled, <code>gl_LastFragData[]</code> is populated with the value last written to the framebuffer at the same (x,y,sample) position. 
+            Prior to fragment shading, if <code>GL_EXT_shader_framebuffer_fetch</code> is enabled, <code>gl_LastFragData[]</code> is populated with the value last written to the framebuffer at the same (x,y,sample) position.
       </feature>
       <feature>
             If <code>EXT_shader_framebuffer_fetch_non_coherent</code> is supported, a call to <code>FramebufferFetchBarrierEXT(void)</code> can be made to ensure <code>gl_LastFragData[]</code> is populated with fragment data drawn before the barrier.
       </feature>
     </features>
   </overview>
-  
+
   <idl xml:space="preserve">
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface EXT_shader_framebuffer_fetch {
     };
 
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface EXT_shader_framebuffer_fetch_non_coherent {
       void FramebufferFetchBarrierEXT(void);
     };

--- a/extensions/proposals/WEBGL_debug/extension.xml
+++ b/extensions/proposals/WEBGL_debug/extension.xml
@@ -112,7 +112,7 @@
   </overview>
 
   <idl xml:space="preserve"><![CDATA[
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_debug : EventTarget {
   const GLenum MAX_DEBUG_MESSAGE_LENGTH_KHR = 0x9143;
   const GLenum MAX_DEBUG_GROUP_STACK_DEPTH_KHR = 0x826C;
@@ -155,7 +155,7 @@ interface WEBGL_debug : EventTarget {
   DOMString getObjectLabelKHR(WebGLObject? object);
 }; // interface WEBGL_debug
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WebGLDebugMessage : Event {
   readonly attribute GLenum source;
   readonly attribute GLenum type;
@@ -245,7 +245,7 @@ function init(gl) {
 
   <samplecode><div class="example">
     Skip a section of the code.
-    
+
     <pre xml:space="preserve"><![CDATA[
 function draw(gl, ext) {
   ...
@@ -298,7 +298,7 @@ function draw(gl, ext) {
   <samplecode><div class="example">
     Only output a subsection of the code and disable some messages for the
     entire application.
-  
+
     <pre xml:space="preserve"><![CDATA[
 function draw(gl, ext) {
   ...

--- a/extensions/proposals/WEBGL_dynamic_texture/extension.xml
+++ b/extensions/proposals/WEBGL_dynamic_texture/extension.xml
@@ -192,7 +192,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_dynamic_texture {
   typedef double WDTNanoTime;
 
@@ -202,7 +202,7 @@ interface WEBGL_dynamic_texture {
   const GLenum REQUIRED_TEXTURE_IMAGE_UNITS_OES = 0x8D68;
 
   WDTStream? createStream();
- 
+
   WDTNanoTime getLastDrawingBufferPresentTime();
   void setDrawingBufferPresentTime(WDTNanoTime pt);
   WDTNanoTime ustnow();
@@ -360,7 +360,7 @@ interface WEBGL_dynamic_texture {
     following <code>/* Uniform Types */</code>:<pre class="idl"
     xml:space="preserve">SAMPLER_EXTERNAL = 0x8D66;</pre></li><li>In the
     alphabetical list of commands add the following :<pre class="idl"
-    xml:space="preserve">WDTStream? createStream(); 
+    xml:space="preserve">WDTStream? createStream();
 WDTNanoTime getLastDrawingBufferPresentTime();
 void setDrawingBufferPresentationTime(WDTNanoTime pt);
 WDTNanoTime ustnow();</pre></li></p>
@@ -501,7 +501,7 @@ WDTNanoTime ustnow();</pre></li></p>
       <p>The <code>WDTStreamFrameInfo</code> interface represents information
       about a frame acquired from a WDTStream.</p>
 
-      <pre class="idl" xml:space="preserve">[LegacyNoInterfaceObject] interface WDTStreamFrameInfo {
+      <pre class="idl" xml:space="preserve">[Exposed=(Window,Worker), LegacyNoInterfaceObject] interface WDTStreamFrameInfo {
   readonly attribute double frameTime;
   readonly attribute WDTNanoTime presentTime;
 };</pre>
@@ -531,7 +531,7 @@ WDTNanoTime ustnow();</pre></li></p>
       for controlling an image stream being fed to a dynamic texture
       object.</p>
 
-      <pre class="idl" xml:space="preserve">[LegacyNoInterfaceObject] interface WDTStream {
+      <pre class="idl" xml:space="preserve">[Exposed=(Window,Worker), LegacyNoInterfaceObject] interface WDTStream {
   typedef (HTMLCanvasElement or
            HTMLImageElement or
            HTMLVideoElement) StreamSource;
@@ -549,7 +549,7 @@ WDTNanoTime ustnow();</pre></li></p>
 
   readonly attribute WDTNanoTime minFrameDuration;
 
-  readonly attribute GLenum state;  
+  readonly attribute GLenum state;
 
   attribute WDTNanotime acquireTimeout;
   attribute WDTNanoTime consumerLatency;
@@ -800,7 +800,7 @@ WDTNanoTime ustnow();</pre></li></p>
     Note that the surrounding <code>&lt;script&gt;</code> tag is not
     essential; it is merely one way to include shader text in an HTML
     file.<pre xml:space="preserve">&lt;script id="fshader" type="x-shader/x-fragment"&gt;
-  #extension OES_EGL_image_external : enable 
+  #extension OES_EGL_image_external : enable
   precision mediump float;
 
   uniform samplerExternalOES videoSampler;

--- a/extensions/proposals/WEBGL_subarray_uploads/extension.xml
+++ b/extensions/proposals/WEBGL_subarray_uploads/extension.xml
@@ -26,7 +26,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_subarray_uploads {
     void bufferSubData(GLenum target, GLsizeiptr bufferOffset, GLsizeiptr subarrayOffset,
                        GLsizeiptr subarraySize, (ArrayBuffer or SharedArrayBuffer) data);

--- a/extensions/proposals/WEBGL_texture_multisample/extension.xml
+++ b/extensions/proposals/WEBGL_texture_multisample/extension.xml
@@ -27,7 +27,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [LegacyNoInterfaceObject]
+    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
     interface WEBGL_texture_storage_multisample {
       const GLenum TEXTURE_2D_MULTISAMPLE = 0x9100;
 

--- a/extensions/proposals/WEBGL_texture_multisample/extension.xml
+++ b/extensions/proposals/WEBGL_texture_multisample/extension.xml
@@ -27,7 +27,7 @@
   </overview>
 
   <idl xml:space="preserve">
-    [NoInterfaceObject]
+    [LegacyNoInterfaceObject]
     interface WEBGL_texture_storage_multisample {
       const GLenum TEXTURE_2D_MULTISAMPLE = 0x9100;
 

--- a/extensions/proposals/WEBGL_texture_source_iframe/extension.xml
+++ b/extensions/proposals/WEBGL_texture_source_iframe/extension.xml
@@ -25,7 +25,7 @@
     limitaion may be lifted in the future.</p>
   </overview>
   <idl xml:space="preserve"><![CDATA[
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_texture_source_iframe {
   Promise<void> bindTextureSource(GLenum target, HTMLIFrameElement iframe);
   Promise<void> requestFrame(GLenum target);

--- a/extensions/proposals/WEBGL_texture_source_iframe/extension.xml
+++ b/extensions/proposals/WEBGL_texture_source_iframe/extension.xml
@@ -25,7 +25,7 @@
     limitaion may be lifted in the future.</p>
   </overview>
   <idl xml:space="preserve"><![CDATA[
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_texture_source_iframe {
   Promise<void> bindTextureSource(GLenum target, HTMLIFrameElement iframe);
   Promise<void> requestFrame(GLenum target);

--- a/extensions/proposals/WEBGL_video_texture/extension.xml
+++ b/extensions/proposals/WEBGL_video_texture/extension.xml
@@ -55,14 +55,14 @@
   </overview>
 
   <idl xml:space="preserve">
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WebGLVideoFrameInfo {
   readonly attribute double currentTime;
   readonly attribute unsigned long textureWidth;
   readonly attribute unsigned long textureHeight;
 };
 
-[NoInterfaceObject]
+[LegacyNoInterfaceObject]
 interface WEBGL_video_texture {
     const GLenum TEXTURE_VIDEO_IMAGE_WEBGL             = 0x9248;
     const GLenum SAMPLER_VIDEO_IMAGE_WEBGL             = 0x9249;

--- a/extensions/proposals/WEBGL_video_texture/extension.xml
+++ b/extensions/proposals/WEBGL_video_texture/extension.xml
@@ -55,14 +55,14 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WebGLVideoFrameInfo {
   readonly attribute double currentTime;
   readonly attribute unsigned long textureWidth;
   readonly attribute unsigned long textureHeight;
 };
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_video_texture {
     const GLenum TEXTURE_VIDEO_IMAGE_WEBGL             = 0x9248;
     const GLenum SAMPLER_VIDEO_IMAGE_WEBGL             = 0x9249;

--- a/extensions/rejected/OES_depth24/extension.xml
+++ b/extensions/rejected/OES_depth24/extension.xml
@@ -30,7 +30,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface OES_depth24 {
   const GLenum DEPTH_COMPONENT24_OES = 0x81A6;
 };
@@ -48,7 +48,7 @@ interface OES_depth24 {
             var fbo = gl.createFramebuffer();
             gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
             gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, depth);
-            
+
             var fboStatus = gl.checkFramebufferStatus(gl.FRAMEBUFFER);
             console.assert(fboStatus == gl.FRAMEBUFFER_COMPLETE, 'Framebuffer is not complete');
 

--- a/extensions/rejected/WEBGL_compressed_texture_atc/extension.xml
+++ b/extensions/rejected/WEBGL_compressed_texture_atc/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture formats defined in the 
+      This extension exposes the compressed texture formats defined in the
       <a href="http://www.khronos.org/registry/gles/extensions/AMD/AMD_compressed_ATC_texture.txt">
       AMD_compressed_ATC_texture</a> OpenGL extension to WebGL.
     </p>
@@ -81,7 +81,7 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_compressed_texture_atc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_ATC_WEBGL                     = 0x8C92;

--- a/extensions/rejected/WEBGL_debug_shader_precision/extension.xml
+++ b/extensions/rejected/WEBGL_debug_shader_precision/extension.xml
@@ -85,7 +85,7 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_debug_shader_precision {
 };
   </idl>

--- a/extensions/rejected/WEBGL_draw_elements_no_range_check/extension.xml
+++ b/extensions/rejected/WEBGL_draw_elements_no_range_check/extension.xml
@@ -62,7 +62,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_draw_elements_no_range_check {
 };
   </idl>

--- a/extensions/rejected/WEBGL_get_buffer_sub_data_async/extension.xml
+++ b/extensions/rejected/WEBGL_get_buffer_sub_data_async/extension.xml
@@ -28,7 +28,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_get_buffer_sub_data_async {
   // Asynchronous version of getBufferSubData which fulfills the returned promise when the data becomes available.
   Promise&lt;ArrayBuffer&gt; getBufferSubDataAsync(GLenum target, GLintptr srcByteOffset, ArrayBufferView dstBuffer,

--- a/extensions/rejected/WEBGL_security_sensitive_resources/extension.xml
+++ b/extensions/rejected/WEBGL_security_sensitive_resources/extension.xml
@@ -92,7 +92,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_security_sensitive_resources {
   WebGLFramebuffer? createSecuritySensitiveFramebuffer();
   WebGLTexture? createSecuritySensitiveTexture();

--- a/extensions/rejected/WEBGL_shared_resources/extension.xml
+++ b/extensions/rejected/WEBGL_shared_resources/extension.xml
@@ -317,7 +317,7 @@ var ctx2 = canvas2.getContext("webgl", {
     </ul>
   </issues>
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_shared_resources {
      const GLenum READ_ONLY  = 0x0001;
      const GLenum EXCLUSIVE  = 0x0004;
@@ -338,7 +338,7 @@ interface WEBGL_shared_resources {
 
 callback AcquireSharedResourcesCallback = void ();
 
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WebGLShareGroup {
 };
 

--- a/extensions/rejected/WEBGL_subscribe_uniform/extension.xml
+++ b/extensions/rejected/WEBGL_subscribe_uniform/extension.xml
@@ -18,33 +18,33 @@
 
 
   <overview id="overview">
-    <p> This extension exposes the ability to subscribe to a set of uniform targets 
+    <p> This extension exposes the ability to subscribe to a set of uniform targets
         which can be used to populate uniforms within shader programs. This extension
         is generic, but currently only supports mouse position as a subscription target.
-    </p><p>Background: 
-    </p><p>The depth of the web pipeline makes it difficult to support low latency 
+    </p><p>Background:
+    </p><p>The depth of the web pipeline makes it difficult to support low latency
            interaction as event information retrieved via javascript
-           is outdated by the time it's displayed to clients. By populating event 
+           is outdated by the time it's displayed to clients. By populating event
            information later in the pipeline one can reduce perceived input latency.
-    </p><p>This extension creates a new buffer type <code>'Valuebuffer'</code> to 
+    </p><p>This extension creates a new buffer type <code>'Valuebuffer'</code> to
            maintain the active state for predefined subscription targets. Since a
            mechanism for buffering uniform information isn't available pre 2.0 (UBOs)
-           an additional data type was needed. See 'New Types' for additional 
+           an additional data type was needed. See 'New Types' for additional
            information.</p>
     <p> When this extension is enabled: </p>
     <ul>
-      <li>This extension provides a mechanism to store mouse positional information 
-          in buffers and defer modification of uniform variables which use mouse 
+      <li>This extension provides a mechanism to store mouse positional information
+          in buffers and defer modification of uniform variables which use mouse
           positional information until the WebGL commands are executed.
       </li>
-      <li>This extension provides a mechanism to explicitly update mouse 
+      <li>This extension provides a mechanism to explicitly update mouse
           positional information to maintain per frame consistency.
       </li>
     </ul>
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_subscribe_uniform {
   const GLenum SUBSCRIBED_VALUES_BUFFER = 0x924B;
 
@@ -71,21 +71,21 @@ interface WEBGL_subscribe_uniform {
     object.</function>
 
     <function name="isValuebuffer" type="bool"><param
-    name="buffer" type="WebGLValuebuffer"/>Returns whether an object is a 
+    name="buffer" type="WebGLValuebuffer"/>Returns whether an object is a
     <code>Valuebuffer</code> object.</function>
 
     <function name="bindValuebuffer" type="void"><param
     name="target" type="GLenum"/><param
-    name="buffer" type="WebGLValuebuffer"/>Lets you use a named 
+    name="buffer" type="WebGLValuebuffer"/>Lets you use a named
     <code>Valuebuffer</code> object.</function>
 
     <function name="subscribeValuebuffer" type="void"><param
     name="target" type="GLenum"/><param
-    name="subscription" type="GLenum"/>Subscribes the currently bound 
+    name="subscription" type="GLenum"/>Subscribes the currently bound
     <code>Valuebuffer</code> object to a subscription target.</function>
 
     <function name="populateSubscribedValues" type="void"><param
-    name="target" type="GLenum"/>Populates the currently bound 
+    name="target" type="GLenum"/>Populates the currently bound
     <code>Valuebuffer</code> object with the state of the subscriptions to
     which it is subscribed.</function>
 
@@ -99,50 +99,50 @@ interface WEBGL_subscribe_uniform {
 
   <newtypes>
     <interface name="WebGLValuebuffer" noobject="true">
-      <p>This interface is used to maintain a reference to internal 
+      <p>This interface is used to maintain a reference to internal
       <code>Valuebuffer</code> subscription states.</p>
     </interface>
-    <p>A <code>Valuebuffer</code> abstracts the mapping of subscription targets to internal 
-       state and acts as a single storage object for subscription information (e.g. current 
+    <p>A <code>Valuebuffer</code> abstracts the mapping of subscription targets to internal
+       state and acts as a single storage object for subscription information (e.g. current
        mouse position). Clients can then use the objects data to populate uniform variables.</p>
     <p>Post WebGL API 2.0, this abstraction could exist as a layer ontop of UBOs
        which managers the mapping of subscription targets to internal state and the mapping
-       of subscription targets to offsets within the buffer. The UBO would be used to store the 
+       of subscription targets to offsets within the buffer. The UBO would be used to store the
        active buffer state as well as the uniform location mapping. Clients would be required to
-       state all their subscription targets at once to allocate the appropriate amount of memory. 
+       state all their subscription targets at once to allocate the appropriate amount of memory.
        Aside from this small change the implementation is essentially the same, with UBOs replacing
        <code>Valuebuffers</code> and relevant create, delete, bind methods being replaced.
-       Additionally, the inclusion of UBOs would replace the need for 
+       Additionally, the inclusion of UBOs would replace the need for
        <code>uniformValueBuffer(...)</code>.</p>
   </newtypes>
 
   <newtok>
-    <function name="bindValuebuffer" type="any"><param 
+    <function name="bindValuebuffer" type="any"><param
     name="target" type="GLenum"/><param
     name="buffer" type="WebGLValuebuffer"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to bindValuebuffer</p></function>
 
     <function name="subscribeValuebuffer" type="void"><param
     name="target" type="GLenum"/><param
     name="subscription" type="GLenum"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to subscribeValuebuffer</p>
-    <p><code>MOUSE_POSITION</code> 
+    <p><code>MOUSE_POSITION</code>
     is accepted as the subscription parameter to subscribeValuebuffer</p></function>
 
     <function name="populateSubscribedValues" type="void"><param
     name="target" type="GLenum"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to populateSubscribedValues</p></function>
 
     <function name="uniformValuebuffer" type="void"><param
     name="location" type="WebGLUniformLocation"/><param
     name="target" type="GLenum"/><param
     name="subscription" type="GLenum"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to uniformValuebuffer</p>
-    <p><code>MOUSE_POSITION</code> 
+    <p><code>MOUSE_POSITION</code>
     is accepted as the subscription parameter to uniformValuebuffer</p></function>
   </newtok>
 
@@ -161,15 +161,15 @@ function init(gl) {
   ...
 
   var ext = gl.getExtension('WEBGL_subscribe_uniform');
-    
+
   // Create the value buffer and subscribe.
   var valuebuffer = ext.createValuebuffer();
   ext.bindValuebuffer(SUBSCRIBED_VALUES_BUFFER, valuebuffer);
   ext.subscribeValue(MOUSE_POSITION);
   ...
 }
-     
-function draw(gl) {   
+
+function draw(gl) {
   // Populate buffer and populate uniform
   ext.bindValuebuffer(SUBSCRIBED_VALUES_BUFFER, valuebuffer);
   ext.populateSubscribedValues(SUBSCRIBED_VALUES_BUFFER);

--- a/extensions/rejected/WEBGL_texture_from_depth_video/extension.xml
+++ b/extensions/rejected/WEBGL_texture_from_depth_video/extension.xml
@@ -21,17 +21,17 @@
   <overview id="overview">
 
     <p>This extension provides support for the <a
-    href="http://w3c.github.io/mediacapture-depth/">Media 
+    href="http://w3c.github.io/mediacapture-depth/">Media
     Capture Depth Stream Extensions</a>. Specifically, it supports
     uploading to a WebGL texture a <code>video</code> element whose
-    source is a <code>MediaStream</code> object containing a <a 
+    source is a <code>MediaStream</code> object containing a <a
     href="http://w3c.github.io/mediacapture-depth/#dfn-depth-track">
     depth track</a>.</p>
 
     <features>
       <feature>
-        A <code>video</code> element whose source is a <code>MediaStream</code> 
-        object containing a <a 
+        A <code>video</code> element whose source is a <code>MediaStream</code>
+        object containing a <a
         href="http://w3c.github.io/mediacapture-depth/#dfn-depth-track">
         depth track</a> may be uploaded to a WebGL
         texture of format <code>RGB</code> and type
@@ -41,7 +41,7 @@
   </overview>
 
   <idl xml:space="preserve">
-[LegacyNoInterfaceObject]
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_texture_from_depth_video {
 };
   </idl>
@@ -78,7 +78,7 @@ if (ext) {
      gl.RGB,
      gl.UNSIGNED_SHORT_5_6_5,
      depthVideo
-   );  
+   );
 }
 
 &lt;script id="fragment-shader" type="x-shader/x-fragment"&gt;


### PR DESCRIPTION
[Web IDL now requires `[Exposed]` for every interface](https://github.com/heycam/webidl/pull/920), including those with `[LegacyNoInterfaceObject]`. This patch matches the change.