### PR TITLE
Move script tag from head to body.

### DIFF
--- a/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
+++ b/sdk/tests/conformance/rendering/color-mask-preserved-during-implicit-clears.html
@@ -12,6 +12,11 @@ found in the LICENSE.txt file.
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="canvases"></div>
+<div id="console"></div>
 <script>
 "use strict";
 const wtu = WebGLTestUtils;
@@ -102,10 +107,5 @@ function runTest() {
 
 requestAnimationFrame(initTest);
 </script>
-</head>
-<body>
-<div id="description"></div>
-<div id="canvases"></div>
-<div id="console"></div>
 </body>
 </html>

--- a/sdk/tests/conformance/rendering/draw-webgl-to-canvas-2d-repeatedly.html
+++ b/sdk/tests/conformance/rendering/draw-webgl-to-canvas-2d-repeatedly.html
@@ -12,6 +12,12 @@ found in the LICENSE.txt file.
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas-webgl" width="256" height="256"></canvas>
+<canvas id="canvas-2d" width="256" height="256"></canvas>
 <script>
 "use strict";
 const wtu = WebGLTestUtils;
@@ -81,11 +87,5 @@ function runTest() {
 
 requestAnimationFrame(runTest);
 </script>
-</head>
-<body>
-<div id="description"></div>
-<div id="console"></div>
-<canvas id="canvas-webgl" width="256" height="256"></canvas>
-<canvas id="canvas-2d" width="256" height="256"></canvas>
 </body>
 </html>


### PR DESCRIPTION
In the tests:
  conformance/rendering/color-mask-preserved-during-implicit-clears.html
  conformance/rendering/draw-webgl-to-canvas-2d-repeatedly.html

on very slow devices, it seems that the script tag can run before the
document is fully loaded, causing the description() call to fail to
look up the named div.

Associated with https://crbug.com/1341423 .