### PR TITLE
Revise invalid-passed-params test.

### DIFF
--- a/conformance-suites/1.0.3/conformance/misc/invalid-passed-params.html
+++ b/conformance-suites/1.0.3/conformance/misc/invalid-passed-params.html
@@ -160,9 +160,8 @@ for (var i = 0; i < invalidSet.length; ++i) {
   var validShaderSource = generateShaderSource(undefined, invalidSet[i]);
   context.shaderSource(vShader, validShaderSource);
   shouldBe("context.getError()", "context.NO_ERROR");
-  var invalidShaderSource = generateShaderSource(invalidSet[i], undefined);
-  context.shaderSource(vShader, invalidShaderSource);
-  shouldBe("context.getError()", "context.INVALID_VALUE");
+  // Test of invalid identifier characters removed after
+  // https://github.com/KhronosGroup/WebGL/pull/3206 .
 }
 
 debug("");

--- a/conformance-suites/2.0.0/conformance/misc/invalid-passed-params.html
+++ b/conformance-suites/2.0.0/conformance/misc/invalid-passed-params.html
@@ -150,9 +150,8 @@ for (var i = 0; i < invalidSet.length; ++i) {
   var validShaderSource = generateShaderSource(undefined, invalidSet[i]);
   context.shaderSource(vShader, validShaderSource);
   shouldBe("context.getError()", "context.NO_ERROR");
-  var invalidShaderSource = generateShaderSource(invalidSet[i], undefined);
-  context.shaderSource(vShader, invalidShaderSource);
-  shouldBe("context.getError()", "context.INVALID_VALUE");
+  // Test of invalid identifier characters removed after
+  // https://github.com/KhronosGroup/WebGL/pull/3206 .
 }
 
 debug("");

--- a/sdk/tests/conformance/misc/invalid-passed-params.html
+++ b/sdk/tests/conformance/misc/invalid-passed-params.html
@@ -126,12 +126,15 @@ for (var i = 0; i < invalidSet.length; ++i) {
   // Backslash as line-continuation is allowed in WebGL 2.0.
   if (contextVersion > 1 && invalidSet[i] == '\\')
     continue;
+  // With recent specification changes from
+  // https://github.com/KhronosGroup/WebGL/pull/3206 , shaderSource no
+  // longer generates INVALID_VALUE.
   var validShaderSource = generateShaderSource(undefined, invalidSet[i]);
   context.shaderSource(vShader, validShaderSource);
   shouldBe("context.getError()", "context.NO_ERROR");
   var invalidShaderSource = generateShaderSource(invalidSet[i], undefined);
   context.shaderSource(vShader, invalidShaderSource);
-  shouldBe("context.getError()", "context.INVALID_VALUE");
+  shouldBe("context.getError()", "context.NO_ERROR");
 }
 
 debug("");


### PR DESCRIPTION
After #3206 , the top-of-tree test must expect that shaderSource no
longer generates INVALID_VALUE. This portion of the test is removed in
the 1.0.3 and 2.0.0 snapshots to keep them passing on both old and new
browsers.