### PR TITLE
Add tolerance to multisample-draws-between-blits.html.

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/multisample-draws-between-blits.html
+++ b/sdk/tests/conformance2/renderbuffers/multisample-draws-between-blits.html
@@ -127,7 +127,8 @@ function runTest(gl, sampleCount) {
 
     const check = (x, y, w, h, expected, msg) => {
       gl.bindFramebuffer(gl.FRAMEBUFFER, dFB);
-      wtu.checkCanvasRect(gl, x, y, w, h, expected, msg);
+      const tolerance = 2; // For multisampling resolution differences between GPUs
+      wtu.checkCanvasRect(gl, x, y, w, h, expected, msg, tolerance);
     };
 
     const f32Red    = [1, 0, 0, 1];


### PR DESCRIPTION
conformance2/renderbuffers/multisample-draws-between-blits.html needs
a tolerance of 1 in its image comparisons on certain GPUs (NVIDIA
specifically); add a tolerance of 2 to accommodate other GPUs.

Follow-on to #3390 and #3412 .

Associated with https://crbug.com/1326332 .