### PR TITLE
Extra test for attribute divisor reset to 0 in angle-instanced-arrays.html

### DIFF
--- a/sdk/tests/conformance/extensions/angle-instanced-arrays.html
+++ b/sdk/tests/conformance/extensions/angle-instanced-arrays.html
@@ -196,6 +196,9 @@ function runOutputTests() {
         0.0, 1.0, 0.0, 1.0, // Green
         0.0, 0.0, 1.0, 1.0, // Blue
         1.0, 1.0, 0.0, 1.0, // Yellow
+        // extra data when colorLoc divisor is set back to 0
+        1.0, 1.0, 0.0, 1.0, // Yellow
+        1.0, 1.0, 0.0, 1.0, // Yellow
     ]);
     var colorBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
@@ -276,6 +279,17 @@ function runOutputTests() {
     wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0.5*canvas.height, w, h, [0, 255, 0, 255]);
     wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0, w, h, [0, 0, 255, 255]);
     wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0, w, h, [255, 255, 0, 255]);
+
+    debug("");
+    debug("Testing drawArraysInstancedANGLE with attributes 'divisor' reset to 0");
+    ext.vertexAttribDivisorANGLE(colorLoc, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    ext.drawArraysInstancedANGLE(gl.TRIANGLES, 3, 3, instanceCount);
+    wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0.5*canvas.height, w, h, [255, 255, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0.5*canvas.height, w, h, [255, 255, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0, w, h, [255, 255, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0, w, h, [255, 255, 0, 255]);
+    ext.vertexAttribDivisorANGLE(colorLoc, 1);
 
     wtu.setupUnitQuad(gl, 0);
     wtu.setupIndexedQuad(gl, 1, 0);

--- a/sdk/tests/conformance/extensions/angle-instanced-arrays.html
+++ b/sdk/tests/conformance/extensions/angle-instanced-arrays.html
@@ -282,6 +282,8 @@ function runOutputTests() {
 
     debug("");
     debug("Testing drawArraysInstancedANGLE with attributes 'divisor' reset to 0");
+    debug("Correct rendering output: 4 yellow triangles");
+    debug("Possible incorrect rendering output: missing triangles, or triangles with different color at each vertex");
     ext.vertexAttribDivisorANGLE(colorLoc, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
     ext.drawArraysInstancedANGLE(gl.TRIANGLES, 3, 3, instanceCount);

--- a/sdk/tests/conformance2/rendering/instanced-arrays.html
+++ b/sdk/tests/conformance2/rendering/instanced-arrays.html
@@ -123,6 +123,9 @@ function runOutputTests() {
         0.0, 1.0, 0.0, 1.0, // Green
         0.0, 0.0, 1.0, 1.0, // Blue
         1.0, 1.0, 0.0, 1.0, // Yellow
+        // extra data when colorLoc divisor is set back to 0
+        1.0, 1.0, 0.0, 1.0, // Yellow
+        1.0, 1.0, 0.0, 1.0, // Yellow
     ]);
     var colorBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, colorBuffer);
@@ -173,6 +176,45 @@ function runOutputTests() {
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with QUADS should return INVALID_ENUM");
     gl.drawArraysInstanced(desktopGL['POLYGON'], 0, 6, instanceCount);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with POLYGON should return INVALID_ENUM");
+
+    debug("Testing drawArraysInstancedANGLE with param 'first' > 0");
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.setupQuad(gl, {
+        positionLocation: 0,
+        scale: 0.5
+    });
+    var offsetsHalf = new Float32Array([
+        -0.5,  0.5,
+         0.5,  0.5,
+        -0.5, -0.5,
+         0.5, -0.5
+    ]);
+    gl.bindBuffer(gl.ARRAY_BUFFER, offsetBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, offsetsHalf, gl.STATIC_DRAW);
+
+    gl.drawArraysInstanced(gl.TRIANGLES, 3, 3, instanceCount);
+    var w = Math.floor(0.25*canvas.width),
+        h = Math.floor(0.25*canvas.height);
+    wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0.5*canvas.height, w, h, [255, 0, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0.5*canvas.height, w, h, [0, 255, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0, w, h, [0, 0, 255, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0, w, h, [255, 255, 0, 255]);
+
+    debug("Testing drawArraysInstancedANGLE with attributes 'divisor' reset to 0");
+    debug("Correct rendering output: 4 yellow triangles");
+    debug("Possible incorrect rendering output: missing triangles, or triangles with different color at each vertex");
+    gl.vertexAttribDivisor(colorLoc, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.drawArraysInstanced(gl.TRIANGLES, 3, 3, instanceCount);
+    wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0.5*canvas.height, w, h, [255, 255, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0.5*canvas.height, w, h, [255, 255, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0, w, h, [255, 255, 0, 255]);
+    wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0, w, h, [255, 255, 0, 255]);
+    gl.vertexAttribDivisor(colorLoc, 1);
+
+    wtu.setupUnitQuad(gl, 0);
+    gl.bindBuffer(gl.ARRAY_BUFFER, offsetBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, offsets, gl.STATIC_DRAW);
 
     // Draw 2: Draw indexed instances
     debug("Testing drawElementsInstanced");

--- a/sdk/tests/conformance2/rendering/instanced-arrays.html
+++ b/sdk/tests/conformance2/rendering/instanced-arrays.html
@@ -177,7 +177,7 @@ function runOutputTests() {
     gl.drawArraysInstanced(desktopGL['POLYGON'], 0, 6, instanceCount);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "drawArraysInstanced with POLYGON should return INVALID_ENUM");
 
-    debug("Testing drawArraysInstancedANGLE with param 'first' > 0");
+    debug("Testing drawArraysInstanced with param 'first' > 0");
     gl.clear(gl.COLOR_BUFFER_BIT);
     wtu.setupQuad(gl, {
         positionLocation: 0,
@@ -200,7 +200,7 @@ function runOutputTests() {
     wtu.checkCanvasRect(gl, Math.ceil(0.25*canvas.width), 0, w, h, [0, 0, 255, 255]);
     wtu.checkCanvasRect(gl, Math.ceil(0.75*canvas.width), 0, w, h, [255, 255, 0, 255]);
 
-    debug("Testing drawArraysInstancedANGLE with attributes 'divisor' reset to 0");
+    debug("Testing drawArraysInstanced with attributes 'divisor' reset to 0");
     debug("Correct rendering output: 4 yellow triangles");
     debug("Possible incorrect rendering output: missing triangles, or triangles with different color at each vertex");
     gl.vertexAttribDivisor(colorLoc, 0);


### PR DESCRIPTION
Related to workaround for latest Mac Intel opengl driver bug http://crbug.com/1144207

Test description: we want to make sure webgl does instanced draw correctly when the non-zero divisor of an attribute is reset to zero. The attribute with the new divisor == 0 should be treated as a regular vertex attribute.

The test turns divisor of color attribute to zero. with `drawArraysInstancedANGLE(gl.TRIANGLES, 3, 3, instanceCount);`, it's the last three yellow vec4 that would be accessed by vertices. The test should draw 4 yellow triangles.

Tested locally on Mac AMD (passes chrome/firefox, patched chrome), Mac Intel (fails chrome/firefox, passes patched chrome)