### PR TITLE
Fix broken / redirected links in References

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -149,7 +149,7 @@
 
     <p>
       The remaining sections of this document are intended to be read in conjunction
-      with the OpenGL ES 3.0 specification (3.0.4 at the time of this writing, available
+      with the OpenGL ES 3.0 specification (3.0.6 at the time of this writing, available
       from the <a href="http://www.khronos.org/registry/gles/">Khronos OpenGL ES API Registry</a>).
       Unless otherwise specified, the behavior of each method is defined by the
       OpenGL ES 3.0 specification.  This specification may diverge from OpenGL ES 3.0
@@ -280,22 +280,22 @@ typedef unsigned long long GLuint64;
         The <code>WebGLQuery</code> interface represents an OpenGL Query Object.
         The underlying object is created as if by calling glGenQueries
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGenQueries.xhtml">man page</a>)
         </span>,
         made active as if by calling glBeginQuery
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBeginQuery.xhtml">man page</a>)
         </span>,
         concluded as if by calling glEndQuery
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
-          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBeginQuery.xhtml">man page</a>)
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glEndQuery.xhtml">man page</a>)
         </span>
         and destroyed as if by calling glDeleteQueries
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteQueries.xhtml">man page</a>)
         </span>.
     </p>
@@ -311,17 +311,17 @@ interface <dfn data-dfn-type="interface" id="WebGLQuery">WebGLQuery</dfn> : WebG
         The <code>WebGLSampler</code> interface represents an OpenGL Sampler Object.
         The underlying object is created as if by calling glGenSamplers
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.2">OpenGL ES 3.0.6 &sect;3.8.2</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGenSamplers.xhtml">man page</a>)
         </span>,
          bound as if by calling glBindSampler
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.2">OpenGL ES 3.0.6 &sect;3.8.2</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindSampler.xhtml">man page</a>)
         </span>
         and destroyed as if by calling glDeleteSamplers
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.2">OpenGL ES 3.0.6 &sect;3.8.2</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteSamplers.xhtml">man page</a>)
         </span>.
     </p>
@@ -337,27 +337,27 @@ interface <dfn data-dfn-type="interface" id="WebGLSampler">WebGLSampler</dfn> : 
         The <code>WebGLSync</code> interface represents an OpenGL Sync Object.
         The underlying object is created as if by calling glFenceSync
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2">OpenGL ES 3.0.4 &sect;5.2</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.5.2">OpenGL ES 3.0.6 &sect;5.2</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glFenceSync.xhtml">man page</a>)
         </span>,
         blocked on as if by calling glClientWaitSync
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2.1">OpenGL ES 3.0.4 &sect;5.2.1</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.5.2.1">OpenGL ES 3.0.6 &sect;5.2.1</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glClientWaitSync.xhtml">man page</a>)
         </span>,
         waited on internal to GL as if by calling glWaitSync
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2.1">OpenGL ES 3.0.4 &sect;5.2.1</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.5.2.1">OpenGL ES 3.0.6 &sect;5.2.1</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glWaitSync.xhtml">man page</a>)
         </span>,
         queried as if by calling glGetSynciv
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.8">OpenGL ES 3.0.4 &sect;6.2.8</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.8">OpenGL ES 3.0.6 &sect;6.1.8</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetSynciv.xhtml">man page</a>)
         </span>,
         and destroyed as if by calling glDeleteSync
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2">OpenGL ES 3.0.4 &sect;5.2</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.5.2">OpenGL ES 3.0.6 &sect;5.2</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteSync.xhtml">man page</a>)
         </span>.
     </p>
@@ -375,17 +375,17 @@ interface <dfn data-dfn-type="interface" id="WebGLSync">WebGLSync</dfn> : WebGLO
         The <code>WebGLTransformFeedback</code> interface represents an OpenGL Transform Feedback Object.
         The underlying object is created as if by calling glGenTransformFeedbacks
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.1">OpenGL ES 3.0.4 &sect;2.14.1</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.1">OpenGL ES 3.0.6 &sect;2.15.1</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGenTransformFeedbacks.xhtml">man page</a>)
         </span>,
         bound as if by calling glBindTransformFeedback
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.1">OpenGL ES 3.0.4 &sect;2.14.1</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.1">OpenGL ES 3.0.6 &sect;2.15.1</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindTransformFeedback.xhtml">man page</a>)
         </span>
         and destroyed as if by calling glDeleteTransformFeedbacks
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.1">OpenGL ES 3.0.4 &sect;2.14.1</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.1">OpenGL ES 3.0.6 &sect;2.15.1</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteTransformFeedbacks.xhtml">man page</a>)
         </span>.
     </p>
@@ -401,17 +401,17 @@ interface <dfn data-dfn-type="interface" id="WebGLTransformFeedback">WebGLTransf
         The <code>WebGLVertexArrayObject</code> interface represents an OpenGL Vertex Array Object.
         The underlying object is created as if by calling glGenVertexArrays
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10">OpenGL ES 3.0.4 &sect;2.10</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.10">OpenGL ES 3.0.6 &sect;2.10</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGenVertexArrays.xhtml">man page</a>)
         </span>,
         bound as if by calling glBindVertexArray
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10">OpenGL ES 3.0.4 &sect;2.10</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.10">OpenGL ES 3.0.6 &sect;2.10</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindVertexArray.xhtml">man page</a>)
         </span>
         and destroyed as if by calling glDeleteVertexArrays
         <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10">OpenGL ES 3.0.4 &sect;2.10</a>,
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.10">OpenGL ES 3.0.6 &sect;2.10</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteVertexArrays.xhtml">man page</a>)
         </span>.
     </p>
@@ -991,7 +991,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
       <dt class="idl-code">void bindBuffer(GLenum target, WebGLBuffer? buffer)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.1">OpenGL ES 3.0.4 &sect;2.9.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindBuffer.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.10.1">OpenGL ES 3.0.6 &sect;2.10.1</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindBuffer.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           Binds the given WebGLBuffer object to the given binding point(target). <em>target</em> is given in the following table:
@@ -1013,7 +1016,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       </div>
 
       <dt class="idl-code">void bindFramebuffer(GLenum target, WebGLFramebuffer? framebuffer)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.4.1">OpenGL ES 3.0.4 &sect;4.4.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindFramebuffer.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.4.1">OpenGL ES 3.0.6 &sect;4.4.1</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindFramebuffer.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           Binds the given WebGLFramebuffer object to the given binding point(target). <em>target</em> is given in the following table:
@@ -1027,7 +1033,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       </dd>
 
       <dt class="idl-code">void bindTexture(GLenum target, WebGLTexture? texture)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.1">OpenGL ES 3.0.4 &sect;3.8.1</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindTexture.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.1">OpenGL ES 3.0.6 &sect;3.8.1</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindTexture.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           Binds the given WebGLTexture object to the given binding point(target). <em>target</em> is given in the following table:
@@ -1048,9 +1057,11 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
         <dt class="idl-code"><a name="GETPARAMETER">any getParameter</a>(GLenum pname)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.1">OpenGL ES 3.0.4 &sect;6.1.1</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGet.xhtml">glGet OpenGL ES 3.0 man page</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetString.xhtml">glGetString OpenGL ES 3.0 man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.1">OpenGL ES 3.0.6 &sect;6.1.1</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGet.xhtml">glGet OpenGL ES 3.0 man page</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetString.xhtml">glGetString OpenGL ES 3.0 man page</a>)
