### PR TITLE
Track main branch of WebGLDeveloperTools submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "sdk/devtools"]
 	path = sdk/devtools
 	url = https://github.com/KhronosGroup/WebGLDeveloperTools.git
+	branch = main


### PR DESCRIPTION
This will make submodule initialization behave more intuitively.
