### PR TITLE
Test compressed formats rejection with texStorage

### DIFF
--- a/sdk/tests/js/tests/compressed-texture-utils.js
+++ b/sdk/tests/js/tests/compressed-texture-utils.js
@@ -69,7 +69,7 @@ let testCompressedFormatsUnavailableWhenExtensionDisabled = function(gl, compres
             wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Trying to use format " + name + " with extension disabled.");
             if (gl.texStorage2D) {
                 gl.texStorage2D(gl.TEXTURE_2D, 1, compressedFormats[name], testSize, testSize);
-                wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Trying to use format " + name + " with extension disabled.");
+                wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Trying to use format " + name + " with texStorage2D with extension disabled.");
             }
         }
     }

--- a/sdk/tests/js/tests/compressed-texture-utils.js
+++ b/sdk/tests/js/tests/compressed-texture-utils.js
@@ -67,6 +67,10 @@ let testCompressedFormatsUnavailableWhenExtensionDisabled = function(gl, compres
         if (compressedFormats.hasOwnProperty(name)) {
             gl.compressedTexImage2D(gl.TEXTURE_2D, 0, compressedFormats[name], testSize, testSize, 0, new Uint8Array(expectedByteLength(testSize, testSize, compressedFormats[name])));
             wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Trying to use format " + name + " with extension disabled.");
+            if (gl.texStorage2D) {
+                gl.texStorage2D(gl.TEXTURE_2D, 1, compressedFormats[name], testSize, testSize);
+                wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "Trying to use format " + name + " with extension disabled.");
+            }
         }
     }
     gl.bindTexture(gl.TEXTURE_2D, null);


### PR DESCRIPTION
In `GLES2DecoderPassthroughImpl::Initialize`, Chromium implicitly enables many requestable extensions, including those that provide compressed texture formats; the `texStorage` calls defer all validation to ANGLE, and that's why the tests fail there for ASTC, ETC1, S3TC, and S3TC sRGB extensions.

~~On top of that, ANGLE currently behaves as if ETC2/EAC formats are always supported for ES 3.x clients, even in WebGL compatibility mode. WebKit also defers all `texStorage` validation to ANGLE, so ETC2/EAC tests fail both in Chromium and WebKit with this PR.~~