### PR TITLE
Don't use await for video.play() promise.

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3132,7 +3132,12 @@ var runSteps = function(steps) {
  * @param {!function(!HTMLVideoElement): void} callback Function to call when
  *        video is ready.
  */
-async function startPlayingAndWaitForVideo(video, callback) {
+function startPlayingAndWaitForVideo(video, callback) {
+  if (video.error) {
+    testFailed('Video failed to load: ' + video.error);
+    return;
+  }
+
   video.addEventListener(
       'error', e => { testFailed('Video playback failed: ' + e.message); },
       true);
@@ -3157,11 +3162,7 @@ async function startPlayingAndWaitForVideo(video, callback) {
   video.muted = true;
   // See whether setting the preload flag de-flakes video-related tests.
   video.preload = 'auto';
-  try {
-    await video.play();
-  } catch (error) {
-    testFailed('Video failed to play(): ' + error);
-  }
+  video.play();
 };
 
 var getHost = function(url) {


### PR DESCRIPTION
Some tests are finishing as soon as the first frame has come in
and triggering a pause() or other condition which thorws a
'AssertionError: Video failed to play(): AbortError: The play()
request was interrupted by a call to pause().' error.

So just check for no sources and use the error handler like we
do on older WebGL test versions.

Addresses new failures seen while rolling forward WebGL
conformance in Chromium:
https://chromium-review.googlesource.com/2775887/
for http://crbug.com/1136205 .