### PR TITLE
Allow makeXRCompatible as an optional method

### DIFF
--- a/conformance-suites/1.0.3/conformance/context/context-methods.js
+++ b/conformance-suites/1.0.3/conformance/context/context-methods.js
@@ -1,0 +1,52 @@
+"use strict";
+
+// Properties to be ignored because they were added in versions of the
+// spec that are backward-compatible with this version
+const IGNORED_METHODS = [
+  // There is no official spec for the commit API yet, the proposal link is:
+  // https://wiki.whatwg.org/wiki/OffscreenCanvas
+  "commit",
+
+  // For WebXR integration:
+  "makeXRCompatible",
+];
+
+function assertFunction(v, f) {
+  try {
+    if (typeof v[f] != "function") {
+      testFailed(`Property either does not exist or is not a function: ${f}`);
+      return false;
+    } else {
+      return true;
+    }
+  } catch(e) {
+    testFailed(`Trying to access the property '${f}' threw an error: ${e.toString()}`);
+  }
+}
+
+function testContextMethods(gl, requiredContextMethods) {
+  const acceptableMethods = [].concat(requiredContextMethods, IGNORED_METHODS);
+
+  let passed = true;
+  requiredContextMethods.forEach(method => {
+    const r = assertFunction(gl, method);
+    passed = passed && r;
+  });
+  if (passed) {
+    testPassed("All WebGL methods found.");
+  }
+  let extended = false;
+  for (let propertyName of Object.getOwnPropertyNames(gl)) {
+    if (typeof gl[propertyName] == "function" && !acceptableMethods.includes(propertyName)) {
+      if (!extended) {
+        extended = true;
+        testFailed("Also found the following extra methods:");
+      }
+      testFailed(propertyName);
+    }
+  }
+
+  if (!extended) {
+    testPassed("No extra methods found on WebGL context.");
+  }
+}

--- a/conformance-suites/1.0.3/conformance/context/methods.html
+++ b/conformance-suites/1.0.3/conformance/context/methods.html
@@ -32,6 +32,7 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../resources/js-test-pre.js"></script>
 <script src="../resources/webgl-test-utils.js"></script>
+<script src="context-methods.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -180,52 +181,14 @@ var methods = [
 "viewport"
 ];
 
-// Properties to be ignored because they were added in versions of the
-// spec that are backward-compatible with this version
-var ignoredMethods = [
-];
-
-function assertFunction(v, f) {
-  try {
-    if (typeof v[f] != "function") {
-      testFailed("Property either does not exist or is not a function: " + f);
-      return false;
-    } else {
-      return true;
-    }
-  } catch(e) {
-    testFailed("Trying to access the property '" + f + "' threw an error: "+e.toString());
-  }
-}
-
 debug("");
 debug("Canvas.getContext");
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
-var passed = true;
-for (var i=0; i<methods.length; i++) {
-  var r = assertFunction(gl, methods[i]);
-  passed = passed && r;
-}
-if (passed) {
-  testPassed("All WebGL methods found.");
-}
-var extended = false;
-for (var i in gl) {
-  if (typeof gl[i] == "function" && methods.indexOf(i) == -1 && ignoredMethods.indexOf(i) == -1) {
-    if (!extended) {
-      extended = true;
-      testFailed("Also found the following extra methods:");
-    }
-    testFailed(i);
-  }
-}
 
-if (!extended) {
-  testPassed("No extra methods found on WebGL context.");
-}
+testContextMethods(gl, methods);
 
 debug("");
 var successfullyParsed = true;

--- a/conformance-suites/2.0.0/conformance/context/methods.html
+++ b/conformance-suites/2.0.0/conformance/context/methods.html
@@ -32,6 +32,7 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/context-methods.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -180,55 +181,14 @@ var methods = [
   "viewport"
 ];
 
