### PR TITLE
Expand simultaneous XFB binding test

### DIFF
--- a/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
+++ b/sdk/tests/conformance2/transform_feedback/simultaneous_binding.html
@@ -304,6 +304,17 @@ for (let genericBindPointValue of genericBindPointValues) {
   gl.copyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, 1);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "copyBufferSubData with double bound buffer");
 
+  debug("<hr/>Test that rejected operations do not change the bound buffer size");
+
+  gl.bindBuffer(gl.ARRAY_BUFFER, tfBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, 8, gl.STATIC_DRAW);
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "bufferData with double bound buffer");
+
+  gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+  gl.bufferSubData(gl.ARRAY_BUFFER, 0, new Uint8Array(16));
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "bufferSubData should succeed");
+  gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
   debug("<hr/>Test bufferData family with tf object unbound");
 
   gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);


### PR DESCRIPTION
When a `bufferData` call is rejected due to simultaneous bindings, the bound buffer size must not reset. The new test fails in Chromium, passes in WebKit and Firefox.