### PR TITLE
In EXT_disjoint_timer_query examples, delete query objects.

### DIFF
--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -224,6 +224,7 @@ interface EXT_disjoint_timer_query {
         ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
+        // (Note that this code might be called multiple times)
         if (query) {
           let available = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
           let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
@@ -260,6 +261,7 @@ interface EXT_disjoint_timer_query {
         ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
+        // (Note that this code might be called multiple times)
         if (startQuery) {
           let available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
           let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
@@ -324,6 +326,7 @@ interface EXT_disjoint_timer_query {
         }
 
         // ...at some point in the future, after returning control to the browser and being called again:
+        // (Note that this code might be called multiple times)
         if (startQuery || endQuery || timeElapsedQuery) {
           let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
           let available;

--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -224,21 +224,26 @@ interface EXT_disjoint_timer_query {
         ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        let available = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
-        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        if (query) {
+          let available = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
+          let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
-        if (available &amp;&amp; !disjoint) {
-          // See how much time the rendering of the object took in nanoseconds.
-          let timeElapsed = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
+          if (available &amp;&amp; !disjoint) {
+            // See how much time the rendering of the object took in nanoseconds.
+            let timeElapsed = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
 
-          // Do something useful with the time.  Note that care should be
-          // taken to use all significant bits of the result, not just the
-          // least significant 32 bits.
-          adjustObjectLODBasedOnDrawTime(timeElapsed);
+            // Do something useful with the time.  Note that care should be
+            // taken to use all significant bits of the result, not just the
+            // least significant 32 bits.
+            adjustObjectLODBasedOnDrawTime(timeElapsed);
+          }
 
-          // Clean up the query object.
-          ext.deleteQueryEXT(query);
-          query = null;
+          if (available || disjoint) {
+            // Clean up the query object.
+            ext.deleteQueryEXT(query);
+            // Don't re-enter this polling loop.
+            query = null;
+          }
         }
 
         //----------------------------------------------------------------------
@@ -255,24 +260,30 @@ interface EXT_disjoint_timer_query {
         ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        let available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
-        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        if (startQuery) {
+          let available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
+          let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
-        if (available &amp;&amp; !disjoint) {
-          // See how much time the rendering of the object took in nanoseconds.
-          let timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
-          let timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
+          if (available &amp;&amp; !disjoint) {
+            // See how much time the rendering of the object took in nanoseconds.
+            let timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
+            let timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
 
-          // Do something useful with the time.  Note that care should be
-          // taken to use all significant bits of the result, not just the
-          // least significant 32 bits.
-          adjustObjectLODBasedOnDrawTime(timeEnd - timeStart);
+            // Do something useful with the time.  Note that care should be
+            // taken to use all significant bits of the result, not just the
+            // least significant 32 bits.
+            adjustObjectLODBasedOnDrawTime(timeEnd - timeStart);
+          }
 
-          // Clean up the query objects.
-          ext.deleteQueryEXT(startQuery);
-          ext.deleteQueryEXT(endQuery);
-          startQuery = null;
-          endQuery = null;
+          if (available || disjoint) {
+            // Clean up the query objects.
+            ext.deleteQueryEXT(startQuery);
+            ext.deleteQueryEXT(endQuery);
+
+            // Don't re-enter this polling loop.
+            startQuery = null;
+            endQuery = null;
+          }
         }
 
         //----------------------------------------------------------------------
@@ -313,38 +324,48 @@ interface EXT_disjoint_timer_query {
         }
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
-        if (disjoint) {
-          // Have to redo all of the measurements.
-        } else {
+        if (startQuery || endQuery || timeElapsedQuery) {
+          let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
           let available;
-          if (useTimestamps) {
-            available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
+          if (disjoint) {
+            // Have to redo all of the measurements.
           } else {
-            available = ext.getQueryObjectEXT(timeElapsedQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
-          }
-
-          if (available) {
-            let timeElapsed;
             if (useTimestamps) {
-              // See how much time the rendering of the object took in nanoseconds.
-              let timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
-              let timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
-              timeElapsed = timeEnd - timeStart;
+              available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
             } else {
-              timeElapsed = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
+              available = ext.getQueryObjectEXT(timeElapsedQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
             }
 
-            // Do something useful with the time.  Note that care should be
-            // taken to use all significant bits of the result, not just the
-            // least significant 32 bits.
-            adjustObjectLODBasedOnDrawTime(timeElapsed);
+            if (available) {
+              let timeElapsed;
+              if (useTimestamps) {
+                // See how much time the rendering of the object took in nanoseconds.
+                let timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
+                let timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
+                timeElapsed = timeEnd - timeStart;
+              } else {
+                timeElapsed = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
+              }
 
+              // Do something useful with the time.  Note that care should be
+              // taken to use all significant bits of the result, not just the
+              // least significant 32 bits.
+              adjustObjectLODBasedOnDrawTime(timeElapsed);
+            }
+          }
+
+          if (available || disjoint) {
             // Clean up the query objects.
-            ext.deleteQueryEXT(startQuery);
-            ext.deleteQueryEXT(endQuery);
-            startQuery = null;
-            endQuery = null;
+            if (useTimestamps) {
+              ext.deleteQueryEXT(startQuery);
+              ext.deleteQueryEXT(endQuery);
+              // Don't re-enter the polling loop above.
+              startQuery = null;
+              endQuery = null;
+            } else {
+              ext.deleteQueryEXT(timeElapsedQuery);
+              timeElapsedQuery = null;
+            }
           }
         }
     </pre>

--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -214,8 +214,8 @@ interface EXT_disjoint_timer_query {
   <samplecode xml:space="preserve">
     <pre>
         // Example (1) -- uses beginQueryEXT/endQueryEXT.
-        var ext = gl.getExtension('EXT_disjoint_timer_query');
-        var query = ext.createQueryEXT();
+        let ext = gl.getExtension('EXT_disjoint_timer_query');
+        let query = ext.createQueryEXT();
         ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
         // Draw object
@@ -224,25 +224,29 @@ interface EXT_disjoint_timer_query {
         ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        var available = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
-        var disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        let available = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_AVAILABLE_EXT);
+        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
         if (available &amp;&amp; !disjoint) {
           // See how much time the rendering of the object took in nanoseconds.
-          var timeElapsed = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
+          let timeElapsed = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
 
           // Do something useful with the time.  Note that care should be
           // taken to use all significant bits of the result, not just the
           // least significant 32 bits.
           adjustObjectLODBasedOnDrawTime(timeElapsed);
+
+          // Clean up the query object.
+          ext.deleteQueryEXT(query);
+          query = null;
         }
 
         //----------------------------------------------------------------------
 
         // Example (2) -- same as the example above, but uses queryCounterEXT instead.
-        var ext = gl.getExtension('EXT_disjoint_timer_query');
-        var startQuery = ext.createQueryEXT();
-        var endQuery = ext.createQueryEXT();
+        let ext = gl.getExtension('EXT_disjoint_timer_query');
+        let startQuery = ext.createQueryEXT();
+        let endQuery = ext.createQueryEXT();
         ext.queryCounterEXT(startQuery, ext.TIMESTAMP_EXT);
 
         // Draw object
@@ -251,30 +255,36 @@ interface EXT_disjoint_timer_query {
         ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        var available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
-        var disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        let available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
+        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
         if (available &amp;&amp; !disjoint) {
           // See how much time the rendering of the object took in nanoseconds.
-          var timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
-          var timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
+          let timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
+          let timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
 
           // Do something useful with the time.  Note that care should be
           // taken to use all significant bits of the result, not just the
           // least significant 32 bits.
           adjustObjectLODBasedOnDrawTime(timeEnd - timeStart);
+
+          // Clean up the query objects.
+          ext.deleteQueryEXT(startQuery);
+          ext.deleteQueryEXT(endQuery);
+          startQuery = null;
+          endQuery = null;
         }
 
         //----------------------------------------------------------------------
 
         // Example (3) -- check the number of timestamp bits to determine how to best
         // measure elapsed time.
-        var ext = gl.getExtension('EXT_disjoint_timer_query');
-        var timeElapsedQuery;
-        var startQuery;
-        var endQuery;
+        let ext = gl.getExtension('EXT_disjoint_timer_query');
+        let timeElapsedQuery;
+        let startQuery;
+        let endQuery;
 
-        var useTimestamps = false;
+        let useTimestamps = false;
 
         if (ext.getQueryEXT(ext.TIMESTAMP_EXT, ext.QUERY_COUNTER_BITS_EXT) > 0) {
           useTimestamps = true;
@@ -303,11 +313,11 @@ interface EXT_disjoint_timer_query {
         }
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        var disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
         if (disjoint) {
           // Have to redo all of the measurements.
         } else {
-          var available;
+          let available;
           if (useTimestamps) {
             available = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_AVAILABLE_EXT);
           } else {
@@ -315,11 +325,11 @@ interface EXT_disjoint_timer_query {
           }
 
           if (available) {
-            var timeElapsed;
+            let timeElapsed;
             if (useTimestamps) {
               // See how much time the rendering of the object took in nanoseconds.
-              var timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
-              var timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
+              let timeStart = ext.getQueryObjectEXT(startQuery, ext.QUERY_RESULT_EXT);
+              let timeEnd = ext.getQueryObjectEXT(endQuery, ext.QUERY_RESULT_EXT);
               timeElapsed = timeEnd - timeStart;
             } else {
               timeElapsed = ext.getQueryObjectEXT(query, ext.QUERY_RESULT_EXT);
@@ -329,6 +339,12 @@ interface EXT_disjoint_timer_query {
             // taken to use all significant bits of the result, not just the
             // least significant 32 bits.
             adjustObjectLODBasedOnDrawTime(timeElapsed);
+
+            // Clean up the query objects.
+            ext.deleteQueryEXT(startQuery);
+            ext.deleteQueryEXT(endQuery);
+            startQuery = null;
+            endQuery = null;
           }
         }
     </pre>
@@ -358,6 +374,9 @@ interface EXT_disjoint_timer_query {
     </revision>
     <revision date="2016/09/30">
       <change>Added clarifying note that this document only applies to WebGL 1.0. Minor reformatting and typo fixes.</change>
+    </revision>
+    <revision date="2021/04/01">
+      <change>Clean up query objects via deleteQueryEXT. Modernize examples' JavaScript code.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -119,21 +119,26 @@ interface EXT_disjoint_timer_query_webgl2 {
         gl.endQuery(ext.TIME_ELAPSED_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        let available = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
-        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        if (query) {
+          let available = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
+          let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
-        if (available &amp;&amp; !disjoint) {
-          // See how much time the rendering of the object took in nanoseconds.
-          let timeElapsed = gl.getQueryParameter(query, gl.QUERY_RESULT);
+          if (available &amp;&amp; !disjoint) {
+            // See how much time the rendering of the object took in nanoseconds.
+            let timeElapsed = gl.getQueryParameter(query, gl.QUERY_RESULT);
 
-          // Do something useful with the time.  Note that care should be
-          // taken to use all significant bits of the result, not just the
-          // least significant 32 bits.
-          adjustObjectLODBasedOnDrawTime(timeElapsed);
+            // Do something useful with the time.  Note that care should be
+            // taken to use all significant bits of the result, not just the
+            // least significant 32 bits.
+            adjustObjectLODBasedOnDrawTime(timeElapsed);
+          }
 
-          // Clean up the query object.
-          gl.deleteQuery(query);
-          query = null;
+          if (available || disjoint) {
+            // Clean up the query object.
+            gl.deleteQuery(query);
+            // Don't re-enter this polling loop.
+            query = null;
+          }
         }
 
         //----------------------------------------------------------------------
@@ -150,24 +155,30 @@ interface EXT_disjoint_timer_query_webgl2 {
         ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        let available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
-        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        if (startQuery) {
+          let available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
+          let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
-        if (available &amp;&amp; !disjoint) {
-          // See how much time the rendering of the object took in nanoseconds.
-          let timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
-          let timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
+          if (available &amp;&amp; !disjoint) {
+            // See how much time the rendering of the object took in nanoseconds.
+            let timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
+            let timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
 
-          // Do something useful with the time.  Note that care should be
-          // taken to use all significant bits of the result, not just the
-          // least significant 32 bits.
-          adjustObjectLODBasedOnDrawTime(timeEnd - timeStart);
+            // Do something useful with the time.  Note that care should be
+            // taken to use all significant bits of the result, not just the
+            // least significant 32 bits.
+            adjustObjectLODBasedOnDrawTime(timeEnd - timeStart);
+          }
 
-          // Clean up the query objects.
-          gl.deleteQuery(startQuery);
-          gl.deleteQuery(endQuery);
-          startQuery = null;
-          endQuery = null;
+          if (available || disjoint) {
+            // Clean up the query objects.
+            gl.deleteQuery(startQuery);
+            gl.deleteQuery(endQuery);
+
+            // Don't re-enter this polling loop.
+            startQuery = null;
+            endQuery = null;
+          }
         }
 
         //----------------------------------------------------------------------
@@ -208,38 +219,49 @@ interface EXT_disjoint_timer_query_webgl2 {
         }
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
-        if (disjoint) {
-          // Have to redo all of the measurements.
-        } else {
+        if (startQuery || endQuery || timeElapsedQuery) {
+          let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
           let available;
-          if (useTimestamps) {
-            available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
+          if (disjoint) {
+            // Have to redo all of the measurements.
           } else {
-            available = gl.getQueryParameter(timeElapsedQuery, gl.QUERY_RESULT_AVAILABLE);
-          }
-
-          if (available) {
-            let timeElapsed;
             if (useTimestamps) {
-              // See how much time the rendering of the object took in nanoseconds.
-              let timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
-              let timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
-              timeElapsed = timeEnd - timeStart;
+              available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
             } else {
-              timeElapsed = gl.getQueryParameter(query, gl.QUERY_RESULT);
+              available = gl.getQueryParameter(timeElapsedQuery, gl.QUERY_RESULT_AVAILABLE);
             }
 
-            // Do something useful with the time.  Note that care should be
-            // taken to use all significant bits of the result, not just the
-            // least significant 32 bits.
-            adjustObjectLODBasedOnDrawTime(timeElapsed);
+            if (available) {
+              let timeElapsed;
+              if (useTimestamps) {
+                // See how much time the rendering of the object took in nanoseconds.
+                let timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
+                let timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
+                timeElapsed = timeEnd - timeStart;
+              } else {
+                timeElapsed = gl.getQueryParameter(query, gl.QUERY_RESULT);
+              }
 
+              // Do something useful with the time.  Note that care should be
+              // taken to use all significant bits of the result, not just the
+              // least significant 32 bits.
+              adjustObjectLODBasedOnDrawTime(timeElapsed);
+            }
+          }
+
+          if (available || disjoint) {
             // Clean up the query objects.
-            gl.deleteQuery(startQuery);
-            gl.deleteQuery(endQuery);
-            startQuery = null;
-            endQuery = null;
+            if (useTimestamps) {
+              gl.deleteQuery(startQuery);
+              gl.deleteQuery(endQuery);
+              // Don't re-enter the polling loop above.
+              startQuery = null;
+              endQuery = null;
+            } else {
+              gl.deleteQuery(timeElapsedQuery);
+              // Don't re-enter the polling loop above.
+              timeElapsedQuery = null;
+            }
           }
         }
     </pre>

--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -119,6 +119,7 @@ interface EXT_disjoint_timer_query_webgl2 {
         gl.endQuery(ext.TIME_ELAPSED_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
+        // (Note that this code might be called multiple times)
         if (query) {
           let available = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
           let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
@@ -155,6 +156,7 @@ interface EXT_disjoint_timer_query_webgl2 {
         ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
+        // (Note that this code might be called multiple times)
         if (startQuery) {
           let available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
           let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
@@ -219,6 +221,7 @@ interface EXT_disjoint_timer_query_webgl2 {
         }
 
         // ...at some point in the future, after returning control to the browser and being called again:
+        // (Note that this code might be called multiple times)
         if (startQuery || endQuery || timeElapsedQuery) {
           let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
           let available;

--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -109,8 +109,8 @@ interface EXT_disjoint_timer_query_webgl2 {
   <samplecode xml:space="preserve">
     <pre>
         // Example (1) -- uses beginQuery/endQuery.
-        var ext = gl.getExtension('EXT_disjoint_timer_query_webgl2');
-        var query = gl.createQuery();
+        let ext = gl.getExtension('EXT_disjoint_timer_query_webgl2');
+        let query = gl.createQuery();
         gl.beginQuery(ext.TIME_ELAPSED_EXT, query);
 
         // Draw object
@@ -119,25 +119,29 @@ interface EXT_disjoint_timer_query_webgl2 {
         gl.endQuery(ext.TIME_ELAPSED_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        var available = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
-        var disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        let available = gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
+        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
         if (available &amp;&amp; !disjoint) {
           // See how much time the rendering of the object took in nanoseconds.
-          var timeElapsed = gl.getQueryParameter(query, gl.QUERY_RESULT);
+          let timeElapsed = gl.getQueryParameter(query, gl.QUERY_RESULT);
 
           // Do something useful with the time.  Note that care should be
           // taken to use all significant bits of the result, not just the
           // least significant 32 bits.
           adjustObjectLODBasedOnDrawTime(timeElapsed);
+
+          // Clean up the query object.
+          gl.deleteQuery(query);
+          query = null;
         }
 
         //----------------------------------------------------------------------
 
         // Example (2) -- same as the example above, but uses queryCounterEXT instead.
-        var ext = gl.getExtension('EXT_disjoint_timer_query_webgl2');
-        var startQuery = gl.createQuery();
-        var endQuery = gl.createQuery();
+        let ext = gl.getExtension('EXT_disjoint_timer_query_webgl2');
+        let startQuery = gl.createQuery();
+        let endQuery = gl.createQuery();
         ext.queryCounterEXT(startQuery, ext.TIMESTAMP_EXT);
 
         // Draw object
@@ -146,30 +150,36 @@ interface EXT_disjoint_timer_query_webgl2 {
         ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        var available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
-        var disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        let available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
+        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
 
         if (available &amp;&amp; !disjoint) {
           // See how much time the rendering of the object took in nanoseconds.
-          var timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
-          var timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
+          let timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
+          let timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
 
           // Do something useful with the time.  Note that care should be
           // taken to use all significant bits of the result, not just the
           // least significant 32 bits.
           adjustObjectLODBasedOnDrawTime(timeEnd - timeStart);
+
+          // Clean up the query objects.
+          gl.deleteQuery(startQuery);
+          gl.deleteQuery(endQuery);
+          startQuery = null;
+          endQuery = null;
         }
 
         //----------------------------------------------------------------------
 
         // Example (3) -- check the number of timestamp bits to determine how to best
         // measure elapsed time.
-        var ext = gl.getExtension('EXT_disjoint_timer_query_webgl2');
-        var timeElapsedQuery;
-        var startQuery;
-        var endQuery;
+        let ext = gl.getExtension('EXT_disjoint_timer_query_webgl2');
+        let timeElapsedQuery;
+        let startQuery;
+        let endQuery;
 
-        var useTimestamps = false;
+        let useTimestamps = false;
 
         if (gl.getQuery(ext.TIMESTAMP_EXT, ext.QUERY_COUNTER_BITS_EXT) > 0) {
           useTimestamps = true;
@@ -198,11 +208,11 @@ interface EXT_disjoint_timer_query_webgl2 {
         }
 
         // ...at some point in the future, after returning control to the browser and being called again:
-        var disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
+        let disjoint = gl.getParameter(ext.GPU_DISJOINT_EXT);
         if (disjoint) {
           // Have to redo all of the measurements.
         } else {
-          var available;
+          let available;
           if (useTimestamps) {
             available = gl.getQueryParameter(endQuery, gl.QUERY_RESULT_AVAILABLE);
           } else {
@@ -210,11 +220,11 @@ interface EXT_disjoint_timer_query_webgl2 {
           }
 
           if (available) {
-            var timeElapsed;
+            let timeElapsed;
             if (useTimestamps) {
               // See how much time the rendering of the object took in nanoseconds.
-              var timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
-              var timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
+              let timeStart = gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
+              let timeEnd = gl.getQueryParameter(endQuery, gl.QUERY_RESULT);
               timeElapsed = timeEnd - timeStart;
             } else {
               timeElapsed = gl.getQueryParameter(query, gl.QUERY_RESULT);
@@ -224,6 +234,12 @@ interface EXT_disjoint_timer_query_webgl2 {
             // taken to use all significant bits of the result, not just the
             // least significant 32 bits.
             adjustObjectLODBasedOnDrawTime(timeElapsed);
+
+            // Clean up the query objects.
+            gl.deleteQuery(startQuery);
+            gl.deleteQuery(endQuery);
+            startQuery = null;
+            endQuery = null;
           }
         }
     </pre>
@@ -236,6 +252,9 @@ interface EXT_disjoint_timer_query_webgl2 {
     </revision>
     <revision date="2016/10/11">
       <change>Fixed errors in sample code pointed out by @juj.</change>
+    </revision>
+    <revision date="2021/04/01">
+      <change>Clean up query objects via deleteQuery. Modernize examples' JavaScript code.</change>
     </revision>
   </history>
 </extension>


### PR DESCRIPTION
Follows best practices for WebGL objects. Also modernize the
JavaScript in these examples (var -> let).