### PR TITLE
Fix quiet mode test reporting

### DIFF
--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -268,9 +268,9 @@ function getCurrentTestName()
  */
 function testPassedOptions(msg, addSpan)
 {
+    reportTestResultsToHarness(true, _currentTestName + ": " + msg);
     if (addSpan && !quietMode())
     {
-        reportTestResultsToHarness(true, _currentTestName + ": " + msg);
         _addSpan('<span><span class="pass">PASS</span> ' + escapeHTML(_currentTestName) + ": " + escapeHTML(msg) + '</span>');
     }
     if (_jsTestPreVerboseLogging) {
@@ -285,9 +285,9 @@ function testPassedOptions(msg, addSpan)
  */
 function testSkippedOptions(msg, addSpan)
 {
+    reportSkippedTestResultsToHarness(true, _currentTestName + ": " + msg);
     if (addSpan && !quietMode())
     {
-        reportSkippedTestResultsToHarness(true, _currentTestName + ": " + msg);
         _addSpan('<span><span class="warn">SKIP</span> ' + escapeHTML(_currentTestName) + ": " + escapeHTML(msg) + '</span>');
     }
     if (_jsTestPreVerboseLogging) {


### PR DESCRIPTION
Fixes testPassedOptions and testSkippedOptions only reporting
results when actually adding the <span> to the page. The test
harness should be notified when a test is done regardless of
whether the page contents are going to be modified.