### PR TITLE
Add video element playback error detection, use it to fail test.

### DIFF
--- a/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
@@ -1335,6 +1335,10 @@ var getRequestVidFrameCallback = function() {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed('Video failed to load: ' + video.error);
+    return;
+  }
   video.addEventListener(
       'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
@@ -1378,11 +1382,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
 
   video.loop = true;
   video.muted = true;
-  try {
-    await video.play();
-  } catch (error) {
-    testFailed('Video failed to play(): ' + error);
-  }
+  video.play();
 };
 
 return {

--- a/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
@@ -1335,6 +1335,15 @@ var getRequestVidFrameCallback = function() {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed("Video playback failed: " + e.message);
+    return;
+  }
+
+  video.addEventListener(
+      'error', e => { testFailed("Video playback failed: " + e.message); },
+      true);
+
   var rvfc = getRequestVidFrameCallback();
 
   if(rvfc === undefined) {

--- a/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.1/conformance/resources/webgl-test-utils.js
@@ -1335,13 +1335,8 @@ var getRequestVidFrameCallback = function() {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  if (video.error) {
-    testFailed("Video playback failed: " + e.message);
-    return;
-  }
-
   video.addEventListener(
-      'error', e => { testFailed("Video playback failed: " + e.message); },
+      'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
 
   var rvfc = getRequestVidFrameCallback();
@@ -1383,7 +1378,11 @@ var startPlayingAndWaitForVideo = function(video, callback) {
 
   video.loop = true;
   video.muted = true;
-  video.play();
+  try {
+    await video.play();
+  } catch (error) {
+    testFailed('Video failed to play(): ' + error);
+  }
 };
 
 return {

--- a/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
@@ -2000,13 +2000,8 @@ var waitForComposite = function(gl, callback) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  if (video.error) {
-    testFailed("Video playback failed: " + e.message);
-    return;
-  }
-
   video.addEventListener(
-      'error', e => { testFailed("Video playback failed: " + e.message); },
+      'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
 
   var rvfc = getRequestVidFrameCallback();
@@ -2048,7 +2043,11 @@ var startPlayingAndWaitForVideo = function(video, callback) {
 
   video.loop = true;
   video.muted = true;
-  video.play();
+  try {
+    await video.play();
+  } catch (error) {
+    testFailed('Video failed to play(): ' + error);
+  }
 };
 
 return {

--- a/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
@@ -2000,6 +2000,10 @@ var waitForComposite = function(gl, callback) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed('Video failed to load: ' + video.error);
+    return;
+  }
   video.addEventListener(
       'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
@@ -2043,11 +2047,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
 
   video.loop = true;
   video.muted = true;
-  try {
-    await video.play();
-  } catch (error) {
-    testFailed('Video failed to play(): ' + error);
-  }
+  video.play();
 };
 
 return {

--- a/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.2/conformance/resources/webgl-test-utils.js
@@ -2000,6 +2000,15 @@ var waitForComposite = function(gl, callback) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed("Video playback failed: " + e.message);
+    return;
+  }
+
+  video.addEventListener(
+      'error', e => { testFailed("Video playback failed: " + e.message); },
+      true);
+
   var rvfc = getRequestVidFrameCallback();
 
   if(rvfc === undefined) {

--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -2594,6 +2594,15 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed("Video playback failed: " + e.message);
+    return;
+  }
+
+  video.addEventListener(
+      'error', e => { testFailed("Video playback failed: " + e.message); },
+      true);
+
   var rvfc = getRequestVidFrameCallback();
   if (rvfc === undefined) {
     var gotPlaying = false;

--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -2594,13 +2594,8 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  if (video.error) {
-    testFailed("Video playback failed: " + e.message);
-    return;
-  }
-
   video.addEventListener(
-      'error', e => { testFailed("Video playback failed: " + e.message); },
+      'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
 
   var rvfc = getRequestVidFrameCallback();
@@ -2641,7 +2636,11 @@ var startPlayingAndWaitForVideo = function(video, callback) {
 
   video.loop = true;
   video.muted = true;
-  video.play();
+  try {
+    await video.play();
+  } catch (error) {
+    testFailed('Video failed to play(): ' + error);
+  }
 };
 
 var getHost = function(url) {

--- a/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
+++ b/conformance-suites/1.0.3/conformance/resources/webgl-test-utils.js
@@ -2594,6 +2594,10 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed('Video failed to load: ' + video.error);
+    return;
+  }
   video.addEventListener(
       'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
@@ -2636,11 +2640,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
 
   video.loop = true;
   video.muted = true;
-  try {
-    await video.play();
-  } catch (error) {
-    testFailed('Video failed to play(): ' + error);
-  }
+  video.play();
 };
 
 var getHost = function(url) {

--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -2883,6 +2883,15 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed("Video playback failed: " + e.message);
+    return;
+  }
+
+  video.addEventListener(
+      'error', e => { testFailed("Video playback failed: " + e.message); },
+      true);
+
   var rvfc = getRequestVidFrameCallback();
   if (rvfc === undefined) {
     var gotPlaying = false;

--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -2883,6 +2883,10 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed('Video failed to load: ' + video.error);
+    return;
+  }
   video.addEventListener(
       'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
@@ -2927,11 +2931,7 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   video.muted = true;
   // See whether setting the preload flag de-flakes video-related tests.
   video.preload = 'auto';
-  try {
-    await video.play();
-  } catch (error) {
-    testFailed('Video failed to play(): ' + error);
-  }
+  video.play();
 };
 
 var getHost = function(url) {

--- a/conformance-suites/2.0.0/js/webgl-test-utils.js
+++ b/conformance-suites/2.0.0/js/webgl-test-utils.js
@@ -2883,13 +2883,8 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  if (video.error) {
-    testFailed("Video playback failed: " + e.message);
-    return;
-  }
-
   video.addEventListener(
-      'error', e => { testFailed("Video playback failed: " + e.message); },
+      'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
 
   var rvfc = getRequestVidFrameCallback();
@@ -2932,7 +2927,11 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   video.muted = true;
   // See whether setting the preload flag de-flakes video-related tests.
   video.preload = 'auto';
-  video.play();
+  try {
+    await video.play();
+  } catch (error) {
+    testFailed('Video failed to play(): ' + error);
+  }
 };
 
 var getHost = function(url) {

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3132,7 +3132,7 @@ var runSteps = function(steps) {
  * @param {!function(!HTMLVideoElement): void} callback Function to call when
  *        video is ready.
  */
-var startPlayingAndWaitForVideo = function(video, callback) {
+async function startPlayingAndWaitForVideo(video, callback) {
   video.addEventListener(
       'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3133,13 +3133,8 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
-  if (video.error) {
-    testFailed("Video playback failed: " + e.message);
-    return;
-  }
-
   video.addEventListener(
-      'error', e => { testFailed("Video playback failed: " + e.message); },
+      'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
 
   var rvfc = getRequestVidFrameCallback();
@@ -3162,7 +3157,11 @@ var startPlayingAndWaitForVideo = function(video, callback) {
   video.muted = true;
   // See whether setting the preload flag de-flakes video-related tests.
   video.preload = 'auto';
-  video.play();
+  try {
+    await video.play();
+  } catch (error) {
+    testFailed('Video failed to play(): ' + error);
+  }
 };
 
 var getHost = function(url) {

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3133,6 +3133,15 @@ var runSteps = function(steps) {
  *        video is ready.
  */
 var startPlayingAndWaitForVideo = function(video, callback) {
+  if (video.error) {
+    testFailed("Video playback failed: " + e.message);
+    return;
+  }
+
+  video.addEventListener(
+      'error', e => { testFailed("Video playback failed: " + e.message); },
+      true);
+
   var rvfc = getRequestVidFrameCallback();
   if (rvfc === undefined) {
     var timeWatcher = function() {


### PR DESCRIPTION
Some tests will silently hang when playback errors occur, so add
an error listener so the failure reason is more obvious.