### PR TITLE
Simplify WebGLRenderingContextBase#canvas attribute

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1717,8 +1717,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGLRenderingContextBase">We
     const GLenum UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243;
     const GLenum BROWSER_DEFAULT_WEBGL          = 0x9244;
 
-    [Exposed=Window] readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
-    [Exposed=Worker] readonly attribute OffscreenCanvas canvas;
+    readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
     readonly attribute GLsizei drawingBufferWidth;
     readonly attribute GLsizei drawingBufferHeight;
 


### PR DESCRIPTION
Web IDL should automatically drop the HTMLCanvasElement part from workers, [as in ImageBitmapRenderingContext](https://html.spec.whatwg.org/multipage/canvas.html#the-imagebitmaprenderingcontext-interface):

```webidl
[Exposed=(Window,Worker)]
interface ImageBitmapRenderingContext {
  readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
  undefined transferFromImageBitmap(ImageBitmap? bitmap);
};
```

Thus there is no need to process it manually. (Doing so makes things hard for IDL processing tools actually, e.g. https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1050.)