### PR TITLE
Proposal: EXT_conservative_depth

### DIFF
--- a/extensions/proposals/EXT_conservative_depth/extension.xml
+++ b/extensions/proposals/EXT_conservative_depth/extension.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proposal href="proposals/EXT_conservative_depth/">
+  <name>EXT_conservative_depth</name>
+
+  <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
+  working group</a> (public_webgl 'at' khronos.org) </contact>
+
+  <contributors>
+    <contributor>Members of the WebGL working group</contributor>
+  </contributors>
+
+  <number>NN</number>
+
+  <depends>
+    <api version="2.0"/>
+  </depends>
+
+  <overview>
+    <mirrors href="https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_conservative_depth.txt"
+             name="EXT_conservative_depth">
+      <addendum>
+        The <code>depth_unchanged</code> layout qualifier is not supported.
+      </addendum>
+      <addendum>
+        If the final value of <code>gl_FragDepth</code> is inconsistent with its layout qualifier,
+        implementations may enforce consistency by clamping it to the value of <code>gl_FragCoord.z</code>.
+      </addendum>
+    </mirrors>
+    <features>
+      <glsl extname="GL_EXT_conservative_depth">
+        <stage type="fragment"/>
+        <feature>
+          The <code>gl_FragDepth</code> built-in output variable may be redeclared with a depth layout qualifier.
+        </feature>
+      </glsl>
+    </features>
+  </overview>
+
+  <idl xml:space="preserve">
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
+interface EXT_conservative_depth {
+};
+  </idl>
+
+  <samplecode xml:space="preserve">
+    <pre>
+    #ifdef GL_EXT_conservative_depth
+      #extension GL_EXT_conservative_depth : enable
+      layout (depth_greater) out float gl_FragDepth;
+    #endif
+
+    void main() {
+        // Assign to gl_FragDepth as usual
+    }
+    </pre>
+  </samplecode>
+
+  <history>
+    <revision date="2023/06/01">
+      <change>Initial Draft.</change>
+    </revision>
+  </history>
+</proposal>


### PR DESCRIPTION
Writing to `gl_FragDepth`, e.g., to render soft particles, disables implicit hardware optimizations and therefore increases the number of wasted fragment shader invocations.

The proposed extension would allow applications to hint hardware in what direction the written fragment depth is different from the rasterizer’s output. This re-enables implicit hardware optimizations and therefore prevents fragment shader invocations that are supposed to fail the depth test anyway.