### PR TITLE
Upgrade ABV offset args from u32->u64.

### DIFF
--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -707,7 +707,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   // can not be exposed safely to JavaScript. GetBufferSubData
   // replaces it for the purpose of fetching data back from the GPU.
   undefined getBufferSubData(GLenum target, GLintptr srcByteOffset, [AllowShared] ArrayBufferView dstBuffer,
-                             optional GLuint dstOffset = 0, optional GLuint length = 0);
+                             optional unsigned long long dstOffset = 0, optional GLuint length = 0);
 
   /* Framebuffer objects */
   undefined blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0,
@@ -739,7 +739,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
                        GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData);
   undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                        GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
-                       GLuint srcOffset);
+                       unsigned long long srcOffset);
 
   undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                           GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
@@ -749,7 +749,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
                           TexImageSource source); // May throw DOMException
   undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                           GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type,
-                          [AllowShared] ArrayBufferView? srcData, optional GLuint srcOffset = 0);
+                          [AllowShared] ArrayBufferView? srcData, optional unsigned long long srcOffset = 0);
 
   undefined copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset,
                               GLint x, GLint y, GLsizei width, GLsizei height);
@@ -758,7 +758,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
                                  GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, GLintptr offset);
   undefined compressedTexImage3D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                                  GLsizei height, GLsizei depth, GLint border, [AllowShared] ArrayBufferView srcData,
-                                 optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
+                                 optional unsigned long long srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
   undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                     GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
@@ -766,7 +766,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                     GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                                     GLenum format, [AllowShared] ArrayBufferView srcData,
-                                    optional GLuint srcOffset = 0,
+                                    optional unsigned long long srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0);
 
   /* Programs and shaders */
@@ -778,28 +778,28 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   undefined uniform3ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2);
   undefined uniform4ui(WebGLUniformLocation? location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
 
-  undefined uniform1uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+  undefined uniform1uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0,
                         optional GLuint srcLength = 0);
-  undefined uniform2uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+  undefined uniform2uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0,
                         optional GLuint srcLength = 0);
-  undefined uniform3uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+  undefined uniform3uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0,
                         optional GLuint srcLength = 0);
-  undefined uniform4uiv(WebGLUniformLocation? location, Uint32List data, optional GLuint srcOffset = 0,
+  undefined uniform4uiv(WebGLUniformLocation? location, Uint32List data, optional unsigned long long srcOffset = 0,
                         optional GLuint srcLength = 0);
   undefined uniformMatrix3x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                               optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                               optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
   undefined uniformMatrix4x2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                               optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                               optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
 
   undefined uniformMatrix2x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                               optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                               optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
   undefined uniformMatrix4x3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                               optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                               optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
 
   undefined uniformMatrix2x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                               optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                               optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
   undefined uniformMatrix3x4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                               optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                               optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
 
   /* Vertex attribs */
   undefined vertexAttribI4i(GLuint index, GLint x, GLint y, GLint z, GLint w);
@@ -818,11 +818,11 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   undefined drawBuffers(sequence&lt;GLenum&gt; buffers);
 
   undefined clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values,
-                          optional GLuint srcOffset = 0);
+                          optional unsigned long long srcOffset = 0);
   undefined clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values,
-                          optional GLuint srcOffset = 0);
+                          optional unsigned long long srcOffset = 0);
   undefined clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values,
-                           optional GLuint srcOffset = 0);
+                           optional unsigned long long srcOffset = 0);
 
   undefined clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
 
@@ -889,10 +889,10 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextOverloa
   undefined bufferData(GLenum target, AllowSharedBufferSource? srcData, GLenum usage);
   undefined bufferSubData(GLenum target, GLintptr dstByteOffset, AllowSharedBufferSource srcData);
   // WebGL2:
-  undefined bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset,
+  undefined bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, unsigned long long srcOffset,
                        optional GLuint length = 0);
   undefined bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData,
-                          GLuint srcOffset, optional GLuint length = 0);
+                          unsigned long long srcOffset, optional GLuint length = 0);
 
   // WebGL1 legacy entrypoints:
   undefined texImage2D(GLenum target, GLint level, GLint internalformat,
@@ -915,7 +915,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextOverloa
                        TexImageSource source); // May throw DOMException
   undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height,
                        GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