+            </span>
         <dd>
             Return the value for the passed pname. As well as supporting all
             the pname/type values from WebGL 1.0, the following parameters are supported:
@@ -1125,8 +1136,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             <p>For <code>RED_BITS</code>, <code>GREEN_BITS</code>, <code>BLUE_BITS</code>, and <code>ALPHA_BITS</code>, if active color attachments of the draw framebuffer do not have identical formats, generates an <code>INVALID_OPERATION</code> error and returns 0.</p>
 
         <dt class="idl-code">any getIndexedParameter(GLenum target, GLuint index)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.1">OpenGL ES 3.0.4 &sect;6.1.1</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGet.xhtml">glGet OpenGL ES 3.0 man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.1">OpenGL ES 3.0.6 &sect;6.1.1</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGet.xhtml">glGet OpenGL ES 3.0 man page</a>)
+            </span>
         <dd>
             Return the indexed value for the passed <code class="param">target</code>. The type returned is the natural type for the requested <code class="param">pname</code>,
             as given in the following table:
@@ -1143,12 +1156,17 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             <p>If <code class="param">index</code> is outside of the valid range for the indexed state <code class="param">target</code>, generates an <code>INVALID_VALUE</code> error.</p>
             <p>If an OpenGL error is generated, returns null.</p>
         <dt class="idl-code"><a name="ISENABLED">GLboolean isEnabled</a>(GLenum cap)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.1">OpenGL ES 3.0.4 &sect;6.1.1</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsEnabled.xhtml">OpenGL ES 3.0 man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.1">OpenGL ES 3.0.6 &sect;6.1.1</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsEnabled.xhtml">OpenGL ES 3.0 man page</a>)
+            </span>
         <dd>
             In addition to all of the <code class="param">cap</code> values from WebGL 1.0, RASTERIZER_DISCARD is supported.
         <dt class="idl-code">void pixelStorei(GLenum pname, GLint param)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.7.1">OpenGL ES 3.0.4 &sect;3.7.1</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glPixelStorei.xhtml">OpenGL ES 3.0 man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.7.1">OpenGL ES 3.0.6 &sect;3.7.1</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glPixelStorei.xhtml">OpenGL ES 3.0 man page</a>)
+            </span>
         <dd>
             In addition to the parameters from WebGL 1.0, the WebGL 2.0 specification accepts the following extra parameters:
             <table class="foo">
@@ -1172,8 +1190,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
       <dt class="idl-code">void bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset, optional GLuint length = 0);
           <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10.2">OpenGL ES 3.0.4 &sect;2.10.2</a>,
-           <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferData.xhtml" class="nonnormative">man page</a>)
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.10.2">OpenGL ES 3.0.6 &sect;2.10.2</a>,
+            <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferData.xhtml" class="nonnormative">man page</a>)
           </span>
       </dt>
       <dd>
@@ -1207,8 +1225,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
       <dt class="idl-code">void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData, GLuint srcOffset, optional GLuint length = 0);
           <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10.2">OpenGL ES 3.0.4 &sect;2.10.2</a>,
-           <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferSubData.xhtml" class="nonnormative">man page</a>)
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.10.2">OpenGL ES 3.0.6 &sect;2.10.2</a>,
+            <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferSubData.xhtml" class="nonnormative">man page</a>)
           </span>
       </dt>
       <dd>
@@ -1246,8 +1264,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
       <dt class="idl-code">any getBufferParameter(GLenum target, GLenum pname)
           <span class="gl-spec">
