### PR TITLE
Warn in two video tests if the tab was backgrounded.

### DIFF
--- a/sdk/tests/conformance/textures/misc/texture-npot-video.html
+++ b/sdk/tests/conformance/textures/misc/texture-npot-video.html
@@ -23,6 +23,8 @@ function init()
 {
     description('Verify npot video');
 
+    document.addEventListener("visibilitychange", visibilityChanged, false);
+
     var canvas = document.getElementById("example");
     gl = wtu.create3DContext(canvas);
     var program = wtu.setupTexturedQuad(gl);
@@ -37,6 +39,14 @@ function init()
 
     var video = document.getElementById("vid");
     wtu.startPlayingAndWaitForVideo(video, runTest);
+}
+
+function visibilityChanged() {
+    if (document.hidden) {
+        console.log('*** Tab was backgrounded (if running in automated test harness, why?) ***');
+    } else {
+        console.log('Tab was foregrounded');
+    }
 }
 
 function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottomColor, badMinFilter, badClamp, genMips)

--- a/sdk/tests/conformance/textures/misc/texture-video-transparent.html
+++ b/sdk/tests/conformance/textures/misc/texture-video-transparent.html
@@ -24,6 +24,8 @@ function init()
 {
     description("Upload texture from animating transparent WebM");
 
+    document.addEventListener("visibilitychange", visibilityChanged, false);
+
     const canvas = document.getElementById("example");
     gl = wtu.create3DContext(canvas);
 
@@ -50,6 +52,14 @@ function init()
         return;
     };
     wtu.startPlayingAndWaitForVideo(video, runTest);
+}
+
+function visibilityChanged() {
+    if (document.hidden) {
+        console.log('*** Tab was backgrounded (if running in automated test harness, why?) ***');
+    } else {
+        console.log('Tab was foregrounded');
+    }
 }
 
 function runTest(videoElement)


### PR DESCRIPTION
There is a hypothesis that this is occurring on some platforms when
running the conformance tests in an automated test harness. Attempt to
confirm this.

Associated with http://crbug.com/1293967 .