### PR TITLE
Reject WEBGL_texture_source_iframe extension.

### DIFF
--- a/extensions/rejected/WEBGL_texture_source_iframe/extension.xml
+++ b/extensions/rejected/WEBGL_texture_source_iframe/extension.xml
@@ -2,7 +2,7 @@
 <!-- vi:set sw=2 ts=4: -->
 <?xml-stylesheet href="../../extension.xsl" type="text/xsl"?>
 
-<proposal href="proposals/WEBGL_texture_source_iframe/">
+<rejected href="rejected/WEBGL_texture_source_iframe/">
   <name>WEBGL_texture_source_iframe</name>
   <contact><a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
   working group</a> (public_webgl 'at' khronos.org) </contact>
@@ -109,5 +109,8 @@ interface WEBGL_texture_source_iframe {
     <revision date="2017/09/20">
       <change>Initial revision.</change>
     </revision>
+    <revision date="2023/07/10">
+      <change>Moved to rejected state because security constraints were too difficult to define.</change>
+    </revision>
   </history>
-</proposal>
+</rejected>


### PR DESCRIPTION
The security constraints needed for this extension were too difficult to define, despite a couple of attempts over a couple of years' time.