### PR TITLE
Add WebCodecs VideoFrame as a TexImageSource.

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3924,7 +3924,7 @@ sub-rectangle updated by <code>texSubImage2D</code> are determined based on the 
             The width and height of the texture are set to the current values of the width and
             height properties of the <code>HTMLCanvasElement</code> or <code>OffscreenCanvas</code>
             object.
-        <dt><code>source</code> of type <code>HTMLVideoElement</code>
+        <dt><code>source</code> of type <code>HTMLVideoElement</code> or <code>VideoFrame</code>
         <dd>
             The width and height of the texture are set to the width and height of the uploaded
             frame of the video in pixels.

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3924,7 +3924,7 @@ sub-rectangle updated by <code>texSubImage2D</code> are determined based on the 
             The width and height of the texture are set to the current values of the width and
             height properties of the <code>HTMLCanvasElement</code> or <code>OffscreenCanvas</code>
             object.
-        <dt><code>source</code> of type <code>HTMLVideoElement</code> or <code>VideoFrame</code>
+        <dt><code>source</code> of type <code>HTMLVideoElement</code> or <code>VideoFrame</code><a href="#refsWEBCODECS">[WEBCODECS]</a>
         <dd>
             The width and height of the texture are set to the width and height of the uploaded
             frame of the video in pixels.
@@ -4543,13 +4543,17 @@ extensions.
             World Wide Web Consortium (W3C).
         </dd>
         <dt id="refsKHRROBUSTACCESS">[KHRROBUSTACCESS]</dt>
-        <dd><cide><a href="https://www.opengl.org/registry/specs/KHR/robust_buffer_access_behavior.txt">
+        <dd><cite><a href="https://www.opengl.org/registry/specs/KHR/robust_buffer_access_behavior.txt">
             KHR_robust_buffer_access_behavior OpenGL ES extension</a></cite>,
             Leech, J. and Daniell, P., August, 2014.
         </dd>
         <dt id="refsMULTIPLEBUFFERING">[MULTIPLEBUFFERING]</dt>
         <dd>(Non-normative) <cite><a href="https://en.wikipedia.org/wiki/Multiple_buffering">
             Multiple buffering</a></cite>. Wikipedia.
+        </dd>
+        <dt id="refsWEBCODECS">[WEBCODECS]</dt>
+        <dd>(Non-normative) <cite><a href="https://w3c.github.io/webcodecs/">WebCodecs API</a></cite>,
+            C. Cunningham, P. Adenot, B. Aboba. W3C.
         </dd>
     </dl>
 

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -108,7 +108,8 @@ typedef (ImageBitmap or
          HTMLImageElement or
          HTMLCanvasElement or
          HTMLVideoElement or
-         OffscreenCanvas) TexImageSource;
+         OffscreenCanvas or
+         VideoFrame) TexImageSource;
 
 typedef ([AllowShared] Float32Array or sequence<GLfloat>) Float32List;
 typedef ([AllowShared] Int32Array or sequence<GLint>) Int32List;


### PR DESCRIPTION
Adding VideoFrame as a TexImageSource allows texImage*() methods to
interoperate with VideoFrames. VideoFrames work with texImage*() the
same way the existing point-in-time capture for HTMLVideoElement does.

This adds a non-normative reference on the WebCodecs spec for the
VideoFrame interface and associated properties to accomplish this.

Note: VideoFrame objects are always same-origin, so I did not add
any text around origin restrictions for video frames.

https://www.w3.org/TR/webcodecs/#videoframe-interface

Bug: w3c/webcodecs#158