### PR TITLE
Relax texture error codes

### DIFF
--- a/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
+++ b/sdk/tests/conformance/extensions/ext-texture-compression-bptc.html
@@ -115,17 +115,17 @@ function runTestExtension() {
     gl.bindTexture(gl.TEXTURE_2D, tex);
 
     gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_BPTC_UNORM_EXT, 4, 4, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RGBA_BPTC_UNORM_EXT fails with texImage2D");
+    wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "COMPRESSED_RGBA_BPTC_UNORM_EXT fails with texImage2D");
 
     gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT, 4, 4, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
-    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT fails with texImage2D");
+    wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT fails with texImage2D");
 
     if (contextVersion >= 2) {
       gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT, 4, 4, 0, gl.RGB, gl.FLOAT, null);
-      wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT fails with texImage2D");
+      wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT fails with texImage2D");
 
       gl.texImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT, 4, 4, 0, gl.RGB, gl.FLOAT, null);
-      wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT fails with texImage2D");
+      wtu.glErrorShouldBe(gl, [gl.INVALID_VALUE, gl.INVALID_OPERATION], "COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT fails with texImage2D");
     }
 
     gl.deleteTexture(tex);

--- a/sdk/tests/conformance2/textures/misc/copy-texture-image.html
+++ b/sdk/tests/conformance2/textures/misc/copy-texture-image.html
@@ -190,7 +190,7 @@ var testInternalformat = function () {
 
     snormFormats.forEach(function(internalformat) {
         const srcTexFormatsTypes = { internalformat: "RGBA8", format: gl.RGBA, type: gl.UNSIGNED_BYTE };
-        testFormat(internalformat, srcTexFormatsTypes, gl.COLOR_ATTACHMENT0, gl.INVALID_ENUM, "copyTexImage2D should fail for snorm internalformat ");
+        testFormat(internalformat, srcTexFormatsTypes, gl.COLOR_ATTACHMENT0, [gl.INVALID_ENUM, gl.INVALID_OPERATION], "copyTexImage2D should fail for snorm internalformat ");
     });
 
     if (gl.getExtension("EXT_color_buffer_float")) {

--- a/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args.html
+++ b/sdk/tests/conformance2/textures/misc/tex-image-with-bad-args.html
@@ -44,7 +44,7 @@ var tests = [
     { internalformat: gl.RGBA, format: gl.RGBA, type: gl.HALF_FLOAT, errors: [gl.INVALID_OPERATION] },
     { internalformat: gl.LUMINANCE, format: gl.LUMINANCE, type: gl.FLOAT, errors: [gl.INVALID_OPERATION] },
     { internalformat: gl.LUMINANCE_ALPHA, format: gl.LUMINANCE_ALPHA, type: gl.HALF_FLOAT, errors: [gl.INVALID_OPERATION] },
-    { internalformat: 0x822A /*GL_R16_EXT*/ , format: gl.RED, type: gl.UNSIGNED_SHORT, errors: [gl.INVALID_VALUE] },
+    { internalformat: 0x822A /*GL_R16_EXT*/ , format: gl.RED, type: gl.UNSIGNED_SHORT, errors: [gl.INVALID_VALUE, gl.INVALID_OPERATION] },
     { internalformat: gl.RED, format: gl.RED, type: gl.UNSIGNED_SHORT, errors: [gl.INVALID_VALUE, gl.INVALID_OPERATION] },
 ];
 

--- a/sdk/tests/js/tests/tex-input-validation.js
+++ b/sdk/tests/js/tests/tex-input-validation.js
@@ -275,7 +275,7 @@ var testCases = [
     border: 0,
     format: 0x1903, // GL_RED
     type: gl.UNSIGNED_BYTE,
-    expectedError: [gl.INVALID_ENUM, gl.INVALID_VALUE] },
+    expectedError: [gl.INVALID_ENUM, gl.INVALID_VALUE, gl.INVALID_OPERATION] },
   { target: gl.TEXTURE_2D,
     internalFormat: gl.RGBA,
     border: 1,
@@ -517,7 +517,7 @@ var testCases = [
     border: 0,
     format: gl.RGBA,
     type: gl.UNSIGNED_BYTE,
-    expectedError: gl.INVALID_VALUE},
+    expectedError: [gl.INVALID_VALUE, gl.INVALID_OPERATION]},
   { target: gl.TEXTURE_3D,
     internalFormat: gl.RGBA,
     border: 0,


### PR DESCRIPTION
ANGLE returns `INVALID_VALUE` only for never-valid `internalformat` values regardless of enabled extensions.

Fixes #3453.