### PR TITLE
Fix typo in texture-video-transparent

### DIFF
--- a/sdk/tests/conformance/textures/misc/texture-video-transparent.html
+++ b/sdk/tests/conformance/textures/misc/texture-video-transparent.html
@@ -47,7 +47,7 @@ function init()
         return;
     }
     if (!video.canPlayType(type).replace(/no/, '')) {
-        debug(info.type + " unsupported");
+        debug(type + " unsupported");
         finishTest();
         return;
     };


### PR DESCRIPTION
Avoid JS error when WebM support is not present.