### PR TITLE
Fix generateTOC always scrolling to top of document

### DIFF
--- a/resources/generateTOC.js
+++ b/resources/generateTOC.js
@@ -46,8 +46,7 @@ function generateTOC(toc)
     if (id.length > 0) {
         var target = document.getElementById(id);
         if (target) {
-            var rect = target.getBoundingClientRect();
-            setTimeout(function() { window.scrollTo(0, rect.top) }, 0);
+            target.scrollIntoView();
         }
     }
 }


### PR DESCRIPTION
Currently when following links with a fragment (linking to a specific section of the page, [an example](https://www.khronos.org/registry/webgl/specs/latest/2.0/#TEXTURE_TYPES_FORMATS_FROM_DOM_ELEMENTS_TABLE)) `generateTOC` will always scroll to the top of the page, as the element bounding rect is invalidated (all zeros) by reflow.

Interestingly such links work as expected when removing this code entirely, even in Internet Explorer. However I opted to keep the code and use `scrollIntoView` as it has suitably wide support and I'm unsure whether there are browsers that still need this fix.