### PR TITLE
Fix slow tests runs for e.g. multiple_attributes.output.html when run via harness.

### DIFF
--- a/sdk/tests/deqp/framework/common/tcuTestCase.js
+++ b/sdk/tests/deqp/framework/common/tcuTestCase.js
@@ -453,7 +453,32 @@ goog.scope(function() {
 
                 if (inited) {
                     // Run the test, save the result.
+
+                    const debug = tcuTestCase._debug = tcuTestCase._debug || (() => {
+                        function LapStopwatch() {
+                            this.lap = function() {
+                                const now = performance.now();
+                                const ret = now - this.last;
+                                this.last = now;
+                                return ret;
+                            };
+                            this.lap();
+                        }
+                        return {
+                            stopwatch: new LapStopwatch(),
+                            testDoneCount: 0,
+                        };
+                    })();
+                    const overheadDur = debug.stopwatch.lap();
+
                     tcuTestCase.lastResult = state.currentTest.iterate();
+
+                    const testDur = debug.stopwatch.lap();
+                    debug.testDoneCount += 1;
+                    console.log(
+                        `[test ${debug.testDoneCount}] Ran in ${testDur}ms`,
+                        `(+ ${overheadDur}ms overhead)`,
+                    );
                 } else {
                     // Skip uninitialized test.
                     tcuTestCase.lastResult = tcuTestCase.IterateResult.STOP;
@@ -484,8 +509,8 @@ goog.scope(function() {
             }
 
             tcuTestCase.runner.runCallback(tcuTestCase.runTestCases);
-        } else
+        } else {
             tcuTestCase.runner.terminate();
+        }
     };
-
 });


### PR DESCRIPTION
On my machine, the subtests in multiple_attributes.output.html still run over 100% slower when run in harness (at least in Firefox), but they do run in tolerable time now.