-          (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.9">OpenGL ES 3.0.4 &sect;6.1.9</a>,
-          <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetBufferParameter.xhtml" class="nonnormative">man page</a>)
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.9">OpenGL ES 3.0.6 &sect;6.1.9</a>,
+            <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetBufferParameter.xhtml" class="nonnormative">man page</a>)
           </span>
       </dt>
       <dd>
@@ -1258,7 +1276,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void copyBufferSubData(GLenum readTarget, GLenum writeTarget, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.5">OpenGL ES 3.0.4 &sect;2.9.5</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.10.5">OpenGL ES 3.0.6 &sect;2.10.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCopyBufferSubData.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1352,7 +1370,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
       <dt class="idl-code">[WebGLHandlesContextLoss] GLenum checkFramebufferStatus(GLenum target)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.4.5">OpenGL ES 3.0.4 &sect;4.4.4</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCheckFramebufferStatus.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.4.4.4.2">OpenGL ES 3.0.6 &sect;4.4.4.2</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCheckFramebufferStatus.xhtml">man page</a>)
+          </span>
       <dd>
         <p>Only differences from <a href="../1.0/index.html#CHECK_FRAMEBUFFER_STATUS">checkFramebufferStatus</a> in WebGL 1.0 are described here.</p>
         <p><em>target</em> must be <code>DRAW_FRAMEBUFFER</code>, <code>READ_FRAMEBUFFER</code> or <code>FRAMEBUFFER</code>. <code>FRAMEBUFFER</code> is equivalent to <code>DRAW_FRAMEBUFFER</code>.</p>
@@ -1364,7 +1385,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       </dd>
 
       <dt class="idl-code">any getFramebufferAttachmentParameter(GLenum target, GLenum attachment, GLenum pname)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.13">OpenGL ES 3.0.4 &sect;6.1.13</a>, similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetFramebufferAttachmentParameteriv.xhtml">glGetFramebufferAttachmentParameteriv</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.13">OpenGL ES 3.0.6 &sect;6.1.13</a>,
+            similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetFramebufferAttachmentParameteriv.xhtml">glGetFramebufferAttachmentParameteriv</a>)
+          </span>
       </dt>
       <dd>
           Return the value for the passed pname given the passed target and attachment. The type
@@ -1392,7 +1416,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.3.3">OpenGL ES 3.0.4 &sect;4.3.3</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.3.3">OpenGL ES 3.0.6 &sect;4.3.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBlitFramebuffer.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1421,7 +1445,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level, GLint layer)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.4.2">OpenGL ES 3.0.4 &sect;4.4.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.4.4.2.4">OpenGL ES 3.0.6 &sect;4.4.2.4</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glFramebufferTextureLayer.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1433,7 +1457,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void invalidateFramebuffer(GLenum target, sequence&lt;GLenum&gt; attachments)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.5">OpenGL ES 3.0.4 &sect;4.5</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.4.5">OpenGL ES 3.0.6 &sect;4.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glInvalidateFramebuffer.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1446,7 +1470,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void invalidateSubFramebuffer (GLenum target, sequence&lt;GLenum&gt; attachments, GLint x, GLint y, GLsizei width, GLsizei height)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.5">OpenGL ES 3.0.4 &sect;4.5</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.4.5">OpenGL ES 3.0.6 &sect;4.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glInvalidateSubFramebuffer.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1457,7 +1481,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void readBuffer(GLenum src)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.3.1">OpenGL ES 3.0.4 &sect;4.3.1</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.3.1">OpenGL ES 3.0.6 &sect;4.3.1</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glReadBuffer.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1475,7 +1499,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.15">OpenGL ES 3.0.4 &sect;6.1.15</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.15">OpenGL ES 3.0.6 &sect;6.1.15</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetInternalformativ.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1492,7 +1516,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           <p>Each query for SAMPLES returns a new typed array object instance.</p>
       </dd>
       <dt class="idl-code">any getRenderbufferParameter(GLenum target, GLenum pname)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.14">OpenGL ES 2.0 &sect;6.1.14</a>, similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetRenderbufferParameteriv.xhtml">glGetRenderbufferParameteriv</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.14">OpenGL ES 2.0 &sect;6.1.14</a>,
+            similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetRenderbufferParameteriv.xhtml">glGetRenderbufferParameteriv</a>)
+          </span>
       </dt>
       <dd>
           Return the value for the passed pname given the passed target. The type returned is the natural
@@ -1516,19 +1543,19 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void renderbufferStorage(GLenum target, GLenum internalformat, GLsizei width, GLsizei height)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.4.2">OpenGL ES 3.0.4 &sect;4.4.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.4.4.2.1">OpenGL ES 3.0.6 &sect;4.4.2.1</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glRenderbufferStorage.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
       </dt>
       <dd>
-        <p>Accepts internal formats from OpenGL ES 3.0 as detailed in the <a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.4.2">specification</a> and <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glRenderbufferStorage.xhtml" class="nonnormative">man page</a>.</p>
+        <p>Accepts internal formats from OpenGL ES 3.0 as detailed in the <a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.4.4.2.1">specification</a> and <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glRenderbufferStorage.xhtml" class="nonnormative">man page</a>.</p>
         <p>To be backward compatible with WebGL 1, also accepts internal format <code>DEPTH_STENCIL</code>, which should be mapped to <code>DEPTH24_STENCIL8</code> by implementations.</p>
       </dd>
       <dt>
         <p class="idl-code">void renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.4.2">OpenGL ES 3.0.4 &sect;4.4.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.4.4.2.1">OpenGL ES 3.0.6 &sect;4.4.2.1</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glRenderbufferStorageMultisample.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1549,7 +1576,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
       <dt class="idl-code">any getTexParameter(GLenum target, GLenum pname)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.3">OpenGL ES 3.0.4 &sect;6.1.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetTexParameter.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.3">OpenGL ES 3.0.6 &sect;6.1.3</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetTexParameter.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           Return the value for the passed pname given the passed target. The type returned is the natural type for the
@@ -1576,7 +1606,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           <p>If an OpenGL error is generated, returns null.</p>
       </dd>
       <dt class="idl-code">void texParameterf(GLenum target, GLenum pname, GLfloat param)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.7">OpenGL ES 3.0.4 &sect;3.8.7</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexParameter.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.7">OpenGL ES 3.0.6 &sect;3.8.7</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexParameter.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           Set the value for the passed pname given the passed target. <em>pname</em> is given in the following table:
@@ -1599,7 +1632,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           <code>INVALID_OPERATION</code> error.</p>
       </dd>
       <dt class="idl-code">void texParameteri(GLenum target, GLenum pname, GLint param)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.7">OpenGL ES 3.0.4 &sect;3.8.7</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexParameter.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.7">OpenGL ES 3.0.6 &sect;3.8.7</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexParameter.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           <p>Set the value for the passed pname given the passed target. <em>pname</em> is this same with that of texParameterf, as given in the table above.</p>
@@ -1610,7 +1646,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void texStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.4">OpenGL ES 3.0.4 &sect;3.8.4</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.4">OpenGL ES 3.0.6 &sect;3.8.4</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexStorage2D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1621,7 +1657,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         The image contents are set as if a buffer of sufficient size initialized to 0 would be passed to
         each texImage2D (or compressedTexImage2D for compressed formats) call in the pseudocode in
         The OpenGL ES 3.0 specification section 3.8.4
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.4">OpenGL ES 3.0.4 &sect;3.8.4</a>)</span>.
+        <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.4">OpenGL ES 3.0.6 &sect;3.8.4</a>)</span>.
 
         <div class="note"><code>texStorage2D</code> should be considered a preferred alternative to
         <code>texImage2D</code>. It may have lower memory costs than <code>texImage2D</code> in some
@@ -1630,7 +1666,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code"><a name="TEXSTORAGE3D">void texStorage3D</a>(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.4">OpenGL ES 3.0.4 &sect;3.8.4</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.4">OpenGL ES 3.0.6 &sect;3.8.4</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexStorage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1641,14 +1677,17 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         The image contents are set as if a buffer of sufficient size initialized to 0 would be passed to
         each texImage3D (or compressedTexImage3D for compressed formats) call in the pseudocode in
         The OpenGL ES 3.0 specification section 3.8.4
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.4">OpenGL ES 3.0.4 &sect;3.8.4</a>)</span>.
+        <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.4">OpenGL ES 3.0.6 &sect;3.8.4</a>)</span>.
       </dd>
 
       <dt class="idl-code">
         undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                         GLsizei height, GLint border, GLenum format, GLenum type,
                         [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)</span>
+        <span class="gl-spec">
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)
+        </span>
       </dt>
       <dd>
         <p>Only differences from <a href="../1.0/index.html#TEXIMAGE2D">texImage2D</a> in WebGL 1.0 are described here. </p>
@@ -1693,7 +1732,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                         GLsizei height, GLint border, GLenum format, GLenum type,
                         TexImageSource source) // May throw DOMException
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)</span>
+        <span class="gl-spec">
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)
+        </span>
       </dt>
       <dd>
         <p>Only differences from <a href="../1.0/index.html#TEXIMAGE2D_HTML">texImage2D</a> in WebGL 1.0 are described here. </p>
@@ -1762,7 +1804,11 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         <div class="note rationale">When the data source is a DOM element (<code>HTMLImageElement</code>, <code>HTMLCanvasElement</code>, or <code>HTMLVideoElement</code>), or is an <code>ImageBitmap</code>, <code>ImageData</code>, or <code>OffscreenCanvas</code> object, commonly each channel's representation is an unsigned integer type of at least 8 bits. Converting such representation to signed integers or unsigned integers with more bits is not clearly defined. For example, when converting RGBA8 to RGBA16UI,  it is unclear whether or not the intention is to scale up values to the full range of a 16-bit unsigned integer. Therefore, only converting to unsigned integer of at most 8 bits, half float, or float is allowed.</div>
       </dd>
 
-      <dt class="idl-code"><a name="TEXIMAGE2D_SERVER_SIDE">void texImage2D</a>(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, GLintptr offset) <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)</span>
+      <dt class="idl-code"><a name="TEXIMAGE2D_SERVER_SIDE">void texImage2D</a>(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, GLintptr offset)
+        <span class="gl-spec">
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)
+        </span>
       </dt>
       <dd>
         <p>Upload data to the currently bound WebGLTexture from the WebGLBuffer bound to the <code>PIXEL_UNPACK_BUFFER</code> target.</p>
@@ -1780,7 +1826,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         undefined texSubImage2D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format, GLenum type,
                                [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)</span>
+        <span class="gl-spec">
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)
+        </span>
       </dt>
       <dd>
         <p>Only differences from <a href="../1.0/index.html#TEXSUBIMAGE2D">texSubImage2D</a> in WebGL 1.0 are described here. </p>
