### PR TITLE
Replace GLuint64EXT with GLuint64

### DIFF
--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -40,8 +40,6 @@
   </overview>
 
   <idl xml:space="preserve">
-typedef unsigned long long GLuint64EXT;
-
 [LegacyNoInterfaceObject]
 interface EXT_disjoint_timer_query_webgl2 {
   const GLenum QUERY_COUNTER_BITS_EXT      = 0x8864;
@@ -102,7 +100,7 @@ interface EXT_disjoint_timer_query_webgl2 {
       The return type depends on the parameter queried:
       <table width="30%">
       <tr><th>pname</th><th>returned type</th></tr>
-      <tr><td>TIMESTAMP_EXT</td><td>GLuint64EXT</td></tr>
+      <tr><td>TIMESTAMP_EXT</td><td>GLuint64</td></tr>
       <tr><td>GPU_DISJOINT_EXT</td><td>boolean</td></tr>
       </table>      
     </function>


### PR DESCRIPTION
Back in the old days [there was no GLuint64](https://github.com/KhronosGroup/WebGL/pull/2076#discussion_r81674534), but [now there is](https://www.khronos.org/registry/webgl/specs/latest/2.0/#3.1).

The current definition causes IDL parser warning because there are two definitions, one here and another in [EXT_disjoint_timer_query](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/).