### PR TITLE
Set gl_PointSize in primitive restart tests for GL_POINTS.

### DIFF
--- a/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
+++ b/sdk/tests/conformance/context/context-attributes-alpha-depth-stencil-antialias.html
@@ -47,6 +47,7 @@ var framebuffer;
 var fbHasColor;
 var fbHasDepth;
 var fbHasStencil;
+var contextVersion = wtu.getDefault3DContextVersion();
 
 function init()
 {
@@ -54,6 +55,23 @@ function init()
 
     runTest();
 }
+
+var vertices = new Float32Array([
+    1.0, 1.0, 0.0,
+    -1.0, 1.0, 0.0,
+    -1.0, -1.0, 0.0,
+    1.0, 1.0, 0.0,
+    -1.0, -1.0, 0.0,
+    1.0, -1.0, 0.0]);
+
+var colors = new Uint8Array([
+    255, 0, 0, 255,
+    255, 0, 0, 255,
+    255, 0, 0, 255,
+    255, 0, 0, 255,
+    255, 0, 0, 255,
+    255, 0, 0, 255]);
+
 
 function getWebGL(canvasWidth, canvasHeight, contextAttribs, clearColor, clearDepth, clearStencil)
 {
@@ -63,7 +81,7 @@ function getWebGL(canvasWidth, canvasHeight, contextAttribs, clearColor, clearDe
     canvas.width = canvasWidth;
     canvas.height = canvasHeight;
 
-    gl = wtu.create3DContext(canvas, contextAttribs);
+    gl = wtu.create3DContext(canvas, contextAttribs, contextVersion);
     if (!gl)
         return null;
 
@@ -102,27 +120,75 @@ function getWebGL(canvasWidth, canvasHeight, contextAttribs, clearColor, clearDe
       }
     }
     gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
 
-    return gl;
-}
-
-function drawAndReadPixel(gl, vertices, colors)
-{
     var colorOffset = vertices.byteLength;
-
     var vbo = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
     gl.bufferData(gl.ARRAY_BUFFER, colorOffset + colors.byteLength, gl.STATIC_DRAW);
     gl.bufferSubData(gl.ARRAY_BUFFER, 0, vertices);
     gl.bufferSubData(gl.ARRAY_BUFFER, colorOffset, colors);
-
     gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
     gl.enableVertexAttribArray(0);
     gl.vertexAttribPointer(1, 4, gl.UNSIGNED_BYTE, true, 0, colorOffset);
     gl.enableVertexAttribArray(1);
 
-    gl.drawArrays(gl.TRIANGLES, 0, vertices.length / 3);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+    return gl;
+}
+
+function draw(gl, verticesCount)
+{
+    verticesCount = verticesCount || vertices.length / 3;
+    gl.drawArrays(gl.TRIANGLES, 0, verticesCount);
+}
+
+function checkDraw(hasAlpha, hasStencil, hasDepth, hasAntialias)
+{
+    let red = [255, 0, 0, 255 ];
+    let black = [0, 0, 0, hasAlpha ? 0 : 255 ];
+    debug(`Testing that stencil ${ hasStencil ? 'affects': 'does not affect'} the rendering.`);
+    gl.stencilFunc(gl.NEVER, 1, 1);
+    gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
+    draw(gl);
+    correctColor = hasStencil ? black : red;
+    wtu.checkCanvas(gl, correctColor)
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+    wtu.checkCanvas(gl, black);
+    gl.stencilFunc(gl.ALWAYS, 1, 1);
+
+    debug(`Testing that depth ${ hasDepth ? 'affects': 'does not affect'} the rendering.`);
+    gl.depthFunc(gl.NEVER);
+    draw(gl);
+    correctColor = hasDepth ? black : red;
+    wtu.checkCanvas(gl, correctColor);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+    wtu.checkCanvas(gl, black);
+    gl.depthFunc(gl.ALWAYS);
+
+    debug(`Testing that rendering is ${hasAntialias ? 'antialiased' : 'aliased'}.`);
+    draw(gl, 3);
+    let N = 2;
+    let buf = new Uint8Array(N * N * 4);
+    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
+    redChannels[1] = buf[4 * N * (N - 1)]; // left top
+    redChannels[2] = buf[4 * (N - 1)]; // right bottom
+    shouldBe("redChannels[1]", "255");
+    shouldBe("redChannels[2]", "0");
+    if (hasAntialias) {
+        shouldNotBe("redChannels[0]", "255");
+        shouldNotBe("redChannels[0]", "0");
+    } else {
+        shouldBeTrue("redChannels[0] == 255 || redChannels[0] == 0");
+    }
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+    wtu.checkCanvas(gl, black);
+
+    debug("Testing that rendering works.");
+    draw(gl);
+    wtu.checkCanvas(gl, red);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+    wtu.checkCanvas(gl, black);
 }
 
 function testDefault()
