### PR TITLE
Fix & expand blend color clamping test

### DIFF
--- a/extensions/EXT_color_buffer_float/extension.xml
+++ b/extensions/EXT_color_buffer_float/extension.xml
@@ -53,10 +53,6 @@
         <li>Fragment shader outputs to buffers with these internal formats are
         not clamped.</li>
 
-        <li>Colors specified with <code>clearColor</code> and
-        <code>blendColor</code> are not clamped when applied to buffers with
-        these internal formats.</li>
-
         <li>The format and type combination <code>RGBA</code> and
         <code>UNSIGNED_BYTE</code> cannot be used for reading from a
         floating-point color buffer.</li>

--- a/extensions/EXT_color_buffer_half_float/extension.xml
+++ b/extensions/EXT_color_buffer_half_float/extension.xml
@@ -48,7 +48,7 @@
 
       <feature>
         <p><b>In WebGL 2.0 contexts</b>, the 16-bit floating-point types
-        <code>RGBA16F,</code>, <code>RG16F</code> and <code>R16F</code> become
+        <code>RGBA16F</code>, <code>RG16F</code>, and <code>R16F</code> become
         available as color-renderable formats.  Renderbuffers can be created in
         these formats. These and textures created with <code>type =
         HALF_FLOAT</code>, which will have one of these internal formats, can be
@@ -60,11 +60,19 @@
 
       <feature>
         <p><span style="color: red">NOTE:</span> fragment shaders' outputs
-        gl_FragColor and gl_FragData[0] will only be clamped and converted when
-        the color buffer is fixed-point, and <code>blendColor()</code> and
-        <code>clearColor()</code> will no longer clamp their parameter values on
+        <code>gl_FragColor</code> and <code>gl_FragData[0]</code> will only be
+        clamped and converted when the color buffer is fixed-point, and
+        <code>clearColor()</code> will no longer clamp its parameter values on
         input. Clamping will be applied as necessary at draw time according to
         the type of color buffer in use.</p>
+      </feature>
+
+      <feature>
+        <p>If the implementation supports unclamped blend color, the
+        <code>blendColor()</code> will no longer clamp its parameter values on
+        input. Clamping will be applied as necessary at draw time according to
+        the type of color buffer in use. Applications may check the effective
+        blend color with <code>getParameter</code>.</p>
       </feature>
 
       <feature>

--- a/extensions/WEBGL_color_buffer_float/extension.xml
+++ b/extensions/WEBGL_color_buffer_float/extension.xml
@@ -50,11 +50,19 @@
 
       <feature>
         <p><span style="color: red">NOTE:</span> fragment shaders outputs
-        gl_FragColor and gl_FragData[0] will only be clamped and converted
-        when the color buffer is fixed-point and <code>blendColor()</code> and
-        <code>clearColor()</code> will no longer clamp their parameter values
+        <code>gl_FragColor</code> and <code>gl_FragData[0]</code> will only be
+        clamped and converted when the color buffer is fixed-point and
+        <code>clearColor()</code> will no longer clamp its parameter values
         on input. Clamping will be applied as necessary at draw time according
         to the type of color buffer in use.</p>
+      </feature>
+
+      <feature>
+        <p>If the implementation supports unclamped blend color, the
+        <code>blendColor()</code> will no longer clamp its parameter values on
+        input. Clamping will be applied as necessary at draw time according to
+        the type of color buffer in use. Applications may check the effective
+        blend color with <code>getParameter</code>.</p>
       </feature>
 
       <feature>

--- a/sdk/tests/conformance/rendering/blending.html
+++ b/sdk/tests/conformance/rendering/blending.html
@@ -66,7 +66,6 @@ function CreateContext() {
 
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.CONSTANT_COLOR, gl.ZERO);
-    gl.blendColor(10, 1, 1, 1);
 
     return gl;
 }
