### PR TITLE
texImage2D takes in gl.RGB10_A2UI, gl.RGBA_INTEGER for DOMElement gen…

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-image-with-different-data-source.html
+++ b/sdk/tests/conformance2/textures/misc/tex-image-with-different-data-source.html
@@ -41,7 +41,7 @@ gl.bindTexture(gl.TEXTURE_2D, tex);
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2UI, 16, 16, 0, gl.RGBA_INTEGER, gl.UNSIGNED_INT_2_10_10_10_REV, null);
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Teximage2D taking a null array buffer should succeed");
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGB10_A2UI, gl.RGBA_INTEGER, gl.UNSIGNED_INT_2_10_10_10_REV, c);
-wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "TexImage2D taking RGB10_A2UI internalformat and a canvas source should fail");
+wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_ENUM], "TexImage2D taking RGB10_A2UI internalformat and a canvas source should fail");
 gl.deleteTexture(tex);
 
 var successfullyParsed = true;


### PR DESCRIPTION
…erates either gl.INVALID_VALUE or gl.INVALID_ENUM

Removing some redundant validations in Chromium fails this test (that unrelated validation accidently make it pass this test): https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc;l=7493-7499?q=webgl_rendering_context_base&ss=chromium

Usually invalid formats enum combinations generates `gl.INVALID_ENUM`. `gl.INVALID_VALUE` is used mostly for integer value error (width, level, border etc.)
(This one is a bit different as it's valid for takingin arrayBuffer but invalid various DOMElements; Although I still interprets this as invalid enum for DOMElements)

Simply extending expecting result to either `gl.INVALID_VALUE` or `gl.INVALID_ENUM`, which requires the least effort and shall create the least noise if any.

(Related spec discussion at: https://github.com/KhronosGroup/WebGL/issues/2274#issue-203074505)