### PR TITLE
Allow makeXRCompatible on context.

### DIFF
--- a/conformance-suites/1.0.3/conformance/context/methods.html
+++ b/conformance-suites/1.0.3/conformance/context/methods.html
@@ -181,8 +181,11 @@ var methods = [
 ];
 
 // Properties to be ignored because they were added in versions of the
-// spec that are backward-compatible with this version
+// spec that are backward-compatible with this version or are added in
+// other specs.
 var ignoredMethods = [
+// Added by WebXR.
+"makeXRCompatible",
 ];
 
 function assertFunction(v, f) {

--- a/sdk/tests/conformance/context/methods.html
+++ b/sdk/tests/conformance/context/methods.html
@@ -160,11 +160,14 @@ var methods = [
 ];
 
 // Properties to be ignored because they were added in versions of the
-// spec that are backward-compatible with this version
+// spec that are backward-compatible with this version or are added in
+// other specs.
 var ignoredMethods = [
   // There is no official spec for the commit API yet, the proposal link is:
   // https://wiki.whatwg.org/wiki/OffscreenCanvas
-  "commit"
+  "commit",
+  // Added by WebXR.
+  "makeXRCompatible",
 ];
 
 function assertFunction(v, f) {


### PR DESCRIPTION
This method comes from the WebXR spec.