@@ -1805,7 +1854,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         undefined texSubImage2D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format, GLenum type,
                                TexImageSource source) // May throw DOMException
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)</span>
+        <span class="gl-spec">
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)
+        </span>
       </dt>
       <dd>
         <p>Only differences from <a href="../1.0/index.html#TEXSUBIMAGE2D_HTML">texSubImage2D</a> in WebGL 1.0 are described here. </p>
@@ -1819,7 +1871,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         undefined texSubImage2D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format, GLenum type,
                                GLintptr offset)
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)</span>
+        <span class="gl-spec">
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)
+        </span>
       </dt>
       <dd>
         <p>Updates a sub-rectangle of the currently bound WebGLTexture with data from the WebGLBuffer bound to <code>PIXEL_UNPACK_BUFFER</code> target.</p>
@@ -1839,7 +1894,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         <p>void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                            GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
                            [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
+            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)
+          </span>
         </p>
       </dt>
       <dd>
@@ -1872,7 +1930,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           undefined texImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                           GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
                           TexImageSource source) // May throw DOMException
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
+            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)
+          </span>
         </p>
       </dt>
       <dd>
@@ -1891,7 +1952,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       </dd>
 
       <dt class="idl-code"><a name="TEXIMAGE3D_SERVER_SIDE">void texImage3D</a>(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, GLintptr offset)
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.3">OpenGL ES 3.0.4 &sect;3.8.4</a>, <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)</span>
+        <span class="gl-spec">
+          (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
+          <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)
+        </span>
       </dt>
       <dd>
         <p>Upload data to the currently bound WebGLTexture from the WebGLBuffer bound to the <code>PIXEL_UNPACK_BUFFER</code> target.</p>
@@ -1911,7 +1975,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                              GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData,
                              optional GLuint srcOffset = 0)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1943,7 +2007,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                              GLenum format, GLenum type,
                              TexImageSource source) // May throw DOMException
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1966,7 +2030,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code"><a name="TEXSUBIMAGE3D_SERVER_SIDE">void texSubImage3D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -1985,7 +2049,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.5">OpenGL ES 3.0.4 &sect;3.8.5</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCopyTexSubImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2011,7 +2075,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                                     optional GLuint srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexImage2D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2033,7 +2097,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                                        optional GLuint srcOffset = 0,
                                        optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexSubImage2D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2056,7 +2120,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                                     optional GLuint srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2078,7 +2142,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                                        optional GLuint srcOffset = 0,
                                        optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexSubImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2102,7 +2166,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexImage2D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2110,7 +2174,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexSubImage2D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2118,7 +2182,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2126,7 +2190,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.6">OpenGL ES 3.0.4 &sect;3.8.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glCompressedTexSubImage3D.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2148,7 +2212,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">[WebGLHandlesContextLoss] GLint getFragDataLocation(WebGLProgram program, DOMString name)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.9.2">OpenGL ES 3.0.4 &sect;3.9.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.3.9.2.3">OpenGL ES 3.0.6 &sect;3.9.2.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetFragDataLocation.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2158,7 +2222,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           than this one, generates an <code>INVALID_OPERATION</code> error and returns -1.
       </dd>
       <dt class="idl-code">any getProgramParameter(WebGLProgram? program, GLenum pname)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.12">OpenGL ES 3.0.4 &sect;6.1.12</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetProgramiv.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.12">OpenGL ES 3.0.6 &sect;6.1.12</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetProgramiv.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
@@ -2192,7 +2259,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt class="idl-code">
         any getUniform(WebGLProgram program, WebGLUniformLocation location)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.12">OpenGL ES 3.0.4 &sect;6.1.12</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.12">OpenGL ES 3.0.6 &sect;6.1.12</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetUniform.xhtml" class="nonnormative">man page</a>)
           </span>
       </dt>
@@ -2225,7 +2292,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         <p class="idl-code">void uniform[1234]uiv(WebGLUniformLocation? location, ...)</p>
         <p class="idl-code">void uniformMatrix[234]x[234]fv(WebGLUniformLocation? location, ...)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.6">OpenGL ES 3.0.4 &sect;2.11.6</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.6">OpenGL ES 3.0.6 &sect;2.12.6</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glUniform.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2253,7 +2320,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt><p class="idl-code">void vertexAttribI4[u]i(GLuint index, ...)</p>
           <p class="idl-code">void vertexAttribI4[u]iv(GLuint index, ...)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.7">OpenGL ES 3.0.4 &sect;2.7</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.8">OpenGL ES 3.0.6 &sect;2.8</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glVertexAttrib.xhtml" class="nonnormative">man page</a>)
           </span>
       </dt>
@@ -2269,7 +2336,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void vertexAttribIPointer(GLuint index, GLint size, GLenum type, GLsizei stride, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.8">OpenGL ES 3.0.4 &sect;2.8</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.9">OpenGL ES 3.0.6 &sect;2.9</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glVertexAttribPointer.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2287,7 +2354,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         Attribute Data Stride</a>.
       </dd>
       <dt class="idl-code">any getVertexAttrib(GLuint index, GLenum pname)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.12">OpenGL ES 3.0.4 &sect;6.1.12</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetVertexAttrib.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.12">OpenGL ES 3.0.6 &sect;6.1.12</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetVertexAttrib.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           Return the information requested in pname about the vertex attribute at the passed index. The
@@ -2323,7 +2393,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void clear(GLbitfield mask)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.2.3">OpenGL ES 3.0.4 &sect;4.2.3</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.2.3">OpenGL ES 3.0.6 &sect;4.2.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glClear.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2335,7 +2405,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void vertexAttribDivisor(GLuint index, GLuint divisor)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.8">OpenGL ES 3.0.4 &sect;2.8</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.9">OpenGL ES 3.0.6 &sect;2.9</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glVertexAttribDivisor.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2346,7 +2416,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void drawArrays(GLenum mode, GLint first, GLsizei count)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.3">OpenGL ES 3.0.4 &sect;2.9.3</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.9.3">OpenGL ES 3.0.6 &sect;2.9.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDrawArrays.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2354,7 +2424,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void drawElements(GLenum mode, GLsizei count, GLenum type, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.3">OpenGL ES 3.0.4 &sect;2.9.3</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.9.3">OpenGL ES 3.0.6 &sect;2.9.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDrawElements.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2362,7 +2432,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void drawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.3">OpenGL ES 3.0.4 &sect;2.9.3</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.9.3">OpenGL ES 3.0.6 &sect;2.9.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDrawArraysInstanced.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2374,7 +2444,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void drawElementsInstanced(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei instanceCount)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.3">OpenGL ES 3.0.4 &sect;2.9.3</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.9.3">OpenGL ES 3.0.6 &sect;2.9.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDrawElementsInstanced.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2386,7 +2456,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void drawRangeElements(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, GLintptr offset)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.3">OpenGL ES 3.0.4 &sect;2.9.3</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.9.3">OpenGL ES 3.0.6 &sect;2.9.3</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDrawRangeElements.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2425,7 +2495,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         <dt class="idl-code">
           undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
                           GLenum type, [AllowShared] ArrayBufferView dstData, GLuint dstOffset)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.3.2">OpenGL ES 3.0 &sect;4.3.2</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glReadPixels.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.3.2">OpenGL ES 3.0 &sect;4.3.2</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glReadPixels.xhtml">man page</a>)
+          </span>
         </dt>
         <dd>
           <p>If a WebGLBuffer is bound to the <code>PIXEL_PACK_BUFFER</code> target, generates an <code>INVALID_OPERATION</code> error.</p>
@@ -2455,7 +2528,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         </dd>
 
         <dt class="idl-code">void readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLintptr offset)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.3.2">OpenGL ES 3.0 &sect;4.3.2</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glReadPixels.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.3.2">OpenGL ES 3.0 &sect;4.3.2</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glReadPixels.xhtml">man page</a>)
