### PR TITLE
Clarify working of EXT_texture_norm16, and expand tests.

### DIFF
--- a/extensions/EXT_texture_norm16/extension.xml
+++ b/extensions/EXT_texture_norm16/extension.xml
@@ -20,8 +20,6 @@
 
     <mirrors href="https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_norm16.txt"
              name="EXT_texture_norm16">
-        <addendum>Support for <code>UNSIGNED_SHORT</code> textures as FBO
-        attachments.</addendum>
     </mirrors>
 
     <features>
@@ -30,14 +28,11 @@
       buffer formats. The 16-bit normalized fixed point types
       <code>R16_EXT</code>, <code>RG16_EXT</code> and <code>RGBA16_EXT</code>
       become available as color-renderable formats. Renderbuffers can be
-      created in these formats. These and textures created with
-      <code>type = UNSIGNED_SHORT</code>, which will have one of these internal
-      formats, can be attached to framebuffer object color attachments for
-      rendering.
+      created in these formats.
       </feature>
 
-      <feature> The <code>texImage2D</code> and <code>texSubImage2D</code>
-      entry points taking <code>ArrayBufferView</code> are extended to accept
+      <feature> The <code>texImage</code> and <code>texSubImage</code>
+      entrypoints taking <code>ArrayBufferView</code> are extended to accept
       <code>Uint16Array</code> with the pixel type <code>UNSIGNED_SHORT</code>
       and <code>Int16Array</code> with the pixel type <code>SHORT</code>.
       </feature>
@@ -75,6 +70,9 @@ interface EXT_texture_norm16 {
     </revision>
     <revision date="2020/12/03">
       <change>Constrain the scope to only support ArrayBufferView.</change>
+    </revision>
+    <revision date="2022/06/08">
+      <change>Drop ambiguous wording regarding texImage with UNSIGNED_SHORT.</change>
     </revision>
   </history>
 </extension>

--- a/sdk/tests/conformance2/extensions/ext-texture-norm16.html
+++ b/sdk/tests/conformance2/extensions/ext-texture-norm16.html
@@ -49,12 +49,13 @@ function generateFormatColor(format, value, alpha) {
   }
 }
 