@@ -120,8 +119,8 @@ const TESTS = [
         debug('Clamping of blendColor args:');
 
         const gl = wtu.create3DContext();
-        if (!gl.texImage3D) { // webgl1
-            // WebGL 1 clamps without EXT_color_buffer_half_float or WEBGL_color_buffer_float.
+        if (!gl.texImage3D) { // WebGL 1.0
+            // WebGL 1.0 clamps without EXT_color_buffer_half_float or WEBGL_color_buffer_float.
             gl.blendColor(1000, 1, 1, 1);
             const was = gl.getParameter(gl.BLEND_COLOR);
             expectArray(was, [1, 1, 1, 1]);
@@ -131,7 +130,7 @@ const TESTS = [
             if (!ext) return;
         }
 
-        // WebGL 2, or 1 with EXT_color_buffer_half_float or WEBGL_color_buffer_float
+        // WebGL 2.0, or 1.0 with EXT_color_buffer_half_float or WEBGL_color_buffer_float
         // do not clamp at blendColor invocation.
         // (but clamping will still happen at draw time for non-float formats)
         gl.blendColor(1000, 1, 1, 1);
@@ -146,13 +145,17 @@ const TESTS = [
         fb = CreateValidFb(gl, [[gl.RGBA8, gl.RGBA, gl.UNSIGNED_BYTE]]);
         shouldBeNonNull('fb');
 
+        // Regardless of the context version and enabled extensions,
+        // the value will be clamped at draw time,
+        gl.blendColor(10, 1, 1, 1);
         const was = gl.drawAndRead(gl.UNSIGNED_BYTE);
         expectArray(was, [1, 2, 3, 4]);
 
-        if (gl.getExtension('EXT_color_buffer_float') ||
-            gl.getExtension('EXT_color_buffer_half_float'))
+        if (gl.getExtension('EXT_color_buffer_half_float') ||
+            gl.getExtension('WEBGL_color_buffer_float') ||
+            gl.getExtension('EXT_color_buffer_float'))
         {
-            debug('Enable color_buffer_half_float and retest');
+            debug('Enable floating-point color buffers and retest');
             gl.blendColor(1000, 1, 1, 1);
             const was = gl.drawAndRead(gl.UNSIGNED_BYTE);
             expectArray(was, [1, 2, 3, 4]);
@@ -163,16 +166,15 @@ const TESTS = [
         debug('Blending for RGBA16F:');
 
         const gl = CreateContext();
-        if (gl.blitFramebuffer) {
-            if (!gl.getExtension('EXT_color_buffer_float')) {
-                testPassed('Missing ext EXT_color_buffer_float is optional, skipping.');
-                return;
-            }
-        } else {
-            if (!gl.getExtension('EXT_color_buffer_half_float')) {
-                testPassed('Missing ext EXT_color_buffer_half_float is optional, skipping.');
-                return;
-            }
+
+        // Set the value before enabling the extension.
+        // It must be clamped only on WebGL 1.0 contexts.
+        gl.blendColor(10, 1, 1, 1);
+        if (!gl.getExtension('EXT_color_buffer_half_float')) {
+            testPassed('Missing ext EXT_color_buffer_half_float is optional, skipping.');
+            return;
+        }
+        if (!gl.texImage3D) { // WebGL 1.0
             const ext = gl.getExtension('OES_texture_half_float');
             gl.HALF_FLOAT = ext.HALF_FLOAT_OES; // These aren't the same value, but this'll work.
         }
@@ -180,15 +182,29 @@ const TESTS = [
         fb = CreateValidFb(gl, [[gl.RGBA16F, gl.RGBA, gl.HALF_FLOAT]]);
         shouldBeNonNull('fb');
         gl.prog.uColor([1, 2, 3, 4]);
-        const was = gl.drawAndRead(gl.FLOAT);
-        expectArray(was, [10, 2, 3, 4]);
+
+        let was = gl.drawAndRead(gl.FLOAT);
+        if (!gl.texImage3D) { // WebGL 1.0
+            expectArray(was, [1, 2, 3, 4]);
+        } else {
+            expectArray(was, [10, 2, 3, 4]);
+        }
+
+        // Re-set the value after the extension was enabled.
+        gl.blendColor(100, 1, 1, 1);
+        was = gl.drawAndRead(gl.FLOAT);
+        expectArray(was, [100, 2, 3, 4]);
     },
     () => {
         debug('');
         debug('Blending for RGBA32F:');
 
         const gl = CreateContext();
-        if (gl.blitFramebuffer) {
+
+        // Set the value before enabling the extension.
+        // It must be clamped only on WebGL 1.0 contexts.
+        gl.blendColor(10, 1, 1, 1);
+        if (gl.texImage3D) { // WebGL 2.0
             if (!gl.getExtension('EXT_color_buffer_float')) {
                 testPassed('Missing ext EXT_color_buffer_float is optional, skipping.');
                 return;
@@ -203,14 +219,24 @@ const TESTS = [
         fb = CreateValidFb(gl, [[gl.RGBA32F, gl.RGBA, gl.FLOAT]]);
         shouldBeNonNull('fb');
         gl.prog.uColor([1, 2, 3, 4]);
-        const was = gl.drawAndRead(gl.FLOAT);
+
+        let was = gl.drawAndRead(gl.FLOAT);
+        if (!gl.texImage3D) { // WebGL 1.0
+            expectArray(was, [1, 2, 3, 4]);
+        } else {
+            expectArray(was, [10, 2, 3, 4]);
+        }
+
+        // Re-set the value after the extension was enabled.
+        gl.blendColor(100, 1, 1, 1);
+        was = gl.drawAndRead(gl.FLOAT);
 
         if (!gl.getExtension('EXT_float_blend')) {
             wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, 'Should not be able to blend 32F formats.');
             return;
         }
         wtu.glErrorShouldBe(gl, 0, 'Should be able to blend 32F formats.');
-        expectArray(was, [10, 2, 3, 4]);
+        expectArray(was, [100, 2, 3, 4]);
     },
 ];
 

--- a/sdk/tests/conformance/rendering/blending.html
+++ b/sdk/tests/conformance/rendering/blending.html
@@ -130,12 +130,16 @@ const TESTS = [
             if (!ext) return;
         }
 
-        // WebGL 2.0, or 1.0 with EXT_color_buffer_half_float or WEBGL_color_buffer_float
-        // do not clamp at blendColor invocation.
-        // (but clamping will still happen at draw time for non-float formats)
+        // WebGL 2.0 or extended WebGL 1.0 may still clamp the value on store
+        // when the underlying platform does the same.
         gl.blendColor(1000, 1, 1, 1);
         const was = gl.getParameter(gl.BLEND_COLOR);
-        expectArray(was, [1000, 1, 1, 1]);
+        if (was[0] == 1000) {
+            expectArray(was, [1000, 1, 1, 1]);
+        } else {
+            debug("Platform does not support unclamped blend color.")
+            expectArray(was, [1, 1, 1, 1]);
+        }
     },
     () => {
         debug('');
@@ -187,13 +191,16 @@ const TESTS = [
         if (!gl.texImage3D) { // WebGL 1.0
             expectArray(was, [1, 2, 3, 4]);
         } else {
-            expectArray(was, [10, 2, 3, 4]);
+            // Some WebGL 2.0 implementations may clamp the blend color anyway.
+            const r = gl.getParameter(gl.BLEND_COLOR)[0];
+            expectArray(was, [r, 2, 3, 4]);
         }
 
         // Re-set the value after the extension was enabled.
         gl.blendColor(100, 1, 1, 1);
+        const r = gl.getParameter(gl.BLEND_COLOR)[0];
         was = gl.drawAndRead(gl.FLOAT);
-        expectArray(was, [100, 2, 3, 4]);
+        expectArray(was, [r, 2, 3, 4]);
     },
     () => {
         debug('');
@@ -224,11 +231,14 @@ const TESTS = [
         if (!gl.texImage3D) { // WebGL 1.0
             expectArray(was, [1, 2, 3, 4]);
         } else {
-            expectArray(was, [10, 2, 3, 4]);
+            // Some WebGL 2.0 implementations may clamp the blend color anyway.
+            const r = gl.getParameter(gl.BLEND_COLOR)[0];
+            expectArray(was, [r, 2, 3, 4]);
         }
 
         // Re-set the value after the extension was enabled.
         gl.blendColor(100, 1, 1, 1);
+        const r = gl.getParameter(gl.BLEND_COLOR)[0];
         was = gl.drawAndRead(gl.FLOAT);
 
         if (!gl.getExtension('EXT_float_blend')) {
@@ -236,7 +246,7 @@ const TESTS = [
             return;
         }
         wtu.glErrorShouldBe(gl, 0, 'Should be able to blend 32F formats.');
-        expectArray(was, [100, 2, 3, 4]);
+        expectArray(was, [r, 2, 3, 4]);
     },
 ];
 

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -4407,6 +4407,13 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
            to be liberal here, though implementations may warn on requests for this functionality.</p>
     </div>
 
+    <h3><a name="CLAMPED_BLEND_COLOR">Clamped Constant Blend Color</a></h3>
+    <p>
+        Implementations may clamp constant blend color on store when
+        the underlying platform does the same. Applications may query
+        <code>BLEND_COLOR</code> parameter to check the effective behavior.
+    </p>
+
 <!-- ======================================================================================================= -->
 
     <h2>References</h2>


### PR DESCRIPTION
This PR updates the test to match the spec. Notable failures:
1. Firefox does not clamp constant blend color on store on unextended WebGL 1.0.
2. Adreno drivers clamp constant blend color internally even on ES 3.2 contexts and correctly reflect that via `getFloatv(GL_BLEND_COLOR, ...)` query.

Instead of permanently suppressing the test on [2], we may consider making this behavior implementation-dependent.