### PR TITLE
Replace RGBA with LUMINANCE in invalid texture format test

### DIFF
--- a/sdk/tests/conformance/textures/misc/texture-with-flip-y-and-premultiply-alpha.html
+++ b/sdk/tests/conformance/textures/misc/texture-with-flip-y-and-premultiply-alpha.html
@@ -30,8 +30,8 @@ var tex = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex);
 
 function testUpload() {
-  // Because WEBGL_depth_texture is enabled, UNSIGNED_SHORT becomes a valid type, but RGBA/UNSIGNED_SHORT is invalid.
-  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 2, 2, 0, gl.RGBA, gl.UNSIGNED_SHORT, new Uint16Array(2*2*4));
+  // Because WEBGL_depth_texture is enabled, UNSIGNED_SHORT becomes a valid type, but LUMINANCE/UNSIGNED_SHORT is invalid.
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.LUMINANCE, 2, 2, 0, gl.LUMINANCE, gl.UNSIGNED_SHORT, new Uint16Array(2*2));
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "texImage2D() with invalid format/type combination");
 }
 


### PR DESCRIPTION
ANGLE is going to support GL_EXT_texture_norm16 on ES2/D3D11 since Chromium's Skia context uses ES2 and R16/RG16 support is needed for texturing from P010 HDR videos. Unfortunately, texture-with-flip-y-and-premultiply-alpha.html expects RGBA/UNSIGNED_SHORT to be an invalid format/type combination which is no longer the case after texture_norm16 is enabled on ES2. Use LUMINANCE/UNSIGNED_SHORT as the expected invalid format/type since that's always invalid irrespective of extensions.

See anglebug.com/7322 for context.