### PR TITLE
Fix typos in multi-draw extensions

### DIFF
--- a/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_draw_instanced_base_vertex_base_instance/extension.xml
@@ -18,6 +18,7 @@
   </depends>
 
   <overview>
+    <mirrors href="https://chromium.googlesource.com/angle/angle/+/main/extensions/ANGLE_base_vertex_base_instance.txt" name="ANGLE_base_vertex_base_instance">
       <addendum>
         This extension exposes the <code>DrawArraysInstancedBaseInstanceANGLE</code> and
         <code>DrawElementsInstancedBaseVertexBaseInstanceANGLE</code> entrypoints as
@@ -41,6 +42,7 @@
           Range Checking
         </a> of the WebGL specification.
       </addendum>
+    </mirrors>
 
     <div class="nonnormative">
       <p>
@@ -58,9 +60,13 @@
         The <code>drawArraysInstancedBaseInstanceWEBGL</code>
         and <code>drawElementsInstancedBaseVertexBaseInstanceWEBGL</code> entry points are added.
         These provide a counterpoint to instanced rendering and are more flexible for certain
-        scenarios. <code>drawArraysInstancedBaseInstanceWEBGL</code> behaves identically to
+        scenarios.
+      </feature>
+      <feature><code>drawArraysInstancedBaseInstanceWEBGL</code> behaves identically to
         <code>drawArraysInstanced</code> except that the first element within those instanced
         vertex attributes is specified in <code>baseInstance</code>.
+      </feature>
+      <feature>
         <code>drawElementsInstancedBaseVertexBaseInstanceWEBGL</code> is equivalent to
         <code>drawElementsInstanced</code> except that the value of the base vertex passed into
         driver is <code>baseVertex</code> instead of zero, and that the first element within those

--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -17,7 +17,7 @@
   </depends>
 
   <overview>
-    <mirrors href="https://chromium.googlesource.com/angle/angle/+/master/extensions/ANGLE_multi_draw.txt" name="ANGLE_multi_draw">
+    <mirrors href="https://chromium.googlesource.com/angle/angle/+/main/extensions/ANGLE_multi_draw.txt" name="ANGLE_multi_draw">
       <addendum>
         This extension only exposes the <code>MultiDrawArraysANGLE</code>, <code>MultiDrawElementsANGLE</code>, <code>MultiDrawArraysInstancedANGLE</code>, and <code>MultiDrawElementsInstancedANGLE</code> entrypoints as <code>multiDrawArraysWEBGL</code>, <code>multiDrawElementsWEBGL</code>, <code>multiDrawArraysInstancedWEBGL</code>, and <code>multiDrawElementsInstancedWEBGL</code>.
       </addendum>
@@ -73,7 +73,7 @@ interface WEBGL_multi_draw {
       GLsizei drawcount);
   undefined multiDrawElementsWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       GLenum type,
       ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
       GLsizei drawcount);
@@ -85,7 +85,7 @@ interface WEBGL_multi_draw {
       GLsizei drawcount);
   undefined multiDrawElementsInstancedWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       GLenum type,
       ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
       ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