+            </span>
         </dt>
         <dd>
           <p>If no WebGLBuffer is bound to the <code>PIXEL_PACK_BUFFER</code> target, generates an
@@ -2476,7 +2552,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void drawBuffers(sequence&lt;GLenum&gt; buffers)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.2.1">OpenGL ES 3.0.4 &sect;4.2.1</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.2.1">OpenGL ES 3.0.6 &sect;4.2.1</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDrawBuffers.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2494,7 +2570,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                                  optional GLuint srcOffset = 0);</p>
           <p>void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
             <span class="gl-spec">
-              (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.2.3">OpenGL ES 3.0.4 &sect;4.2.3</a>,
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.2.3">OpenGL ES 3.0.6 &sect;4.2.3</a>,
               <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glClearBuffer.xhtml" class="nonnormative">man page</a>)
             </span>
           </p>
@@ -2536,7 +2612,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">WebGLQuery? createQuery()
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGenQueries.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2547,7 +2623,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void deleteQuery(WebGLQuery? query)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteQueries.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2564,7 +2640,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">[WebGLHandlesContextLoss] GLboolean isQuery(WebGLQuery? query)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.7">OpenGL ES 3.0.4 &sect;6.1.7</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.7">OpenGL ES 3.0.6 &sect;6.1.7</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsQuery.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2581,7 +2657,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void beginQuery(GLenum target, WebGLQuery query)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBeginQuery.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2594,7 +2670,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void endQuery(GLenum target)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.13">OpenGL ES 3.0.4 &sect;2.13</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.14">OpenGL ES 3.0.6 &sect;2.14</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBeginQuery.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2607,7 +2683,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">WebGLQuery? getQuery(GLenum target, GLenum pname)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.7">OpenGL ES 3.0.4 &sect;6.1.7</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.7">OpenGL ES 3.0.6 &sect;6.1.7</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetQueryiv.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2629,7 +2705,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code"><a name="GET_QUERY_PARAMETER">any getQueryParameter</a>(WebGLQuery query, GLenum pname)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.7">OpenGL ES 3.0.4 &sect;6.1.7</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.7">OpenGL ES 3.0.6 &sect;6.1.7</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetQueryObjectuiv.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2694,7 +2770,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">WebGLSampler? createSampler()
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.2">OpenGL ES 3.0.6 &sect;3.8.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGenSamplers.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2706,7 +2782,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void deleteSampler(WebGLSampler? sampler)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.2">OpenGL ES 3.0.6 &sect;3.8.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteSamplers.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2723,7 +2799,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">[WebGLHandlesContextLoss] GLboolean isSampler(WebGLSampler? sampler)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.5">OpenGL ES 3.0.6 &sect;6.1.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsSampler.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2740,7 +2816,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void bindSampler(GLuint unit, WebGLSampler? sampler)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.2">OpenGL ES 3.0.6 &sect;3.8.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindSampler.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2762,7 +2838,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         <p class="idl-code">void samplerParameteri(WebGLSampler sampler, GLenum pname, GLint param)</p>
         <p class="idl-code">void samplerParameterf(WebGLSampler sampler, GLenum pname, GLfloat param)</p>
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8.2">OpenGL ES 3.0.4 &sect;3.8.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.2">OpenGL ES 3.0.6 &sect;3.8.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glSamplerParameter.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2788,7 +2864,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         <p>If <em>sampler</em> is not a valid sampler object, generates an <code>INVALID_OPERATION</code> error.</p>
       </dd>
       <dt class="idl-code">any getSamplerParameter(WebGLSampler sampler, GLenum pname)
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.5">OpenGL ES 3.0.4 &sect;6.1.5</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetSamplerParameter.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.5">OpenGL ES 3.0.6 &sect;6.1.5</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetSamplerParameter.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           If <code>sampler</code> was generated by a different <code>WebGL2RenderingContext</code>
@@ -2825,7 +2904,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">WebGLSync? fenceSync(GLenum condition, GLbitfield flags)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2">OpenGL ES 3.0.4 &sect;5.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.5.2">OpenGL ES 3.0.6 &sect;5.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glFenceSync.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2836,7 +2915,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">[WebGLHandlesContextLoss] GLboolean isSync(WebGLSync? sync)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.8">OpenGL ES 3.0.4 &sect;6.1.8</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.8">OpenGL ES 3.0.6 &sect;6.1.8</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsSync.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2853,7 +2932,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void deleteSync(WebGLSync? sync)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2">OpenGL ES 3.0.4 &sect;5.2</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.5.2">OpenGL ES 3.0.6 &sect;5.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteSync.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2870,7 +2949,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code"><a name="CLIENT_WAIT_SYNC">GLenum clientWaitSync(WebGLSync sync, GLbitfield flags, GLuint64 timeout)</a>
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2.1">OpenGL ES 3.0.4 &sect;5.2.1</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.5.2.1">OpenGL ES 3.0.6 &sect;5.2.1</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glClientWaitSync.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2932,7 +3011,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <p class="idl-code">void waitSync(WebGLSync sync, GLbitfield flags, GLint64 timeout)
           <span class="gl-spec">
-            (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-5.2.1">OpenGL ES 3.0.4 &sect;5.2.1</a>,
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.5.2.1">OpenGL ES 3.0.6 &sect;5.2.1</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glWaitSync.xhtml" class="nonnormative">man page</a>)
           </span>
         </p>
@@ -2949,7 +3028,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         </div>
       </dd>
       <dt class="idl-code"><a name="GET_SYNC_PARAMETER">any getSyncParameter(WebGLSync sync, GLenum pname)</a>
-          <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.8">OpenGL ES 3.0.4 &sect;6.1.8</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetSynciv.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.8">OpenGL ES 3.0.6 &sect;6.1.8</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetSynciv.xhtml">man page</a>)
+          </span>
       </dt>
       <dd>
           If <code>sync</code> was generated by a different <code>WebGL2RenderingContext</code>
@@ -3001,15 +3083,19 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
         <dt class="idl-code">WebGLTransformFeedback? createTransformFeedback()
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.1">OpenGL ES 3.0.4 &sect;2.14.1</a>,
-            similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGenTransformFeedbacks.xhtml">glGenTransformFeedbacks</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.1">OpenGL ES 3.0.6 &sect;2.15.1</a>,
+              similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGenTransformFeedbacks.xhtml">glGenTransformFeedbacks</a>)
+            </span>
         <dd>
             Create a <code class="interface">WebGLTransformFeedback</code> object and initialize it with a transform feedback object name as if by
             calling glGenTransformFeedbacks.
 
         <dt class="idl-code">void deleteTransformFeedback(WebGLTransformFeedback? transformFeedback)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.1">OpenGL ES 3.0.4 &sect;2.14.1</a>,
-            similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteTransformFeedbacks.xhtml">glDeleteTransformFeedbacks</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.1">OpenGL ES 3.0.6 &sect;2.15.1</a>,
+              similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteTransformFeedbacks.xhtml">glDeleteTransformFeedbacks</a>)
+            </span>
         <dd>
             If <code>transformFeedback</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3022,8 +3108,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             destroyed, however this method allows authors to mark an object for deletion early.
 
         <dt class="idl-code">[WebGLHandlesContextLoss] GLboolean isTransformFeedback(WebGLTransformFeedback? transformFeedback)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.11">OpenGL ES 3.0.4 &sect;6.1.11</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsTransformFeedback.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.11">OpenGL ES 3.0.6 &sect;6.1.11</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glIsTransformFeedback.xhtml">man page</a>)
+            </span>
         <dd>
             Return true if the passed <code class="interface">WebGLTransformFeedback</code> is valid and false otherwise. <br><br>
 
@@ -3034,8 +3122,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             flag</a> is set.
 
         <dt class="idl-code">void bindTransformFeedback (GLenum target, WebGLTransformFeedback? transformFeedback)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.1">OpenGL ES 3.0.4 &sect;2.14.1</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindTransformFeedback.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.1">OpenGL ES 3.0.6 &sect;2.15.1</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBindTransformFeedback.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>transformFeedback</code> was generated by a
             different <code>WebGL2RenderingContext</code> than this one, generates
@@ -3048,35 +3138,47 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             <code>INVALID_OPERATION</code> error, and the current binding will remain untouched.
 
         <dt class="idl-code">void beginTransformFeedback(GLenum primitiveMode)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.2">OpenGL ES 3.0.4 &sect;2.14.2</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBeginTransformFeedback.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.2">OpenGL ES 3.0.6 &sect;2.15.2</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBeginTransformFeedback.xhtml">man page</a>)
+            </span>
         <dd>
 
         <dt class="idl-code">void endTransformFeedback()
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.2">OpenGL ES 3.0.4 &sect;2.14.2</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBeginTransformFeedback.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.2">OpenGL ES 3.0.6 &sect;2.15.2</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBeginTransformFeedback.xhtml">man page</a>)
+            </span>
         <dd>
 
         <dt class="idl-code">void pauseTransformFeedback()
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.2">OpenGL ES 3.0.4 &sect;2.14.2</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glPauseTransformFeedback.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.2">OpenGL ES 3.0.6 &sect;2.15.2</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glPauseTransformFeedback.xhtml">man page</a>)
+            </span>
         <dd>
 
         <dt class="idl-code">void resumeTransformFeedback()
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.14.2">OpenGL ES 3.0.4 &sect;2.14.2</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glResumeTransformFeedback.xhtml">man page</a>)</span>
+          <span class="gl-spec">
+            (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.2">OpenGL ES 3.0.6 &sect;2.15.2</a>,
+            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glPauseTransformFeedback.xhtml">man page</a>)
+          </span>
         <dd>
 
         <dt class="idl-code">void transformFeedbackVaryings(WebGLProgram program, sequence&lt;DOMString&gt; varyings, GLenum bufferMode)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.8">OpenGL ES 3.0.4 &sect;2.11.8</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTransformFeedbackVaryings.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.8">OpenGL ES 3.0.6 &sect;2.12.8</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTransformFeedbackVaryings.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
 
         <dt class="idl-code">WebGLActiveInfo? getTransformFeedbackVarying(WebGLProgram program, GLuint index)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.8">OpenGL ES 3.0.4 &sect;2.11.8</a>,
-            <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetTransformFeedbackVarying.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.8">OpenGL ES 3.0.6 &sect;2.12.8</a>,
+              <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glGetTransformFeedbackVarying.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error and returns null. <br><br>
@@ -3094,8 +3196,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
         <dt class="idl-code">void bindBufferBase(GLenum target, GLuint index, WebGLBuffer? buffer)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.1">OpenGL ES 3.0.4 &sect;2.9.1</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindBufferBase.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.2.10.1.1">OpenGL ES 3.0.6 &sect;2.10.1.1</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindBufferBase.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>buffer</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3104,8 +3208,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             specified by <code class="param">target</code>.
 
         <dt class="idl-code">void bindBufferRange(GLenum target, GLuint index, WebGLBuffer? buffer, GLintptr offset, GLsizeiptr size)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.1">OpenGL ES 3.0.4 &sect;2.9.1</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindBufferRange.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.2.10.1.1">OpenGL ES 3.0.6 &sect;2.10.1.1</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindBufferRange.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>buffer</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3114,8 +3220,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             to the binding point at <code class="param">index</code> of the array of targets specified by <code class="param">target</code>.
 
         <dt class="idl-code">sequence&lt;GLuint&gt;? getUniformIndices(WebGLProgram program, sequence&lt;DOMString&gt; uniformNames)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.6">OpenGL ES 3.0.4 &sect;2.11.6</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetUniformIndices.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.6">OpenGL ES 3.0.6 &sect;2.12.6</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetUniformIndices.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different
             <code>WebGL2RenderingContext</code> than this one, generates
@@ -3127,8 +3235,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             function.
 
         <dt class="idl-code">any getActiveUniforms(WebGLProgram program, sequence&lt;GLuint&gt; uniformIndices, GLenum pname)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.6">OpenGL ES 3.0.4 &sect;2.11.6</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetActiveUniformsiv.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.6">OpenGL ES 3.0.6 &sect;2.12.6</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetActiveUniformsiv.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3152,8 +3262,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             function.</p>
 
         <dt class="idl-code">GLuint getUniformBlockIndex(WebGLProgram program, DOMString uniformBlockName)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.6">OpenGL ES 3.0.4 &sect;2.11.6</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetUniformBlockIndex.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.6">OpenGL ES 3.0.6 &sect;2.12.6</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetUniformBlockIndex.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3161,8 +3273,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             Retrieves the index of a uniform block within <code class="param">program</code>.
 
         <dt class="idl-code">any getActiveUniformBlockParameter(WebGLProgram program, GLuint uniformBlockIndex, GLenum pname)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.6">OpenGL ES 3.0.4 &sect;2.11.6</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetActiveUniformBlockiv.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.6">OpenGL ES 3.0.6 &sect;2.12.6</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetActiveUniformBlockiv.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3184,8 +3298,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             <p>If an OpenGL error is generated, returns null.</p>
 
         <dt class="idl-code">DOMString? getActiveUniformBlockName(WebGLProgram program, GLuint uniformBlockIndex)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.6">OpenGL ES 3.0.4 &sect;2.11.6</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetActiveUniformBlockName.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.6">OpenGL ES 3.0.6 &sect;2.12.6</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGetActiveUniformBlockName.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3193,8 +3309,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             Retrieves the name of the active uniform block at <code class="param">uniformBlockIndex</code> within <code class="param">program</code>.
 
         <dt class="idl-code">void uniformBlockBinding(WebGLProgram program, GLuint uniformBlockIndex, GLuint uniformBlockBinding)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.6">OpenGL ES 3.0.4 &sect;2.11.6</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glUniformBlockBinding.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.2.12.6.5">OpenGL ES 3.0.6 &sect;2.12.6.5</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glUniformBlockBinding.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>program</code> was generated by a different <code>WebGL2RenderingContext</code>
             than this one, generates an <code>INVALID_OPERATION</code> error. <br><br>
@@ -3213,8 +3331,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
         <dt class="idl-code">void bindVertexArray(WebGLVertexArrayObject? vertexArray)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10">OpenGL ES 3.0.4 &sect;2.10</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindVertexArray.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.11">OpenGL ES 3.0.6 &sect;2.11</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glBindVertexArray.xhtml">man page</a>)
+            </span>
         <dd>
             If <code>vertexArray</code> was generated by a
             different <code>WebGL2RenderingContext</code> than this one, generates
@@ -3227,15 +3347,19 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             the current binding will remain untouched.
 
         <dt class="idl-code">WebGLVertexArrayObject? createVertexArray()
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10">OpenGL ES 3.0.4 &sect;2.10</a>,
-            similar to <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGenVertexArrays.xhtml">glGenVertexArrays</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.11">OpenGL ES 3.0.6 &sect;2.11</a>,
+              similar to <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glGenVertexArrays.xhtml">glGenVertexArrays</a>)
+            </span>
         <dd>
             Create a <code class="interface">WebGLVertexArrayObject</code> object and initialize it with a vertex array object name as if by
             calling glGenVertexArrays.
 
         <dt class="idl-code">void deleteVertexArray(WebGLVertexArrayObject? vertexArray)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.10">OpenGL ES 3.0.4 &sect;2.10</a>,
-            similar to <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteVertexArrays.xhtml">glDeleteVertexArrays</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.11">OpenGL ES 3.0.6 &sect;2.11</a>,
+              similar to <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glDeleteVertexArrays.xhtml">glDeleteVertexArrays</a>)
+            </span>
         <dd>
             If <code>vertexArray</code> was generated by a
             different <code>WebGL2RenderingContext</code> than this one, generates
@@ -3249,8 +3373,10 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             destroyed, however this method allows authors to mark an object for deletion early.
 
         <dt class="idl-code">[WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray)
-            <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-6.1.10">OpenGL ES 3.0.4 &sect;6.1.10</a>,
-            <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glIsVertexArray.xhtml">man page</a>)</span>
+            <span class="gl-spec">
+              (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.6.1.10">OpenGL ES 3.0.6 &sect;6.1.10</a>,
+              <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glIsVertexArray.xhtml">man page</a>)
+            </span>
         <dd>
             Return true if the passed <code class="interface">WebGLVertexArrayObject</code> is valid and false otherwise. <br><br>
 
@@ -3378,9 +3504,9 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
     <h3>New Features Supported in the WebGL 2.0 API</h3>
 
     <ul>
-      <li>Pixel buffer objects <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.7.1">OpenGL ES 3.0.4 &sect;3.7.1</a> and <a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.3">OpenGL ES 3.0.4 &sect;4.3</a>)</span></li>
-      <li>Primitive restart <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.8.1">OpenGL ES 3.0.4 &sect;2.8.1</a>)</span></li>
-      <li>Rasterizer discard <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.1">OpenGL ES 3.0.4 &sect;3.1</a>)</span></li>
+      <li>Pixel buffer objects <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.7.1">OpenGL ES 3.0.6 &sect;3.7.1</a> and <a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.4.3">OpenGL ES 3.0.6 &sect;4.3</a>)</span></li>
+      <li>Primitive restart <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.9.1">OpenGL ES 3.0.6 &sect;2.9.1</a>)</span></li>
+      <li>Rasterizer discard <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.3.1">OpenGL ES 3.0.6 &sect;3.1</a>)</span></li>
     </ul>
 
     <h3>GLSL ES 3.00 support</h3>
