### PR TITLE
Add depth-stencil type and null read receiver tests

### DIFF
--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -39,6 +39,18 @@ function runTest(canvas, antialias) {
   gl = wtu.create3DContext(canvas, {antialias: antialias});
   var contextVersion = wtu.getDefault3DContextVersion();
 
+  debug("");
+  debug("Test null receiver");
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, null);
+  wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
+
+  debug("");
+  debug("Test combined depth-stencil type");
+  // The combined type is undefined in WebGL 1.0 and never allowed as a read type in WebGL 2.0
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, 0x8DAD /* FLOAT_32_UNSIGNED_INT_24_8_REV */, new Uint8Array(32));
+  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
   var width = 2;
   var height = 2;
   var continueTestFunc = continueTestPart1;

--- a/sdk/tests/conformance/reading/read-pixels-test.html
+++ b/sdk/tests/conformance/reading/read-pixels-test.html
@@ -40,16 +40,41 @@ function runTest(canvas, antialias) {
   var contextVersion = wtu.getDefault3DContextVersion();
 
   debug("");
-  debug("Test null receiver");
+  debug("Test null pixels");
   gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, null);
-  wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
+  wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "null pixels");
+
+  debug("");
+  debug("Test pixels size");
+  gl.readPixels(0, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(0));
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "empty pixels array with 0x0 read data");
+  gl.readPixels(0, 0, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(0));
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "empty pixels array with 1x0 read data");
+  gl.readPixels(0, 0, 0, 1, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(0));
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "empty pixels array with 0x1 read data");
+  gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(3));
+  wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "small pixels array for 1x1 read data");
+  if (contextVersion >= 2) {
+    gl.readPixels(0, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(0), 1);
+    wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "offset is greater than array size");
+    gl.readPixels(0, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(1), 1);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "no space left in pixels array with 0x0 read data");
+    gl.readPixels(0, 0, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(1), 1);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "no space left in pixels array with 1x0 read data");
+    gl.readPixels(0, 0, 0, 1, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(1), 1);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "no space left in pixels array with 0x1 read data");
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(4), 1);
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION, "no space left in pixels array with 1x1 read data");
+    gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(5), 1);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "read 1x1 data fits into pixels with offset");
+  }
 
   debug("");
   debug("Test combined depth-stencil type");
   // The combined type is undefined in WebGL 1.0 and never allowed as a read type in WebGL 2.0
   gl.readPixels(0, 0, 1, 1, gl.RGBA, 0x8DAD /* FLOAT_32_UNSIGNED_INT_24_8_REV */, new Uint8Array(32));
-  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM);
-  wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "FLOAT_32_UNSIGNED_INT_24_8_REV is rejected");
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "no extra error generated");
 
   var width = 2;
   var height = 2;

--- a/sdk/tests/conformance2/textures/misc/tex-new-formats.html
+++ b/sdk/tests/conformance2/textures/misc/tex-new-formats.html
@@ -37,6 +37,7 @@ if (!gl) {
     testPassed("WebGL context exists");
 
     runTexFormatsTest();
+    runDepthStencilFormatTest();
 
     wtu.glErrorShouldBe(gl, gl.NO_ERROR, "there should be no errors");
 }
@@ -554,6 +555,35 @@ function runTexFormatsTest()
             }
         }
     });
+}
+
+function runDepthStencilFormatTest() {
+    debug("");
+    debug("Testing FLOAT_32_UNSIGNED_INT_24_8_REV with data");
+    const fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+
+    const tex2D = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex2D);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH32F_STENCIL8, 1, 1, 0, gl.DEPTH_STENCIL, gl.FLOAT_32_UNSIGNED_INT_24_8_REV, new Uint8Array(8));
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.TEXTURE_2D, tex2D, 0);
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) == gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("2D texture with invalid type was created");
+    } else {
+        testPassed("2D texture with invalid type was not created")
+    }
+
+    const tex3D = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D_ARRAY, tex3D);
+    gl.texImage3D(gl.TEXTURE_2D_ARRAY, 0, gl.DEPTH32F_STENCIL8, 1, 1, 1, 0, gl.DEPTH_STENCIL, gl.FLOAT_32_UNSIGNED_INT_24_8_REV, new Uint8Array(8));
+    wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION);
+    gl.framebufferTextureLayer(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, tex3D, 0, 0);
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) == gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("2D array texture with invalid type was created");
+    } else {
+        testPassed("2D array texture with invalid type was not created")
+    }
 }
 
 debug("");


### PR DESCRIPTION
All new assertions fail in WebKit, pass in Chromium & Firefox.