### PR TITLE
Adjust EXT_sRGB spec and extend its test

### DIFF
--- a/extensions/EXT_sRGB/extension.xml
+++ b/extensions/EXT_sRGB/extension.xml
@@ -22,6 +22,9 @@
   <overview>
     <mirrors href="http://www.khronos.org/registry/gles/extensions/EXT/EXT_sRGB.txt"
              name="EXT_sRGB">
+      <addendum>
+        Support for <code>OES_rgb8_rgba8</code> or equivalent functionality is not required.
+      </addendum>
     </mirrors>
 
     <features>
@@ -82,6 +85,9 @@
     </revision>
     <revision date="2014/07/15">
       <change>Added NoInterfaceObject extended attribute.</change>
+    </revision>
+    <revision date="2022/12/01">
+      <change>Clarified WebGL-specific behavioral changes.</change>
     </revision>
   </history>
 </extension>

--- a/sdk/tests/conformance/extensions/ext-sRGB.html
+++ b/sdk/tests/conformance/extensions/ext-sRGB.html
@@ -222,6 +222,40 @@ if (!gl) {
   runFormatTest(textureFormatFixture, false);
   runFormatTest(renderbufferFormatFixture, false);
 
+  {
+    var fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+
+    debug("Checking getFramebufferAttachmentParameter with a renderbuffer");
+    {
+      var rbo = gl.createRenderbuffer();
+      gl.bindRenderbuffer(gl.RENDERBUFFER, rbo);
+      gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGB565, 1, 1);
+      gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, rbo);
+      wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+      shouldBeNull('gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, 0x8210 /* FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT */)');
+      wtu.glErrorShouldBe(gl, gl.INVALID_ENUM);
+      gl.bindRenderbuffer(gl.RENDERBUFFER, null);
+      gl.deleteRenderbuffer(rbo);
+    }
+
+    debug("Checking getFramebufferAttachmentParameter with a texture");
+    {
+      var tex = gl.createTexture();
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+      gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+      wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+      shouldBeNull('gl.getFramebufferAttachmentParameter(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, 0x8210 /* FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT */)');
+      wtu.glErrorShouldBe(gl, gl.INVALID_ENUM);
+      gl.bindTexture(gl.TEXTURE_2D, null);
+      gl.deleteTexture(tex);
+    }
+
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.deleteFramebuffer(fbo);
+  }
+
   debug("");
   debug("Checking sRGB texture support");
 


### PR DESCRIPTION
- Fixes #3475.
- Exposes a WebKit bug with `getFramebufferAttachmentParameter`. 