### PR TITLE
Replace VideoTrackReader

### DIFF
--- a/extensions/proposals/WEBGL_webcodecs_video_frame/webgl_webcodecs_video_frame.js
+++ b/extensions/proposals/WEBGL_webcodecs_video_frame/webgl_webcodecs_video_frame.js
@@ -329,7 +329,7 @@ function requestWebGLVideoFrameHandler(canvas) {
         // Immediately schedule rendering of the next frame
         setTimeout(renderFrame, 0);
         ext.releaseVideoFrame(videoFrameHandle);
-        frame.destroy();
+        frame.close();
         if (webgl_webcodecs_test_context_ != null && webgl_webcodecs_test_context_.displayed_frame
             == webgl_webcodecs_test_context_.maxFrameTested) {
             webgl_webcodecs_test_context_.finishTest();

--- a/sdk/tests/conformance/extensions/webgl-webcodecs-video-frame.html
+++ b/sdk/tests/conformance/extensions/webgl-webcodecs-video-frame.html
@@ -123,6 +123,7 @@ found in the LICENSE.txt file.
           return;
 
         if (pending_outputs > 30) {
+          console.log("drop this frame");
           // Too many frames in flight, encoder is overwhelmed
           // let's drop this frame.
           value.close();
@@ -130,7 +131,7 @@ found in the LICENSE.txt file.
           return;
         }
 
-        if(!keep_going) {
+        if(frame_counter == kMaxFrame) {
           frame_reader.releaseLock();
           processor.readable.cancel();
           value.close();

--- a/sdk/tests/conformance/extensions/webgl-webcodecs-video-frame.html
+++ b/sdk/tests/conformance/extensions/webgl-webcodecs-video-frame.html
@@ -91,7 +91,7 @@ found in the LICENSE.txt file.
       let fps = 60;
       let pending_outputs = 0;
       let stream = cnv.captureStream(fps);
-      let vtr = new VideoTrackReader(stream.getVideoTracks()[0]);
+      let processor = new MediaStreamTrackProcessor(stream.getVideoTracks()[0]);
 
       const init = {
         output: (chunk) => {
@@ -117,21 +117,32 @@ found in the LICENSE.txt file.
       let encoder = new VideoEncoder(init);
       encoder.configure(config);
 
-      vtr.start((frame) => {
+      const frame_reader = processor.readable.getReader();
+      frame_reader.read().then(function processFrame({done, value}) {
+        if (done)
+          return;
+
         if (pending_outputs > 30) {
-          console.log("drop this frame");
           // Too many frames in flight, encoder is overwhelmed
           // let's drop this frame.
+          value.close();
+          frame_reader.read().then(processFrame);
           return;
         }
-        if (frame_counter == kMaxFrame) {
+
+        if(!keep_going) {
+          frame_reader.releaseLock();
+          processor.readable.cancel();
+          value.close();
           return;
         }
 
         frame_counter++;
         pending_outputs++;
         const insert_keyframe = (frame_counter % 150) == 0;
-        encoder.encode(frame, { keyFrame: insert_keyframe });
+        encoder.encode(value, { keyFrame: insert_keyframe });
+
+        frame_reader.read().then(processFrame);
       });
     }
 

--- a/sdk/tests/performance/webgl_webcodecs_video_frame/index.html
+++ b/sdk/tests/performance/webgl_webcodecs_video_frame/index.html
@@ -121,9 +121,8 @@
         }
 
         if(!keep_going) {
-          frame_reader.releaseLock();
-          processor.readable.cancel();
           value.close();
+          frame_reader.read().then(processFrame);
           return;
         }
 

--- a/sdk/tests/performance/webgl_webcodecs_video_frame/index.html
+++ b/sdk/tests/performance/webgl_webcodecs_video_frame/index.html
@@ -83,7 +83,7 @@
       let pending_outputs = 0;
       let frame_counter = 0;
       let stream = cnv.captureStream(fps);
-      let vtr = new VideoTrackReader(stream.getVideoTracks()[0]);
+      let processor = new MediaStreamTrackProcessor(stream.getVideoTracks()[0]);
 
       const init = {
         output: (chunk) => {
@@ -107,18 +107,32 @@
       let encoder = new VideoEncoder(init);
       encoder.configure(config);
 
-      vtr.start((frame) => {
-        if (!keep_going)
+      const frame_reader = processor.readable.getReader();
+      frame_reader.read().then(function processFrame({done, value}) {
+        if (done)
           return;
+
         if (pending_outputs > 30) {
           // Too many frames in flight, encoder is overwhelmed
           // let's drop this frame.
+          value.close();
+          frame_reader.read().then(processFrame);
           return;
         }
+
+        if(!keep_going) {
+          frame_reader.releaseLock();
+          processor.readable.cancel();
+          value.close();
+          return;
+        }
+
         frame_counter++;
         pending_outputs++;
         const insert_keyframe = (frame_counter % 150) == 0;
-        encoder.encode(frame, { keyFrame: insert_keyframe });
+        encoder.encode(value, { keyFrame: insert_keyframe });
+
+        frame_reader.read().then(processFrame);
       });
     }
 


### PR DESCRIPTION
VideoTrackReader is deprecated (see crbug.com/1157610), and it needs be replaced by the equivalent MediaStreamTrackProcessor.