### PR TITLE
Optional `invariant` on `gl_FragCoord` and `gl_PointCoord`

### DIFF
--- a/sdk/tests/conformance2/glsl3/00_test_list.txt
+++ b/sdk/tests/conformance2/glsl3/00_test_list.txt
@@ -17,6 +17,7 @@ const-array-init.html
 forbidden-operators.html
 --min-version 2.0.1 forward-declaration.html
 frag-depth.html
+--min-version 2.0.1 fragcoord-pointcoord-invariant.html
 --min-version 2.0.1 fragment-shader-loop-crash.html
 --min-version 2.0.1 gradient-in-discontinuous-loop.html
 --min-version 2.0.1 input-with-interpotaion-as-lvalue.html

--- a/sdk/tests/conformance2/glsl3/fragcoord-pointcoord-invariant.html
+++ b/sdk/tests/conformance2/glsl3/fragcoord-pointcoord-invariant.html
@@ -1,0 +1,118 @@
+<!--
+Copyright (c) 2023 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>WebGL GLSL Conformance Tests - invariant gl_FragCoord and gl_PointCoord</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<link rel="stylesheet" href="../../resources/glsl-feature-tests.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"></script>
+<script src="../../js/glsl-conformance-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script id="vertexShaderInvariantGlPosition" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+invariant gl_Position;
+
+void main()
+{
+    gl_Position = vec4(0, 0, 0, 0);
+}
+</script>
+<script id="fragmentShaderInvariantGlFragCoord" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+invariant gl_FragCoord;
+out vec4 my_color;
+
+void main()
+{
+    my_color = gl_FragCoord;
+}
+</script>
+<script id="fragmentShaderVariantGlFragCoord" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+out vec4 my_color;
+
+void main()
+{
+    my_color = gl_FragCoord;
+}
+</script>
+<script id="vertexShaderInvariantGlPointSize" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+invariant gl_PointSize;
+
+void main()
+{
+    gl_PointSize = 1.0;
+    gl_Position = vec4(0, 0, 0, 0);
+}
+</script>
+<script id="fragmentShaderInvariantGlPointCoord" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+invariant gl_PointCoord;
+out vec4 my_color;
+
+void main()
+{
+    my_color = vec4(gl_PointCoord, 0.0, 0.0);
+}
+</script>
+<script id="fragmentShaderVariantGlPointCoord" type="text/something-not-javascript">#version 300 es
+precision mediump float;
+out vec4 my_color;
+
+void main()
+{
+    my_color = vec4(gl_PointCoord, 0.0, 0.0);
+}
+</script>
+<script>
+"use strict";
+GLSLConformanceTester.runTests([
+  {
+      vShaderId: "vertexShaderInvariantGlPosition",
+      vShaderSuccess: true,
+      fShaderId: "fragmentShaderInvariantGlFragCoord",
+      fShaderSuccess: true,
+      linkSuccess: true,
+      passMsg: "vertex shader with invariant gl_Position and fragment shader with invariant gl_FragCoord must succeed",
+  },
+  {
+      vShaderId: "vertexShaderInvariantGlPosition",
+      vShaderSuccess: true,
+      fShaderId: "fragmentShaderVariantGlFragCoord",
+      fShaderSuccess: true,
+      linkSuccess: true,
+      passMsg: "vertex shader with invariant gl_Position and fragment shader with variant gl_FragCoord must succeed",
+  },
+  {
+    vShaderId: "vertexShaderInvariantGlPointSize",
+    vShaderSuccess: true,
+    fShaderId: "fragmentShaderInvariantGlPointCoord",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: "vertex shader with invariant gl_PointSize and fragment shader with invariant gl_PointCoord must succeed",
+  },
+  {
+    vShaderId: "vertexShaderInvariantGlPointSize",
+    vShaderSuccess: true,
+    fShaderId: "fragmentShaderVariantGlPointCoord",
+    fShaderSuccess: true,
+    linkSuccess: true,
+    passMsg: "vertex shader with invariant gl_PointSize and fragment shader with variant gl_PointCoord must succeed",
+  },
+]);
+
+var successfullyParsed = true;
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #3518

As mentioned in #3518, from the ESSL 3.00 specification the variance of `gl_FragCoord` and `gl_PointCoord` is mentioned:
>How does this rule apply to the built-in special variables.
Option 1: It should be the same as for varyings. But gl_Position is used internally by the rasterizer as
well as for gl_FragCoord so there may be cases where rasterization is required to be invariant but
gl_FragCoord is not.
Option 2: gl_FragCoord and gl_PointCoord can be qualified as invariance if and only if gl_Position and
gl_PointSize are qualified invariant, respectively.

The same language is in the ESSL 1.00 specification.

There is no resolution, but option 2 is implied by existing ESSL 1.00 tests, e.g.: https://github.com/KhronosGroup/WebGL/blob/bd18b055a51a280e7535cb12272ecb07ae62b8d8/conformance-suites/2.0.0/conformance/glsl/misc/shaders-with-invariance.html#L289

However ESSL 3.00 also states:

> RESOLUTION: Only allow invariant declarations on outputs.

So we have a choice to either:
1. match ESSL 1.00 behavior and loosen that invariant declaration requirement for `gl_FragCoord` and `gl_PointCoord` only
2. require ESSL 3.00 to be more strict than ESSL 1.00 and disallow `invariant` on `gl_FragCoord` and `gl_PointCoord` (this appears to be the current behavior under ANGLE but doesn't appear to be tested explicitly)

This PR chooses the first option to slightly improve compatibility between ESSL 1.00 and ESSL 3.00 if there's no strong reason to prefer one over the other. The tests in this PR currently expect ESSL 3.00 to match ESSL 1.00 behavior for `invariant gl_FragCoord` and `invariant gl_PointCoord`, which loosen the "only allow invariant declarations on outputs" rule for those two built-ins. I'd happy to update this PR to use the second option instead if that's preferred though.