### PR TITLE
Add getInternalformatParameter for EXT_texture_norm16

### DIFF
--- a/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
+++ b/sdk/tests/conformance2/extensions/ext-color-buffer-float.html
@@ -284,7 +284,7 @@ function runInternalFormatQueryTest()
     debug("testing the internal format query");
 
     var maxSamples = gl.getParameter(gl.MAX_SAMPLES);
-    var formats = new Array(gl.RGBA16F, gl.R32F, gl.RG32F, gl.RGBA32F, gl.R16F, gl.RG16F, gl.R11F_G11F_B10F);
+    const formats = [gl.RGBA16F, gl.R32F, gl.RG32F, gl.RGBA32F, gl.R16F, gl.RG16F, gl.R11F_G11F_B10F];
     var firstMultiOnlyFormat = 4;
     for (var fmt = 0; fmt < formats.length; ++fmt) {
         var samples = gl.getInternalformatParameter(gl.RENDERBUFFER, formats[fmt], gl.SAMPLES);

--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -153,6 +153,23 @@ function testSnorm16Unrenderable(internalFormat, format, type) {
                                 "framebuffer should not be complete with SNORM16 texture attached");
 }
 
+function runInternalFormatQueryTest()
+{
+    debug("");
+    debug("testing the internal format query");
+
+    var maxSamples = gl.getParameter(gl.MAX_SAMPLES);
+    var formats = new Array(ext.R16_EXT, ext.RG16_EXT, ext.RGBA16_EXT);
+    for (var fmt = 0; fmt < formats.length; ++fmt) {
+        var samples = gl.getInternalformatParameter(gl.RENDERBUFFER, formats[fmt], gl.SAMPLES);
+        if (samples == null || samples.length == 0 || samples[0] < maxSamples) {
+            testFailed("the maximum value in SAMPLES should be at least " + maxSamples);
+            return;
+        }
+    }
+    testPassed("Internal format query succeeded");
+}
+
 function runTestExtension() {
   textures = [gl.createTexture(), gl.createTexture()];
   fbos = [gl.createFramebuffer(), gl.createFramebuffer()];
@@ -207,6 +224,7 @@ function runTest() {
     wtu.runExtensionSupportedTest(gl, "EXT_texture_norm16", ext !== null);
 
     if (ext !== null) {
+      runInternalFormatQueryTest();
       runTestExtension();
     } else {
       testPassed("No EXT_texture_norm16 support -- this is legal");

--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -159,9 +159,9 @@ function runInternalFormatQueryTest()
     debug("testing the internal format query");
 
     var maxSamples = gl.getParameter(gl.MAX_SAMPLES);
-    var formats = new Array(ext.R16_EXT, ext.RG16_EXT, ext.RGBA16_EXT);
-    for (var fmt = 0; fmt < formats.length; ++fmt) {
-        var samples = gl.getInternalformatParameter(gl.RENDERBUFFER, formats[fmt], gl.SAMPLES);
+    const formats = [ext.R16_EXT, ext.RG16_EXT, ext.RGBA16_EXT];
+    for (const format of formats) {
+        var samples = gl.getInternalformatParameter(gl.RENDERBUFFER, format, gl.SAMPLES);
         if (samples == null || samples.length == 0 || samples[0] < maxSamples) {
             testFailed("the maximum value in SAMPLES should be at least " + maxSamples);
             return;

--- a/sdk/tests/js/tests/ext-color-buffer-half-float.js
+++ b/sdk/tests/js/tests/ext-color-buffer-half-float.js
@@ -244,7 +244,7 @@ function runInternalFormatQueryTest()
     debug("testing the internal format query");
 
     var maxSamples = gl.getParameter(gl.MAX_SAMPLES);
-    var formats = new Array(gl.RGBA16F, gl.R16F, gl.RG16F);
+    const formats = [gl.RGBA16F, gl.R16F, gl.RG16F];
     var firstMultiOnlyFormat = 4;
     for (var fmt = 0; fmt < formats.length; ++fmt) {
         var samples = gl.getInternalformatParameter(gl.RENDERBUFFER, formats[fmt], gl.SAMPLES);


### PR DESCRIPTION
Add a regression test as chrome is missing return for formats added in `EXT_texture_norm16` in `getInternalformatParameter`
`R16`, `RG16`, `RGBA16` should be all multisample-support