### PR TITLE
Proposal: WEBGL_render_shared_exponent

### DIFF
--- a/extensions/proposals/WEBGL_render_shared_exponent/extension.xml
+++ b/extensions/proposals/WEBGL_render_shared_exponent/extension.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proposal href="proposals/WEBGL_render_shared_exponent/">
+  <name>WEBGL_render_shared_exponent</name>
+
+  <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
+  working group</a> (public_webgl 'at' khronos.org) </contact>
+
+  <contributors>
+    <contributor>Members of the WebGL working group</contributor>
+  </contributors>
+
+  <number>NN</number>
+
+  <depends>
+    <api version="2.0"/>
+  </depends>
+
+  <overview>
+    <mirrors href="https://www.khronos.org/registry/OpenGL/extensions/QCOM/QCOM_render_shared_exponent.txt"
+             name="QCOM_render_shared_exponent">
+    </mirrors>
+
+    <features>
+      <feature>
+        The <code>RGB9_E5</code> floating-point internal format becomes <em>color-renderable</em>.
+      </feature>
+    </features>
+  </overview>
+
+  <idl xml:space="preserve">
+[Exposed=(Window,Worker), LegacyNoInterfaceObject]
+interface WEBGL_render_shared_exponent {
+};
+  </idl>
+
+  <history>
+    <revision date="2023/06/01">
+      <change>Initial Draft.</change>
+    </revision>
+  </history>
+</proposal>


### PR DESCRIPTION
Shared exponent floating-point pixel format, i.e., RGB9_E5 is texturable but not renderable in WebGL 2.0. The only other small-float alternative is R11F_G11F_B10F, which may exhibit hue shifts due to asymmetry in channel encodings.

The proposed extension would allow applications in memory-constrained environments to choose between two small-float formats depending on the acceptable tradeoffs.