### PR TITLE
Immediately invalidate current program if its relink fails.

### DIFF
--- a/sdk/tests/conformance/programs/program-test.html
+++ b/sdk/tests/conformance/programs/program-test.html
@@ -312,9 +312,9 @@ function go() {
     assertMsg(gl.getProgramParameter(progGood2, gl.LINK_STATUS) == false,
               "linking should fail with in-use formerly good program, with new bad shader attached");
 
-    // Invalid link leaves previous valid program intact.
+    // In WebGL, an invalid link immediately invalidates the previous valid program.
     gl.drawArrays(gl.TRIANGLES, 0, 3);
-    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawing with a valid program shouldn't generate a GL error");
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawing with a newly-invalidated program should generate INVALID_OPERATION");
 
     gl.useProgram(progGood1);
     gl.drawArrays(gl.TRIANGLES, 0, 4);

--- a/sdk/tests/conformance/programs/program-test.html
+++ b/sdk/tests/conformance/programs/program-test.html
@@ -312,7 +312,7 @@ function go() {
     assertMsg(gl.getProgramParameter(progGood2, gl.LINK_STATUS) == false,
               "linking should fail with in-use formerly good program, with new bad shader attached");
 
-    // In WebGL, an invalid link immediately invalidates the previous valid program.
+    // In WebGL, an unsuccessful link immediately invalidates the previous valid program.
     gl.drawArrays(gl.TRIANGLES, 0, 3);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "drawing with a newly-invalidated program should generate INVALID_OPERATION");
 

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -3038,15 +3038,26 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             objects attached to a program affect neither that program's link status, nor the
             executable code that program may reference. <br><br>
 
-            If the given program is linked successfully and is also the current program object in
-            use as defined by <code>useProgram</code>, below, then the generated executable code
-            will be immediately installed as part of the current rendering state. Otherwise any
-            executable code referenced by the current rendering state is unmodified by a call to
-            linkProgram. <br><br>
+            If the given program is also the the current program object in use as defined
+            by <code>useProgram</code>, below, then:
+
+            <ul>
+
+            <li> If the program is linked successfully, the generated executable code is immediately
+            installed as part of the current rendering state. </li>
+
+            <li> If the program is not linked successfully, the executable code referenced by the
+            current rendering state is immediately invalidated. Further draw calls that utilize the
+            current program generate an <code>INVALID_OPERATION</code> error.
+            See <a href="#CURRENT_PROGRAM_INVALIDATED">Current program invalidated upon unsuccessful
+            link</a>.
+
+            </ul>
 
             See <a href="#PACKING_RESTRICTIONS">Packing Restrictions for Uniforms and Varyings</a>
             for additional constraints enforced in, and additional validation performed by, WebGL
             implementations.
+
         <dt class="idl-code">void shaderSource(WebGLShader shader, DOMString source)
             <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.10.1">OpenGL ES 2.0 &sect;2.10.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glShaderSource.xml">man page</a>)</span>
         <dd>
@@ -4452,6 +4463,23 @@ extensions.
             If the primitive under consideration is a point, then clipping passes it unchanged if it
             lies within the clip volume; otherwise, it is discarded.
         </blockquote>
+    </p>
+</div>
+
+<h3><a name="CURRENT_PROGRAM_INVALIDATED">Current program invalidated upon unsuccessful link</a></h3>
+<p>
+
+    In the WebGL API, if the program passed to <code>linkProgram</code> is also the current program
+    object in use as defined by <code>useProgram</code>, and the link is unsuccessful, then the
+    executable code referenced by the current rendering state is immediately invalidated. Further
+    draw calls that utilize the current program generate an <code>INVALID_OPERATION</code> error.
+</p>
+<div class="note rationale">
+    <p>
+        Rejecting draw calls eagerly against programs whose relink has failed makes WebGL
+        implementations more robust. The OpenGL ES API's behavior is that the current executable is
+        preserved until the current program is changed. Correctly implementing this behavior in all
+        scenarios is challenging, and has led to security bugs.
     </p>
 </div>
 


### PR DESCRIPTION
Rather than continuing to preserve the current executable as specified
in the OpenGL ES API, generate INVALID_OPERATION for subsequent draw
calls if the currently bound program is relinked, and that relink fails.

Update program-test.html to follow the new behavior.

Agreed upon in the WebGL working group meeting of 2021-10-21.