@@ -3408,7 +3534,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <p>
         WebGL 1.0 supports tokens up to 256 characters in length. WebGL 2.0 follows The OpenGL ES Shading Language, Version 3.00
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.8">OpenGL ES 3.0.4 &sect;3.8</a>)</span>
+        <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.1.5.1">OpenGL ES 3.0.6 &sect;1.5.1</a>)</span>
         and allows tokens up to 1024 characters in length for both ESSL 1 and ESSL 3 shaders. Shaders containing tokens longer than 1024 characters must fail to compile.
     </p>
 
@@ -3423,7 +3549,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
     <p>
         In the WebGL 2.0 API, vertex attributes which have a non-zero divisor do not advance during calls to
         <code>drawArrays</code> and <code>drawElements</code>.
-        <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.9.3">OpenGL ES 3.0.4 &sect;2.9.3</a>)</span>
+        <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.9.3">OpenGL ES 3.0.6 &sect;2.9.3</a>)</span>
     </p>
 
 <!-- ======================================================================================================= -->
@@ -3520,8 +3646,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <div class="note rationale">
         If an error were not generated, the values read or written would be undefined. <span class="gl-spec">
-        (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.pdf#nameddest=section-2.15.2">
-        OpenGL ES 3.0.5 &sect;2.15.2</a>)</span>
+        (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.2">
+        OpenGL ES 3.0.6 &sect;2.15.2</a>)</span>
     </div>
 
     <p>
