### PR TITLE
Test all draw functions fail if attributes are invalid

### DIFF
--- a/sdk/tests/conformance/attribs/gl-enable-vertex-attrib.html
+++ b/sdk/tests/conformance/attribs/gl-enable-vertex-attrib.html
@@ -12,49 +12,39 @@ found in the LICENSE.txt file.
     <link rel="stylesheet" href="../../resources/js-test-style.css"/>
     <script src="../../js/js-test-pre.js"></script>
     <script src="../../js/webgl-test-utils.js"> </script>
+    <script src="../../js/tests/invalid-vertex-attrib-test.js"></script>
 </head>
 <body>
 <canvas id="example" width="50" height="50">
 </canvas>
 <div id="description"></div>
 <div id="console"></div>
-<script id="vshader" type="x-shader/x-vertex">
-    attribute vec4 vPosition;
-    void main()
-    {
-        gl_Position = vPosition;
-    }
-</script>
-
-<script id="fshader" type="x-shader/x-fragment">
-    void main()
-    {
-        gl_FragColor = vec4(1.0,0.0,0.0,1.0);
-    }
-</script>
 
 <script>
 "use strict";
 description("tests that turning on attribs that have no buffer bound fails to draw");
-var wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("example");
-var program = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
+const wtu = WebGLTestUtils;
+const gl = wtu.create3DContext("example");
 
-var vertexObject = gl.createBuffer();
-gl.bindBuffer(gl.ARRAY_BUFFER, vertexObject);
-gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([ 0,0.5,0, -0.5,-0.5,0, 0.5,-0.5,0 ]), gl.STATIC_DRAW);
-gl.enableVertexAttribArray(0);
-gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 0, 0);
+async function runInvalidAttribTests() {
+    const invalidAttribTestFn = createInvalidAttribTestFn(gl);
 
-gl.enableVertexAttribArray(3);
-wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+    function drawArrays(gl) {
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
 
-gl.drawArrays(gl.TRIANGLES, 0, 3);
-wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
+    function drawElements(gl) {
+      gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0);
+    }
+
+    await invalidAttribTestFn(drawArrays);
+    await invalidAttribTestFn(drawElements);
+    finishTest();
+}
+runInvalidAttribTests();
 
 var successfullyParsed = true;
 </script>
-<script src="../../js/js-test-post.js"></script>
 
 </body>
 </html>

--- a/sdk/tests/conformance/extensions/angle-instanced-arrays.html
+++ b/sdk/tests/conformance/extensions/angle-instanced-arrays.html
@@ -14,6 +14,7 @@ found in the LICENSE.txt file.
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/compositing-test.js"></script>
+<script src="../../js/tests/invalid-vertex-attrib-test.js"></script>
 </head>
 <body>
 <div id="description"></div>
@@ -102,6 +103,7 @@ if (!gl) {
             runDrawArraysWithOffsetTest();
             runVAOInstancingInteractionTest();
             await runANGLECorruptionTest();
+            await runInvalidAttribTests(gl);
             await runCompositingTests();
             finishTest();
         }());
@@ -655,26 +657,7 @@ async function runANGLECorruptionTest()
     ext.vertexAttribDivisorANGLE(colorLoc, 0);
 }
 
