### PR TITLE
Expose the clearing canvas with scissor issue on Intel D3D drivers

### DIFF
--- a/sdk/tests/conformance/rendering/00_test_list.txt
+++ b/sdk/tests/conformance/rendering/00_test_list.txt
@@ -1,6 +1,7 @@
 --min-version 1.0.4 bind-framebuffer-flush-bug.html
 --min-version 1.0.4 blending.html
 --min-version 1.0.4 canvas-alpha-bug.html
+--min-version 1.0.4 clear-default-framebuffer-with-scissor-test.html
 --min-version 1.0.4 --max-version 1.9.9 clipping-wide-points.html
 --min-version 1.0.4 color-mask-preserved-during-implicit-clears.html
 --min-version 1.0.2 culling.html

--- a/sdk/tests/conformance/rendering/clear-default-framebuffer-with-scissor-test.html
+++ b/sdk/tests/conformance/rendering/clear-default-framebuffer-with-scissor-test.html
@@ -21,7 +21,7 @@ found in the LICENSE.txt file.
 
 <script>
 "use strict";
-// This test exposes an Intel D3D driver issue.
+// This test exposes an issue in older Intel D3D drivers.
 var wtu = WebGLTestUtils;
 
 function test_clear_with_scissor_on_canvas()
@@ -34,6 +34,7 @@ function test_clear_with_scissor_on_canvas()
   gl.clearColor(0, 1, 0, 1);
   gl.clear(gl.COLOR_BUFFER_BIT);
 
+  // The issue is found in the Chromium compositor so we need another canvas element for reproduction.
   var canvas2D = document.getElementById("canvas-2d");
   var context2D = canvas2D.getContext('2d');
   context2D.drawImage(canvasWebGL, 0, 0);

--- a/sdk/tests/conformance/rendering/clear-default-framebuffer-with-scissor-test.html
+++ b/sdk/tests/conformance/rendering/clear-default-framebuffer-with-scissor-test.html
@@ -1,0 +1,67 @@
+<!--
+Copyright (c) 2021 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Clear with scissor bug on WebGL canvas</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas-webgl" width="20" height="20"> </canvas>
+<canvas id="canvas-2d" width="20" height="20"> </canvas>
+
+<script>
+"use strict";
+// This test exposes an Intel D3D driver issue.
+var wtu = WebGLTestUtils;
+
+function test_clear_with_scissor_on_canvas()
+{
+  var canvasWebGL = document.getElementById("canvas-webgl");
+  var gl = canvasWebGL.getContext("webgl", { antialias:false });
+  const scissorRectSize = 16;
+  gl.enable(gl.SCISSOR_TEST);
+  gl.scissor(0, 0, scissorRectSize, scissorRectSize);
+  gl.clearColor(0, 1, 0, 1);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  var canvas2D = document.getElementById("canvas-2d");
+  var context2D = canvas2D.getContext('2d');
+  context2D.drawImage(canvasWebGL, 0, 0);
+  context2D.fill();
+
+  var imageData =
+    context2D.getImageData(0, canvas2D.clientHeight - scissorRectSize, scissorRectSize, scissorRectSize);
+  var data = imageData.data;
+  var expectedColor = [0, 255, 0, 255];
+  for (var pixelIndex = 0; pixelIndex < scissorRectSize * scissorRectSize; ++pixelIndex) {
+    for (var colorIndex = 0; colorIndex < 4; ++colorIndex) {
+      if (data[pixelIndex * 4 + colorIndex] !== expectedColor[colorIndex]) {
+        var y = Math.floor(pixelIndex / scissorRectSize);
+        var x = pixelIndex % scissorRectSize;
+        testFailed("The canvas color at (" + x + ", " + y + ") is not expected");
+        return;
+      }
+    }
+  }
+}
+
+test_clear_with_scissor_on_canvas();
+
+description("Exposes clearing WebGL canvas with scissor bug on Intel D3D drivers - see https://crbug.com/1206763");
+var successfullyParsed = true;
+
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This patch adds a conformance test to expose an Intel D3D driver
bug about clearing canvas with scissor test in WebGL.

See https://crbug.com/1206763 for more details.