### PR TITLE
Remove LegacyNoInterfaceObject annotations and expose prototypes.

### DIFF
--- a/extensions/ANGLE_instanced_arrays/extension.xml
+++ b/extensions/ANGLE_instanced_arrays/extension.xml
@@ -27,12 +27,12 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface ANGLE_instanced_arrays {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionAngleInstancedArrays {
     const GLenum VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE = 0x88FE;
     undefined drawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
     undefined drawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
-    undefined vertexAttribDivisorANGLE(GLuint index, GLuint divisor); 
+    undefined vertexAttribDivisorANGLE(GLuint index, GLuint divisor);
 };
   </idl>
   <issues>
@@ -73,6 +73,9 @@ interface ANGLE_instanced_arrays {
     </revision>
     <revision date="2015/09/23">
       <change>Clarified interaction with OES_vertex_array_object.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/EXT_blend_minmax/extension.xml
+++ b/extensions/EXT_blend_minmax/extension.xml
@@ -31,8 +31,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_blend_minmax {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtBlendMinmax {
   const GLenum MIN_EXT = 0x8007;
   const GLenum MAX_EXT = 0x8008;
 };
@@ -65,6 +65,9 @@ interface EXT_blend_minmax {
     </revision>
     <revision date="2015/05/29">
       <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/EXT_clip_cull_distance/extension.xml
+++ b/extensions/EXT_clip_cull_distance/extension.xml
@@ -41,8 +41,8 @@
   </overview>
 
   <idl xml:space="preserve">
-    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
-    interface EXT_clip_cull_distance {
+    [Exposed=(Window,Worker)]
+    interface WebGLExtensionExtClipCullDistance {
       const GLenum MAX_CLIP_DISTANCES_EXT                       = 0x0D32;
       const GLenum MAX_CULL_DISTANCES_EXT                       = 0x82F9;
       const GLenum MAX_COMBINED_CLIP_AND_CULL_DISTANCES_EXT     = 0x82FA;
@@ -85,6 +85,9 @@
     </revision>
     <revision date="2020/07/01">
       <change>Added addendum that allows for the number of cull planes to be 0.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </draft>

--- a/extensions/EXT_color_buffer_float/extension.xml
+++ b/extensions/EXT_color_buffer_float/extension.xml
@@ -72,9 +72,9 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_color_buffer_float {
-}; // interface EXT_color_buffer_float
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtColorBufferFloat {
+};
 </idl>
 
   <history>
@@ -109,6 +109,10 @@ interface EXT_color_buffer_float {
 
     <revision date="2017/04/19">
       <change>Allowed these float formats for CopyTexImage2D.</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -83,13 +83,13 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_color_buffer_half_float {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtColorBufferHalfFloat {
   const GLenum RGBA16F_EXT = 0x881A;
   const GLenum RGB16F_EXT = 0x881B;
   const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
   const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
-}; // interface EXT_color_buffer_half_float
+};
   </idl>
 
   <additions>
@@ -167,6 +167,10 @@ interface EXT_color_buffer_half_float {
       <change>Expose to WebGL 2.0 contexts to support devices which can render
       only to 16-bit floating point targets, and therefore can not support
       EXT_color_buffer_float.</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -48,12 +48,12 @@
   <idl xml:space="preserve">
 typedef unsigned long long GLuint64EXT;
 
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
+[Exposed=(Window,Worker)]
 interface WebGLTimerQueryEXT : WebGLObject {
 };
 
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_disjoint_timer_query {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtDisjointTimerQuery {
   const GLenum QUERY_COUNTER_BITS_EXT      = 0x8864;
   const GLenum CURRENT_QUERY_EXT           = 0x8865;
   const GLenum QUERY_RESULT_EXT            = 0x8866;
@@ -401,6 +401,9 @@ interface EXT_disjoint_timer_query {
     </revision>
     <revision date="2021/04/01">
       <change>Clean up query objects via deleteQueryEXT. Modernize examples' JavaScript code.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
+++ b/extensions/EXT_disjoint_timer_query_webgl2/extension.xml
@@ -40,8 +40,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_disjoint_timer_query_webgl2 {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtDisjointTimerQueryWebgl2 {
   const GLenum QUERY_COUNTER_BITS_EXT      = 0x8864;
   const GLenum TIME_ELAPSED_EXT            = 0x88BF;
   const GLenum TIMESTAMP_EXT               = 0x8E28;
@@ -87,7 +87,7 @@ interface EXT_disjoint_timer_query_webgl2 {
       <tr><td>TIMESTAMP_EXT</td><td>CURRENT_QUERY</td><td>null</td></tr>
       <tr><td>TIME_ELAPSED_EXT</td><td>QUERY_COUNTER_BITS_EXT</td><td>GLint</td></tr>
       <tr><td>TIMESTAMP_EXT</td><td>QUERY_COUNTER_BITS_EXT</td><td>GLint</td></tr>
-      </table>      
+      </table>
     </function>
   </newtok>
 
@@ -102,7 +102,7 @@ interface EXT_disjoint_timer_query_webgl2 {
       <tr><th>pname</th><th>returned type</th></tr>
       <tr><td>TIMESTAMP_EXT</td><td>GLuint64</td></tr>
       <tr><td>GPU_DISJOINT_EXT</td><td>boolean</td></tr>
-      </table>      
+      </table>
     </function>
   </newtok>
 
@@ -280,6 +280,9 @@ interface EXT_disjoint_timer_query_webgl2 {
     </revision>
     <revision date="2021/04/01">
       <change>Clean up query objects via deleteQuery. Modernize examples' JavaScript code.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_float_blend/extension.xml
+++ b/extensions/EXT_float_blend/extension.xml
@@ -52,9 +52,9 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_float_blend {
-}; // interface EXT_float_blend
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtFloatBlend {
+};
 </idl>
 
   <history>
@@ -77,6 +77,10 @@ interface EXT_float_blend {
 
     <revision date="2019/08/27">
       <change>Clarified that this extension applies to both WebGL 1.0 and 2.0 contexts.</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_frag_depth/extension.xml
+++ b/extensions/EXT_frag_depth/extension.xml
@@ -34,10 +34,10 @@
       </glsl>
     </features>
   </overview>
-  
+
   <idl xml:space="preserve">
-    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
-    interface EXT_frag_depth {
+    [Exposed=(Window,Worker)]
+    interface WebGLExtensionExtFragDepth {
     };
   </idl>
 
@@ -65,6 +65,9 @@
     </revision>
     <revision date="2015/05/29">
       <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/EXT_sRGB/extension.xml
+++ b/extensions/EXT_sRGB/extension.xml
@@ -32,8 +32,8 @@
   </overview>
 
   <idl xml:space="preserve">
-    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
-    interface EXT_sRGB {
+    [Exposed=(Window,Worker)]
+    interface WebGLExtensionExtSrgb {
       const GLenum SRGB_EXT                                     = 0x8C40;
       const GLenum SRGB_ALPHA_EXT                               = 0x8C42;
       const GLenum SRGB8_ALPHA8_EXT                             = 0x8C43;
@@ -82,6 +82,9 @@
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_shader_texture_lod/extension.xml
+++ b/extensions/EXT_shader_texture_lod/extension.xml
@@ -79,10 +79,10 @@
       </glsl>
     </features>
   </overview>
-  
+
   <idl xml:space="preserve">
-    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
-    interface EXT_shader_texture_lod {
+    [Exposed=(Window,Worker)]
+    interface WebGLExtensionExtShaderTextureLod {
     };
   </idl>
 
@@ -119,6 +119,9 @@
     </revision>
     <revision date="2015/05/29">
       <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/EXT_texture_compression_bptc/extension.xml
+++ b/extensions/EXT_texture_compression_bptc/extension.xml
@@ -75,8 +75,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_texture_compression_bptc {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtTextureCompressionBptc {
     const GLenum COMPRESSED_RGBA_BPTC_UNORM_EXT = 0x8E8C;
     const GLenum COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT = 0x8E8D;
     const GLenum COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT = 0x8E8E;
@@ -141,6 +141,9 @@ interface EXT_texture_compression_bptc {
     </revision>
     <revision date="2020/07/07">
       <change>Clarified WebGL-specific dimensions restriction.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_texture_compression_rgtc/extension.xml
+++ b/extensions/EXT_texture_compression_rgtc/extension.xml
@@ -79,8 +79,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_texture_compression_rgtc {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtTextureCompressionRgtc {
     const GLenum COMPRESSED_RED_RGTC1_EXT = 0x8DBB;
     const GLenum COMPRESSED_SIGNED_RED_RGTC1_EXT = 0x8DBC;
     const GLenum COMPRESSED_RED_GREEN_RGTC2_EXT = 0x8DBD;
@@ -151,6 +151,9 @@ interface EXT_texture_compression_rgtc {
     </revision>
     <revision date="2020/07/07">
       <change>Clarified WebGL-specific dimensions restriction.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/EXT_texture_filter_anisotropic/extension.xml
+++ b/extensions/EXT_texture_filter_anisotropic/extension.xml
@@ -26,8 +26,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_texture_filter_anisotropic {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtTextureFilterAnisotropic {
   const GLenum TEXTURE_MAX_ANISOTROPY_EXT       = 0x84FE;
   const GLenum MAX_TEXTURE_MAX_ANISOTROPY_EXT   = 0x84FF;
 };
@@ -47,6 +47,9 @@ interface EXT_texture_filter_anisotropic {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -45,8 +45,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface EXT_texture_norm16 {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionExtTextureNorm16 {
   const GLenum R16_EXT = 0x822A;
   const GLenum RG16_EXT = 0x822C;
   const GLenum RGB16_EXT = 0x8054;
@@ -75,6 +75,9 @@ interface EXT_texture_norm16 {
     </revision>
     <revision date="2020/12/03">
       <change>Constrain the scope to only support ArrayBufferView.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/KHR_parallel_shader_compile/extension.xml
+++ b/extensions/KHR_parallel_shader_compile/extension.xml
@@ -48,8 +48,8 @@
   </overview>
 
   <idl xml:space="preserve">
-    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
-    interface KHR_parallel_shader_compile {
+    [Exposed=(Window,Worker)]
+    interface WebGLExtensionKhrParallelShaderCompile {
       const GLenum COMPLETION_STATUS_KHR                = 0x91B1;
     };
   </idl>
@@ -149,6 +149,9 @@
     </revision>
     <revision date="2020/11/24">
       <change>Specify lost context behavior.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/OES_draw_buffers_indexed/extension.xml
+++ b/extensions/OES_draw_buffers_indexed/extension.xml
@@ -39,8 +39,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_draw_buffers_indexed {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesDrawBuffersIndexed {
   undefined enableiOES(GLenum target, GLuint index);
 
   undefined disableiOES(GLenum target, GLuint index);
@@ -227,6 +227,9 @@ interface OES_draw_buffers_indexed {
     </revision>
     <revision date="2021/11/04">
       <change>Moved to community approved.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/OES_element_index_uint/extension.xml
+++ b/extensions/OES_element_index_uint/extension.xml
@@ -23,8 +23,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_element_index_uint {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesElementIndexUint {
 };
   </idl>
   <history>
@@ -45,6 +45,9 @@ interface OES_element_index_uint {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OES_fbo_render_mipmap/extension.xml
+++ b/extensions/OES_fbo_render_mipmap/extension.xml
@@ -30,8 +30,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_fbo_render_mipmap {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesFboRenderMipmap {
 };
   </idl>
 
@@ -75,6 +75,9 @@ interface OES_fbo_render_mipmap {
     </revision>
     <revision date="2019/09/25">
       <change>Moved to Community Approved.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/OES_standard_derivatives/extension.xml
+++ b/extensions/OES_standard_derivatives/extension.xml
@@ -37,8 +37,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_standard_derivatives {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesStandardDerivatives {
     const GLenum FRAGMENT_SHADER_DERIVATIVE_HINT_OES = 0x8B8B;
 };
   </idl>
@@ -57,6 +57,9 @@ interface OES_standard_derivatives {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OES_texture_float/extension.xml
+++ b/extensions/OES_texture_float/extension.xml
@@ -44,8 +44,9 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_texture_float { }; </idl>
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesTextureFloat {
+}; </idl>
 
   <history>
     <revision date="2010/11/29">
@@ -86,6 +87,10 @@ interface OES_texture_float { }; </idl>
 
     <revision date="2017/09/14">
       <change>Clarify behaviors regarding WEBGL_color_buffer_float.</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OES_texture_float_linear/extension.xml
+++ b/extensions/OES_texture_float_linear/extension.xml
@@ -28,8 +28,9 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_texture_float_linear { };</idl>
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesTextureFloatLinear {
+};</idl>
 
   <history>
     <revision date="2013/02/20">
@@ -46,6 +47,9 @@ interface OES_texture_float_linear { };</idl>
     </revision>
     <revision date="2014/08/08">
       <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OES_texture_half_float/extension.xml
+++ b/extensions/OES_texture_half_float/extension.xml
@@ -44,8 +44,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_texture_half_float {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesTextureHalfFloat {
   const GLenum HALF_FLOAT_OES = 0x8D61;
 };
 </idl>
@@ -90,6 +90,10 @@ interface OES_texture_half_float {
 
     <revision date="2017/09/14">
       <change>Clarify behaviors regarding EXT_color_buffer_half_float.</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OES_texture_half_float_linear/extension.xml
+++ b/extensions/OES_texture_half_float_linear/extension.xml
@@ -29,8 +29,9 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_texture_half_float_linear { };</idl>
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesTextureHalfFloatLinear {
+};</idl>
 
   <history>
     <revision date="2013/02/20">
@@ -47,6 +48,9 @@ interface OES_texture_half_float_linear { };</idl>
     </revision>
     <revision date="2014/08/08">
       <change>Ratified by Khronos Board of Promoters.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OES_vertex_array_object/extension.xml
+++ b/extensions/OES_vertex_array_object/extension.xml
@@ -17,12 +17,12 @@
     <mirrors href="http://www.khronos.org/registry/gles/extensions/OES/OES_vertex_array_object.txt" name="OES_vertex_array_object" />
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
+[Exposed=(Window,Worker)]
 interface WebGLVertexArrayObjectOES : WebGLObject {
 };
 
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OES_vertex_array_object {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOesVertexArrayObject {
     const GLenum VERTEX_ARRAY_BINDING_OES = 0x85B5;
 
     WebGLVertexArrayObjectOES? createVertexArrayOES();
@@ -133,6 +133,9 @@ interface OES_vertex_array_object {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute to extension and WebGLVertexArrayObjectOES interface.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/OVR_multiview2/extension.xml
+++ b/extensions/OVR_multiview2/extension.xml
@@ -71,8 +71,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface OVR_multiview2 {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionOvrMultiview2 {
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR = 0x9630;
     const GLenum FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR = 0x9632;
     const GLenum MAX_VIEWS_OVR = 0x9631;
@@ -247,6 +247,10 @@ interface OVR_multiview2 {
 
     <revision date="2019/11/26">
       <change>s/getFramebufferStatus/checkFramebufferStatus/</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_blend_equation_advanced_coherent/extension.xml
+++ b/extensions/WEBGL_blend_equation_advanced_coherent/extension.xml
@@ -4,7 +4,7 @@
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
-  
+
   <contributors>
 	<contributor>Ashley Gullen (ashley at scirra dot com)</contributor>
     <contributor>Members of the WebGL working group</contributor>
@@ -20,12 +20,12 @@
     <mirrors href="https://www.opengl.org/registry/specs/KHR/blend_equation_advanced.txt"
              name="KHR_blend_equation_advanced_coherent">
     </mirrors>
-	
+
     <div class="nonnormative">
       <p>This extension exposes the KHR_blend_equation_advanced_coherent functionality to WebGL.</p>
 
       <p>CanvasRenderingContext2D provides a series of common blend functions with globalCompositeOperation, such as "multiply" and "screen". KHR_blend_equation_advanced_coherent provides, with the exception of "xor", exactly the same list of blend functions for WebGL, as detailed below:</p>
-	  
+
 	  <ul>
 		<li>"multiply": MULTIPLY_KHR</li>
 		<li>"screen": SCREEN_KHR</li>
@@ -43,9 +43,9 @@
 		<li>"color": HSL_COLOR_KHR</li>
 		<li>"luminosity": HSL_LUMINOSITY_KHR</li>
 	  </ul>
-	  
+
 	  <p>These effects are useful for high-quality artistic blends. They can be implemented using shaders and rendering via an intermediate texture. However this has a high performance overhead both in draw calls and GPU bandwidth. Advanced blend modes allow a much simpler, high-performance way of implementing these blends. Using shaders rendering to an intermediate texture can be used as a fallback if this extension is not supported.</p>
-	  
+
 	  <p>Note only the coherent variant of this extension is exposed in order to eliminate the possibility of undefined behavior in KHR_blend_equation_advanced. This also simplifies the extension and removes the need to insert blend barriers during rendering.</p>
     </div>
 
@@ -55,8 +55,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_blend_equation_advanced_coherent  {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglBlendEquationAdvancedCoherent  {
   const GLenum MULTIPLY       = 0x9294;
   const GLenum SCREEN         = 0x9295;
   const GLenum OVERLAY        = 0x9296;
@@ -105,25 +105,29 @@ gl.getParameter(gl.BLEND_EQUATION) == ext.MULTIPLY;
   <issues/>
 
   <history>
-  
+
     <revision date="2019/09/25">
       <change>Moved to draft after WebGL F2F of September 2019</change>
     </revision>
-	
+
     <revision date="2018/09/13">
       <change>Forked from WEBGL_blend_equation_advanced to specify only the coherent variant</change>
     </revision>
-	
+
     <revision date="2018/08/23">
       <change>Converted to extension XML format</change>
     </revision>
-	
-	<revision date="2018/08/21">
+
+    <revision date="2018/08/21">
       <change>Revised description</change>
     </revision>
-	
-	<revision date="2015/05/26">
+
+    <revision date="2015/05/26">
       <change>Original draft as a TXT file</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </draft>

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -73,8 +73,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_color_buffer_float {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglColorBufferFloat {
   const GLenum RGBA32F_EXT = 0x8814;
   const GLenum FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT = 0x8211;
   const GLenum UNSIGNED_NORMALIZED_EXT = 0x8C17;
@@ -140,6 +140,10 @@ interface WEBGL_color_buffer_float {
 
     <revision date="2017/09/14">
       <change>Add optional RGB renderability.</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_compressed_texture_astc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_astc/extension.xml
@@ -15,7 +15,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture format defined in the 
+      This extension exposes the compressed texture format defined in the
       <a href="https://www.opengl.org/registry/specs/KHR/texture_compression_astc_hdr.txt">
       KHR_texture_compression_astc_hdr</a> OpenGL ES extension to WebGL. Consult that extension
       specification for behavioral definitions, including error behaviors.
@@ -70,7 +70,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -87,7 +87,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -104,7 +104,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -121,7 +121,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -138,7 +138,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -155,7 +155,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -172,7 +172,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -189,7 +189,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -206,7 +206,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -223,7 +223,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -240,7 +240,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -257,7 +257,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -274,7 +274,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -291,7 +291,7 @@
           <dt>COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR</dt>
           <dd>
             <p>The <code>byteLength</code> of the ArrayBufferView, <code>pixels</code>, passed to
-              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be 
+              <code>compressedTexImage2D</code> or <code>compressedTexSubImage2D</code> must be
               equal to the following number of bytes:
             </p>
             <blockquote><code>
@@ -304,8 +304,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_compressed_texture_astc {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglCompressedTextureAstc {
     /* Compressed Texture Format */
     const GLenum COMPRESSED_RGBA_ASTC_4x4_KHR = 0x93B0;
     const GLenum COMPRESSED_RGBA_ASTC_5x4_KHR = 0x93B1;
@@ -392,7 +392,7 @@ interface WEBGL_compressed_texture_astc {
       <code>COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR</code>
       <br/>
     </function>
-    
+
     <function name="compressedTexSubImage2D">
       <param name="internalformat" type="GLenum"/>
       Accepted by the <code>internalformat</code> parameter:
@@ -431,7 +431,7 @@ interface WEBGL_compressed_texture_astc {
   <errors>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_4x4_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -440,7 +440,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_5x4_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -449,7 +449,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_5x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -458,7 +458,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_6x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -467,7 +467,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_6x6_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -476,7 +476,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_8x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -485,7 +485,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_8x6_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -494,7 +494,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_8x8_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -503,7 +503,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x5_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -512,7 +512,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x6_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -521,7 +521,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x8_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -530,7 +530,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_10x10_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -539,7 +539,7 @@ interface WEBGL_compressed_texture_astc {
     </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_12x10_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -548,7 +548,7 @@ interface WEBGL_compressed_texture_astc {
      </error>
     <error enum="INVALID_VALUE">
       The error <code>INVALID_VALUE</code> is generated by <code>compressedTexImage2D</code> and <code>compressedTexSubImage2D</code>
-      if the <code>internalformat</code> parameter is 
+      if the <code>internalformat</code> parameter is
       <code>COMPRESSED_RGBA_ASTC_12x12_KHR</code> or <code>COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR</code>
       and the byteLength of the ArrayBufferView is not:
       <blockquote><code>
@@ -572,6 +572,9 @@ interface WEBGL_compressed_texture_astc {
     </revision>
     <revision date="2016/12/12">
       <change>Moved to community approved after discussion on public_webgl list.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_compressed_texture_etc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_etc/extension.xml
@@ -92,8 +92,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_compressed_texture_etc {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglCompressedTextureEtc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_R11_EAC                        = 0x9270;
     const GLenum COMPRESSED_SIGNED_R11_EAC                 = 0x9271;
@@ -107,7 +107,7 @@ interface WEBGL_compressed_texture_etc {
     const GLenum COMPRESSED_SRGB8_ALPHA8_ETC2_EAC          = 0x9279;
 };
   </idl>
-  
+
   <newtok>
     <function name="compressedTexImage2D">
       <param name="internalformat" type="GLenum"/>
@@ -124,7 +124,7 @@ interface WEBGL_compressed_texture_etc {
       <code>COMPRESSED_SRGB8_ALPHA8_ETC2_EAC</code>
       <br/>
     </function>
-    
+
     <function name="compressedTexSubImage2D">
       <param name="internalformat" type="GLenum"/>
       Accepted by the <code>internalformat</code> parameter:
@@ -184,6 +184,9 @@ interface WEBGL_compressed_texture_etc {
       not advertise this extension if these compressed texture formats are decompressed. Renamed to
       WEBGL_compressed_texture_etc after further discussion. Promoted to community
       approved.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_compressed_texture_etc1/extension.xml
+++ b/extensions/WEBGL_compressed_texture_etc1/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture format defined in the 
+      This extension exposes the compressed texture format defined in the
       <a href="http://www.khronos.org/registry/gles/extensions/OES/OES_compressed_ETC1_RGB8_texture.txt">
       OES_compressed_ETC1_RGB8_texture</a> OpenGL ES extension to WebGL.
     </p>
@@ -59,10 +59,10 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_compressed_texture_etc1 {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglCompressedTextureEtc1 {
     /* Compressed Texture Format */
-    const GLenum COMPRESSED_RGB_ETC1_WEBGL = 0x8D64; 
+    const GLenum COMPRESSED_RGB_ETC1_WEBGL = 0x8D64;
 };
   </idl>
   <history>
@@ -86,6 +86,9 @@ interface WEBGL_compressed_texture_etc1 {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_pvrtc/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the compressed texture formats defined in the 
+      This extension exposes the compressed texture formats defined in the
       <a href="http://www.khronos.org/registry/gles/extensions/IMG/IMG_texture_compression_pvrtc.txt">
       IMG_texture_compression_pvrtc</a> OpenGL extension to WebGL.
     </p>
@@ -74,8 +74,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_compressed_texture_pvrtc {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglCompressedTexturePvrtc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_PVRTC_4BPPV1_IMG      = 0x8C00;
     const GLenum COMPRESSED_RGB_PVRTC_2BPPV1_IMG      = 0x8C01;
@@ -95,6 +95,9 @@ interface WEBGL_compressed_texture_pvrtc {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_compressed_texture_s3tc/extension.xml
+++ b/extensions/WEBGL_compressed_texture_s3tc/extension.xml
@@ -98,8 +98,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_compressed_texture_s3tc {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglCompressedTextureS3tc {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_RGB_S3TC_DXT1_EXT        = 0x83F0;
     const GLenum COMPRESSED_RGBA_S3TC_DXT1_EXT       = 0x83F1;
@@ -125,6 +125,9 @@ interface WEBGL_compressed_texture_s3tc {
     </revision>
     <revision date="2019/10/24">
       <change>Added a note about <code>COMPRESSED_RGB_S3TC_DXT1_EXT</code> support.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_compressed_texture_s3tc_srgb/extension.xml
+++ b/extensions/WEBGL_compressed_texture_s3tc_srgb/extension.xml
@@ -14,7 +14,7 @@
   </depends>
   <overview>
     <p>
-      This extension exposes the sRGB compressed texture formats defined in the 
+      This extension exposes the sRGB compressed texture formats defined in the
       <a href="https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_compression_s3tc_srgb.txt">
       EXT_texture_compression_s3tc_srgb</a> OpenGL extension to WebGL.
     </p>
@@ -100,8 +100,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_compressed_texture_s3tc_srgb {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglCompressedTextureS3tcSrgb {
     /* Compressed Texture Formats */
     const GLenum COMPRESSED_SRGB_S3TC_DXT1_EXT        = 0x8C4C;
     const GLenum COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT  = 0x8C4D;
@@ -121,6 +121,9 @@ interface WEBGL_compressed_texture_s3tc_srgb {
     </revision>
     <revision date="2019/10/24">
       <change>Added a note about <code>COMPRESSED_SRGB_S3TC_DXT1_EXT</code> support.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_debug_renderer_info/extension.xml
+++ b/extensions/WEBGL_debug_renderer_info/extension.xml
@@ -14,12 +14,10 @@
     <p>WebGL implementations might mask the <code>RENDERER</code> and <code>VENDOR</code> strings of the underlying graphics driver for privacy reasons. This extension exposes new tokens to query this information in a guaranteed manner for debugging purposes.</p>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_debug_renderer_info {
-
-      const GLenum UNMASKED_VENDOR_WEBGL            = 0x9245;
-      const GLenum UNMASKED_RENDERER_WEBGL          = 0x9246;
-
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglDebugRendererInfo {
+    const GLenum UNMASKED_VENDOR_WEBGL            = 0x9245;
+    const GLenum UNMASKED_RENDERER_WEBGL          = 0x9246;
 };
   </idl>
   <newtok>
@@ -90,6 +88,9 @@ interface WEBGL_debug_renderer_info {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_debug_shaders/extension.xml
+++ b/extensions/WEBGL_debug_shaders/extension.xml
@@ -16,11 +16,9 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_debug_shaders {
-
-      DOMString getTranslatedShaderSource(WebGLShader shader);
-
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglDebugShaders {
+    DOMString getTranslatedShaderSource(WebGLShader shader);
 };
   </idl>
   <newfun>
@@ -74,6 +72,9 @@ interface WEBGL_debug_shaders {
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_depth_texture/extension.xml
+++ b/extensions/WEBGL_depth_texture/extension.xml
@@ -125,8 +125,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_depth_texture {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglDepthTexture {
   const GLenum UNSIGNED_INT_24_8_WEBGL = 0x84FA;
 };
   </idl>
@@ -263,6 +263,9 @@ interface WEBGL_depth_texture {
     </revision>
     <revision date="2020/03/15">
       <change>Update ANGLE_depth_texture link.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_draw_buffers/extension.xml
+++ b/extensions/WEBGL_draw_buffers/extension.xml
@@ -100,8 +100,8 @@
     </features>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_draw_buffers {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglDrawBuffers {
     const GLenum COLOR_ATTACHMENT0_WEBGL     = 0x8CE0;
     const GLenum COLOR_ATTACHMENT1_WEBGL     = 0x8CE1;
     const GLenum COLOR_ATTACHMENT2_WEBGL     = 0x8CE2;
@@ -187,6 +187,9 @@ interface WEBGL_draw_buffers {
     </revision>
     <revision date="2016/07/23">
       <change>Revised behavior of the same image is attached to more than one color attachment point.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
@@ -71,8 +71,8 @@
 
   <idl xml:space="preserve">
 
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_draw_instanced_base_vertex_base_instance {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglDrawInstancedBaseVertexBaseInstance {
   undefined drawArraysInstancedBaseInstanceWEBGL(
       GLenum mode, GLint first, GLsizei count,
       GLsizei instanceCount, GLuint baseInstance);
@@ -161,6 +161,9 @@ void main() {
     </revision>
     <revision date="2021/05/26">
       <change>Removed GLSL extension and builtins.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </draft>

--- a/extensions/WEBGL_lose_context/extension.xml
+++ b/extensions/WEBGL_lose_context/extension.xml
@@ -29,8 +29,8 @@
     </p>
   </overview>
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_lose_context {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglLoseContext {
       undefined loseContext();
       undefined restoreContext();
 };
@@ -128,6 +128,9 @@ interface WEBGL_lose_context {
     </revision>
     <revision date="2020/02/06">
       <change>Clarify timelines and behavior for restoreContext().</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </ratified>

--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -64,8 +64,8 @@
 
   <idl xml:space="preserve">
 
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_multi_draw {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglMultiDraw {
   undefined multiDrawArraysWEBGL(
       GLenum mode,
       ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
@@ -212,6 +212,9 @@ void main() {
     </revision>
     <revision date="2021/05/18">
       <change>Add [AllowShared] to all typed array arguments for compatibility with multi-threaded WebAssembly.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -76,8 +76,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglMultiDrawInstancedBaseVertexBaseInstance {
   undefined multiDrawArraysInstancedBaseInstanceWEBGL(
       GLenum mode,
       ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
@@ -202,6 +202,9 @@ void main() {
     </revision>
     <revision date="2021/05/26">
       <change>Removed GLSL extension and builtins.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </draft>

--- a/extensions/extension.xsl
+++ b/extensions/extension.xsl
@@ -71,7 +71,7 @@
       <xsl:call-template name="logo" />
 
       <h1><xsl:value-of select="$title" /></h1>
-      
+
       <xsl:if test="$spec_status='proposal'">
       <p><strong>DO NOT IMPLEMENT!!!</strong></p>
       </xsl:if>
@@ -188,7 +188,7 @@
     </body>
   </html>
 </xsl:template>
-  
+
 <xsl:template name="logo">
   <xsl:comment>begin-logo</xsl:comment>
   <div class="left">
@@ -416,9 +416,6 @@
 </xsl:template>
 <xsl:template match="interface" mode="newfun">
   <dt class="idl-code">
-	<xsl:if test="@noobject = 'true'">
-	  <xsl:text>[Exposed=(Window,Worker), LegacyNoInterfaceObject]</xsl:text><br/>
-	</xsl:if>
     <xsl:text>interface </xsl:text>
     <em><xsl:value-of select="@name" /></em>
     <xsl:text> {</xsl:text><br/>

--- a/extensions/proposals/EXT_shader_framebuffer_fetch/extension.xml
+++ b/extensions/proposals/EXT_shader_framebuffer_fetch/extension.xml
@@ -21,24 +21,24 @@
 
     <features>
       <feature>
-            It provides a mechanism whereby a fragment shader may read existing framebuffer data as input. 
+            It provides a mechanism whereby a fragment shader may read existing framebuffer data as input.
       </feature>
       <feature>
-            Prior to fragment shading, if <code>GL_EXT_shader_framebuffer_fetch</code> is enabled, <code>gl_LastFragData[]</code> is populated with the value last written to the framebuffer at the same (x,y,sample) position. 
+            Prior to fragment shading, if <code>GL_EXT_shader_framebuffer_fetch</code> is enabled, <code>gl_LastFragData[]</code> is populated with the value last written to the framebuffer at the same (x,y,sample) position.
       </feature>
       <feature>
             If <code>EXT_shader_framebuffer_fetch_non_coherent</code> is supported, a call to <code>FramebufferFetchBarrierEXT(void)</code> can be made to ensure <code>gl_LastFragData[]</code> is populated with fragment data drawn before the barrier.
       </feature>
     </features>
   </overview>
-  
+
   <idl xml:space="preserve">
-    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
-    interface EXT_shader_framebuffer_fetch {
+    [Exposed=(Window,Worker)]
+    interface WebGLExtensionExtShaderFramebufferFetch {
     };
 
-    [Exposed=(Window,Worker), LegacyNoInterfaceObject]
-    interface EXT_shader_framebuffer_fetch_non_coherent {
+    [Exposed=(Window,Worker)]
+    interface WebGLExtensionExtShaderFramebufferFetchNonCoherent {
       undefined FramebufferFetchBarrierEXT(void);
     };
   </idl>
@@ -54,6 +54,9 @@
   <history>
     <revision date="2020/05/22">
       <change>Initial revision.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </proposal>

--- a/extensions/proposals/WEBGL_compress_texture.html
+++ b/extensions/proposals/WEBGL_compress_texture.html
@@ -62,7 +62,7 @@ interface WebGLCompressedTexture : WebGLObject {
     readonly attribute GLenum error;
 };
 
-interface WEBGL_compress_texture {
+interface WebGLExtensionWebglCompressTexture {
     const GLenum PRESERVE_ALPHA = 0x0001;
     const GLenum PRESERVE_TRANSPARENCY = 0x0002;
     const GLenum PRESERVE_RGB = 0x0004;
@@ -176,6 +176,7 @@ interface WEBGL_compress_texture {
       <li> 2011/04/04 Initial draft.</li>
       <li> 2011/04/05 Fixed typos. Changed error mechanism. Added size.</li>
       <li> 2012/01/03 Removed webgl module per changes to Web IDL spec</li>
+      <li> 2022/02/11 Rename and expose prototype.</li>
       </ul>
     </p>
 </body>

--- a/extensions/proposals/WEBGL_debug/extension.xml
+++ b/extensions/proposals/WEBGL_debug/extension.xml
@@ -112,8 +112,8 @@
   </overview>
 
   <idl xml:space="preserve"><![CDATA[
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_debug : EventTarget {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglDebug : EventTarget {
   const GLenum MAX_DEBUG_MESSAGE_LENGTH_KHR = 0x9143;
   const GLenum MAX_DEBUG_GROUP_STACK_DEPTH_KHR = 0x826C;
   const GLenum DEBUG_GROUP_STACK_DEPTH_KHR = 0x826D;
@@ -153,20 +153,20 @@ interface WEBGL_debug : EventTarget {
 
   undefined objectLabelKHR(WebGLObject? object, DOMString label);
   DOMString getObjectLabelKHR(WebGLObject? object);
-}; // interface WEBGL_debug
+};
 
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
+[Exposed=(Window,Worker)]
 interface WebGLDebugMessage : Event {
   readonly attribute GLenum source;
   readonly attribute GLenum type;
   readonly attribute GLuint id;
   readonly attribute GLenum severity;
   readonly attribute DOMString message;
-}; // interface WebGLDebugMessage
+};
   ]]></idl>
 
   <newfun>
-    <p>On <code>WEBGL_debug</code>:</p>
+    <p>On <code>WebGLExtensionWebglDebug</code>:</p>
 
     <function name="debugMessageControlKHR" type="undefined">
       <param name="source" type="GLenum"/>
@@ -354,6 +354,9 @@ function draw(gl, ext) {
   <history>
     <revision date="2015/09/18">
       <change>Initial revision.</change>
+    </revision>
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </proposal>

--- a/extensions/proposals/WEBGL_dynamic_texture/extension.xml
+++ b/extensions/proposals/WEBGL_dynamic_texture/extension.xml
@@ -192,8 +192,8 @@
   </overview>
 
   <idl xml:space="preserve">
-[Exposed=(Window,Worker), LegacyNoInterfaceObject]
-interface WEBGL_dynamic_texture {
+[Exposed=(Window,Worker)]
+interface WebGLExtensionWebglDynamicTexture {
   typedef double WDTNanoTime;
 
   const GLenum TEXTURE_EXTERNAL_OES = 0x8D65;
@@ -202,17 +202,17 @@ interface WEBGL_dynamic_texture {
   const GLenum REQUIRED_TEXTURE_IMAGE_UNITS_OES = 0x8D68;
 
   WDTStream? createStream();
- 
+
   WDTNanoTime getLastDrawingBufferPresentTime();
   undefined setDrawingBufferPresentTime(WDTNanoTime pt);
   WDTNanoTime ustnow();
-}; // interface WEBGL_dynamic_texture
+};
 </idl>
 
   <!-- new functions -->
 
   <newfun>
-    <p>On <code>WEBGL_dynamic_texture</code>:</p>
+    <p>On <code>WebGLExtensionWebglDynamicTexture</code>:</p>
 
     <function name="createStream" type="WDTStream">Creates and returns a
     <code>WDTStream</code> object whose consumer is the
@@ -314,7 +314,7 @@ interface WEBGL_dynamic_texture {
       <p>This type is used for nanosecond time stamps and time periods.</p>
     </typedef>
 
-    <interface name="WDTStreamFrameInfo" noobject="true">
+    <interface name="WDTStreamFrameInfo">
       <member>double frameTime;</member>
 
       <member>WDTNanoTime presentTime</member>
@@ -323,7 +323,7 @@ interface WEBGL_dynamic_texture {
       frame.</p>
     </interface>
 
-    <interface name="WDTStream" noobject="true">
+    <interface name="WDTStream">
       <member>...</member>
 
       <p>This interface is used to manage the image stream between the
@@ -360,7 +360,7 @@ interface WEBGL_dynamic_texture {
     following <code>/* Uniform Types */</code>:<pre class="idl"
     xml:space="preserve">SAMPLER_EXTERNAL = 0x8D66;</pre></li><li>In the
     alphabetical list of commands add the following :<pre class="idl"
-    xml:space="preserve">WDTStream? createStream(); 
+    xml:space="preserve">WDTStream? createStream();
 WDTNanoTime getLastDrawingBufferPresentTime();
 void setDrawingBufferPresentationTime(WDTNanoTime pt);
 WDTNanoTime ustnow();</pre></li></p>
@@ -501,7 +501,9 @@ WDTNanoTime ustnow();</pre></li></p>
       <p>The <code>WDTStreamFrameInfo</code> interface represents information
       about a frame acquired from a WDTStream.</p>
 
-      <pre class="idl" xml:space="preserve">[Exposed=(Window,Worker), LegacyNoInterfaceObject] interface WDTStreamFrameInfo {
+      <pre class="idl" xml:space="preserve">
+[Exposed=(Window,Worker)]
+interface WDTStreamFrameInfo {
   readonly attribute double frameTime;
   readonly attribute WDTNanoTime presentTime;
 };</pre>
@@ -531,7 +533,9 @@ WDTNanoTime ustnow();</pre></li></p>
       for controlling an image stream being fed to a dynamic texture
       object.</p>
 
-      <pre class="idl" xml:space="preserve">[Exposed=(Window,Worker), LegacyNoInterfaceObject] interface WDTStream {
+      <pre class="idl" xml:space="preserve">
+[Exposed=(Window,Worker)]
+interface WDTStream {
   typedef (HTMLCanvasElement or
            HTMLImageElement or
            HTMLVideoElement) StreamSource;
@@ -549,7 +553,7 @@ WDTNanoTime ustnow();</pre></li></p>
 
   readonly attribute WDTNanoTime minFrameDuration;
 
-  readonly attribute GLenum state;  
+  readonly attribute GLenum state;
 
   attribute WDTNanotime acquireTimeout;
   attribute WDTNanoTime consumerLatency;
@@ -800,7 +804,7 @@ WDTNanoTime ustnow();</pre></li></p>
     Note that the surrounding <code>&lt;script&gt;</code> tag is not
     essential; it is merely one way to include shader text in an HTML
     file.<pre xml:space="preserve">&lt;script id="fshader" type="x-shader/x-fragment"&gt;
-  #extension OES_EGL_image_external : enable 
+  #extension OES_EGL_image_external : enable
   precision mediump float;
 
   uniform samplerExternalOES videoSampler;
@@ -1319,6 +1323,10 @@ WDTNanoTime ustnow();</pre></li></p>
     <revision date="2015/10/02">
       <change>Updated link to GL_NV_EGL_stream_consumer_external
       extension.</change>
+    </revision>
+
+    <revision date="2022/02/11">
+      <change>Rename and expose prototype.</change>
     </revision>
   </history>
 </proposal>

--- a/extensions/rejected/WEBGL_subscribe_uniform/extension.xml
+++ b/extensions/rejected/WEBGL_subscribe_uniform/extension.xml
@@ -18,26 +18,26 @@
 
 
   <overview id="overview">
-    <p> This extension exposes the ability to subscribe to a set of uniform targets 
+    <p> This extension exposes the ability to subscribe to a set of uniform targets
         which can be used to populate uniforms within shader programs. This extension
         is generic, but currently only supports mouse position as a subscription target.
-    </p><p>Background: 
-    </p><p>The depth of the web pipeline makes it difficult to support low latency 
+    </p><p>Background:
+    </p><p>The depth of the web pipeline makes it difficult to support low latency
            interaction as event information retrieved via javascript
-           is outdated by the time it's displayed to clients. By populating event 
+           is outdated by the time it's displayed to clients. By populating event
            information later in the pipeline one can reduce perceived input latency.
-    </p><p>This extension creates a new buffer type <code>'Valuebuffer'</code> to 
+    </p><p>This extension creates a new buffer type <code>'Valuebuffer'</code> to
            maintain the active state for predefined subscription targets. Since a
            mechanism for buffering uniform information isn't available pre 2.0 (UBOs)
-           an additional data type was needed. See 'New Types' for additional 
+           an additional data type was needed. See 'New Types' for additional
            information.</p>
     <p> When this extension is enabled: </p>
     <ul>
-      <li>This extension provides a mechanism to store mouse positional information 
-          in buffers and defer modification of uniform variables which use mouse 
+      <li>This extension provides a mechanism to store mouse positional information
+          in buffers and defer modification of uniform variables which use mouse
           positional information until the WebGL commands are executed.
       </li>
-      <li>This extension provides a mechanism to explicitly update mouse 
+      <li>This extension provides a mechanism to explicitly update mouse
           positional information to maintain per frame consistency.
       </li>
     </ul>
@@ -71,21 +71,21 @@ interface WEBGL_subscribe_uniform {
     object.</function>
 
     <function name="isValuebuffer" type="bool"><param
-    name="buffer" type="WebGLValuebuffer"/>Returns whether an object is a 
+    name="buffer" type="WebGLValuebuffer"/>Returns whether an object is a
     <code>Valuebuffer</code> object.</function>
 
     <function name="bindValuebuffer" type="undefined"><param
     name="target" type="GLenum"/><param
-    name="buffer" type="WebGLValuebuffer"/>Lets you use a named 
+    name="buffer" type="WebGLValuebuffer"/>Lets you use a named
     <code>Valuebuffer</code> object.</function>
 
     <function name="subscribeValuebuffer" type="undefined"><param
     name="target" type="GLenum"/><param
-    name="subscription" type="GLenum"/>Subscribes the currently bound 
+    name="subscription" type="GLenum"/>Subscribes the currently bound
     <code>Valuebuffer</code> object to a subscription target.</function>
 
     <function name="populateSubscribedValues" type="undefined"><param
-    name="target" type="GLenum"/>Populates the currently bound 
+    name="target" type="GLenum"/>Populates the currently bound
     <code>Valuebuffer</code> object with the state of the subscriptions to
     which it is subscribed.</function>
 
@@ -98,51 +98,51 @@ interface WEBGL_subscribe_uniform {
   </newfun>
 
   <newtypes>
-    <interface name="WebGLValuebuffer" noobject="true">
-      <p>This interface is used to maintain a reference to internal 
+    <interface name="WebGLValuebuffer">
+      <p>This interface is used to maintain a reference to internal
       <code>Valuebuffer</code> subscription states.</p>
     </interface>
-    <p>A <code>Valuebuffer</code> abstracts the mapping of subscription targets to internal 
-       state and acts as a single storage object for subscription information (e.g. current 
+    <p>A <code>Valuebuffer</code> abstracts the mapping of subscription targets to internal
+       state and acts as a single storage object for subscription information (e.g. current
        mouse position). Clients can then use the objects data to populate uniform variables.</p>
     <p>Post WebGL API 2.0, this abstraction could exist as a layer ontop of UBOs
        which managers the mapping of subscription targets to internal state and the mapping
-       of subscription targets to offsets within the buffer. The UBO would be used to store the 
+       of subscription targets to offsets within the buffer. The UBO would be used to store the
        active buffer state as well as the uniform location mapping. Clients would be required to
-       state all their subscription targets at once to allocate the appropriate amount of memory. 
+       state all their subscription targets at once to allocate the appropriate amount of memory.
        Aside from this small change the implementation is essentially the same, with UBOs replacing
        <code>Valuebuffers</code> and relevant create, delete, bind methods being replaced.
-       Additionally, the inclusion of UBOs would replace the need for 
+       Additionally, the inclusion of UBOs would replace the need for
        <code>uniformValueBuffer(...)</code>.</p>
   </newtypes>
 
   <newtok>
-    <function name="bindValuebuffer" type="any"><param 
+    <function name="bindValuebuffer" type="any"><param
     name="target" type="GLenum"/><param
     name="buffer" type="WebGLValuebuffer"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to bindValuebuffer</p></function>
 
     <function name="subscribeValuebuffer" type="undefined"><param
     name="target" type="GLenum"/><param
     name="subscription" type="GLenum"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to subscribeValuebuffer</p>
-    <p><code>MOUSE_POSITION</code> 
+    <p><code>MOUSE_POSITION</code>
     is accepted as the subscription parameter to subscribeValuebuffer</p></function>
 
     <function name="populateSubscribedValues" type="undefined"><param
     name="target" type="GLenum"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to populateSubscribedValues</p></function>
 
     <function name="uniformValuebuffer" type="undefined"><param
     name="location" type="WebGLUniformLocation"/><param
     name="target" type="GLenum"/><param
     name="subscription" type="GLenum"/>
-    <p><code>SUBSCRIBED_VALUES_BUFFER</code> 
+    <p><code>SUBSCRIBED_VALUES_BUFFER</code>
     is accepted as the target parameter to uniformValuebuffer</p>
-    <p><code>MOUSE_POSITION</code> 
+    <p><code>MOUSE_POSITION</code>
     is accepted as the subscription parameter to uniformValuebuffer</p></function>
   </newtok>
 
@@ -161,15 +161,15 @@ function init(gl) {
   ...
 
   var ext = gl.getExtension('WEBGL_subscribe_uniform');
-    
+
   // Create the value buffer and subscribe.
   var valuebuffer = ext.createValuebuffer();
   ext.bindValuebuffer(SUBSCRIBED_VALUES_BUFFER, valuebuffer);
   ext.subscribeValue(MOUSE_POSITION);
   ...
 }
-     
-function draw(gl) {   
+
+function draw(gl) {
   // Populate buffer and populate uniform
   ext.bindValuebuffer(SUBSCRIBED_VALUES_BUFFER, valuebuffer);
   ext.populateSubscribedValues(SUBSCRIBED_VALUES_BUFFER);

--- a/extensions/template/extension.xml
+++ b/extensions/template/extension.xml
@@ -6,7 +6,7 @@
 http://www.khronos.org/registry/webgl/extensions/
 -->
 <extension href="template/">
-  <!-- The name of the extension. This is also the string which is passed to the 
+  <!-- The name of the extension. This is also the string which is passed to the
        WebGLRenderingContext getExtension API to enable the extension. For example, if
        the extension were OES_texture_float, then the extension would be fetched and
        enabled with a call to getExtension("OES_texture_float")
@@ -163,7 +163,7 @@ interface OES_foo_bar {
       <p>After attempting a connection, the plumber is no longer the same.</p>
     </interface>
 
-    <interface name="Agency" noobject="true"> <member>void
+    <interface name="Agency"> <member>void
     register(Plumber);</member> <member>Plumber find();</member> XHTML
     </interface>
   </newtypes>


### PR DESCRIPTION
Rename prototypes like EXT_frag_depth => WebGLExtensionExtFragDepth.
Remove `noobject:true` xml annotations.
Leave some proposals and all rejected extensions untouched.
Closes #3366.