### PR TITLE
Update mipmapped NPOT compressed texture expectations.

### DIFF
--- a/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
@@ -77,6 +77,16 @@ function runTestExtension() {
   // Test TexImage validation on level dimensions combinations.
   // When level equals 0, width and height must be a multiple of 4.
   // When level is larger than 0, this constraint doesn't apply.
+
+  let npotExpectation, npotMessage;
+  if (contextVersion >= 2) {
+    npotExpectation = gl.NO_ERROR;
+    npotMessage = "valid";
+  } else {
+    npotExpectation = gl.INVALID_VALUE;
+    npotMessage = "invalid";
+  }
+
   ctu.testTexImageLevelDimensions(gl, ext, validFormats, expectedByteLength, getBlockDimensions,
     [
       { level: 0, width: 4, height: 3,
@@ -96,7 +106,7 @@ function runTestExtension() {
       { level: 1, width: 2, height: 2,
         expectation: gl.NO_ERROR, message: "implied base mip 4x4 is valid" },
       { level: 2, width: 1, height: 3,
-        expectation: gl.NO_ERROR, message: "implied base mip 4x12 is valid" },
+        expectation: npotExpectation, message: "implied base mip 4x12 is " + npotMessage },
   ]);
 
   // Test that BPTC enums are not accepted by texImage2D

--- a/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html
@@ -82,6 +82,16 @@ function runTestExtension() {
   // Test TexImage validation on level dimensions combinations.
   // When level equals 0, width and height must be a multiple of 4.
   // When level is larger than 0, this constraint doesn't apply.
+
+  let npotExpectation, npotMessage;
+  if (contextVersion >= 2) {
+    npotExpectation = gl.NO_ERROR;
+    npotMessage = "valid";
+  } else {
+    npotExpectation = gl.INVALID_VALUE;
+    npotMessage = "invalid";
+  }
+
   ctu.testTexImageLevelDimensions(gl, ext, validFormats, expectedByteLength, getBlockDimensions,
     [
       { level: 0, width: 4, height: 3,
@@ -101,7 +111,7 @@ function runTestExtension() {
       { level: 1, width: 2, height: 2,
         expectation: gl.NO_ERROR, message: "implied base mip 4x4 is valid" },
       { level: 2, width: 1, height: 3,
-        expectation: gl.NO_ERROR, message: "implied base mip 4x12 is valid" },
+        expectation: npotExpectation, message: "implied base mip 4x12 is " + npotMessage },
   ]);
 
   // Test that RGTC enums are not accepted by texImage2D

--- a/sdk/tests/conformance/extensions/s3tc-and-rgtc.html
+++ b/sdk/tests/conformance/extensions/s3tc-and-rgtc.html
@@ -833,14 +833,16 @@ function testDXTTexture(test, useTexStorage) {
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
 
         if (width == 4) {
+            // The width/height of the implied base level must be a multiple of the block size.
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 1, height, 0, data);
-            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+            wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions for level > 0");
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 2, height, 0, data);
             wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
         }
         if (height == 4) {
+            // The width/height of the implied base level must be a multiple of the block size.
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 1, 0, data);
-            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+            wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions for level > 0");
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 2, 0, data);
             wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
         }

--- a/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html
+++ b/sdk/tests/conformance/extensions/webgl-compressed-texture-s3tc-srgb.html
@@ -683,14 +683,16 @@ function testDXTTexture(test, useTexStorage) {
         wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions");
 
         if (width == 4) {
+            // The width/height of the implied base level must be a multiple of the block size.
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 1, height, 0, data);
-            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+            wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions for level > 0");
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, 2, height, 0, data);
             wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
         }
         if (height == 4) {
+            // The width/height of the implied base level must be a multiple of the block size.
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 1, 0, data);
-            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
+            wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "invalid dimensions for level > 0");
             gl.compressedTexImage2D(gl.TEXTURE_2D, 1, format, width, 2, 0, data);
             wtu.glErrorShouldBe(gl, gl.NO_ERROR, "valid dimensions for level > 0");
         }


### PR DESCRIPTION
WebGL 1.0's NPOT texture support is limited to textures without any
mip levels. Expect that the newly added RGTC and BPTC NPOT test from
PR #3304 generates an error on WebGL 1.0, and no error on WebGL 2.0.

Also change the expectation of an S3TC and S3TC-sRGB subtest which was
not following the new constraints that the size of the implied base
mip level must be a multiple of the block size.

Associated with ANGLE bug https://crbug.com/angleproject/6245 and
Issue #3117.