-// Properties to be ignored because they were added in versions of the
-// spec that are backward-compatible with this version
-var ignoredMethods = [
-  // There is no official spec for the commit API yet, the proposal link is:
-  // https://wiki.whatwg.org/wiki/OffscreenCanvas
-  "commit"
-];
-
-function assertFunction(v, f) {
-  try {
-    if (typeof v[f] != "function") {
-      testFailed("Property either does not exist or is not a function: " + f);
-      return false;
-    } else {
-      return true;
-    }
-  } catch(e) {
-    testFailed("Trying to access the property '" + f + "' threw an error: "+e.toString());
-  }
-}
-
 debug("");
 debug("Canvas.getContext");
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas);
-var passed = true;
-for (var i=0; i<methods.length; i++) {
-  var r = assertFunction(gl, methods[i]);
-  passed = passed && r;
-}
-if (passed) {
-  testPassed("All WebGL methods found.");
-}
-var extended = false;
-for (var i in gl) {
-  if (typeof gl[i] == "function" && methods.indexOf(i) == -1 && ignoredMethods.indexOf(i) == -1) {
-    if (!extended) {
-      extended = true;
-      testFailed("Also found the following extra methods:");
-    }
-    testFailed(i);
-  }
-}
 
-if (!extended) {
-  testPassed("No extra methods found on WebGL context.");
-}
+testContextMethods(gl, methods);
 
 debug("");
 var successfullyParsed = true;

--- a/conformance-suites/2.0.0/conformance2/context/methods-2.html
+++ b/conformance-suites/2.0.0/conformance2/context/methods-2.html
@@ -32,6 +32,7 @@
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/context-methods.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -270,55 +271,14 @@ var methods = [
   "bindVertexArray",
 ];
 
-// Properties to be ignored because they were added in versions of the
-// spec that are backward-compatible with this version
-var ignoredMethods = [
-  // There is no official spec for the commit API yet, the proposal link is:
-  // https://wiki.whatwg.org/wiki/OffscreenCanvas
-  "commit"
-];
-
-function assertFunction(v, f) {
-  try {
-    if (typeof v[f] != "function") {
-      testFailed("Property either does not exist or is not a function: " + f);
-      return false;
-    } else {
-      return true;
-    }
-  } catch(e) {
-    testFailed("Trying to access the property '" + f + "' threw an error: "+e.toString());
-  }
-}
-
 debug("");
 debug("Canvas.getContext");
 
 var wtu = WebGLTestUtils;
 var canvas = document.getElementById("canvas");
 var gl = wtu.create3DContext(canvas, null, 2);
-var passed = true;
-for (var i=0; i<methods.length; i++) {
-  var r = assertFunction(gl, methods[i]);
-  passed = passed && r;
-}
-if (passed) {
-  testPassed("All WebGL methods found.");
-}
-var extended = false;
-for (var i in gl) {
-  if (typeof gl[i] == "function" && methods.indexOf(i) == -1 && ignoredMethods.indexOf(i) == -1) {
-    if (!extended) {
-      extended = true;
-      testFailed("Also found the following extra methods:");
-    }
-    testFailed(i);
-  }
-}
 
-if (!extended) {
-  testPassed("No extra methods found on WebGL context.");
-}
+testContextMethods(gl, methods);
 
 debug("");
 var successfullyParsed = true;

--- a/conformance-suites/2.0.0/js/tests/context-methods.js
+++ b/conformance-suites/2.0.0/js/tests/context-methods.js
@@ -1,0 +1,52 @@
+"use strict";
+
+// Properties to be ignored because they were added in versions of the
+// spec that are backward-compatible with this version
+const IGNORED_METHODS = [
+  // There is no official spec for the commit API yet, the proposal link is:
+  // https://wiki.whatwg.org/wiki/OffscreenCanvas
+  "commit",
+
+  // For WebXR integration:
+  "makeXRCompatible",
+];
+
+function assertFunction(v, f) {
+  try {
+    if (typeof v[f] != "function") {
+      testFailed(`Property either does not exist or is not a function: ${f}`);
+      return false;
+    } else {
+      return true;
+    }
+  } catch(e) {
+    testFailed(`Trying to access the property '${f}' threw an error: ${e.toString()}`);
+  }
+}
+
+function testContextMethods(gl, requiredContextMethods) {
+  const acceptableMethods = [].concat(requiredContextMethods, IGNORED_METHODS);
+
+  let passed = true;
+  requiredContextMethods.forEach(method => {
+    const r = assertFunction(gl, method);
+    passed = passed && r;
+  });
+  if (passed) {
+    testPassed("All WebGL methods found.");
+  }
+  let extended = false;
+  for (let propertyName of Object.getOwnPropertyNames(gl)) {
+    if (typeof gl[propertyName] == "function" && !acceptableMethods.includes(propertyName)) {
+      if (!extended) {
+        extended = true;
+        testFailed("Also found the following extra methods:");
+      }
+      testFailed(propertyName);
+    }
+  }
+
+  if (!extended) {
+    testPassed("No extra methods found on WebGL context.");
+  }
+}