@@ -130,199 +196,82 @@ function testDefault()
     debug("Testing default attributes: { stencil:false }");
     shouldBeNonNull("gl = getWebGL(1, 1, null, [ 0, 0, 0, 0 ], 1, 0)");
     shouldBeFalse("gl.getContextAttributes().stencil");
-    shouldBeTrue("gl.getParameter(gl.STENCIL_BITS) == 0");
+    shouldBe("gl.getParameter(gl.STENCIL_BITS)", "0");
 }
 
-function testAlpha(alpha)
+function testAttributesAffectContext(alpha, stencil, depth, antialias)
 {
-    debug("Testing alpha = " + alpha);
-    if (alpha) {
-        shouldBeNonNull("gl = getWebGL(1, 1, { alpha: true, depth: false, stencil: false, antialias: false }, [ 0, 0, 0, 0 ], 1, 0)");
-        shouldBeTrue("gl.getParameter(gl.ALPHA_BITS) >= 8");
-    } else {
-        shouldBeNonNull("gl = getWebGL(1, 1, { alpha: false, depth: false, stencil: false, antialias: false }, [ 0, 0, 0, 0 ], 1, 0)");
-        shouldBeTrue("gl.getParameter(gl.ALPHA_BITS) == 0");
-    }
-    shouldBeTrue("gl.getParameter(gl.RED_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.GREEN_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.BLUE_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.DEPTH_BITS) == 0");
-    shouldBeTrue("gl.getParameter(gl.STENCIL_BITS) == 0");
-
+    shouldBeNonNull(`gl = getWebGL(2, 2, { depth: ${depth}, stencil: ${stencil}, antialias: ${antialias}, alpha: ${alpha} }, [ 0, 0, 0, 0 ], 1, 0)`);
     shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
-    shouldBeTrue("contextAttribs.alpha == " + alpha);
 
-    var correctColor = (contextAttribs.alpha ? [0, 0, 0, 0] : [0, 0, 0, 255]);
-    wtu.checkCanvasRect(gl, 0, 0, 1, 1, correctColor);
+    shouldBeGreaterThanOrEqual("gl.getParameter(gl.RED_BITS)", "8");
+    shouldBeGreaterThanOrEqual("gl.getParameter(gl.GREEN_BITS)", "8");
+    shouldBeGreaterThanOrEqual("gl.getParameter(gl.BLUE_BITS)", "8");
+
+    shouldBe("contextAttribs.alpha", "" + alpha);
+    if (contextVersion < 2) {
+        if (!stencil)
+            shouldBeFalse("contextAttribs.stencil");
+        else
+            stencil = contextAttribs.stencil;
+        if (!depth)
+            shouldBeFalse("contextAttribs.depth");
+        else
+            depth = contextAttribs.depth;
+        if (!antialias)
+            shouldBeFalse("contextAttribs.antialias");
+        else
+            antialias = contextAttribs.antialias;
+    } else {
+        shouldBe("contextAttribs.stencil", "" + stencil);
+        shouldBe("contextAttribs.depth", "" + depth);
+        shouldBe("contextAttribs.antialias", "" + antialias);
+    }
+
+    if (alpha)
+        shouldBeGreaterThanOrEqual("gl.getParameter(gl.ALPHA_BITS)", "8");
+    else
+        shouldBe("gl.getParameter(gl.ALPHA_BITS)", "0");
+    if (stencil)
+        shouldBeGreaterThanOrEqual("gl.getParameter(gl.STENCIL_BITS)", "8");
+    else
+        shouldBe("gl.getParameter(gl.STENCIL_BITS)", "0");
+    if (depth)
+        shouldBeGreaterThanOrEqual("gl.getParameter(gl.DEPTH_BITS)", "16");
+    else
+        shouldBe("gl.getParameter(gl.DEPTH_BITS)", "0");
+
+    var correctColor = alpha ? [0, 0, 0, 0] : [0, 0, 0, 255];
+    wtu.checkCanvas(gl, correctColor);
+
+    debug("Testing default framebuffer.");
+    checkDraw(alpha, stencil, depth, antialias);
 
     if (fbHasColor) {
-      gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-      gl.clearColor(0.5, 0.5, 0.5, 0.5);
-      gl.clear(gl.COLOR_BUFFER_BIT);
-      wtu.checkCanvasRect(gl, 0, 0, 1, 1, [127, 127, 127, 127], undefined, 1);
-      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+        debug("Testing bound framebuffer object.");
+        gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+        gl.clearColor(0, 0, 0, 0);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT | gl.STENCIL_BUFFER_BIT);
+        checkDraw(true, fbHasStencil, fbHasDepth, false);
+        gl.bindFramebuffer(gl.FRAMEBUFFER, null);
     }
