### PR TITLE
Require ETC1 support to match ETC2 on WebGL 2.0

### DIFF
--- a/sdk/tests/conformance2/extensions/required-extensions.html
+++ b/sdk/tests/conformance2/extensions/required-extensions.html
@@ -43,7 +43,13 @@ debug(`has_etc: ${has_etc}`);
 
 shouldBeTrue("((has_s3tc && has_s3tc_srgb && has_rgtc) || has_etc)");
 
-debug("")
+// ETC1 extension must not be exposed on WebGL 2.0 contexts without ETC2.
+debug("");
+const has_etc1 = hasExt('WEBGL_compressed_texture_etc1');
+debug(`has_etc1: ${has_etc1}`);
+shouldBeTrue("has_etc1 == has_etc");
+
+debug("");
 var successfullyParsed = true;
 </script>
 


### PR DESCRIPTION
This is as much as we could do on the WebGL CTS side to fix #3014. Another part of the fix was added in #3329 as a guidance for the implementors.

We could also add an extra test for WebGL 1.0 to catch a similar issue there:
```js
shouldBeTrue("!has_etc || has_etc1");
```