-                       GLuint srcOffset);
+                       unsigned long long srcOffset);
 
   undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                           GLsizei height, GLenum format, GLenum type, GLintptr pboOffset);
@@ -924,46 +924,46 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextOverloa
                           TexImageSource source); // May throw DOMException
   undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width,
                           GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData,
-                          GLuint srcOffset);
+                          unsigned long long srcOffset);
 
   undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                                  GLsizei height, GLint border, GLsizei imageSize, GLintptr offset);
   undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width,
                                  GLsizei height, GLint border, [AllowShared] ArrayBufferView srcData,
-                                 optional GLuint srcOffset = 0, optional GLuint srcLengthOverride = 0);
+                                 optional unsigned long long srcOffset = 0, optional GLuint srcLengthOverride = 0);
 
   undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                     GLsizei width, GLsizei height, GLenum format, GLsizei imageSize, GLintptr offset);
   undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                     GLsizei width, GLsizei height, GLenum format,
                                     [AllowShared] ArrayBufferView srcData,
-                                    optional GLuint srcOffset = 0,
+                                    optional unsigned long long srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0);
 
-  undefined uniform1fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+  undefined uniform1fv(WebGLUniformLocation? location, Float32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
-  undefined uniform2fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+  undefined uniform2fv(WebGLUniformLocation? location, Float32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
-  undefined uniform3fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+  undefined uniform3fv(WebGLUniformLocation? location, Float32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
-  undefined uniform4fv(WebGLUniformLocation? location, Float32List data, optional GLuint srcOffset = 0,
+  undefined uniform4fv(WebGLUniformLocation? location, Float32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
 
-  undefined uniform1iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+  undefined uniform1iv(WebGLUniformLocation? location, Int32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
-  undefined uniform2iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+  undefined uniform2iv(WebGLUniformLocation? location, Int32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
-  undefined uniform3iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+  undefined uniform3iv(WebGLUniformLocation? location, Int32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
-  undefined uniform4iv(WebGLUniformLocation? location, Int32List data, optional GLuint srcOffset = 0,
+  undefined uniform4iv(WebGLUniformLocation? location, Int32List data, optional unsigned long long srcOffset = 0,
                        optional GLuint srcLength = 0);
 
   undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                             optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
   undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                             optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
   undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data,
-                             optional GLuint srcOffset = 0, optional GLuint srcLength = 0);
+                             optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
 
   /* Reading back pixels */
   // WebGL1:
@@ -973,7 +973,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextOverloa
   undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
                        GLintptr offset);
   undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type,
-                       [AllowShared] ArrayBufferView dstData, GLuint dstOffset);
+                       [AllowShared] ArrayBufferView dstData, unsigned long long dstOffset);
 };
 
 [Exposed=(Window,Worker)]
@@ -1188,7 +1188,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
 
     <dl class="methods">
 
-      <dt class="idl-code">void bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, GLuint srcOffset, optional GLuint length = 0);
+      <dt class="idl-code">void bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, unsigned long long srcOffset, optional GLuint length = 0);
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.10.2">OpenGL ES 3.0.6 &sect;2.10.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferData.xhtml" class="nonnormative">man page</a>)
@@ -1223,7 +1223,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         If any error is generated, <code>buf</code>'s size is unmodified, and no data is written to it.
       </dd>
 
-      <dt class="idl-code">void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData, GLuint srcOffset, optional GLuint length = 0);
+      <dt class="idl-code">void bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset, optional GLuint length = 0);
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.2.10.2">OpenGL ES 3.0.6 &sect;2.10.2</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glBufferSubData.xhtml" class="nonnormative">man page</a>)
@@ -1289,7 +1289,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
         <p class="idl-code">
           undefined getBufferSubData(GLenum target, GLintptr srcByteOffset,
                                 [AllowShared] ArrayBufferView dstBuffer,
-                                optional GLuint dstOffset = 0,
+                                optional unsigned long long dstOffset = 0,
                                 optional GLuint length = 0)
         </p>
       </dt>
@@ -1693,7 +1693,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt class="idl-code">
         undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                         GLsizei height, GLint border, GLenum format, GLenum type,
