### PR TITLE
Add failure if "Duplicate notifyFinishedToHarness()".

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/character-set.html
+++ b/sdk/tests/conformance/glsl/bugs/character-set.html
@@ -111,7 +111,5 @@ debug("");
 var successfullyParsed = true;
 
 </script>
-<script src="../../../js/js-test-post.js"></script>
-
 </body>
 </html>

--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -112,6 +112,11 @@ function reportSkippedTestResultsToHarness(success, msg) {
 }
 
 function notifyFinishedToHarness() {
+  if (window._didNotifyFinishedToHarness) {
+    testFailed("Duplicate notifyFinishedToHarness()");
+  }
+  window._didNotifyFinishedToHarness = true;
+
   if (window.parent.webglTestHarness) {
     window.parent.webglTestHarness.notifyFinished(window.location.pathname);
   }


### PR DESCRIPTION
This ends up being an error in Firefox's harness, so let's prevent it
upstream too.