### PR TITLE
Disallow emulated compressed formats

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -4073,7 +4073,7 @@ extensions.
 </p>
 
 <p>
-    Unless a WebGL implementation uses a software rasterizer, only hardware-supported compressed texture extensions may be enabled.
+    WebGL implementations should only expose compressed texture formats that are more efficient than the uncompressed form.
 </p>
 
     <h3><a name="MAX_GLSL_TOKEN_SIZE">Maximum GLSL Token Size</a></h3>

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -4072,6 +4072,10 @@ extensions.
     </ul>
 </p>
 
+<p>
+    Unless a WebGL implementation uses a software rasterizer, only hardware-supported compressed texture extensions may be enabled.
+</p>
+
     <h3><a name="MAX_GLSL_TOKEN_SIZE">Maximum GLSL Token Size</a></h3>
 
 <p>


### PR DESCRIPTION
This statement is added to prevent WebGL implementations from exposing ETC* formats on platforms that advertise them regardless of hardware support, most notably desktop OpenGL 4.3+ or any older version combined with `GL_ARB_ES3_compatibility`.

Among "desktop" GPUs, only Intel newer than Haswell support ETC* in hardware when using OpenGL.