### PR TITLE
Test unextended get*Parameter results

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-draw-buffers.html
+++ b/sdk/tests/conformance/extensions/webgl-draw-buffers.html
@@ -192,7 +192,7 @@ function runEnumTestDisabled() {
   // Use the constant directly as we don't have the extension
   extensionConstants.forEach(function(c) {
     if (c.expectedFn) {
-      gl.getParameter(c.enum);
+      shouldBeNull(`gl.getParameter(${c.enum})`);
       wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, c.name + " should not be queryable if extension is disabled");
     }
   });

--- a/sdk/tests/conformance2/extensions/oes-draw-buffers-indexed.html
+++ b/sdk/tests/conformance2/extensions/oes-draw-buffers-indexed.html
@@ -303,19 +303,19 @@ function runTestExtension() {
 
 function runInvalidEnumsTest() {
     debug("Testing new enums for getIndexedParameterTest being invalid before requesting the extension");
-    gl.getIndexedParameter(0x8009, 0);  // BLEND_EQUATION_RGB
+    shouldBeNull("gl.getIndexedParameter(0x8009, 0)");  // BLEND_EQUATION_RGB
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, 'BLEND_EQUATION_RGB');
-    gl.getIndexedParameter(0x883D, 0);  // BLEND_EQUATION_ALPHA
+    shouldBeNull("gl.getIndexedParameter(0x883D, 0)");  // BLEND_EQUATION_ALPHA
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, 'BLEND_EQUATION_ALPHA');
-    gl.getIndexedParameter(0x80C9, 0);  // BLEND_SRC_RGB
+    shouldBeNull("gl.getIndexedParameter(0x80C9, 0)");  // BLEND_SRC_RGB
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, 'BLEND_SRC_RGB');
-    gl.getIndexedParameter(0x80CB, 0);  // BLEND_SRC_ALPHA
+    shouldBeNull("gl.getIndexedParameter(0x80CB, 0)");  // BLEND_SRC_ALPHA
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, 'BLEND_SRC_ALPHA');
-    gl.getIndexedParameter(0x80C8, 0);  // BLEND_DST_RGB
+    shouldBeNull("gl.getIndexedParameter(0x80C8, 0)");  // BLEND_DST_RGB
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, 'BLEND_DST_RGB');
-    gl.getIndexedParameter(0x80CA, 0);  // BLEND_DST_ALPHA
+    shouldBeNull("gl.getIndexedParameter(0x80CA, 0)");  // BLEND_DST_ALPHA
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, 'BLEND_DST_ALPHA');
-    gl.getIndexedParameter(0x0C23, 0);  // COLOR_WRITEMASK
+    shouldBeNull("gl.getIndexedParameter(0x0C23, 0)");  // COLOR_WRITEMASK
     wtu.glErrorShouldBe(gl, [gl.INVALID_OPERATION, gl.INVALID_ENUM], 'invalid operations or invalid enums for COLOR_WRITEMASK');
 }
 

--- a/sdk/tests/js/tests/ext-texture-filter-anisotropic.js
+++ b/sdk/tests/js/tests/ext-texture-filter-anisotropic.js
@@ -7,6 +7,7 @@ let wtu = WebGLTestUtils;
 let canvas = document.getElementById("canvas");
 let gl = wtu.create3DContext(canvas, undefined, contextVersion);
 let ext = null;
+let sampler;
 
 if (!gl) {
     testFailed("WebGL context does not exist");
@@ -57,7 +58,7 @@ function runHintTestDisabled() {
     debug("Testing MAX_TEXTURE_MAX_ANISOTROPY_EXT with extension disabled");
 
     const MAX_TEXTURE_MAX_ANISOTROPY_EXT = 0x84FF;
-    gl.getParameter(MAX_TEXTURE_MAX_ANISOTROPY_EXT);
+    shouldBeNull(`gl.getParameter(${MAX_TEXTURE_MAX_ANISOTROPY_EXT})`);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "MAX_TEXTURE_MAX_ANISOTROPY_EXT should not be queryable if extension is disabled");
 
     debug("Testing TEXTURE_MAX_ANISOTROPY_EXT with extension disabled");
@@ -65,7 +66,7 @@ function runHintTestDisabled() {
     let texture = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, texture);
 
-    gl.getTexParameter(gl.TEXTURE_2D, TEXTURE_MAX_ANISOTROPY_EXT);
+    shouldBeNull(`gl.getTexParameter(gl.TEXTURE_2D, ${TEXTURE_MAX_ANISOTROPY_EXT})`);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "TEXTURE_MAX_ANISOTROPY_EXT should not be queryable if extension is disabled");
 
     gl.texParameterf(gl.TEXTURE_2D, TEXTURE_MAX_ANISOTROPY_EXT, 1);
@@ -141,10 +142,12 @@ function runHintTestEnabled() {
 }
 
 function runSamplerTestDisabled() {
-    let sampler = gl.createSampler();
+    sampler = gl.createSampler();
     const TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE;
     gl.samplerParameterf(sampler, TEXTURE_MAX_ANISOTROPY_EXT, 1.0);
     wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "setting TEXTURE_MAX_ANISOTROPY_EXT on sampler without extension enabled should fail");
+    shouldBeNull(`gl.getSamplerParameter(sampler, ${TEXTURE_MAX_ANISOTROPY_EXT})`);
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "querying TEXTURE_MAX_ANISOTROPY_EXT on sampler without extension enabled should fail");
     gl.deleteSampler(sampler);
 }
 


### PR DESCRIPTION
Check that `get*Parameter` functions return `null` (instead of `0` or `false`, like native GL) when unextended.