### PR TITLE
Allow passing in context creation options in URL

### DIFF
--- a/sdk/tests/README.md
+++ b/sdk/tests/README.md
@@ -65,6 +65,18 @@ There are various URL options you can pass in.
 
                  Note the tests are not required to run with anything other than frames = 1.
 
+To individual tests you can pass
+
+    showRenderer: 1 to show the renderer or unmasked renderer if `WEBGL_debug_renderer_info`
+                  is available
+
+    runUntilFail: 1 to re-run the test until it fails
+
+    Also, all of [the context creation attributes](https://www.khronos.org/registry/webgl/specs/latest/1.0/#5.2
+    
+                  Example: some-test.html?powerPreference=high-performance&antialias=false&depth=false
+   
+
 History
 -------
 

--- a/sdk/tests/js/js-test-post.js
+++ b/sdk/tests/js/js-test-post.js
@@ -15,6 +15,17 @@ if (_jsTestPreVerboseLogging) {
     let fails_class = 'pass';
     if (RESULTS.fail) {
         fails_class = 'fail';
+    } else {
+        const parseBoolean = v => v.toLowerCase().startsWith('t') || parseFloat(v) > 0;
+        const params = new URLSearchParams(window.location.search);
+        if (parseBoolean(params.get('runUntilFail') || '')) {
+          setTimeout(() => {
+            params.set('runCount', parseInt(params.get('runCount') || '0') + 1);
+            const url = new URL(window.location.href);
+            url.search = params.toString();
+            window.location.href = url.toString();
+          }, 100);
+        }
     }
     e_results.classList.add('pass');
     e_results.innerHTML = `<p>TEST COMPLETE: ${RESULTS.pass} PASS, ` +

--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -1573,6 +1573,29 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
   if (!hasAttributeCaseInsensitive(attributes, "antialias")) {
     attributes.antialias = false;
   }
+
+  const parseString = v => v;
+  const parseBoolean = v => v.toLowerCase().startsWith('t') || parseFloat(v) > 0;
+  const params = new URLSearchParams(window.location.search);
+  for (const [key, parseFn] of Object.entries({
+    alpha: parseBoolean,
+    antialias: parseBoolean,
+    depth: parseBoolean,
+    desynchronized: parseBoolean,
+    failIfMajorPerformanceCaveat: parseBoolean,
+    powerPreference: parseString,
+    premultipliedAlpha: parseBoolean,
+    preserveDrawingBuffer: parseBoolean,
+    stencil: parseBoolean,
+  })) {
+    const value = params.get(key);
+    if (value) {
+      const v = parseFn(value);
+      attributes[key] = v;
+      debug(`setting context attribute: ${key} = ${v}`);
+    }
+  }
+
   if (!opt_version) {
     opt_version = getDefault3DContextVersion();
   }
@@ -1607,6 +1630,12 @@ var create3DContext = function(opt_canvas, opt_attributes, opt_version) {
     }
     window._wtu_contexts.push(context);
   }
+
+  if (params.get('showRenderer')) {
+    const ext = context.getExtension('WEBGL_debug_renderer_info');
+    debug(`RENDERER: ${context.getParameter(ext ? ext.UNMASKED_RENDERER_WEBGL : context.RENDERER)}`);
+  }
+
   return context;
 };
 


### PR DESCRIPTION
And for showing the `RENDERER`.

This CL allows you to set any context creation parameters
in the URL. Example:

    sometest.html?antialias=false&powerPreference=high-performance

Also, `showRenderer` which will print the renderer, unmasked
if the `WEBGL_debug_renderer_info` exists. Example:

    sometest.html?showRenderer=true

These are useful for testing on dual GPU systems and verifying
that the correct GPU is being tested.

`runUntilFail` which will reload the test until it fails. Useful for tracking down flakes.

    sometest.html?runUntilFail=true
