### PR TITLE
Fix a typo in troubleshooting script

### DIFF
--- a/other/get.webgl.org/troubleshooting/DoNotCopyOrLinkThisFileElseYouWillNotGetAutoUpdatedHelpForYourUsers.js
+++ b/other/get.webgl.org/troubleshooting/DoNotCopyOrLinkThisFileElseYouWillNotGetAutoUpdatedHelpForYourUsers.js
@@ -177,7 +177,7 @@ var BrowserDetect = {
     subString: "iPad",
     identity: "iPad",
     browsers: [
-      {url: "https://www.mozilla.org/en-US/firefox/new/", name: "Mozilla Firefox"}
+      {url: "https://www.mozilla.org/en-US/firefox/new/", name: "Mozilla Firefox"},
       {url: "https://chrome.com/", name: "Google Chrome"}
     ]
   },


### PR DESCRIPTION
The author of #3204 forgot to add `,` and the script fails to execute. This patch fixes that problem.