### PR TITLE
Proposal: EXT_depth_clamp

### DIFF
--- a/extensions/proposals/EXT_depth_clamp/extension.xml
+++ b/extensions/proposals/EXT_depth_clamp/extension.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proposal href="proposals/EXT_depth_clamp/">
+  <name>EXT_depth_clamp</name>
+
+  <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
+  working group</a> (public_webgl 'at' khronos.org) </contact>
+
+  <contributors>
+    <contributor>Members of the WebGL working group</contributor>
+  </contributors>
+
+  <number>NN</number>
+
+  <depends>
+    <api version="1.0"/>
+  </depends>
+
+  <overview>
+    <mirrors href="https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_depth_clamp.txt"
+             name="EXT_depth_clamp">
+    </mirrors>
+  </overview>
+
+  <idl xml:space="preserve">
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
+interface EXT_depth_clamp {
+    const GLenum DEPTH_CLAMP_EXT = 0x864F;
+};
+  </idl>
+
+  <newtok>
+    <function name="enable" type="undefined">
+      <param name="cap" type="GLenum"/>
+      New enum <code>DEPTH_CLAMP_EXT</code> is accepted as the <code>cap</code> parameter.
+    </function>
+
+    <function name="disable" type="undefined">
+      <param name="cap" type="GLenum"/>
+      New enum <code>DEPTH_CLAMP_EXT</code> is accepted as the <code>cap</code> parameter.
+    </function>
+
+    <function name="isEnabled" type="GLboolean">
+      <param name="cap" type="GLenum"/>
+      New enum <code>DEPTH_CLAMP_EXT</code> is accepted as the <code>cap</code> parameter.
+    </function>
+
+    <function name="getParameter" type="any">
+      <param name="pname" type="GLenum"/>
+      <p>
+        A new enum <code>DEPTH_CLAMP_EXT</code> is accepted as the <code>pname</code> parameter.
+      </p>
+      <p>
+        The return type of this method depends on the parameter queried:
+      </p>
+      <table class="foo">
+        <tr><th>pname</th><th>returned type</th></tr>
+        <tr><td>DEPTH_CLAMP_EXT</td><td>GLboolean</td></tr>
+      </table>
+    </function>
+  </newtok>
+
+  <history>
+    <revision date="2023/06/01">
+      <change>Initial Draft.</change>
+    </revision>
+  </history>
+</proposal>


### PR DESCRIPTION
Vertices located closer than the near or farther than the far planes are always clipped. Various shadow rendering techniques greatly benefit from being able to squash (aka “pancake”) all geometry outside of the defined range instead of clipping it.

The proposed extension would allow applications to enable depth clamping while implicitly disabling near and far clipping planes.