-async function runCompositingTests() {
-    const compositingTestFn = createCompositingTestFn({
-      webglVersion: 1,
-      shadersFn(gl) {
-        const vs = `\
-        attribute vec4 position;
-        void main() {
-          gl_Position = position;
-        }
-        `;
-        const fs = `\
-        precision mediump float;
-        void main() {
-          gl_FragColor = vec4(1, 0, 0, 1);
-        }
-        `;
-        return [vs, fs];
-      },
-    });
-
+async function runDrawTests(testFn) {
     function drawArrays(gl) {
       gl.drawArrays(gl.TRIANGLES, 0, 6);
     }
@@ -701,12 +684,40 @@ async function runCompositingTests() {
       ext.drawElementsInstancedANGLE(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1);
     }
 
-    await compositingTestFn(drawArrays);             // sanity check
-    await compositingTestFn(drawElements);           // sanity check
+    await testFn(drawArrays);             // sanity check
+    await testFn(drawElements);           // sanity check
 
-    await compositingTestFn(drawArraysInstancedANGLE);
-    await compositingTestFn(drawElementsInstancedANGLE);
+    await testFn(drawArraysInstancedANGLE);
+    await testFn(drawElementsInstancedANGLE);
 }
+
+async function runCompositingTests() {
+    const compositingTestFn = createCompositingTestFn({
+      webglVersion: 1,
+      shadersFn(gl) {
+        const vs = `\
+        attribute vec4 position;
+        void main() {
+          gl_Position = position;
+        }
+        `;
+        const fs = `\
+        precision mediump float;
+        void main() {
+          gl_FragColor = vec4(1, 0, 0, 1);
+        }
+        `;
+        return [vs, fs];
+      },
+    });
+    await runDrawTests(compositingTestFn);
+}
+
+async function runInvalidAttribTests(gl) {
+  const invalidAttribTestFn = createInvalidAttribTestFn(gl);
+  await runDrawTests(invalidAttribTestFn);
+}
+
 </script>
 </body>
 </html>

--- a/sdk/tests/conformance/extensions/webgl-multi-draw.html
+++ b/sdk/tests/conformance/extensions/webgl-multi-draw.html
@@ -8,6 +8,7 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/compositing-test.js"></script>
+<script src="../../js/tests/invalid-vertex-attrib-test.js"></script>
 </head>
 <body>
 <script id="vshaderIllegalDrawID" type="x-shader/x-vertex">
@@ -910,27 +911,7 @@ async function doCompositingTests([glPreserveDrawingBufferFalse, glPreserveDrawi
   await testPreserveDrawingBufferTrue(glPreserveDrawingBufferTrue, drawFn);
 }
 
-async function runCompositingTests() {
-  const compositingTestFn = createCompositingTestFn({
-    webglVersion: 1,
-    shadersFn(gl) {
-      const vs = `\
-      //#extension GL_ANGLE_multi_draw : enable
-      attribute vec4 position;
-      void main() {
-        gl_Position = position;
-      }
-      `;
-      const fs = `\
-      precision mediump float;
-      void main() {
-        gl_FragColor = vec4(1, 0, 0, 1);
-      }
-      `;
-      return [vs, fs];
-    },
-  });
-
+async function runDrawTests(testFn) {
   function drawArrays(gl) {
     gl.drawArrays(gl.TRIANGLES, 0, 6);
   }
@@ -1005,13 +986,41 @@ async function runCompositingTests() {
     );
   }
 
-  await compositingTestFn(drawArrays);             // sanity check
-  await compositingTestFn(drawElements);           // sanity check
+  await testFn(drawArrays);             // sanity check
+  await testFn(drawElements);           // sanity check
 
-  await compositingTestFn(multiDrawArraysWEBGL);
-  await compositingTestFn(multiDrawElementsWEBGL);
-  await compositingTestFn(multiDrawArraysInstancedWEBGL);
-  await compositingTestFn(multiDrawElementsInstancedWEBGL);
+  await testFn(multiDrawArraysWEBGL);
+  await testFn(multiDrawElementsWEBGL);
+  await testFn(multiDrawArraysInstancedWEBGL);
+  await testFn(multiDrawElementsInstancedWEBGL);
+}
+
+async function runCompositingTests() {
+  const compositingTestFn = createCompositingTestFn({
+    webglVersion: 1,
+    shadersFn(gl) {
+      const vs = `\
+      //#extension GL_ANGLE_multi_draw : enable
+      attribute vec4 position;
+      void main() {
+        gl_Position = position;
+      }
+      `;
+      const fs = `\
+      precision mediump float;
+      void main() {
+        gl_FragColor = vec4(1, 0, 0, 1);
+      }
+      `;
+      return [vs, fs];
+    },
+  });
+  await runDrawTests(compositingTestFn);
+}
+
+async function runInvalidAttribTests(gl) {
+  const invalidAttribTestFn = createInvalidAttribTestFn(gl);
+  await runDrawTests(invalidAttribTestFn);
 }
 
 function testSideEffects() {
@@ -1038,6 +1047,7 @@ function testSideEffects() {
 async function main() {
   runTest();
   testSideEffects();
+  await runInvalidAttribTests(gl);
   await runCompositingTests();
   finishTest();
 }

--- a/sdk/tests/conformance/extensions/webgl-multi-draw.html
+++ b/sdk/tests/conformance/extensions/webgl-multi-draw.html
@@ -931,7 +931,7 @@ async function runDrawTests(testFn) {
   function multiDrawArraysWEBGL(gl) {
     const ext = gl.getExtension('WEBGL_multi_draw');
     if (!ext) {
-      return true;
+      throw 'Should not have run this test without WEBGL_multi_draw';
     }
 
     ext.multiDrawArraysWEBGL(
@@ -945,7 +945,7 @@ async function runDrawTests(testFn) {
   function multiDrawElementsWEBGL(gl) {
     const ext = gl.getExtension('WEBGL_multi_draw');
     if (!ext) {
-      return true;
+      throw 'Should not have run this test without WEBGL_multi_draw';
     }
 
     ext.multiDrawElementsWEBGL(
@@ -960,7 +960,7 @@ async function runDrawTests(testFn) {
   function multiDrawArraysInstancedWEBGL(gl) {
     const ext = gl.getExtension('WEBGL_multi_draw');
     if (!ext) {
-      return true;
+      throw 'Should not have run this test without WEBGL_multi_draw';
     }
     ext.multiDrawArraysInstancedWEBGL(
         gl.TRIANGLES,
@@ -974,7 +974,7 @@ async function runDrawTests(testFn) {
   function multiDrawElementsInstancedWEBGL(gl) {
     const ext = gl.getExtension('WEBGL_multi_draw');
     if (!ext) {
-      return true;
+      throw 'Should not have run this test without WEBGL_multi_draw';
     }
     ext.multiDrawElementsInstancedWEBGL(
         gl.TRIANGLES,
@@ -989,10 +989,15 @@ async function runDrawTests(testFn) {
   await testFn(drawArrays);             // sanity check
   await testFn(drawElements);           // sanity check
 
-  await testFn(multiDrawArraysWEBGL);
-  await testFn(multiDrawElementsWEBGL);
-  await testFn(multiDrawArraysInstancedWEBGL);
-  await testFn(multiDrawElementsInstancedWEBGL);
+  // It's only legal to call testFn if the extension is supported,
+  // since the invalid vertex attrib tests, in particular, expect the
+  // draw function to have an effect.
+  if (gl.getExtension('WEBGL_multi_draw')) {
+    await testFn(multiDrawArraysWEBGL);
+    await testFn(multiDrawElementsWEBGL);
+    await testFn(multiDrawArraysInstancedWEBGL);
+    await testFn(multiDrawElementsInstancedWEBGL);
+  }
 }
 
 async function runCompositingTests() {

--- a/sdk/tests/conformance2/attribs/00_test_list.txt
+++ b/sdk/tests/conformance2/attribs/00_test_list.txt
@@ -4,4 +4,5 @@ gl-vertex-attrib-i-render.html
 --min-version 2.0.1 gl-vertex-attrib-normalized-int.html
 gl-vertexattribipointer.html
 gl-vertexattribipointer-offsets.html
+--min-version 2.0.1 invalid-vertex-attribs.html
 --min-version 2.0.1 render-no-enabled-attrib-arrays.html

--- a/sdk/tests/conformance2/attribs/invalid-vertex-attribs.html
+++ b/sdk/tests/conformance2/attribs/invalid-vertex-attribs.html
@@ -1,0 +1,73 @@
+<!--
+Copyright (c) 2022 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL2 draw functions have expected behavior with invalid vertex attribs</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+<script src="../../js/tests/invalid-vertex-attrib-test.js"></script>
+<style>
+body {
+    height: 3000px;
+}
+</style>
+</head>
+<body>
+<!-- Important to put the canvas at the top so that it's always visible even in the test suite runner.
+     Otherwise it just doesn't get composited in Firefox. -->
+<div id="description"></div>
+<canvas id="canvas" width="16" height="16"> </canvas>
+<div id="console"></div>
+<script>
+"use strict";
+
+description(`\
+This test ensures WebGL implementations correctly generate INVALID_OPERATION
+when an attribute is enabled but no buffer is bound`);
+debug("");
+
+const wtu = WebGLTestUtils;
+const gl = wtu.create3DContext('canvas', undefined, 2);
+
+async function runInvalidAttribTests() {
+    const invalidAttribTestFn = createInvalidAttribTestFn(gl);
+
+    function drawArrays(gl) {
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+    }
+
+    function drawElements(gl) {
+      gl.drawElements(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0);
+    }
+
+    function drawArraysInstanced(gl) {
+      gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, 1);
+    }
+
+    function drawElementsInstanced(gl) {
+      gl.drawElementsInstanced(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1);
+    }
+
+    function drawRangeElements(gl) {
+      gl.drawRangeElements(gl.TRIANGLES, 0, 5, 6, gl.UNSIGNED_BYTE, 0);
+    }
+
+    await invalidAttribTestFn(drawArrays);
+    await invalidAttribTestFn(drawElements);
+    await invalidAttribTestFn(drawArraysInstanced);
+    await invalidAttribTestFn(drawElementsInstanced);
+    await invalidAttribTestFn(drawRangeElements);
+    finishTest();
+}
+runInvalidAttribTests();
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>

--- a/sdk/tests/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html
+++ b/sdk/tests/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html
@@ -919,7 +919,7 @@ async function runDrawTests(testFn) {
     function drawArraysInstancedBaseInstanceWEBGL(gl) {
       const ext = gl.getExtension('WEBGL_draw_instanced_base_vertex_base_instance');
       if (!ext) {
-        return true;
+        throw 'Should not have run this test without WEBGL_draw_instanced_base_vertex_base_instance';
       }
 
       ext.drawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, 0, 6, 1, 0);
@@ -928,16 +928,16 @@ async function runDrawTests(testFn) {
     function drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl) {
       const ext = gl.getExtension('WEBGL_draw_instanced_base_vertex_base_instance');
       if (!ext) {
-        return true;
+        throw 'Should not have run this test without WEBGL_draw_instanced_base_vertex_base_instance';
       }
 
-      ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1, 0, 1);
+      ext.drawElementsInstancedBaseVertexBaseInstanceWEBGL(gl.TRIANGLES, 6, gl.UNSIGNED_BYTE, 0, 1, 0, 0);
     }
 
     function multiDrawArraysInstancedBaseInstanceWEBGL(gl) {
       const ext = gl.getExtension('WEBGL_multi_draw_instanced_base_vertex_base_instance');
       if (!ext) {
-        return true;
+        throw 'Should not have run this test without WEBGL_multi_draw_instanced_base_vertex_base_instance';
       }
       ext.multiDrawArraysInstancedBaseInstanceWEBGL(gl.TRIANGLES, [0], 0, [6], 0, [1], 0, [0], 0, 1);
     }
@@ -945,7 +945,7 @@ async function runDrawTests(testFn) {
     function multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(gl) {
       const ext = gl.getExtension('WEBGL_multi_draw_instanced_base_vertex_base_instance');
       if (!ext) {
-        return true;
+        throw 'Should not have run this test without WEBGL_multi_draw_instanced_base_vertex_base_instance';
       }
       ext.multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
           gl.TRIANGLES,
@@ -964,10 +964,17 @@ async function runDrawTests(testFn) {
     await testFn(drawArraysInstanced);    // sanity check
     await testFn(drawElementsInstanced);  // sanity check
 
-    await testFn(drawArraysInstancedBaseInstanceWEBGL);
-    await testFn(drawElementsInstancedBaseVertexBaseInstanceWEBGL);
-    await testFn(multiDrawArraysInstancedBaseInstanceWEBGL);
-    await testFn(multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL);
+    // It's only legal to call testFn if the extension is supported,
+    // since the invalid vertex attrib tests, in particular, expect the
+    // draw function to have an effect.
+    if (gl.getExtension('WEBGL_draw_instanced_base_vertex_base_instance')) {
+      await testFn(drawArraysInstancedBaseInstanceWEBGL);
+      await testFn(drawElementsInstancedBaseVertexBaseInstanceWEBGL);
+    }
+    if (gl.getExtension('WEBGL_multi_draw_instanced_base_vertex_base_instance')) {
+      await testFn(multiDrawArraysInstancedBaseInstanceWEBGL);
+      await testFn(multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL);
+    }
 }
 
 async function runCompositingTests() {
@@ -1001,7 +1008,7 @@ async function runInvalidAttribTests(gl) {
 }
 
 async function main() {
-  //runTest();
+  runTest();
   await runInvalidAttribTests(gl);
   await runCompositingTests();
   finishTest();

--- a/sdk/tests/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html
+++ b/sdk/tests/conformance2/extensions/webgl-multi-draw-instanced-base-vertex-base-instance.html
@@ -8,6 +8,7 @@
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
 <script src="../../js/tests/compositing-test.js"></script>
+<script src="../../js/tests/invalid-vertex-attrib-test.js"></script>
 </head>
 <body>
 <script id="vshaderBaseInstanceWithoutExt" type="x-shader/x-vertex">#version 300 es
@@ -897,29 +898,8 @@ function doTest(extensionName, multiDraw) {
   }
 }
 
-async function runCompositingTests() {
-    const compositingTestFn = createCompositingTestFn({
-      webglVersion: 2,
-      shadersFn(gl) {
-        const vs = `\
-        #version 300 es
-        layout(location = 0) in vec4 position;
-        void main() {
-          gl_Position = position;
-        }
-        `;
-        const fs = `\
-        #version 300 es
-        precision highp float;
-        out vec4 fragColor;
-        void main() {
-          fragColor = vec4(1, 0, 0, 1);
-        }
-        `;
-        return [vs, fs];
-      },
-    });
 
+async function runDrawTests(testFn) {
     function drawArrays(gl) {
       gl.drawArrays(gl.TRIANGLES, 0, 6);
     }
@@ -979,19 +959,50 @@ async function runCompositingTests() {
       );
     }
 
-    await compositingTestFn(drawArrays);             // sanity check
-    await compositingTestFn(drawElements);           // sanity check
-    await compositingTestFn(drawArraysInstanced);    // sanity check
-    await compositingTestFn(drawElementsInstanced);  // sanity check
+    await testFn(drawArrays);             // sanity check
+    await testFn(drawElements);           // sanity check
+    await testFn(drawArraysInstanced);    // sanity check
+    await testFn(drawElementsInstanced);  // sanity check
 
-    await compositingTestFn(drawArraysInstancedBaseInstanceWEBGL);
-    await compositingTestFn(drawElementsInstancedBaseVertexBaseInstanceWEBGL);
-    await compositingTestFn(multiDrawArraysInstancedBaseInstanceWEBGL);
-    await compositingTestFn(multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL);
+    await testFn(drawArraysInstancedBaseInstanceWEBGL);
+    await testFn(drawElementsInstancedBaseVertexBaseInstanceWEBGL);
+    await testFn(multiDrawArraysInstancedBaseInstanceWEBGL);
+    await testFn(multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL);
+}
+
+async function runCompositingTests() {
+    const compositingTestFn = createCompositingTestFn({
+      webglVersion: 2,
+      shadersFn(gl) {
+        const vs = `\
+        #version 300 es
+        layout(location = 0) in vec4 position;
+        void main() {
+          gl_Position = position;
+        }
+        `;
+        const fs = `\
+        #version 300 es
+        precision highp float;
+        out vec4 fragColor;
+        void main() {
+          fragColor = vec4(1, 0, 0, 1);
+        }
+        `;
+        return [vs, fs];
+      },
+    });
+    await runDrawTests(compositingTestFn);
+}
+
+async function runInvalidAttribTests(gl) {
+  const invalidAttribTestFn = createInvalidAttribTestFn(gl);
+  await runDrawTests(invalidAttribTestFn);
 }
 
 async function main() {
-  runTest();
+  //runTest();
+  await runInvalidAttribTests(gl);
   await runCompositingTests();
   finishTest();
 }

--- a/sdk/tests/js/tests/invalid-vertex-attrib-test.js
+++ b/sdk/tests/js/tests/invalid-vertex-attrib-test.js
@@ -1,0 +1,129 @@
+var createInvalidAttribTestFn = (function() {
+
+async function testPreserveDrawingBufferTrue(gl, drawFn, clear) {
+  debug('');
+  debug(`test preserveDrawingBuffer: true with ${drawFn.name} ${clear ? 'with' : 'without'} clear`);
+
+  if (clear) {
+    gl.clearColor(0, 0, 0, 0);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+  }
+
+  const skipTest = drawFn(gl);
+  if (skipTest) {
+    debug('skipped: extension does not exist');
+    return;
+  }
+
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "canvas should be red");
+
+  await waitForComposite();
+
+  wtu.checkCanvas(gl, [255, 0, 0, 255], "canvas should be red");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+}
+
+function setupWebGL({
+    webglVersion,
+    shadersFn,
+    attribs,
+}) {
+    const positionBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+      -1, -1,
+       1, -1,
+      -1,  1,
+      -1,  1,
+       1, -1,
+       1,  1,
+    ]), gl.STATIC_DRAW);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    const indexBuf = gl.createBuffer();
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuf);
+    gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, new Uint8Array([0, 1, 2, 3, 4, 5]), gl.STATIC_DRAW);
+    return gl;
+}
+
+function createInvalidAttribTestFn(gl) {
+  const vs = `
+  attribute vec4 vPosition;
+  void main()
+  {
+      gl_Position = vPosition;
+  }
+  `;
+
+  const fs = `
+  precision mediump float;
+  void main()
+  {
+      gl_FragColor = vec4(1, 0, 0, 1);
+  }
+  `
+
+  const program = wtu.setupProgram(gl, [vs, fs], ["vPosition"]);
+  if (!program) {
+    debug(`program failed to compile: ${wtu.getLastError()}`);
+  }
+
+  const positionBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+    -1, -1,
+     1, -1,
+    -1,  1,
+    -1,  1,
+     1, -1,
+     1,  1,
+  ]), gl.STATIC_DRAW);
+
+  const indexBuffer = gl.createBuffer();
+  gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, indexBuffer);
+  gl.bufferData(gl.ELEMENT_ARRAY_BUFFER,
+                new Uint8Array([0, 1, 2, 3, 4, 5]),
+                gl.STATIC_DRAW);
+
+  return async function invalidAttribTestFn(drawFn) {
+    debug('');
+
+    // reset attribs
+    gl.bindBuffer(gl.ARRAY_BUFFER, null);
+    const numAttribs = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+    for (let i = 0; i < numAttribs; ++i) {
+      gl.disableVertexAttribArray(i);
+      gl.vertexAttribPointer(1, 1, gl.FLOAT, false, 0, 0);
+    }
+
+    debug(`test ${drawFn.name} draws with valid attributes`);
+    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
+    gl.enableVertexAttribArray(0);
+    gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+
+    gl.clearColor(0, 0, 0, 0,);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.checkCanvas(gl, [0, 0, 0, 0], "canvas should be zero");
+
+    drawFn(gl);
+
+    wtu.checkCanvas(gl, [255, 0, 0, 255], "canvas should be red");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
+
+    debug(`test ${drawFn.name} generates INVALID_OPERATION draws with enabled attribute no buffer bound`);
+    gl.enableVertexAttribArray(1);
+
+    gl.clearColor(0, 0, 0, 0,);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.checkCanvas(gl, [0, 0, 0, 0], "canvas should be zero");
+
+    drawFn(gl);
+
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "should generate INVALID_OPERATION");
+    wtu.checkCanvas(gl, [0, 0, 0, 0], "canvas should be zero");
+  };
+}
+
+return createInvalidAttribTestFn;
+}());


### PR DESCRIPTION
#3434 

ATM this test only tests if an attribute is enabled but
no buffer is bound that each draw function generates
INVALID_OPERATION

Not sure what else needs to be test. Maybe mis-matching attributes (an ivec4 attribute in shader but float attribute in vao)