### PR TITLE
Test calling getUniform from non-current program

### DIFF
--- a/sdk/tests/conformance/uniforms/00_test_list.txt
+++ b/sdk/tests/conformance/uniforms/00_test_list.txt
@@ -2,6 +2,7 @@ gl-uniform-arrays.html
 # This test is no longer valid with the new packing restrictions
 #--min-version 1.0.02 gl-uniform-unused-array-elements-get-truncated.html
 gl-uniform-bool.html
+--min-version 1.0.4 gl-get-uniform-non-current-program.html
 gl-uniformmatrix4fv.html
 gl-unknown-uniform.html
 no-over-optimization-on-uniform-array-00.html

--- a/sdk/tests/conformance/uniforms/gl-get-uniform-non-current-program.html
+++ b/sdk/tests/conformance/uniforms/gl-get-uniform-non-current-program.html
@@ -1,0 +1,79 @@
+<!--
+Copyright (c) 2022 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL getUniform from non-current program</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="example" width="2" height="2"> </canvas>
+    <script id="vshader" type="x-shader/x-vertex">
+        attribute vec4 vPosition;
+        void main()
+        {
+            gl_Position = vPosition;
+        }
+    </script>
+
+    <script id="fshader" type="x-shader/x-fragment">
+        precision mediump float;
+        uniform float color;
+        void main()
+        {
+            gl_FragColor = vec4(color);
+        }
+    </script>
+<script>
+"use strict";
+description("This test ensures WebGL implementations handle getUniform when the program is not the current program");
+
+debug("");
+
+var wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("example");
+var program1 = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
+var program2 = wtu.setupProgram(gl, ["vshader", "fshader"], ["vPosition"]);
+var loc = gl.getUniformLocation(program1, "color");
+
+debug("check we can call getUniform when the program is current")
+gl.useProgram(program1);
+shouldBe("gl.getUniform(program1, loc)", "0");
+debug("check we can call getUniform when a different program is current")
+gl.useProgram(program2);
+shouldBe("gl.getUniform(program1, loc)", "0");
+debug("check we can call getUniform when no program is current")
+gl.useProgram(null);
+shouldBe("gl.getUniform(program1, loc)", "0");
+
+debug("check we can call getUniform when the program is current")
+gl.useProgram(program1);
+gl.uniform1f(loc, 123)
+shouldBe("gl.getUniform(program1, loc)", "123");
+debug("check we can call getUniform when a different program is current")
+gl.useProgram(program2);
+shouldBe("gl.getUniform(program1, loc)", "123");
+debug("check we can call getUniform when no program is current")
+gl.useProgram(null);
+shouldBe("gl.getUniform(program1, loc)", "123");
+
+
+wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should no errors");
+
+debug("");
+var successfullyParsed = true;
+
+</script>
+<script src="../../js/js-test-post.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
It's possible this is already tested but I didn't see anything obvious and Firefox fails this test

There's 3yr old bug to fix it here: https://bugzilla.mozilla.org/show_bug.cgi?id=1645092

Turns out the bug made [this webgl-state-diagram](https://webglfundamentals.org/webgl/lessons/resources/webgl-state-diagram.html?exampleId=use-2-programs#no-help) fail in Firefox. I've since [hacked in a workaround](https://github.com/gfxfundamentals/webgl-fundamentals/commit/e6d75517941ff1a9895a1a4d051ac32b08b97933) but it would be nice if that hadn't been needed.