### PR TITLE
Verify that loops in ESSL 3.00 fragment shaders compile and link.

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -17,6 +17,7 @@ const-array-init.html
 forbidden-operators.html
 --min-version 2.0.1 forward-declaration.html
 frag-depth.html
+--min-version 2.0.1 fragment-shader-loop-crash.html
 --min-version 2.0.1 gradient-in-discontinuous-loop.html
 --min-version 2.0.1 input-with-interpotaion-as-lvalue.html
 invalid-default-precision.html

--- a/sdk/tests/conformance2/glsl3/fragment-shader-loop-crash.html
+++ b/sdk/tests/conformance2/glsl3/fragment-shader-loop-crash.html
@@ -1,0 +1,72 @@
+<!--
+Copyright (c) 2021 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Fragment shader containing loop should not crash</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+precision highp float;
+out vec2 v_tex_coord;
+uniform mat4 matrix;
+
+void main() {
+   v_tex_coord = vec2(0.0, 0.0);
+   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+}
+</script>
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+
+in vec2 v_tex_coord;
+out vec4 out_color;
+
+uniform sampler2D texture_1;
+uniform vec2 resolution;
+
+vec4 do_loops(vec4 z)
+{
+    vec4 v[16];
+    for (int i = 0; i < 16; i++)
+    {
+        v[i] = z;
+    }
+    return v[1];
+}
+
+void main() {
+    out_color = do_loops(vec4(0.2, 0.4, 0.6, 1.0)) - texture(texture_1, v_tex_coord);
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description();
+const wtu = WebGLTestUtils;
+const tests = [
+    {
+        vShaderSource: wtu.getScript('vshader'),
+        fShaderSource: wtu.getScript('fshader'),
+        vShaderSuccess: true,
+        fShaderSuccess: true,
+        linkSuccess: true,
+        passMsg: 'Fragment shader containing a simple loop should compile and link'
+    }
+];
+
+GLSLConformanceTester.runTests(tests, 2);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Issues seen on some Adreno drivers from Qualcomm. Fixed in their
latest driver.

Regression test for http://crbug.com/1076188 .