--- a/sdk/tests/conformance/context/methods.html
+++ b/sdk/tests/conformance/context/methods.html
@@ -20,7 +20,7 @@ found in the LICENSE.txt file.
 "use strict";
 description("This test ensures that the WebGL context has all the methods in the specification.");
 
-var methods = [
+const methods = [
   "getContextAttributes",
   "activeTexture",
   "attachShader",
@@ -161,47 +161,51 @@ var methods = [
 
 // Properties to be ignored because they were added in versions of the
 // spec that are backward-compatible with this version
-var ignoredMethods = [
+const ignoredMethods = [
   // There is no official spec for the commit API yet, the proposal link is:
   // https://wiki.whatwg.org/wiki/OffscreenCanvas
   "commit"
 ];
 
+const optionalMethods = [
+  "makeXRCompatible"
+];
+
 function assertFunction(v, f) {
   try {
     if (typeof v[f] != "function") {
-      testFailed("Property either does not exist or is not a function: " + f);
+      testFailed(`Property either does not exist or is not a function: ${f}`);
       return false;
     } else {
       return true;
     }
   } catch(e) {
-    testFailed("Trying to access the property '" + f + "' threw an error: "+e.toString());
+    testFailed(`Trying to access the property '${f}' threw an error: ${e.toString()}`);
   }
 }
 
 debug("");
 debug("Canvas.getContext");
 
-var wtu = WebGLTestUtils;
-var canvas = document.getElementById("canvas");
-var gl = wtu.create3DContext(canvas);
-var passed = true;
-for (var i=0; i<methods.length; i++) {
-  var r = assertFunction(gl, methods[i]);
+const wtu = WebGLTestUtils;
+const canvas = document.getElementById("canvas");
+const gl = wtu.create3DContext(canvas);
+let passed = true;
+methods.forEach(method => {
+  const r = assertFunction(gl, method);
   passed = passed && r;
-}
+});
 if (passed) {
   testPassed("All WebGL methods found.");
 }
-var extended = false;
-for (var i in gl) {
-  if (typeof gl[i] == "function" && methods.indexOf(i) == -1 && ignoredMethods.indexOf(i) == -1) {
+let extended = false;
+for (let propertyName of Object.getOwnPropertyNames(gl)) {
+  if (typeof gl[propertyName] == "function" && !methods.includes(propertyName) && !ignoredMethods.includes(propertyName) && !optionalMethods.includes(propertyName)) {
     if (!extended) {
       extended = true;
       testFailed("Also found the following extra methods:");
     }
-    testFailed(i);
+    testFailed(propertyName);
   }
 }
 

--- a/sdk/tests/conformance/context/methods.html
+++ b/sdk/tests/conformance/context/methods.html
@@ -11,6 +11,7 @@ found in the LICENSE.txt file.
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/context-methods.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -159,59 +160,14 @@ const methods = [
   "viewport"
 ];
 
-// Properties to be ignored because they were added in versions of the
-// spec that are backward-compatible with this version
-const ignoredMethods = [
-  // There is no official spec for the commit API yet, the proposal link is:
-  // https://wiki.whatwg.org/wiki/OffscreenCanvas
-  "commit"
-];
-
-const optionalMethods = [
-  "makeXRCompatible"
-];
-
-function assertFunction(v, f) {
-  try {
-    if (typeof v[f] != "function") {
-      testFailed(`Property either does not exist or is not a function: ${f}`);
-      return false;
-    } else {
-      return true;
-    }
-  } catch(e) {
-    testFailed(`Trying to access the property '${f}' threw an error: ${e.toString()}`);
-  }
-}
-
 debug("");
 debug("Canvas.getContext");
 
 const wtu = WebGLTestUtils;
 const canvas = document.getElementById("canvas");
 const gl = wtu.create3DContext(canvas);
-let passed = true;
-methods.forEach(method => {
-  const r = assertFunction(gl, method);
-  passed = passed && r;
-});
-if (passed) {
-  testPassed("All WebGL methods found.");
-}
-let extended = false;
-for (let propertyName of Object.getOwnPropertyNames(gl)) {
-  if (typeof gl[propertyName] == "function" && !methods.includes(propertyName) && !ignoredMethods.includes(propertyName) && !optionalMethods.includes(propertyName)) {
-    if (!extended) {
-      extended = true;
-      testFailed("Also found the following extra methods:");
-    }
-    testFailed(propertyName);
-  }
-}
 
-if (!extended) {
-  testPassed("No extra methods found on WebGL context.");
-}
+testContextMethods(gl, methods);
 
 debug("");
 var successfullyParsed = true;

--- a/sdk/tests/conformance2/context/methods-2.html
+++ b/sdk/tests/conformance2/context/methods-2.html
@@ -20,7 +20,7 @@ found in the LICENSE.txt file.
 "use strict";
 description("This test ensures that the WebGL context has all the methods in the specification.");
 
-var methods = [
+const methods = [
   "getContextAttributes",
   "activeTexture",
   "attachShader",
@@ -251,47 +251,51 @@ var methods = [
 
 // Properties to be ignored because they were added in versions of the
 // spec that are backward-compatible with this version
-var ignoredMethods = [
+const ignoredMethods = [
   // There is no official spec for the commit API yet, the proposal link is:
   // https://wiki.whatwg.org/wiki/OffscreenCanvas
   "commit"
 ];
 
+const optionalMethods = [
+  "makeXRCompatible"
+];
+
 function assertFunction(v, f) {
   try {
     if (typeof v[f] != "function") {
-      testFailed("Property either does not exist or is not a function: " + f);
+      testFailed(`Property either does not exist or is not a function: ${f}`);
       return false;
     } else {
       return true;
     }
   } catch(e) {
-    testFailed("Trying to access the property '" + f + "' threw an error: "+e.toString());
+    testFailed(`Trying to access the property '${f}' threw an error: ${e.toString()}`);
   }
 }
 
 debug("");
 debug("Canvas.getContext");
 
-var wtu = WebGLTestUtils;
-var canvas = document.getElementById("canvas");
-var gl = wtu.create3DContext(canvas, null, 2);
-var passed = true;
-for (var i=0; i<methods.length; i++) {
-  var r = assertFunction(gl, methods[i]);
+const wtu = WebGLTestUtils;
+const canvas = document.getElementById("canvas");
+const gl = wtu.create3DContext(canvas, null, 2);
+let passed = true;
+methods.forEach(method => {
+  const r = assertFunction(gl, method);
   passed = passed && r;
-}
+});
 if (passed) {
   testPassed("All WebGL methods found.");
 }
-var extended = false;
-for (var i in gl) {
-  if (typeof gl[i] == "function" && methods.indexOf(i) == -1 && ignoredMethods.indexOf(i) == -1) {
+let extended = false;
+for (let propertyName of Object.getOwnPropertyNames(gl)) {
+  if (typeof gl[propertyName] == "function" && !methods.includes(propertyName) && !ignoredMethods.includes(propertyName) && !optionalMethods.includes(propertyName)) {
     if (!extended) {
       extended = true;
       testFailed("Also found the following extra methods:");
     }
-    testFailed(i);
+    testFailed(propertyName);
   }
 }
 

--- a/sdk/tests/conformance2/context/methods-2.html
+++ b/sdk/tests/conformance2/context/methods-2.html
@@ -11,6 +11,7 @@ found in the LICENSE.txt file.
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/tests/context-methods.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -249,59 +250,14 @@ const methods = [
   "bindVertexArray",
 ];
 
-// Properties to be ignored because they were added in versions of the
-// spec that are backward-compatible with this version
-const ignoredMethods = [
-  // There is no official spec for the commit API yet, the proposal link is:
-  // https://wiki.whatwg.org/wiki/OffscreenCanvas
-  "commit"
-];
-
-const optionalMethods = [
-  "makeXRCompatible"
-];
-
-function assertFunction(v, f) {
-  try {
-    if (typeof v[f] != "function") {
-      testFailed(`Property either does not exist or is not a function: ${f}`);
-      return false;
-    } else {
-      return true;
-    }
-  } catch(e) {
-    testFailed(`Trying to access the property '${f}' threw an error: ${e.toString()}`);
-  }
-}
-
 debug("");
 debug("Canvas.getContext");
 
 const wtu = WebGLTestUtils;
 const canvas = document.getElementById("canvas");
 const gl = wtu.create3DContext(canvas, null, 2);
-let passed = true;
-methods.forEach(method => {
-  const r = assertFunction(gl, method);
-  passed = passed && r;
-});
-if (passed) {
-  testPassed("All WebGL methods found.");
-}
-let extended = false;
-for (let propertyName of Object.getOwnPropertyNames(gl)) {
-  if (typeof gl[propertyName] == "function" && !methods.includes(propertyName) && !ignoredMethods.includes(propertyName) && !optionalMethods.includes(propertyName)) {
-    if (!extended) {
-      extended = true;
-      testFailed("Also found the following extra methods:");
-    }
-    testFailed(propertyName);
-  }
-}
 
-if (!extended) {
-  testPassed("No extra methods found on WebGL context.");
-}
+testContextMethods(gl, methods);
 
 debug("");
 var successfullyParsed = true;

--- a/sdk/tests/js/tests/context-methods.js
+++ b/sdk/tests/js/tests/context-methods.js
@@ -1,0 +1,52 @@
+"use strict";
+
+// Properties to be ignored because they were added in versions of the
+// spec that are backward-compatible with this version
+const IGNORED_METHODS = [
+  // There is no official spec for the commit API yet, the proposal link is:
+  // https://wiki.whatwg.org/wiki/OffscreenCanvas
+  "commit",
+
+  // For WebXR integration:
+  "makeXRCompatible",
+];
+
+function assertFunction(v, f) {
+  try {
+    if (typeof v[f] != "function") {
+      testFailed(`Property either does not exist or is not a function: ${f}`);
+      return false;
+    } else {
+      return true;
+    }
+  } catch(e) {
+    testFailed(`Trying to access the property '${f}' threw an error: ${e.toString()}`);
+  }
+}
+
+function testContextMethods(gl, requiredContextMethods) {
+  const acceptableMethods = [].concat(requiredContextMethods, IGNORED_METHODS);
+
+  let passed = true;
+  requiredContextMethods.forEach(method => {
+    const r = assertFunction(gl, method);
+    passed = passed && r;
+  });
+  if (passed) {
+    testPassed("All WebGL methods found.");
+  }
+  let extended = false;
+  for (let propertyName of Object.getOwnPropertyNames(gl)) {
+    if (typeof gl[propertyName] == "function" && !acceptableMethods.includes(propertyName)) {
+      if (!extended) {
+        extended = true;
+        testFailed("Also found the following extra methods:");
+      }
+      testFailed(propertyName);
+    }
+  }
+
+  if (!extended) {
+    testPassed("No extra methods found on WebGL context.");
+  }
+}


### PR DESCRIPTION
The WebXR device specification mixes in a new function makeXRCompatible.
The methods.html and methods-2.html tests should allow for the possibility
of the method existing.

While here, update the code to more modern JavaScript.