### PR TITLE
Cache window values

### DIFF
--- a/sdk/tests/js/js-test-pre.js
+++ b/sdk/tests/js/js-test-pre.js
@@ -93,20 +93,25 @@ const RESULTS = {
   fail: 0,
 };
 
+// We cache these values since they will potentially be accessed many (100k+)
+// times and accessing window can be significantly slower than a local variable.
+const locationPathname = window.location.pathname;
+const webglTestHarness = window.parent.webglTestHarness;
+
 function reportTestResultsToHarness(success, msg) {
   if (success) {
     RESULTS.pass += 1;
   } else {
     RESULTS.fail += 1;
   }
-  if (window.parent.webglTestHarness) {
-    window.parent.webglTestHarness.reportResults(window.location.pathname, success, msg);
+  if (webglTestHarness) {
+    webglTestHarness.reportResults(locationPathname, success, msg);
   }
 }
 
 function reportSkippedTestResultsToHarness(success, msg) {
-  if (window.parent.webglTestHarness) {
-    window.parent.webglTestHarness.reportResults(window.location.pathname, success, msg, true);
+  if (webglTestHarness) {
+    webglTestHarness.reportResults(locationPathname, success, msg, true);
   }
 }
 
@@ -116,8 +121,8 @@ function notifyFinishedToHarness() {
   }
   window._didNotifyFinishedToHarness = true;
 
-  if (window.parent.webglTestHarness) {
-    window.parent.webglTestHarness.notifyFinished(window.location.pathname);
+  if (webglTestHarness) {
+    webglTestHarness.notifyFinished(locationPathname);
   }
   if (window.nonKhronosFrameworkNotifyDone) {
     window.nonKhronosFrameworkNotifyDone();


### PR DESCRIPTION
Adds caching for window.location.pathname and
window.parent.webglTestHarness. These values are accessed every
time reportTestResultsToHarness is called and accessing a variable
via window can be significantly slower than a local copy.

As an extreme example,
deqp/functional/gles3/vertexarrays/multiple_attributes.output.html
reports 33,013,505 results. On my local machine with Chromium, the
test takes ~20 seconds with this fix and ~215 seconds without it.

Related to crbug.com/1357073.