### PR TITLE
Allow either bad-size=>INVALID_OP or bad-stride=>INVALID_VAL for vert…

### DIFF
--- a/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
+++ b/sdk/tests/conformance/attribs/gl-vertexattribpointer.html
@@ -152,7 +152,7 @@ if (!gl) {
               gl, size < info.minSize ? gl.INVALID_OPERATION : gl.NO_ERROR, "at stride limit",
               size, info.type, false, stride, offset);
           checkVertexAttribPointer(
-              gl, size < info.minSize ? gl.INVALID_OPERATION : gl.INVALID_VALUE, "over stride limit",
+              gl, size < info.minSize ? [gl.INVALID_OPERATION, gl.INVALID_VALUE] : gl.INVALID_VALUE, "over stride limit",
               size, info.type, false,
               stride + info.bytesPerComponent, offset);
         }


### PR DESCRIPTION
…exAttribPointer.

Bad size is specified as INVALID_OPERATION here:
https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.10

Too-large stride is specified as INVALID_VALUE here:
https://www.khronos.org/registry/webgl/specs/latest/1.0/#6.13
