### PR TITLE
Fix a variable reference in red-format video-to-texture tests.

### DIFF
--- a/sdk/tests/js/webgl-test-utils.js
+++ b/sdk/tests/js/webgl-test-utils.js
@@ -3373,7 +3373,7 @@ var colorAsSampledWithInternalFormat = function(color, internalFormat) {
     case 'R8UI':
     case 'RED':
     case 'RED_INTEGER':
-      return [result[0], 0, 0, 0];
+      return [color[0], 0, 0, 0];
     case 'RG':
     case 'RG16F':
     case 'RG32F':


### PR DESCRIPTION
Follow-on to #3404 .

Associated with http://crbug.com/1208480 .