### PR TITLE
Fix serve_localhost.py to bind to localhost again.

### DIFF
--- a/serve_localhost.py
+++ b/serve_localhost.py
@@ -35,4 +35,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     handler_class = partial(NoCacheRequestHandler, directory=args.directory)
-    http.server.test(HandlerClass=handler_class, port=args.port, bind=args.bind)
+
+    server = http.server.ThreadingHTTPServer((args.bind, args.port), handler_class)
+    print('Serving ThreadingHTTPServer for', args, '...')
+    server.serve_forever()


### PR DESCRIPTION
It was only binding to [::1], sometimes causing pages to fail to load.
This was probably due to changes in http.server.test, which we probably
shouldn't have been abusing for this.