-                        [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
+                        [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset)
         <span class="gl-spec">
           (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage2D.xhtml">man page</a>)
@@ -1835,7 +1835,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt class="idl-code"><a name="TEXSUBIMAGE2D">
         undefined texSubImage2D</a>(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                GLsizei width, GLsizei height, GLenum format, GLenum type,
-                               [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
+                               [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset)
         <span class="gl-spec">
           (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
           <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage2D.xhtml">man page</a>)
@@ -1903,7 +1903,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
                            [AllowShared] ArrayBufferView? srcData)</p>
         <p>void texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width,
                            GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type,
-                           [AllowShared] ArrayBufferView srcData, GLuint srcOffset)
+                           [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset)
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.3">OpenGL ES 3.0.6 &sect;3.8.3</a>,
             <a class="nonnormative" href="https://www.khronos.org/opengles/sdk/docs/man3/html/glTexImage3D.xhtml">man page</a>)
@@ -1983,7 +1983,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                              GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                              GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData,
-                             optional GLuint srcOffset = 0)
+                             optional unsigned long long srcOffset = 0)
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.5">OpenGL ES 3.0.6 &sect;3.8.5</a>,
             <a href="http://www.khronos.org/opengles/sdk/docs/man3/html/glTexSubImage3D.xhtml" class="nonnormative">man page</a>)
@@ -2085,7 +2085,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat,
                                     GLsizei width, GLsizei height, GLint border,
                                     [AllowShared] ArrayBufferView srcData,
-                                    optional GLuint srcOffset = 0,
+                                    optional unsigned long long srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
@@ -2107,7 +2107,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                        GLsizei width, GLsizei height, GLenum format,
                                        [AllowShared] ArrayBufferView srcData,
-                                       optional GLuint srcOffset = 0,
+                                       optional unsigned long long srcOffset = 0,
                                        optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
@@ -2130,7 +2130,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           undefined compressedTexImage3D(GLenum target, GLint level, GLenum internalformat,
                                     GLsizei width, GLsizei height, GLsizei depth, GLint border,
                                     [AllowShared] ArrayBufferView srcData,
-                                    optional GLuint srcOffset = 0,
+                                    optional unsigned long long srcOffset = 0,
                                     optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
@@ -2152,7 +2152,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
           undefined compressedTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                        GLint zoffset, GLsizei width, GLsizei height, GLsizei depth,
                                        GLenum format, [AllowShared] ArrayBufferView srcData,
-                                       optional GLuint srcOffset = 0,
+                                       optional unsigned long long srcOffset = 0,
                                        optional GLuint srcLengthOverride = 0)
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.3.8.6">OpenGL ES 3.0.6 &sect;3.8.6</a>,
@@ -2519,7 +2519,7 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
     <dl class="methods">
         <dt class="idl-code">
           undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format,
-                          GLenum type, [AllowShared] ArrayBufferView dstData, GLuint dstOffset)
+                          GLenum type, [AllowShared] ArrayBufferView dstData, unsigned long long dstOffset)
           <span class="gl-spec">
             (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.3.2">OpenGL ES 3.0 &sect;4.3.2</a>,
             <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/docs/man3/html/glReadPixels.xhtml">man page</a>)
@@ -2593,11 +2593,11 @@ WebGL2RenderingContext includes WebGL2RenderingContextOverloads;
       <dt>
         <div class="idl-code">
           <p>void clearBufferfv(GLenum buffer, GLint drawbuffer, Float32List values,
-                                optional GLuint srcOffset = 0);</p>
+                                optional unsigned long long srcOffset = 0);</p>
           <p>void clearBufferiv(GLenum buffer, GLint drawbuffer, Int32List values,
-                                optional GLuint srcOffset = 0);</p>
+                                optional unsigned long long srcOffset = 0);</p>
           <p>void clearBufferuiv(GLenum buffer, GLint drawbuffer, Uint32List values,
-                                 optional GLuint srcOffset = 0);</p>
+                                 optional unsigned long long srcOffset = 0);</p>
           <p>void clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
             <span class="gl-spec">
               (<a href="https://www.khronos.org/registry/OpenGL/specs/es/3.0/es_spec_3.0.pdf#nameddest=subsection.4.2.3">OpenGL ES 3.0.6 &sect;4.2.3</a>,


### PR DESCRIPTION
Not sizes right now because we don't expect to support >4G sizes for uploads.

This change better supports large WebAssembly heaps. Related to crbug.com/1476859 ;
conformance test for all browsers forthcoming.