### PR TITLE
KHR_parallel_shader_compile: lost context behavior spec & test

### DIFF
--- a/extensions/KHR_parallel_shader_compile/extension.xml
+++ b/extensions/KHR_parallel_shader_compile/extension.xml
@@ -32,6 +32,11 @@
         availability (<code>COMPLETION_STATUS_KHR</code>) can be queried without potentially incurring
         stalls.
       </feature>
+
+      <feature>
+        When the context is lost, completion status queries must return true unconditionally. This is
+        intended to prevent applications from entering an infinite status polling loop.
+      </feature>
     </features>
 
     <p>Notes: <ul style="list-style-type: circle">
@@ -141,6 +146,9 @@
     </revision>
     <revision date="2019/05/10">
       <change>Moved to community approved.</change>
+    </revision>
+    <revision date="2020/11/24">
+      <change>Specify lost context behavior.</change>
     </revision>
   </history>
 </extension>

--- a/sdk/tests/conformance/extensions/00_test_list.txt
+++ b/sdk/tests/conformance/extensions/00_test_list.txt
@@ -11,6 +11,7 @@
 --min-version 1.0.3 --max-version 1.9.9 ext-sRGB.html
 --min-version 1.0.2 ext-texture-filter-anisotropic.html
 --min-version 1.0.2 get-extension.html
+--min-version 1.0.4 khr-parallel-shader-compile.html
 --max-version 1.9.9 oes-standard-derivatives.html
 --max-version 1.9.9 oes-texture-float-with-canvas.html
 --max-version 1.9.9 oes-texture-float-with-image-data.html

--- a/sdk/tests/conformance/extensions/khr-parallel-shader-compile.html
+++ b/sdk/tests/conformance/extensions/khr-parallel-shader-compile.html
@@ -1,0 +1,93 @@
+<!--
+Copyright (c) 2020 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+
+<script>
+"use strict";
+description("Test KHR_parallel_shader_compile");
+
+const wtu = WebGLTestUtils;
+
+const gl = wtu.create3DContext();
+const loseContext = wtu.getExtensionWithKnownPrefixes(gl, "WEBGL_lose_context");
+
+let counter = 0;
+const vertexSource = () => `
+void main() {
+    gl_Position = vec4(${counter++}, 1, 1, 1);
+}`;
+const fragmentSource = () => `
+void main() {
+    gl_FragColor = vec4(0.${counter++}, 1, 1, 1);
+}`;
+
+const vs = gl.createShader(gl.VERTEX_SHADER);
+const fs = gl.createShader(gl.FRAGMENT_SHADER);
+const program = gl.createProgram();
+gl.attachShader(program, vs);
+gl.attachShader(program, fs);
+
+const COMPLETION_STATUS_KHR = 0x91B1;
+
+gl.shaderSource(vs, vertexSource());
+gl.compileShader(vs);
+let status = gl.getShaderParameter(vs, COMPLETION_STATUS_KHR);
+if (status !== null) testFailed('Extension disabled, status should be null');
+wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "extension disabled");
+
+gl.shaderSource(fs, fragmentSource());
+gl.compileShader(fs);
+
+gl.linkProgram(program);
+status = gl.getProgramParameter(program, COMPLETION_STATUS_KHR);
+if (status !== null) testFailed('Extension disabled, status should be null');
+wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "extension disabled");
+
+const ext = wtu.getExtensionWithKnownPrefixes(gl, "KHR_parallel_shader_compile");
+if (!ext) {
+    testPassed("No KHR_parallel_shader_compile support -- this is legal");
+} else {
+    testPassed("Successfully enabled KHR_parallel_shader_compile extension");
+
+    shouldBe("ext.COMPLETION_STATUS_KHR", "0x91B1");
+
+    debug("Checking that status is a boolean.");
+    gl.shaderSource(vs, vertexSource());
+    gl.compileShader(vs);
+    let status = gl.getShaderParameter(vs, COMPLETION_STATUS_KHR);
+    if (status !== true && status !== false) testFailed("status should be a boolean");
+
+    gl.linkProgram(program);
+    status = gl.getProgramParameter(program, COMPLETION_STATUS_KHR);
+    if (status !== true && status !== false) testFailed("status should be a boolean");
+
+    debug("Checking that status is true when context is lost.");
+    if (loseContext) {
+        loseContext.loseContext();
+        status = gl.getShaderParameter(vs, COMPLETION_STATUS_KHR);
+        if (status !== true) testFailed("status should be true when context is lost");
+        status = gl.getProgramParameter(program, COMPLETION_STATUS_KHR);
+        if (status !== true) testFailed("status should be true when context is lost");
+    }
+}
+
+const successfullyParsed = true;
+</script>
+
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This was proposed on the public WebGL mailing list, where it was pointed out that KHR_robustness seems to imply that this should be the behavior of all queries. https://www.khronos.org/webgl/public-mailing-list/public_webgl/1904/msg00004.php. The OpenGL working group agrees: https://github.com/KhronosGroup/OpenGL-Registry/issues/263