-function testNorm16Texture(internalFormat, format, type) {
+function testNorm16Texture(internalFormat, format, type, error="NO_ERROR") {
+  debug(`\ntestNorm16Texture(${[].slice.call(arguments).join(", ")})`);
   let pixelValue;
   let expectedValue;
   let imageData;
 
-  switch(type) {
+  switch(gl[type]) {
     case gl.SHORT:
       pixelValue = 0x7fff;
       expectedValue = 0xff;
@@ -73,14 +74,16 @@ function testNorm16Texture(internalFormat, format, type) {
   // Texture sampled from
   gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(gl.TEXTURE_2D, textures[0]);
-  gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 1, 1, 0, format, type, imageData);
+  gl.texImage2D(gl.TEXTURE_2D, 0, ext[internalFormat] || gl[internalFormat],
+        1, 1, 0, gl[format], gl[type], imageData);
 
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture bindings succeed");
+  wtu.glErrorShouldBe(gl, gl[error], `texImage should generate error:${error}`);
+  if (gl[error]) return;
 
   gl.drawArrays(gl.TRIANGLES, 0, 6);
 
   // Read back as gl.UNSIGNED_BYTE
-  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(format, expectedValue));
+  wtu.checkCanvasRect(gl, 0, 0, 1, 1, generateFormatColor(gl[format], expectedValue));
 }
 
 function testNorm16Render(interalFormat, format, type, tolerance) {
@@ -138,9 +141,9 @@ function testNorm16Render(interalFormat, format, type, tolerance) {
   gl.bindTexture(gl.TEXTURE_2D, null);
 }
 
-function testSnorm16Unrenderable(internalFormat, format, type) {
+function testExtFormatUnrenderable(internalFormatName, format, type) {
   gl.bindTexture(gl.TEXTURE_2D, textures[1]);
-  gl.texImage2D(gl.TEXTURE_2D, 0, internalFormat, 1, 1, 0, format, type, null);
+  gl.texImage2D(gl.TEXTURE_2D, 0, ext[internalFormatName], 1, 1, 0, format, type, null);
 
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texture definition succeeded");
 
@@ -150,7 +153,7 @@ function testSnorm16Unrenderable(internalFormat, format, type) {
   wtu.glErrorShouldBe(gl, gl.NO_ERROR, "fbo binding succeeded");
 
   wtu.framebufferStatusShouldBe(gl, gl.FRAMEBUFFER, [ gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT, gl.FRAMEBUFFER_UNSUPPORTED ],
-                                "framebuffer should not be complete with SNORM16 texture attached");
+                                `framebuffer should not be complete with ${internalFormatName} texture attached`);
 }
 
 function runInternalFormatQueryTest()
@@ -188,14 +191,22 @@ function runTestExtension() {
   let program300 = wtu.setupSimpleTextureProgramESSL300(gl);
   let program100 = wtu.setupTexturedQuad(gl, 0, 1, wtu.simpleHighPrecisionTextureFragmentShader);
 
-  testNorm16Texture(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT);
-  testNorm16Texture(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT);
-  testNorm16Texture(ext.RGB16_EXT, gl.RGB, gl.UNSIGNED_SHORT);
-  testNorm16Texture(ext.RGBA16_EXT, gl.RGBA, gl.UNSIGNED_SHORT);
-  testNorm16Texture(ext.R16_SNORM_EXT, gl.RED, gl.SHORT);
-  testNorm16Texture(ext.RG16_SNORM_EXT, gl.RG, gl.SHORT);
-  testNorm16Texture(ext.RGB16_SNORM_EXT, gl.RGB, gl.SHORT);
-  testNorm16Texture(ext.RGBA16_SNORM_EXT, gl.RGBA, gl.SHORT);
+  debug("");
+  debug("Texture creation");
+  testNorm16Texture("R16_EXT", "RED", "UNSIGNED_SHORT");
+  testNorm16Texture("RG16_EXT", "RG", "UNSIGNED_SHORT");
+  testNorm16Texture("RGB16_EXT", "RGB", "UNSIGNED_SHORT");
+  testNorm16Texture("RGBA16_EXT", "RGBA", "UNSIGNED_SHORT");
+  testNorm16Texture("R16_SNORM_EXT", "RED", "SHORT");
+  testNorm16Texture("RG16_SNORM_EXT", "RG", "SHORT");
+  testNorm16Texture("RGB16_SNORM_EXT", "RGB", "SHORT");
+  testNorm16Texture("RGBA16_SNORM_EXT", "RGBA", "SHORT");
+
+  testNorm16Texture("RGBA", "RGBA", "UNSIGNED_SHORT", "INVALID_OPERATION");
+  testNorm16Texture("RGBA", "RGBA", "SHORT", "INVALID_OPERATION");
+
+  debug("");
+  debug("Texture renderability");
 
   testNorm16Render(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT, 8);
   testNorm16Render(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT, 8);
@@ -205,12 +216,13 @@ function runTestExtension() {
 
   testNorm16Render(ext.R16_EXT, gl.RED, gl.UNSIGNED_SHORT, 0);
   testNorm16Render(ext.RG16_EXT, gl.RG, gl.UNSIGNED_SHORT, 0);
+  testExtFormatUnrenderable("RGB16_EXT", gl.RGB, gl.UNSIGNED_SHORT);
   testNorm16Render(ext.RGBA16_EXT, gl.RGBA, gl.UNSIGNED_SHORT, 0);
 
-  testSnorm16Unrenderable(ext.R16_SNORM_EXT, gl.RED, gl.SHORT);
-  testSnorm16Unrenderable(ext.RG16_SNORM_EXT, gl.RG, gl.SHORT);
-  testSnorm16Unrenderable(ext.RGB16_SNORM_EXT, gl.RGB, gl.SHORT);
-  testSnorm16Unrenderable(ext.RGBA16_SNORM_EXT, gl.RGBA, gl.SHORT);
+  testExtFormatUnrenderable("R16_SNORM_EXT", gl.RED, gl.SHORT);
+  testExtFormatUnrenderable("RG16_SNORM_EXT", gl.RG, gl.SHORT);
+  testExtFormatUnrenderable("RGB16_SNORM_EXT", gl.RGB, gl.SHORT);
+  testExtFormatUnrenderable("RGBA16_SNORM_EXT", gl.RGBA, gl.SHORT);
 };
 
 function runTest() {


### PR DESCRIPTION
Closes #3417.

In test:
* Forbid RGBA/RGBA/UNSIGNED_SHORT (and SHORT)
* Forbid renderability of RGB16.
* Add more/better debug info for what each subtest is testing.