-}
-
-function testDepth(depth)
-{
-    debug("Testing depth = " + depth);
-    if (depth) {
-        shouldBeNonNull("gl = getWebGL(1, 1, { stencil: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
-        shouldBeTrue("gl.getParameter(gl.DEPTH_BITS) >= 16");
-    } else {
-        shouldBeNonNull("gl = getWebGL(1, 1, { depth: false, stencil: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
-        shouldBeTrue("gl.getParameter(gl.DEPTH_BITS) == 0");
-    }
-    shouldBeTrue("gl.getParameter(gl.RED_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.GREEN_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.BLUE_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.ALPHA_BITS) >= 8");
-
-    shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
-
-    gl.depthFunc(gl.NEVER);
-
-    var vertices = new Float32Array([
-         1.0,  1.0, 0.0,
-        -1.0,  1.0, 0.0,
-        -1.0, -1.0, 0.0,
-         1.0,  1.0, 0.0,
-        -1.0, -1.0, 0.0,
-         1.0, -1.0, 0.0]);
-    var colors = new Uint8Array([
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255]);
-
-    drawAndReadPixel(gl, vertices, colors, 0, 0);
-    correctColor = (contextAttribs.depth ? [0, 0, 0, 255] : [255, 0, 0, 255]);
-    wtu.checkCanvasRect(gl, 0, 0, 1, 1, correctColor);
-
-    if (fbHasDepth) {
-      gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-      drawAndReadPixel(gl, vertices, colors, 0, 0);
-      wtu.checkCanvasRect(gl, 0, 0, 1, 1, [0, 0, 0, 255]);
-      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    }
-}
-
-function testStencilAndDepth(stencil, depth)
-{
-    debug("Testing stencil = " + stencil + ", depth = " + depth);
-    var creationString =
-        "gl = getWebGL(1, 1, { depth: " + depth + ", stencil: " + stencil + ", antialias: false }, [ 0, 0, 0, 1 ], 1, 0)";
-    shouldBeNonNull(creationString);
-
-    shouldBeTrue("gl.getParameter(gl.RED_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.GREEN_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.BLUE_BITS) >= 8");
-    shouldBeTrue("gl.getParameter(gl.ALPHA_BITS) >= 8");
-    if (depth)
-        shouldBeTrue("gl.getParameter(gl.DEPTH_BITS) >= 16");
-    else
-        shouldBeTrue("gl.getParameter(gl.DEPTH_BITS) == 0");
-
-    if (stencil)
-        shouldBeTrue("gl.getParameter(gl.STENCIL_BITS) >= 8");
-    else
-        shouldBeTrue("gl.getParameter(gl.STENCIL_BITS) == 0");
-
-    shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
-    if (!depth && contextAttribs.depth) {
-        testFailed("WebGL implementation provided a depth buffer when it should not have");
-    }
-    if (!contextAttribs.depth)
-        depth = false;
-    if (!stencil && contextAttribs.stencil) {
-        testFailed("WebGL implementation provided a stencil buffer when it should not have");
-    }
-    if (!contextAttribs.stencil)
-        stencil = false;
-
-    gl.depthFunc(gl.ALWAYS);
-
-    gl.stencilFunc(gl.NEVER, 1, 1);
-    gl.stencilOp(gl.KEEP, gl.KEEP, gl.KEEP);
-
-    var vertices = new Float32Array([
-         1.0, 1.0, 0.0,
-        -1.0, 1.0, 0.0,
-        -1.0, -1.0, 0.0,
-         1.0, 1.0, 0.0,
-        -1.0, -1.0, 0.0,
-         1.0, -1.0, 0.0]);
-    var colors = new Uint8Array([
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255]);
-
-    drawAndReadPixel(gl, vertices, colors, 0, 0);
-    correctColor = (stencil ? [0, 0, 0, 255] : [255, 0, 0, 255]);
-    wtu.checkCanvasRect(gl, 0, 0, 1, 1, correctColor)
-
-    if (fbHasStencil) {
-      gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
-      gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
-      drawAndReadPixel(gl, vertices, colors, 0, 0);
-      wtu.checkCanvasRect(gl, 0, 0, 1, 1, [0, 0, 0, 255]);
-      gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-    }
-}
-
-function testAntialias(antialias)
-{
-    debug("Testing antialias = " + antialias);
-    // Both the width and height of canvas are N.
-    var N = 2;
-    if (antialias)
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: true }, [ 0, 0, 0, 1 ], 1, 0)");
-    else
-        shouldBeNonNull("gl = getWebGL(" + N + ", " + N + ", { depth: false, stencil: false, alpha: false, antialias: false }, [ 0, 0, 0, 1 ], 1, 0)");
-    shouldBeNonNull("contextAttribs = gl.getContextAttributes()");
-
-    var vertices = new Float32Array([
-         1.0, 1.0, 0.0,
-        -1.0, 1.0, 0.0,
-        -1.0, -1.0, 0.0]);
-    var colors = new Uint8Array([
-        255, 0, 0, 255,
-        255, 0, 0, 255,
-        255, 0, 0, 255]);
-    drawAndReadPixel(gl, vertices, colors, 0, 0);
-    var buf = new Uint8Array(N * N * 4);
-    gl.readPixels(0, 0, N, N, gl.RGBA, gl.UNSIGNED_BYTE, buf);
-    redChannels[0] = buf[4 * (N + 1)]; // (1, 1)
-    redChannels[1] = buf[4 * N * (N - 1)]; // left top
-    redChannels[2] = buf[4 * (N - 1)]; // right bottom
-    shouldBeTrue("redChannels[1] == 255 && redChannels[2] == 0");
-    shouldBe("redChannels[0] != 255 && redChannels[0] != 0", "contextAttribs.antialias");
 }
 
 function runTest()
 {
     testDefault();
-    testAlpha(true);
-    testAlpha(false);
-    testDepth(true);
-    testDepth(false);
-    testStencilAndDepth(true, false);
-    testStencilAndDepth(false, false);
-    testStencilAndDepth(true, true);
-    testStencilAndDepth(false, true);
-    testAntialias(true);
-    testAntialias(false);
-
+    let cases = [false, true];
+    for (let alpha of cases) {
+        for (let stencil of cases) {
+            for (let depth of cases) {
+                for (let antialias of cases) {
+                    testAttributesAffectContext(alpha, stencil, depth, antialias);
+                }
+            }
+        }
+    }
     finishTest();
 }
