### PR TITLE
Update EXT_texture_norm16 extension spec with support constrained to ArrayBufferView only

### DIFF
--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -53,7 +53,7 @@
       can be queried from calling the <code>getSupportedInputs</code> function.
       When the data source is a DOM element (HTMLImageElement, HTMLCanvasElement, or HTMLVideoElement),
       or is an ImageBitmap, ImageData, or OffscreenCanvas object with only 8 bits unsigned integer content,
-      a <code>DOMException</code> should be rasied and the behavior is undefined.
+      the conversion to 16 bit would have to requantize (e.g. 0x42 -> 0x4242).
       </feature>
     </features>
   </overview>

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -74,7 +74,7 @@ interface EXT_texture_norm16 {
       <change>Promoted to Community Approved.</change>
     </revision>
     <revision date="2020/12/03">
-      <change>Constraint the scope to only support ArrayBufferView</change>
+      <change>Constrain the scope to only support ArrayBufferView.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -53,7 +53,7 @@
       can be queried from calling the <code>getSupportedInputs</code> function.
       When the data source is a DOM element (HTMLImageElement, HTMLCanvasElement, or HTMLVideoElement),
       or is an ImageBitmap, ImageData, or OffscreenCanvas object with only 8 bits unsigned integer content,
-      the conversion to 16 bit would have to requantize (e.g. 0x42 -> 0x4242).
+      the conversion to 16 bit is requantized (e.g. 0x42 -> 0x4242).
       </feature>
     </features>
   </overview>
@@ -70,13 +70,23 @@ interface EXT_texture_norm16 {
   const GLenum RGB16_SNORM_EXT = 0x8F9A;
   const GLenum RGBA16_SNORM_EXT = 0x8F9B;
 };
+
+enum TextureNorm16SupportedInputTypes {
+  "arraybufferview",
+  "imagebitmap",
+  "imagedata",
+  "htmlimageelement",
+  "htmlcanvaselement",
+  "htmlvideoelement",
+  "offscreencanvas"
+};
   </idl>
 
   <newfun>
     <function name="getSupportedInputs" type="sequence&lt;DOMString&gt;">
       Returns the names of the input types supported by the implementation. As of this writing,
-      possibly valid return values will include "ArrayBufferView", "ImageBitmap", "ImageData",
-      "HTMLImageElement", "HTMLCanvasElement", "HTMLVideoElement", and "OffscreenCanvas".
+      possibly valid return values are "arraybufferview", "imagebitmap", "imagedata",
+      "htmlimageelement", "htmlcanvaselement", "htmlvideoelement", and "offscreencanvas" as stated in the idl <code>enum TextureNorm16SupportedInputTypes</code>.
     </function>
     <div class="note">
       The intent of the <code>getSupportedInputs</code> function is to not blocking broswers from advertising

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -46,13 +46,13 @@
       entry points taking <code>ImageBitmap</code>, <code>ImageData</code>,
       <code>HTMLImageElement</code>, <code>HTMLCanvasElement</code>, <code>HTMLVideoElement</code>,
       and <code>OffscreenCanvas</code> are extended to accept the pixel type
-      <code>UNSIGNED_SHORT</code>, with combination internal format being one of
+      <code>UNSIGNED_SHORT</code>, with associated internal format being one of
       <code>R16_EXT</code>, <code>RG16_EXT</code>,
       <code>RGB16_EXT</code>, and <code>RGBA16_EXT</code>.
       Information on whether each type is supported
       can be queried from calling the <code>getSupportedInputs</code> function.
       When the data source is a DOM element (HTMLImageElement, HTMLCanvasElement, or HTMLVideoElement),
-      or is an ImageBitmap, ImageData, or OffscreenCanvas object with only 8 bits unsigned integer content,
+      or is an ImageBitmap, ImageData, or OffscreenCanvas object with only 8 bit per channel unsigned integer content,
       the conversion to 16 bit is requantized (e.g. 0x42 -> 0x4242).
       </feature>
     </features>
@@ -83,7 +83,7 @@ enum TextureNorm16SupportedInputTypes {
   </idl>
 
   <newfun>
-    <function name="getSupportedInputs" type="sequence&lt;DOMString&gt;">
+    <function name="getSupportedInputs" type="sequence&lt;TextureNorm16SupportedInputTypes&gt;">
       Returns the names of the input types supported by the implementation. As of this writing,
       possibly valid return values are "arraybufferview", "imagebitmap", "imagedata",
       "htmlimageelement", "htmlcanvaselement", "htmlvideoelement", and "offscreencanvas" as stated in the idl <code>enum TextureNorm16SupportedInputTypes</code>.

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -41,20 +41,6 @@
       <code>Uint16Array</code> with the pixel type <code>UNSIGNED_SHORT</code>
       and <code>Int16Array</code> with the pixel type <code>SHORT</code>.
       </feature>
-
-      <feature> The <code>texImage2D</code> and <code>texSubImage2D</code>
-      entry points taking <code>ImageBitmap</code>, <code>ImageData</code>,
-      <code>HTMLImageElement</code>, <code>HTMLCanvasElement</code>, <code>HTMLVideoElement</code>,
-      and <code>OffscreenCanvas</code> are extended to accept the pixel type
-      <code>UNSIGNED_SHORT</code>, with associated internal format being one of
-      <code>R16_EXT</code>, <code>RG16_EXT</code>,
-      <code>RGB16_EXT</code>, and <code>RGBA16_EXT</code>.
-      Information on whether each type is supported
-      can be queried from calling the <code>getSupportedInputs</code> function.
-      When the data source is a DOM element (HTMLImageElement, HTMLCanvasElement, or HTMLVideoElement),
-      or is an ImageBitmap, ImageData, or OffscreenCanvas object with only 8 bit per channel unsigned integer content,
-      the conversion to 16 bit is requantized (e.g. 0x42 -> 0x4242).
-      </feature>
     </features>
   </overview>
 
@@ -70,30 +56,7 @@ interface EXT_texture_norm16 {
   const GLenum RGB16_SNORM_EXT = 0x8F9A;
   const GLenum RGBA16_SNORM_EXT = 0x8F9B;
 };
-
-enum TextureNorm16SupportedInputTypes {
-  "arraybufferview",
-  "imagebitmap",
-  "imagedata",
-  "htmlimageelement",
-  "htmlcanvaselement",
-  "htmlvideoelement",
-  "offscreencanvas"
-};
   </idl>
-
-  <newfun>
-    <function name="getSupportedInputs" type="sequence&lt;TextureNorm16SupportedInputTypes&gt;">
-      Returns the names of the input types supported by the implementation. As of this writing,
-      possibly valid return values are "arraybufferview", "imagebitmap", "imagedata",
-      "htmlimageelement", "htmlcanvaselement", "htmlvideoelement", and "offscreencanvas" as stated in the idl <code>enum TextureNorm16SupportedInputTypes</code>.
-    </function>
-    <div class="note">
-      The intent of the <code>getSupportedInputs</code> function is to not blocking broswers from advertising
-      this extension without having decoding support for 16-bit-per-channel-color-depth unsigned normalized images, and users
-      from using it not caring about the image element uploading.
-    </div>
-  </newfun>
 
   <history>
     <revision date="2019/03/27">
@@ -110,9 +73,8 @@ enum TextureNorm16SupportedInputTypes {
     <revision date="2020/08/13">
       <change>Promoted to Community Approved.</change>
     </revision>
-    <revision date="2020/11/09">
-      <change>Update behaviors for uploading various image element types.</change>
-      <change>Add a new function getSupportedInputs.</change>
+    <revision date="2020/12/03">
+      <change>Constraint the scope to only support ArrayBufferView</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -43,16 +43,22 @@
       </feature>
 
       <feature> The <code>texImage2D</code> and <code>texSubImage2D</code>
-      entry points taking <code>ImageData</code>,
-      <code>HTMLImageElement</code>, <code>HTMLCanvasElement</code> and
-      <code>HTMLVideoElement</code> are extended to accept the pixel type
-      <code>UNSIGNED_SHORT</code>. </feature>
-
+      entry points taking <code>ImageBitmap</code>, <code>ImageData</code>,
+      <code>HTMLImageElement</code>, <code>HTMLCanvasElement</code>, <code>HTMLVideoElement</code>,
+      and <code>OffscreenCanvas</code> are extended to accept the pixel type
+      <code>UNSIGNED_SHORT</code>, with combination internal format being one of
+      <code>R16_EXT</code>, <code>RG16_EXT</code>,
+      <code>RGB16_EXT</code>, and <code>RGBA16_EXT</code>.
+      Information on whether each type is supported
+      can be queried from calling the <code>getSupportedInputs</code> function.
+      When the data source is a DOM element (HTMLImageElement, HTMLCanvasElement, or HTMLVideoElement),
+      or is an ImageBitmap, ImageData, or OffscreenCanvas object with only 8 bits unsigned integer content,
+      a <code>DOMException</code> should be rasied and the behavior is undefined.
+      </feature>
     </features>
   </overview>
 
   <idl xml:space="preserve">
-
 [NoInterfaceObject]
 interface EXT_texture_norm16 {
   const GLenum R16_EXT = 0x822A;
@@ -65,6 +71,19 @@ interface EXT_texture_norm16 {
   const GLenum RGBA16_SNORM_EXT = 0x8F9B;
 };
   </idl>
+
+  <newfun>
+    <function name="getSupportedInputs" type="sequence&lt;DOMString&gt;">
+      Returns the names of the input types supported by the implementation. As of this writing,
+      possibly valid return values will include "ArrayBufferView", "ImageBitmap", "ImageData",
+      "HTMLImageElement", "HTMLCanvasElement", "HTMLVideoElement", and "OffscreenCanvas".
+    </function>
+    <div class="note">
+      The intent of the <code>getSupportedInputs</code> function is to not blocking broswers from advertising
+      this extension without having decoding support for 16-bit-per-channel-color-depth unsigned normalized images, and users
+      from using it not caring about the image element uploading.
+    </div>
+  </newfun>
 
   <history>
     <revision date="2019/03/27">
@@ -80,6 +99,10 @@ interface EXT_texture_norm16 {
     </revision>
     <revision date="2020/08/13">
       <change>Promoted to Community Approved.</change>
+    </revision>
+    <revision date="2020/11/09">
+      <change>Update behaviors for uploading various image element types.</change>
+      <change>Add a new function getSupportedInputs.</change>
     </revision>
   </history>
 </extension>


### PR DESCRIPTION
Update the spec as discovered during implementing the feature in Chrome:
* Add behavior descriptions for uploading various types of image elements with texImage2d
  - Uploading image elements with signed normalized integer type is not allowed (according to https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.7.6
`[throws] void texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, TexImageSource source) // May throw DOMException (OpenGL ES 3.0.4 §3.8.4, man page)`)
  - ~~Uploading image elements with 8-bit content with `UNSIGNED_SHORT` type should raise a `DOMException`. And the behavior is undefined.~~
* Add a getSupportedInputs function to make support for image elements types other than arrayBufferView become easier to be optional