### PR TITLE
Log visibility upon load in two video tests.

### DIFF
--- a/sdk/tests/conformance/textures/misc/texture-npot-video.html
+++ b/sdk/tests/conformance/textures/misc/texture-npot-video.html
@@ -19,11 +19,25 @@ var successfullyParsed = false;
 
 initTestingHarness();
 
+function logVisibility(isOnload)
+{
+    let prefix = '';
+    if (isOnload)
+        prefix = 'Upon load: ';
+    if (document.hidden) {
+        console.log(prefix + '*** Tab was backgrounded (if running in automated test harness, why?) ***');
+    } else {
+        console.log(prefix + 'Tab was foregrounded');
+    }
+}
+
 function init()
 {
     description('Verify npot video');
 
     document.addEventListener("visibilitychange", visibilityChanged, false);
+
+    logVisibility(true);
 
     var canvas = document.getElementById("example");
     gl = wtu.create3DContext(canvas);
@@ -42,11 +56,7 @@ function init()
 }
 
 function visibilityChanged() {
-    if (document.hidden) {
-        console.log('*** Tab was backgrounded (if running in automated test harness, why?) ***');
-    } else {
-        console.log('Tab was foregrounded');
-    }
+    logVisibility(false);
 }
 
 function runOneIteration(videoElement, useTexSubImage2D, flipY, topColor, bottomColor, badMinFilter, badClamp, genMips)

--- a/sdk/tests/conformance/textures/misc/texture-video-transparent.html
+++ b/sdk/tests/conformance/textures/misc/texture-video-transparent.html
@@ -20,11 +20,25 @@ let video;
 
 initTestingHarness();
 
+function logVisibility(isOnload)
+{
+    let prefix = '';
+    if (isOnload)
+        prefix = 'Upon load: ';
+    if (document.hidden) {
+        console.log(prefix + '*** Tab was backgrounded (if running in automated test harness, why?) ***');
+    } else {
+        console.log(prefix + 'Tab was foregrounded');
+    }
+}
+
 function init()
 {
     description("Upload texture from animating transparent WebM");
 
     document.addEventListener("visibilitychange", visibilityChanged, false);
+
+    logVisibility(true);
 
     const canvas = document.getElementById("example");
     gl = wtu.create3DContext(canvas);
@@ -55,11 +69,7 @@ function init()
 }
 
 function visibilityChanged() {
-    if (document.hidden) {
-        console.log('*** Tab was backgrounded (if running in automated test harness, why?) ***');
-    } else {
-        console.log('Tab was foregrounded');
-    }
+    logVisibility(false);
 }
 
 function runTest(videoElement)


### PR DESCRIPTION
The visibility of these tests isn't changing at runtime; log the
visibility state upon load as well.

Follow-on to #3421.

Associated with http://crbug.com/1293967 .