### PR TITLE
Update WEBGL_shader_pixel_local_storage extension's number to 49.

### DIFF
--- a/extensions/WEBGL_shader_pixel_local_storage/extension.xml
+++ b/extensions/WEBGL_shader_pixel_local_storage/extension.xml
@@ -14,7 +14,7 @@
     <contributor>Members of the WebGL working group</contributor>
   </contributors>
 
-  <number>NN</number>
+  <number>49</number>
 
   <depends>
     <api version="2.0"/>


### PR DESCRIPTION
This keeps it properly sorted in the draft extensions list.

Follow-on to #3521.