### PR TITLE
Add test case for reciprocal sqrt of sum of squares crash.

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -28,6 +28,7 @@ loops-with-side-effects.html
 misplaced-version-directive.html
 --min-version 2.0.1 no-attribute-vertex-shader.html
 --min-version 2.0.1 precision-side-effects-bug.html
+--min-version 2.0.1 reciprocal-sqrt-of-sum-of-squares-crash.html
 sampler-no-precision.html
 --min-version 2.0.1 sampler-array-indexing.html
 sequence-operator-returns-non-constant.html

--- a/sdk/tests/conformance2/glsl3/reciprocal-sqrt-of-sum-of-squares-crash.html
+++ b/sdk/tests/conformance2/glsl3/reciprocal-sqrt-of-sum-of-squares-crash.html
@@ -1,0 +1,64 @@
+<!--
+Copyright (c) 2021 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Shader identified as containing reciprocal square root of sum of squares should not crash</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vshader" type="x-shader/x-vertex">#version 300 es
+void main() {
+   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);
+}
+</script>
+<script id="fshader" type="x-shader/x-fragment">#version 300 es
+precision highp float;
+
+#define CRASH 1
+
+out vec4 fragmentColor;
+void main()
+{
+    vec2 p = gl_FragCoord.xy;
+    float d = 1.0 / length(p);
+#if CRASH
+    if (p.x > 0.0)
+    {
+        d *= 2.0;
+    }
+#endif
+    fragmentColor = vec4(d);
+}
+</script>
+<script type="application/javascript">
+"use strict";
+description();
+debug('Regression test for <a href="https://crbug.com/1079309">crbug.com/1079309</a>');
+const wtu = WebGLTestUtils;
+const tests = [
+    {
+        vShaderSource: wtu.getScript('vshader'),
+        fShaderSource: wtu.getScript('fshader'),
+        vShaderSuccess: true,
+        fShaderSuccess: true,
+        linkSuccess: true,
+        passMsg: 'Shader containing expression that driver recognizes as reciprocal square root of sum of squares should compile and link'
+    }
+];
+
+GLSLConformanceTester.runTests(tests, 2);
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/glsl3/reciprocal-sqrt-of-sum-of-squares-crash.html
+++ b/sdk/tests/conformance2/glsl3/reciprocal-sqrt-of-sum-of-squares-crash.html
@@ -32,6 +32,8 @@ out vec4 fragmentColor;
 void main()
 {
     vec2 p = gl_FragCoord.xy;
+    // This expression meets the requirement of being the reciprocal
+    // square root of a sum of squares.
     float d = 1.0 / length(p);
 #if CRASH
     if (p.x > 0.0)


### PR DESCRIPTION
This was occurring when the driver's GLSL compiler was identifying an
expression as containing the reciprocal square root of a sum of squares.

Regression test for https://crbug.com/1079309 and NVIDIA bug 2978301 .