### PR TITLE
WEBGL_webcodecs_video_frame: Allow software video frame support

### DIFF
--- a/extensions/proposals/WEBGL_webcodecs_video_frame/extension.xml
+++ b/extensions/proposals/WEBGL_webcodecs_video_frame/extension.xml
@@ -37,10 +37,10 @@
     <features>
       <feature>
         <code>importVideoFrame</code> imports a <code>VideoFrame</code> from WebCodecs, and returns
-        a <code>WebGLWebCodecsVideoFrameHandle</code>. If the <code>VideoFrame</code> is not backed
-        by GPU, a TypeError exception will be raised. The <code>VideoFrame</code> keeps being locked
-        until <code>releaseVideoFrame</code> is called. While being locked, WebCodecs must NOT
-        manipulate the <code>VideoFrame</code> anymore.
+        a <code>WebGLWebCodecsVideoFrameHandle</code>. If the <code>VideoFrame</code> can't be
+        imported, a TypeError exception will be raised. The <code>VideoFrame</code> may keep being
+        locked until <code>releaseVideoFrame</code> is called. While being locked, WebCodecs must
+        NOT manipulate the <code>VideoFrame</code> anymore.
       </feature>
     </features>
   </overview>
@@ -94,7 +94,7 @@ dictionary WebGLWebCodecsVideoFrameHandle {
 
     <p> Next we can assemble the GLSL fragment shader to access the video frame textures.</p>
     <pre>
-    // Note: there could many textures for 1 VideoFrame. To be simple the sample here assumes only
+    // Note: there could be many textures for 1 VideoFrame. To be simple the sample here assumes only
     // 1 texture.
     let texInfo0 = videoFrameHandle.textureInfoArray[0];
     let fSource =
@@ -127,6 +127,7 @@ dictionary WebGLWebCodecsVideoFrameHandle {
     gl.clearColor(0.0, 0.0, 0.0, 0.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
+    gl.bindTexture(texInfo0.target, null);
     ext.releaseVideoFrame(webcodecsVideoFrame);
     </pre>
     
@@ -146,5 +147,9 @@ dictionary WebGLWebCodecsVideoFrameHandle {
     <revision date="2020/11/25">
       <change>Initial revision.</change>
     </revision>
+    <revision date="2020/12/28">
+      <change>Lift the hardware video frame restriction.</change>
+    </revision>
+
     </history>
 </proposal>

--- a/extensions/proposals/WEBGL_webcodecs_video_frame/webgl_webcodecs_video_frame.js
+++ b/extensions/proposals/WEBGL_webcodecs_video_frame/webgl_webcodecs_video_frame.js
@@ -172,6 +172,14 @@ function requestWebGLVideoFrameHandler(canvas) {
         }
     }
 
+    function unbindVideoFrame(gl, videoFrameHandle, texUnit) {
+        const infoArray = videoFrameHandle.textureInfoArray;
+        for (let i = 0; i < infoArray.length; ++i) {
+            gl.activeTexture(texUnit + i);
+            gl.bindTexture(infoArray[i].target, null);
+        }
+    }
+
     function initVertexBuffers(gl, program, videoFrame, posAttrib, coordAttrib) {
         const vertices = new Float32Array([
             -1.0, -1.0, 1.0, -1.0, 1.0, 1.0,
@@ -298,6 +306,7 @@ function requestWebGLVideoFrameHandler(canvas) {
         gl.clearColor(0.0, 0.0, 0.0, 0.0);
         gl.clear(gl.COLOR_BUFFER_BIT);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
+        unbindVideoFrame(gl, videoFrameHandle, gl.TEXTURE0);
 
         // Immediately schedule rendering of the next frame
         setTimeout(renderFrame, 0);


### PR DESCRIPTION
This lifts the restriction of importing harware video frames only.