### PR TITLE
Incorporate @annevk 's SharedArrayBuffer and other Web IDL changes.

### DIFF
--- a/specs/latest/1.0/extract-idl.py
+++ b/specs/latest/1.0/extract-idl.py
@@ -40,7 +40,7 @@ def elementHasClass(el, classArg):
     """
     Return true if and only if classArg is one of the classes of el
     """
-    classes = [ c for c in el.getAttribute("class").split(" ") if c is not "" ]
+    classes = [ c for c in el.getAttribute("class").split(" ") if c != "" ]
     return classArg in classes
 
 def elementTextContent(el):

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1891,8 +1891,8 @@ interface mixin <dfn data-dfn-type="interface" id="WebGLRenderingContextBase">We
 interface mixin <dfn id="WebGLRenderingContextOverloads">WebGLRenderingContextOverloads</dfn>
 {
     undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-    undefined bufferData(GLenum target, [AllowShared] BufferSource? data, GLenum usage);
-    undefined bufferSubData(GLenum target, GLintptr offset, [AllowShared] BufferSource data);
+    undefined bufferData(GLenum target, AllowSharedBufferSource? data, GLenum usage);
+    undefined bufferSubData(GLenum target, GLintptr offset, AllowSharedBufferSource data);
 
     undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                                    GLsizei width, GLsizei height, GLint border,
@@ -2316,14 +2316,14 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             Set the size of the currently bound WebGLBuffer object for the passed target. The
             buffer is initialized to 0.
 
-        <dt class="idl-code">void bufferData(GLenum target, [AllowShared] BufferSource? data, GLenum usage)
+        <dt class="idl-code">void bufferData(GLenum target, AllowSharedBufferSource? data, GLenum usage)
             <span class="gl-spec">(<a href="http://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glBufferData.xml">man page</a>)</span>
         <dd>
             Set the size of the currently bound WebGLBuffer object for the passed target to the
             size of the passed data, then write the contents of data to the buffer object.
             <br><br>
             If the passed data is null then an <code>INVALID_VALUE</code> error is generated.
-        <dt><p class="idl-code">void bufferSubData(GLenum target, GLintptr offset, [AllowShared] BufferSource data)
+        <dt><p class="idl-code">void bufferSubData(GLenum target, GLintptr offset, AllowSharedBufferSource data)
             <span class="gl-spec">(<a href="http://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glBufferSubData.xml">man page</a>)</span></p>
         <dd>
             For the WebGLBuffer object bound to the passed target write the passed data starting at

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -3,7 +3,7 @@
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/
 
-// Copyright (c) 2021 The Khronos Group Inc.
+// Copyright (c) 2023 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the
@@ -535,10 +535,11 @@ interface mixin WebGLRenderingContextBase
     const GLenum UNPACK_COLORSPACE_CONVERSION_WEBGL = 0x9243;
     const GLenum BROWSER_DEFAULT_WEBGL          = 0x9244;
 
-    [Exposed=Window] readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
-    [Exposed=Worker] readonly attribute OffscreenCanvas canvas;
+    readonly attribute (HTMLCanvasElement or OffscreenCanvas) canvas;
     readonly attribute GLsizei drawingBufferWidth;
     readonly attribute GLsizei drawingBufferHeight;
+    attribute PredefinedColorSpace drawingBufferColorSpace = "srgb";
+    attribute PredefinedColorSpace unpackColorSpace = "srgb";
 
     [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
     [WebGLHandlesContextLoss] boolean isContextLost();
@@ -706,8 +707,8 @@ interface mixin WebGLRenderingContextBase
 interface mixin WebGLRenderingContextOverloads
 {
     undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-    undefined bufferData(GLenum target, [AllowShared] BufferSource? data, GLenum usage);
-    undefined bufferSubData(GLenum target, GLintptr offset, [AllowShared] BufferSource data);
+    undefined bufferData(GLenum target, AllowSharedBufferSource? data, GLenum usage);
+    undefined bufferSubData(GLenum target, GLintptr offset, AllowSharedBufferSource data);
 
     undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                                    GLsizei width, GLsizei height, GLint border,

--- a/specs/latest/2.0/extract-idl.py
+++ b/specs/latest/2.0/extract-idl.py
@@ -40,7 +40,7 @@ def elementHasClass(el, classArg):
     """
     Return true if and only if classArg is one of the classes of el
     """
-    classes = [ c for c in el.getAttribute("class").split(" ") if c is not "" ]
+    classes = [ c for c in el.getAttribute("class").split(" ") if c != "" ]
     return classArg in classes
 
 def elementTextContent(el):

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -886,8 +886,8 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextOverloa
 {
   // WebGL1:
   undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-  undefined bufferData(GLenum target, [AllowShared] BufferSource? srcData, GLenum usage);
-  undefined bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] BufferSource srcData);
+  undefined bufferData(GLenum target, AllowSharedBufferSource? srcData, GLenum usage);
+  undefined bufferSubData(GLenum target, GLintptr dstByteOffset, AllowSharedBufferSource srcData);
   // WebGL2:
   undefined bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
                        optional GLuint length = 0);

--- a/specs/latest/2.0/webgl2.idl
+++ b/specs/latest/2.0/webgl2.idl
@@ -3,7 +3,7 @@
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/
 
-// Copyright (c) 2021 The Khronos Group Inc.
+// Copyright (c) 2023 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the
@@ -505,8 +505,8 @@ interface mixin WebGL2RenderingContextOverloads
 {
   // WebGL1:
   undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
-  undefined bufferData(GLenum target, [AllowShared] BufferSource? srcData, GLenum usage);
-  undefined bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] BufferSource srcData);
+  undefined bufferData(GLenum target, AllowSharedBufferSource? srcData, GLenum usage);
+  undefined bufferSubData(GLenum target, GLintptr dstByteOffset, AllowSharedBufferSource srcData);
   // WebGL2:
   undefined bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
                        optional GLuint length = 0);


### PR DESCRIPTION
See whatwg/webidl#1311 for context.

At the same time adjust extract-idl.py to hold Python correctly ("!=" instead of "is not").

Thanks to @annevk for these changes in #3539 . They were contributed by @annevk and @grorg under Khronos' CLA; merging them separately to bypass the automated checks.