### PR TITLE
Proposal: NV_shader_noperspective_interpolation

### DIFF
--- a/extensions/proposals/NV_shader_noperspective_interpolation/extension.xml
+++ b/extensions/proposals/NV_shader_noperspective_interpolation/extension.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proposal href="proposals/NV_shader_noperspective_interpolation/">
+  <name>NV_shader_noperspective_interpolation</name>
+
+  <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
+  working group</a> (public_webgl 'at' khronos.org) </contact>
+
+  <contributors>
+    <contributor>Members of the WebGL working group</contributor>
+  </contributors>
+
+  <number>NN</number>
+
+  <depends>
+    <api version="2.0"/>
+  </depends>
+
+  <overview>
+    <mirrors href="https://www.khronos.org/registry/OpenGL/extensions/NV/NV_shader_noperspective_interpolation.txt"
+             name="NV_shader_noperspective_interpolation"/>
+    <features>
+      <glsl extname="GL_NV_shader_noperspective_interpolation">
+        <stage type="vertex"/>
+        <stage type="fragment"/>
+        <feature>
+          Vertex outputs and fragment inputs may be declared with a <code>noperspective</code> interpolation qualifier.
+        </feature>
+      </glsl>
+    </features>
+  </overview>
+
+  <idl xml:space="preserve">
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
+interface NV_shader_noperspective_interpolation {
+};
+  </idl>
+
+  <history>
+    <revision date="2023/06/01">
+      <change>Initial Draft.</change>
+    </revision>
+  </history>
+</proposal>


### PR DESCRIPTION
- Perspective correction is always applied to non-flat varyings
- Extra computations are performed when not needed, e.g., for 2D apps
- Applications that need screen-space interpolation of 3D vectors have to implement workarounds to undo perspective correction

The proposed extension would allow applications to disable perspective correction of non-flat varyings.