### PR TITLE
Add [AllowShared] to WEBGL_multi_draw APIs' typed array arguments.

### DIFF
--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -68,27 +68,27 @@
 interface WEBGL_multi_draw {
   undefined multiDrawArraysWEBGL(
       GLenum mode,
-      (Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
-      (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       GLsizei drawcount);
   undefined multiDrawElementsWEBGL(
       GLenum mode,
-      (Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
       GLenum type,
-      (Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
       GLsizei drawcount);
   undefined multiDrawArraysInstancedWEBGL(
       GLenum mode,
-      (Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
-      (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
-      (Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
       GLsizei drawcount);
   undefined multiDrawElementsInstancedWEBGL(
       GLenum mode,
-      (Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
       GLenum type,
-      (Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
-      (Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
       GLsizei drawcount);
 };
 
@@ -97,39 +97,39 @@ interface WEBGL_multi_draw {
   <newfun>
     <function name="multiDrawArraysWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
-      <param name="firstsList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
+      <param name="firstsList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
       <param name="firstsOffset" type="GLuint"/>
-      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
-      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
       <param name="type" type="GLenum"/>
-      <param name="offsetsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="offsetsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="offsetsOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
     <function name="multiDrawArraysInstancedWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
-      <param name="firstsList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
+      <param name="firstsList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
       <param name="firstsOffset" type="GLuint"/>
-      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
-      <param name="instanceCountsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="instanceCountsOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsInstancedWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
-      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
       <param name="type" type="GLenum"/>
-      <param name="offsetsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="offsetsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="offsetsOffset" type="GLuint"/>
-      <param name="instanceCountsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="instanceCountsOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
@@ -209,6 +209,9 @@ void main() {
     </revision>
     <revision date="2020/07/31">
       <change>Moved to Community Approved.</change>
+    </revision>
+    <revision date="2021/05/18">
+      <change>Add [AllowShared] to all typed array arguments for compatibility with multi-threaded WebAssembly.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -91,20 +91,20 @@
 interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   undefined multiDrawArraysInstancedBaseInstanceWEBGL(
       GLenum mode,
-      (Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
-      (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
-      (Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
-      (Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
       GLsizei drawCount
   );
   undefined multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
       GLenum mode,
-      (Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       GLenum type,
-      (Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
-      (Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
-      (Int32Array or sequence&lt;GLint&gt;) baseVerticesList, GLuint baseVerticesOffset,
-      (Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) baseVerticesList, GLuint baseVerticesOffset,
+      ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
       GLsizei drawCount
   );
 };
@@ -113,26 +113,26 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   <newfun>
     <function name="multiDrawArraysInstancedBaseInstanceWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
-      <param name="firstsList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
+      <param name="firstsList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
       <param name="firstsOffset" type="GLuint"/>
-      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
-      <param name="baseInstancesList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="baseInstancesList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="baseInstancesOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
-      <param name="countsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
       <param name="type" type="GLenum"/>
-      <param name="offsetsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="offsetsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="offsetsOffset" type="GLuint"/>
-      <param name="instanceCountsList" type="(Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="instanceCountsOffset" type="GLuint"/>
-      <param name="baseVerticesList" type="(Int32Array or sequence&lt;GLint&gt;)"/>
+      <param name="baseVerticesList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
       <param name="baseVerticesOffset" type="GLuint"/>
-      <param name="baseInstancesList" type="(Uint32Array or sequence&lt;GLuint&gt;)"/>
+      <param name="baseInstancesList" type="([AllowShared] Uint32Array or sequence&lt;GLuint&gt;)"/>
       <param name="baseInstancesOffset" type="GLuint"/>
       <param name="drawCount" type="GLsizei"/>
     </function>
@@ -208,6 +208,9 @@ void main() {
     </revision>
     <revision date="2020/07/28">
       <change>Add parentheses around union types in IDL</change>
+    </revision>
+    <revision date="2021/05/18">
+      <change>Add [AllowShared] to all typed array arguments for compatibility with multi-threaded WebAssembly.</change>
     </revision>
   </history>
 </draft>


### PR DESCRIPTION
Parallels changes made in #2387 to the core WebGL 1.0 and 2.0
specifications to support SharedArrayBuffer, and implicitly,
multithreaded WebAssembly.

Fixes #3219 .