### PR TITLE
Call finishTest() when PLS isn't supported.

### DIFF
--- a/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
+++ b/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
@@ -50,6 +50,7 @@ async function runTest() {
   if (!gl) {
     testFailed("WebGL2 context does not exist");
     finishTest();
+    return;
   }
 
   debug("\nCheck the behavior surrounding WEBGL_shader_pixel_local_storage being enabled.");

--- a/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
+++ b/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
@@ -50,6 +50,7 @@ async function runTest() {
   if (!gl) {
     return function() {
       testFailed("WebGL2 context does not exist");
+      finishTest();
     }
   }
 
@@ -59,8 +60,10 @@ async function runTest() {
   debug("Enable WEBGL_shader_pixel_local_storage.");
   pls = gl.getExtension("WEBGL_shader_pixel_local_storage");
   wtu.runExtensionSupportedTest(gl, "WEBGL_shader_pixel_local_storage", pls != null);
-  if (!pls)
+  if (!pls) {
+    finishTest();
     return;
+  }
   checkDependencyExtensionsEnabled(true);
 
   checkImplementationDependentLimits();

--- a/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
+++ b/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
@@ -48,10 +48,8 @@ function arraysEqual(a, b) {
 
 async function runTest() {
   if (!gl) {
-    return function() {
-      testFailed("WebGL2 context does not exist");
-      finishTest();
-    }
+    testFailed("WebGL2 context does not exist");
+    finishTest();
   }
 
   debug("\nCheck the behavior surrounding WEBGL_shader_pixel_local_storage being enabled.");


### PR DESCRIPTION
Timeouts were accidentally introduced in the last commit by failing to do this. Follow-on to #3562 and #3530.