@@ -3614,8 +3740,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
     <div class="note rationale">
         In OpenGL, insufficient uniform block backing is allowed to cause GL interruption or termination.
         See OpenGL ES 3.0 specification section 2.12.6 <span class="gl-spec">
-        (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.12.6">
-        OpenGL ES 3.0.4 &sect;2.12.6</a>), under "Uniform Buffer Object Bindings."
+        (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.6">
+        OpenGL ES 3.0.6 &sect;2.12.6</a>), under "Uniform Buffer Object Bindings."
     </div>
 
     </div>
@@ -3676,8 +3802,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         A fragment shader written in The OpenGL ES Shading Language, Version 1.00, that statically assigns a
         value to <code>gl_FragData[n]</code> where <code>n</code> does not equal constant value 0 must fail
         to compile in the WebGL 2.0 API. This is to achieve consistency with The OpenGL ES 3.0 specification
-        section 4.2.1 <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-4.2.1">OpenGL ES 3.0.4 &sect;4.2.1</a>)</span>
-        and The OpenGL ES Shading Language 3.00.6 specification section 1.5 <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/GLSL_ES_Specification_3.00.pdf#nameddest=section-1.5">GLSL ES 3.00.6 &sect;1.5</a>)</span>.
+        section 4.2.1 <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.2.1">OpenGL ES 3.0.6 &sect;4.2.1</a>)</span>
+        and The OpenGL ES Shading Language 3.00.6 specification section 1.5 <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf#nameddest=section-1.5">GLSL ES 3.00.6 &sect;1.5</a>)</span>.
         As in the OpenGL ES 3.0 API, multiple fragment shader outputs are only supported for GLSL ES 3.00
         shaders in the WebGL 2.0 API.
     </p>
@@ -3773,7 +3899,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
     <p>
         OpenGL ES 3.0 allows applications to enumerate and query properties of
         active variables and interface blocks of a specified program even if