@@ -101,7 +101,7 @@ interface WEBGL_multi_draw {
       <param name="firstsOffset" type="GLuint"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
-      <param name="drawCount" type="GLsizei"/>
+      <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
@@ -110,7 +110,7 @@ interface WEBGL_multi_draw {
       <param name="type" type="GLenum"/>
       <param name="offsetsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="offsetsOffset" type="GLuint"/>
-      <param name="drawCount" type="GLsizei"/>
+      <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawArraysInstancedWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
@@ -120,7 +120,7 @@ interface WEBGL_multi_draw {
       <param name="countsOffset" type="GLuint"/>
       <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="instanceCountsOffset" type="GLuint"/>
-      <param name="drawCount" type="GLsizei"/>
+      <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsInstancedWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
@@ -131,7 +131,7 @@ interface WEBGL_multi_draw {
       <param name="offsetsOffset" type="GLuint"/>
       <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="instanceCountsOffset" type="GLuint"/>
-      <param name="drawCount" type="GLsizei"/>
+      <param name="drawcount" type="GLsizei"/>
     </function>
   </newfun>
 

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -21,26 +21,28 @@
   </depends>
 
   <overview>
-    <addendum>
-      This extension exposes the <code>MultiDrawArraysInstancedBaseInstanceANGLE</code> and
-      <code>MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE</code> entrypoints as
-      <code>multiDrawArraysInstancedBaseInstanceWEBGL</code> and
-      <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code>.
-    </addendum>
-    <addendum>
-      The implementation must validate the arrays and indices referenced by
-      <code>multiDrawArraysInstancedBaseInstanceWEBGL</code> and
-      <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code>, similarly to how indices
-      referenced by <code>drawArrays</code> and <code>drawElements</code> are validated according
-      to section
-      <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/index.html#6.6">
-        Enabled Vertex Attributes and Range Checking
-      </a>
-      and
-      <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#RANGE_CHECKING">
-        Range Checking
-      </a> of the WebGL specification.
-    </addendum>
+    <mirrors href="https://chromium.googlesource.com/angle/angle/+/main/extensions/ANGLE_base_vertex_base_instance.txt" name="ANGLE_base_vertex_base_instance">
+      <addendum>
+        This extension exposes the <code>MultiDrawArraysInstancedBaseInstanceANGLE</code> and
+        <code>MultiDrawElementsInstancedBaseVertexBaseInstanceANGLE</code> entrypoints as
+        <code>multiDrawArraysInstancedBaseInstanceWEBGL</code> and
+        <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code>.
+      </addendum>
+      <addendum>
+        The implementation must validate the arrays and indices referenced by
+        <code>multiDrawArraysInstancedBaseInstanceWEBGL</code> and
+        <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code>, similarly to how indices
+        referenced by <code>drawArrays</code> and <code>drawElements</code> are validated according
+        to section
+        <a href="https://www.khronos.org/registry/webgl/specs/latest/1.0/index.html#6.6">
+          Enabled Vertex Attributes and Range Checking
+        </a>
+        and
+        <a href="https://www.khronos.org/registry/webgl/specs/latest/2.0/#RANGE_CHECKING">
+          Range Checking
+        </a> of the WebGL specification.
+      </addendum>
+    </mirrors>
 
     <div class="nonnormative">
       <p>The baseVertex functionality could effectly help reduce CPU overhead with static batching
@@ -58,10 +60,11 @@
         They behave identically to multiple calls to <code>drawArraysInstanced</code> and
         <code>drawElementsInstanced</code> except they handle multiple lists of arguments in one
         call, plus that the first element within those instanced vertex attributes is specified in
-        <code>baseInstancesList</code>. The
-        <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code> in addition specifies the
-        value of base vertex of each draw call to be values in<code>baseVerticesList</code> instead
-        of zero.
+        <code>baseInstancesList</code>.
+      </feature>
+      <feature>The <code>multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL</code> in addition
+        specifies the value of base vertex of each draw call to be values in<code>baseVerticesList</code>
+        instead of zero.
       </feature>
 
       <feature>
@@ -84,7 +87,7 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
       ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
       ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
       ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
-      GLsizei drawCount
+      GLsizei drawcount
   );
   undefined multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
       GLenum mode,
@@ -94,7 +97,7 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
       ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
       ([AllowShared] Int32Array or sequence&lt;GLint&gt;) baseVerticesList, GLuint baseVerticesOffset,
       ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
-      GLsizei drawCount
+      GLsizei drawcount
   );
 };
   </idl>
@@ -106,9 +109,11 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
       <param name="firstsOffset" type="GLuint"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
       <param name="countsOffset" type="GLuint"/>
-      <param name="baseInstancesList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
+      <param name="instanceCountsOffset" type="GLuint"/>
+      <param name="baseInstancesList" type="([AllowShared] Uint32Array or sequence&lt;GLuint&gt;)"/>
       <param name="baseInstancesOffset" type="GLuint"/>
-      <param name="drawCount" type="GLsizei"/>
+      <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
@@ -123,7 +128,7 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
       <param name="baseVerticesOffset" type="GLuint"/>
       <param name="baseInstancesList" type="([AllowShared] Uint32Array or sequence&lt;GLuint&gt;)"/>
       <param name="baseInstancesOffset" type="GLuint"/>
-      <param name="drawCount" type="GLsizei"/>
+      <param name="drawcount" type="GLsizei"/>
     </function>
   </newfun>
 


### PR DESCRIPTION
- Added links to the GLES extensions.
- Split features to improve readability.
- Fixed non-working XSL transforms due to missing XML tags.
- Fixed `countsList` and `baseInstancesList` types.
- Added missing `instanceCountsList` and `instanceCountsOffset` entries.
- Fixed `drawcount` spelling.