### PR TITLE
getBufferSubData with offset ArrayBufferView

### DIFF
--- a/sdk/tests/conformance2/buffers/get-buffer-sub-data.html
+++ b/sdk/tests/conformance2/buffers/get-buffer-sub-data.html
@@ -59,17 +59,7 @@ shouldThrow("gl.getBufferSubData(gl.ARRAY_BUFFER, 0, null)");
 wtu.glErrorShouldBe(gl, gl.NO_ERROR, "Should not generate GL error");
 
 debug("Check array data to match original data set by the buffer");
-var failed = false;
-for (var i = 0; i < vertices.length; i++) {
-  if (floatArray[i] != retArray[i]) {
-    failed = true;
-    break;
-  }
-}
-if (failed)
-  testFailed("The returned array buffer fails to match original data");
-else
-  testPassed("The returned array buffer matches original data");
+shouldBeTrue("areArraysEqual(retArray, floatArray)");
 
 debug("Test that getBufferSubData successfully works with dstOffset");
 retArray = new Float32Array(vertices.length);
@@ -99,17 +89,95 @@ shouldBeTrue("areArraysEqual(retArray.slice(8), floatArray.slice(0, 1))");
 debug("Test that getBufferSubData fails when given a dstOffset+length beyond the end of retArray");
 wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray, retArray.length - 1, 2)");
 
+debug("Test that getBufferSubData successfully works with srcByteOffset");
+retArray = new Float32Array(vertices.length - 2);
+const float32Size = Float32Array.BYTES_PER_ELEMENT;
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 2*float32Size, retArray)");
+shouldBeTrue("areArraysEqual(retArray, floatArray.slice(2))");
+
+retArray = new Float32Array(vertices.length);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 2*float32Size, retArray, 2)");
+shouldBeTrue("areArraysEqual(retArray.slice(0, 2), [0, 0])");
+shouldBeTrue("areArraysEqual(retArray.slice(2), floatArray.slice(2))");
+
+retArray = new Float32Array(vertices.length);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 4*float32Size, retArray, 3, 3)");
+shouldBeTrue("areArraysEqual(retArray.slice(0, 3), [0, 0, 0])");
+shouldBeTrue("areArraysEqual(retArray.slice(3, 6), floatArray.slice(4, 7))");
+shouldBeTrue("areArraysEqual(retArray.slice(6), [0, 0, 0])");
+
 debug("Test that getBufferSubData fails when given a buffer with its size larger than the original data");
 var extraLargeBuffer = new Float32Array(vertices.length + 1);
-gl.getBufferSubData(gl.ARRAY_BUFFER, 0, extraLargeBuffer);
 wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE,
                           "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, extraLargeBuffer)",
+                          "Extra length should generate INVALID_VALUE.");
+extraLargeBuffer = new Float32Array(vertices.length - 1);
+wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE,
+                          "gl.getBufferSubData(gl.ARRAY_BUFFER, 2*float32Size, extraLargeBuffer)",
                           "Extra length should generate INVALID_VALUE.");
 
 debug("Test that getBufferSubData fails when offset summed with buffer length is larger than the size of the original data size");
 wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE,
                           "gl.getBufferSubData(gl.ARRAY_BUFFER, retArray.byteLength + 1, retArray)");
 wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "gl.getBufferSubData(gl.ARRAY_BUFFER, 1, retArray)");
+
+debug("Test that getBufferSubData successfully works with offset view into ArrayBuffer");
+const verticesLengthInBytes = vertices.length * float32Size;
+const retStorage = new ArrayBuffer(4* verticesLengthInBytes); // Over allocate 4x
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray)");
+shouldBeTrue("areArraysEqual(retArray, floatArray)");
+
+debug("Test that getBufferSubData successfully works with offset view into ArrayBuffer and dstOffset");
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length);
+retArray.fill(0);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray, 2)");
+shouldBeTrue("areArraysEqual(retArray.slice(0, 2), [0, 0])");
+shouldBeTrue("areArraysEqual(retArray.slice(2), floatArray.slice(0, floatArray.length - 2))");
+
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length);
+retArray.fill(0);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray, retArray.length)");
+shouldBeTrue("areArraysEqual(retArray, [0, 0, 0, 0, 0, 0, 0, 0, 0])");
+
+debug("Test that getBufferSubData fails when given a dstOffset beyond the end of offset view into ArrayBuffer");
+wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray, retArray.length + 1)");
+
+debug("Test that getBufferSubData successfully works with offset view into ArrayBuffer and dstOffset and length");
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length);
+retArray.fill(0);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray, 2, 2)");
+shouldBeTrue("areArraysEqual(retArray.slice(0, 2), [0, 0])");
+shouldBeTrue("areArraysEqual(retArray.slice(2, 4), floatArray.slice(0, 2))");
+shouldBeTrue("areArraysEqual(retArray.slice(4), [0, 0, 0, 0, 0])");
+
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length);
+retArray.fill(0);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray, retArray.length - 1, 1)");
+shouldBeTrue("areArraysEqual(retArray.slice(0, 8), [0, 0, 0, 0, 0, 0, 0, 0])");
+shouldBeTrue("areArraysEqual(retArray.slice(8), floatArray.slice(0, 1))");
+
+debug("Test that getBufferSubData fails when given a dstOffset+length beyond the end of offset view into ArrayBuffer");
+wtu.shouldGenerateGLError(gl, gl.INVALID_VALUE, "gl.getBufferSubData(gl.ARRAY_BUFFER, 0, retArray, retArray.length - 1, 2)");
+
+debug("Test that getBufferSubData successfully works with offset view into ArrayBuffer and srcByteOffset");
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length - 2);
+retArray.fill(0);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 2*float32Size, retArray)");
+shouldBeTrue("areArraysEqual(retArray, floatArray.slice(2))");
+
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length);
+retArray.fill(0);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 2*float32Size, retArray, 2)");
+shouldBeTrue("areArraysEqual(retArray.slice(0, 2), [0, 0])");
+shouldBeTrue("areArraysEqual(retArray.slice(2), floatArray.slice(2))");
+
+retArray = new Float32Array(retStorage, verticesLengthInBytes, vertices.length);
+retArray.fill(0);
+wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.getBufferSubData(gl.ARRAY_BUFFER, 4*float32Size, retArray, 3, 3)");
+shouldBeTrue("areArraysEqual(retArray.slice(0, 3), [0, 0, 0])");
+shouldBeTrue("areArraysEqual(retArray.slice(3, 6), floatArray.slice(4, 7))");
+shouldBeTrue("areArraysEqual(retArray.slice(6), [0, 0, 0])");
 
 debug("Test that getBufferSubData fails when 0 is bound to the target");
 gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, null);


### PR DESCRIPTION
Add tests where the destination for the data returned by `getBufferSubData` does
not coincide with the beginning of array storage.