-        that program failed to link <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.11.3">OpenGL ES 3.0.4 &sect;2.11.3</a>)</span>.
+        that program failed to link <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.12.3">OpenGL ES 3.0.6 &sect;2.12.3</a>)</span>.
         In WebGL, these commands will always generate an INVALID_OPERATION error
         on a program that failed to link, and no information is returned.
     </p>
@@ -3788,7 +3914,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
     <p>
         Color values written by a fragment shader may be floating-point, signed integer, or unsigned
         integer. If the values written by the fragment shader do not match the format(s) of the
-        corresponding color buffer(s), the result is undefined in OpenGL ES 3.0  <span class="gl-spec">(<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.9.2">OpenGL ES 3.0.4 &sect;3.9.2</a>)</span>. In WebGL, generates
+        corresponding color buffer(s), the result is undefined in OpenGL ES 3.0 <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsubsection.3.9.2.3">OpenGL ES 3.0.6 &sect;3.9.2.3</a>)</span>. In WebGL, generates
         an <code>INVALID_OPERATION</code> error in the corresponding draw call, including
         <code>drawArrays</code>, <code>drawElements</code>, <code>drawArraysInstanced
         </code>, <code>drawElementsInstanced </code>, and <code>drawRangeElements</code>.
@@ -3805,7 +3931,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         depending on the sampler type passed to the lookup function. If the wrong sampler type is
         used for texture access, i.e., the sampler type does not match the texture internal format,
         the returned values are undefined in OpenGL ES Shading Language 3.00.6
-        <span class="gl-spec">(<a href="https://www.khronos.org/registry/gles/specs/3.0/GLSL_ES_Specification_3.00.pdf#nameddest=section-8.8">OpenGL ES Shading Language 3.00.6 &sect;8.8</a>)</span>.
+        <span class="gl-spec">(<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf#nameddest=section-8.8">OpenGL ES Shading Language 3.00.6 &sect;8.8</a>)</span>.
         In WebGL, generates an <code>INVALID_OPERATION</code> error in the corresponding draw call,
         including <code>drawArrays</code>, <code>drawElements</code>, <code>drawArraysInstanced</code>,
         <code>drawElementsInstanced </code>, and <code>drawRangeElements</code>.
@@ -3851,8 +3977,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         and <code>std140</code> layout qualifiers for uniform blocks, defining how variables are
         laid out in uniform buffers' storage. Of these, the WebGL 2.0 specification supports only
         the <code>std140</code> layout, which is defined
-        in <a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.12">OpenGL
-        ES 3.0.4 &sect;2.12 "Vertex Shaders"</a>, subsection "Standard Uniform Block
+        in <a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.12">OpenGL
+        ES 3.0.6 &sect;2.12 "Vertex Shaders"</a>, subsection "Standard Uniform Block
         Layout". Shaders attempting to use the <code>shared</code> or <code>packed</code> layout
         qualifiers will fail either the compilation or linking stages.
     </p>
@@ -3960,8 +4086,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <div class="note">
         This undefined behavior is in the OpenGL ES 3.0 specification section 2.8 <span class="gl-spec">
-        (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.8">
-        OpenGL ES 3.0.4 &sect;2.8</a>)</span>.
+        (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=section.2.8">
+        OpenGL ES 3.0.6 &sect;2.8</a>)</span>.
     </div>
 
     <h3><a name="TRANSFORM_FEEDBACK_NOT_WRITTEN">Transform feedback primitive capture</a></h3>
@@ -3973,8 +4099,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <div class="note">
         This undefined behavior is in the OpenGL ES 3.0 specification section 2.15.2 <span class="gl-spec">
-        (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-2.15.2">
-        OpenGL ES 3.0.4 &sect;2.15.2</a>)</span>.
+        (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.15.2">
+        OpenGL ES 3.0.6 &sect;2.15.2</a>)</span>.
     </div>
 
     <h3>gl_FragDepth</h3>
@@ -3986,8 +4112,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <div class="note">
         This undefined behavior is in the OpenGL ES 3.0 specification section 3.9.2 <span class="gl-spec">
-        (<a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf#nameddest=section-3.9.2">
-        OpenGL ES 3.0.4 &sect;3.9.2</a>).
+        (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.9.2">
+        OpenGL ES 3.0.6 &sect;3.9.2</a>).
     </div>
 
     <h3><a name="FRAMEBUFFER_COLOR_ATTACHMENTS">Framebuffer color attachments</a></h3>
@@ -4169,7 +4295,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
     </p>
 
     <div class="note">
-        GLES 3.0.5 technically allows calling GenerateMipmap on 0x0 images, though cubemaps must be
+        GLES 3.0.6 technically allows calling GenerateMipmap on 0x0 images, though cubemaps must be
         cube-complete, thus having positive dimensions.
     </div>
 
@@ -4298,8 +4424,8 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         </dd>
         <dt id="refsGLES30">[GLES30]</dt>
         <dd><cite><a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf">
-            OpenGL&reg; ES Version 3.0.4</a></cite>,
-            B. Lipchak 2014.
+            OpenGL&reg; ES Version 3.0.6</a></cite>,
+            J. Leech, B. Lipchak, August 2019.
         </dd>
         <dt id="refsGLES30GLSL">[GLES30GLSL]</dt>
         <dd><cite><a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf">

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -4297,12 +4297,12 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             WHATWG.
         </dd>
         <dt id="refsGLES30">[GLES30]</dt>
-        <dd><cite><a href="http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf">
+        <dd><cite><a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf">
             OpenGL&reg; ES Version 3.0.4</a></cite>,
             B. Lipchak 2014.
         </dd>
         <dt id="refsGLES30GLSL">[GLES30GLSL]</dt>
-        <dd><cite><a href="http://www.khronos.org/registry/gles/specs/3.0/GLSL_ES_Specification_3.00.pdf">
+        <dd><cite><a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/GLSL_ES_Specification_3.00.pdf">
             The OpenGL&reg; ES Shading Language Version 3.00.6</a></cite>,
             R. Simpson, January 2016.
         </dd>
@@ -4316,7 +4316,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
             S. Bradner. IETF, March 1997.
         </dd>
         <dt id="refsWEBIDL">[WEBIDL]</dt>
-        <dd><cite><a href="https://heycam.github.io/webidl/">
+        <dd><cite><a href="https://webidl.spec.whatwg.org/">
             Web IDL: W3C Editor’s Draft</a></cite>,
             C. McCormack, B. Zbarsky, T. Langel.
         </dd>


### PR DESCRIPTION
Fixing [GLES30], [GLES30GLSL] and [WEBIDL]. Should fix #3373.

~~**HELP WANTED**: The link for **[GLES30]**:~~

> ~~http://www.khronos.org/registry/gles/specs/3.0/es_spec_3.0.4.pdf~~

~~refers to GLES **3.0.4**, but I can only find the latest pdf for GLES **3.0.6** on Khronos' pages~~

> ~~https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf~~

~~which I think cannot be replaced directly.~~
~~Do we need to find an old **3.0.4** version of the pdf, or change the spec to fit the latest **3.0.6** version?~~

All references to GLES 3.0.4 are upgraded to 3.0.6.