-
 </script>
 </head>
 <body onload="init()">

--- a/sdk/tests/conformance2/misc/00_test_list.txt
+++ b/sdk/tests/conformance2/misc/00_test_list.txt
@@ -1,3 +1,4 @@
+--min-version 2.0.1 blend-integer.html
 expando-loss-2.html
 getextension-while-pbo-bound-stability.html
 instanceof-test.html

--- a/sdk/tests/conformance2/misc/blend-integer.html
+++ b/sdk/tests/conformance2/misc/blend-integer.html
@@ -1,0 +1,176 @@
+<!--
+Copyright (c) 2021 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL 2 Blend Integer Conformance Tests</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css" />
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="outputVertexShader" type="x-shader/x-vertex">
+#version 300 es
+in vec4 vPosition;
+void main()
+{
+  gl_Position = vPosition;
+}
+</script>
+<script id="outputFragmentShaderSigned" type="x-shader/x-fragment">
+#version 300 es
+layout(location = 1) out highp vec4 o_drawBuffer1;
+layout(location = 2) out highp ivec4 o_drawBuffer2;
+layout(location = 3) out highp vec4 o_drawBuffer3;
+void main(void)
+{
+  o_drawBuffer1 = vec4(0, 0, 0, 0);
+  o_drawBuffer2 = ivec4(0, 0, 0, 0);
+  o_drawBuffer3 = vec4(0, 0, 0, 0);
+}
+</script>
+<script id="outputFragmentShaderUnsigned" type="x-shader/x-fragment">
+  #version 300 es
+  layout(location = 1) out highp vec4 o_drawBuffer1;
+  layout(location = 2) out highp uvec4 o_drawBuffer2;
+  layout(location = 3) out highp vec4 o_drawBuffer3;
+  void main(void)
+  {
+    o_drawBuffer1 = vec4(0, 0, 0, 0);
+    o_drawBuffer2 = uvec4(0, 0, 0, 0);
+    o_drawBuffer3 = vec4(0, 0, 0, 0);
+  }
+  </script>
+
+<script>
+"use strict";
+description("This test verifies correct behavior of min/max blending operations on integer attachments.");
+
+debug("");
+
+const wtu = WebGLTestUtils;
+const gl = wtu.create3DContext(null, undefined, 2);
+
+if (!gl) {
+  testFailed("WebGL context does not exist");
+} else {
+  testPassed("WebGL context exists");
+
+  debug("")
+  debug("GL_MIN");
+  runTest(false, gl.MIN);
+  runTest(true, gl.MIN);
+
+  debug("")
+  debug("GL_MAX");
+  runTest(false, gl.MAX);
+  runTest(true, gl.MAX);
+}
+
+function compareValue(value, attachment, isSigned) {
+  const pixel = isSigned ? new Int32Array(4) : new Uint32Array(4);
+  gl.readBuffer(attachment);
+  gl.readPixels(0, 0, 1, 1, gl.RGBA_INTEGER, isSigned ? gl.INT : gl.UNSIGNED_INT, pixel);
+  let pass = true;
+  for (let i = 0; i < 4; i++) {
+    if (value[i] != pixel[i]) {
+      testFailed(`Read value of channel ${i} should be ${pixel[i]}, was ${value[i]}.`);
+      pass = false;
+    }
+  }
+  return pass;
+}
+
+function runTest(isSigned, operation) {
+  gl.viewport(0, 0, 1, 1);
+  gl.disable(gl.BLEND);
+
+  const program = wtu.setupProgram(gl,
+    ["outputVertexShader",
+      isSigned ? "outputFragmentShaderSigned" : "outputFragmentShaderUnsigned"],
+    ['vPosition'], [0]);
+  const quadParameters = wtu.setupUnitQuad(gl, 0, 1);
+
+  // Setup render targets
+  const fb = gl.createFramebuffer();
+  gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+
+  const rb1 = gl.createRenderbuffer();
+  gl.bindRenderbuffer(gl.RENDERBUFFER, rb1);
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, 50, 50);
+  gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.RENDERBUFFER, rb1);
+
+  const rb2 = gl.createRenderbuffer();
+  gl.bindRenderbuffer(gl.RENDERBUFFER, rb2);
+  gl.renderbufferStorage(gl.RENDERBUFFER, isSigned ? gl.RGBA32I : gl.RGBA32UI, 50, 50);
+  gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT2, gl.RENDERBUFFER, rb2);
+
+  const rb3 = gl.createRenderbuffer();
+  gl.bindRenderbuffer(gl.RENDERBUFFER, rb3);
+  gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA8, 50, 50);
+  gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT3, gl.RENDERBUFFER, rb3);
+
+  gl.drawBuffers([gl.NONE, gl.COLOR_ATTACHMENT1, gl.COLOR_ATTACHMENT2, gl.COLOR_ATTACHMENT3]);
+
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Pipeline setup complete.");
+
+  if (isSigned) {
+    const clearValue = new Int32Array([-1, 2, -3, 4]);
+    gl.clearBufferiv(gl.COLOR, 2, clearValue);
+    if (compareValue(clearValue, gl.COLOR_ATTACHMENT2, isSigned)) {
+      testPassed("Signed clear passed.");
+    } else {
+      testFailed("Signed clear failed.");
+    }
+  } else {
+    const clearValue = new Uint32Array([1, 2, 3, 4]);
+    gl.clearBufferuiv(gl.COLOR, 2, clearValue);
+    if (compareValue(clearValue, gl.COLOR_ATTACHMENT2, isSigned)) {
+      testPassed("Unsigned clear passed.");
+    } else {
+      testFailed("Unsigned clear failed.");
+    }
+  }
+
+  gl.blendEquation(operation);
+  gl.enable(gl.BLEND);
+
+  wtu.drawUnitQuad(gl);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Draw complete.");
+
+  if (isSigned) {
+    const drawValue = new Int32Array([0, 0, 0, 0]);
+    if (compareValue(drawValue, gl.COLOR_ATTACHMENT2, isSigned)) {
+      testPassed("Signed draw passed.");
+    } else {
+      testFailed("Signed draw failed.");
+    }
+  } else {
+    const drawValue = new Uint32Array([0, 0, 0, 0]);
+    if (compareValue(drawValue, gl.COLOR_ATTACHMENT2, isSigned)) {
+      testPassed("Unsigned draw passed.");
+    } else {
+      testFailed("Unsigned draw failed.");
+    }
+  }
+  gl.deleteRenderbuffer(rb1);
+  gl.deleteRenderbuffer(rb2);
+  gl.deleteRenderbuffer(rb3);
+  gl.deleteFramebuffer(fb);
+  gl.deleteProgram(program);
+}
+
+debug("");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>

--- a/sdk/tests/deqp/functional/gles3/es3fPrimitiveRestartTests.js
+++ b/sdk/tests/deqp/functional/gles3/es3fPrimitiveRestartTests.js
@@ -334,10 +334,15 @@ var gluTextureUtil = framework.opengl.gluTextureUtil;
             '\n' +
             'void main()\n' +
             ' {\n' +
-            ' gl_Position = a_position;\n' +
-            '}\n';
+            ' gl_Position = a_position;\n';
 
-            /** @type {string} */ var fragShaderSource =
+        if (this.m_primType == es3fPrimitiveRestartTests.PrimitiveType.PRIMITIVE_POINTS) {
+            vertShaderSource += ' gl_PointSize = 1.0;\n';
+        }
+
+        vertShaderSource += '}\n';
+
+        /** @type {string} */ var fragShaderSource =
             '#version 300 es\n' +
             'layout(location = 0) out mediump vec4 o_color;\n' +
             '\n' +


### PR DESCRIPTION
Failing to set this was relying on currently-undefined behavior and
causing the tests to fail on Apple's M1.
    
Related to #2818, #2822 and #3356.
