### PR TITLE
Use QUERY_RESULT for webgl2

### DIFF
--- a/sdk/tests/conformance2/extensions/ext-disjoint-timer-query-webgl2.html
+++ b/sdk/tests/conformance2/extensions/ext-disjoint-timer-query-webgl2.html
@@ -114,7 +114,7 @@ function runSanityTests() {
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Attempting to begin an active query should fail.");
     gl.getQueryParameter(query, gl.QUERY_RESULT_AVAILABLE);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Fetching query result availability of an active query should fail.");
-    gl.getQueryParameter(query, gl.QUERY_RESULT_EXT);
+    gl.getQueryParameter(query, gl.QUERY_RESULT);
     wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "Fetching query result of an active query should fail.");
     shouldBe("gl.getQuery(ext.TIME_ELAPSED_EXT, gl.CURRENT_QUERY)", "query");
     gl.endQuery(ext.TIME_ELAPSED_EXT);
@@ -282,10 +282,10 @@ function checkQueryResults() {
         // Cannot validate results make sense, but this is okay.
         testPassed("Disjoint triggered.");
     } else {
-        var elapsed_result = gl.getQueryParameter(elapsed_query, gl.QUERY_RESULT_EXT);
+        var elapsed_result = gl.getQueryParameter(elapsed_query, gl.QUERY_RESULT);
         if (timestamp_counter_bits > 0) {
-            var timestamp_result1 = gl.getQueryParameter(timestamp_query1, gl.QUERY_RESULT_EXT);
-            var timestamp_result2 = gl.getQueryParameter(timestamp_query2, gl.QUERY_RESULT_EXT);
+            var timestamp_result1 = gl.getQueryParameter(timestamp_query1, gl.QUERY_RESULT);
+            var timestamp_result2 = gl.getQueryParameter(timestamp_query2, gl.QUERY_RESULT);
         }
         // Do some basic validity checking of the elapsed time query. There's no way it should
         // take more than about half a second for a no-op query.


### PR DESCRIPTION
Spec example: gl.getQueryParameter(startQuery, gl.QUERY_RESULT);
See: https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/