### PR TITLE
Update ABV offset args in extensions from u32->u64.

### DIFF
--- a/extensions/WEBGL_multi_draw/extension.xml
+++ b/extensions/WEBGL_multi_draw/extension.xml
@@ -68,27 +68,27 @@
 interface WEBGL_multi_draw {
   undefined multiDrawArraysWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, unsigned long long firstsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, unsigned long long countsOffset,
       GLsizei drawcount);
   undefined multiDrawElementsWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, unsigned long long countsOffset,
       GLenum type,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, unsigned long long offsetsOffset,
       GLsizei drawcount);
   undefined multiDrawArraysInstancedWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, unsigned long long firstsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, unsigned long long countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, unsigned long long instanceCountsOffset,
       GLsizei drawcount);
   undefined multiDrawElementsInstancedWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, unsigned long long countsOffset,
       GLenum type,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, unsigned long long offsetsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, unsigned long long instanceCountsOffset,
       GLsizei drawcount);
 };
 
@@ -98,39 +98,39 @@ interface WEBGL_multi_draw {
     <function name="multiDrawArraysWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
       <param name="firstsList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
-      <param name="firstsOffset" type="GLuint"/>
+      <param name="firstsOffset" type="unsigned long long"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="countsOffset" type="GLuint"/>
+      <param name="countsOffset" type="unsigned long long"/>
       <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="countsOffset" type="GLuint"/>
+      <param name="countsOffset" type="unsigned long long"/>
       <param name="type" type="GLenum"/>
       <param name="offsetsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="offsetsOffset" type="GLuint"/>
+      <param name="offsetsOffset" type="unsigned long long"/>
       <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawArraysInstancedWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
       <param name="firstsList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
-      <param name="firstsOffset" type="GLuint"/>
+      <param name="firstsOffset" type="unsigned long long"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="countsOffset" type="GLuint"/>
+      <param name="countsOffset" type="unsigned long long"/>
       <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="instanceCountsOffset" type="GLuint"/>
+      <param name="instanceCountsOffset" type="unsigned long long"/>
       <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsInstancedWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="countsOffset" type="GLuint"/>
+      <param name="countsOffset" type="unsigned long long"/>
       <param name="type" type="GLenum"/>
       <param name="offsetsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="offsetsOffset" type="GLuint"/>
+      <param name="offsetsOffset" type="unsigned long long"/>
       <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="instanceCountsOffset" type="GLuint"/>
+      <param name="instanceCountsOffset" type="unsigned long long"/>
       <param name="drawcount" type="GLsizei"/>
     </function>
   </newfun>
@@ -212,6 +212,9 @@ void main() {
     </revision>
     <revision date="2021/05/18">
       <change>Add [AllowShared] to all typed array arguments for compatibility with multi-threaded WebAssembly.</change>
+    </revision>
+    <revision date="2023/09/08">
+      <change>Changed offset arguments to "unsigned long long" for Wasm.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
+++ b/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/extension.xml
@@ -90,20 +90,20 @@
 interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
   undefined multiDrawArraysInstancedBaseInstanceWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, GLuint firstsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
-      ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) firstsList, unsigned long long firstsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, unsigned long long countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, unsigned long long instanceCountsOffset,
+      ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, unsigned long long baseInstancesOffset,
       GLsizei drawcount
   );
   undefined multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
       GLenum mode,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, GLuint countsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) countsList, unsigned long long countsOffset,
       GLenum type,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, GLuint offsetsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, GLuint instanceCountsOffset,
-      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) baseVerticesList, GLuint baseVerticesOffset,
-      ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, GLuint baseInstancesOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) offsetsList, unsigned long long offsetsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLsizei&gt;) instanceCountsList, unsigned long long instanceCountsOffset,
+      ([AllowShared] Int32Array or sequence&lt;GLint&gt;) baseVerticesList, unsigned long long baseVerticesOffset,
+      ([AllowShared] Uint32Array or sequence&lt;GLuint&gt;) baseInstancesList, unsigned long long baseInstancesOffset,
       GLsizei drawcount
   );
 };
@@ -113,28 +113,28 @@ interface WEBGL_multi_draw_instanced_base_vertex_base_instance {
     <function name="multiDrawArraysInstancedBaseInstanceWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
       <param name="firstsList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
-      <param name="firstsOffset" type="GLuint"/>
+      <param name="firstsOffset" type="unsigned long long"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="countsOffset" type="GLuint"/>
+      <param name="countsOffset" type="unsigned long long"/>
       <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="instanceCountsOffset" type="GLuint"/>
+      <param name="instanceCountsOffset" type="unsigned long long"/>
       <param name="baseInstancesList" type="([AllowShared] Uint32Array or sequence&lt;GLuint&gt;)"/>
-      <param name="baseInstancesOffset" type="GLuint"/>
+      <param name="baseInstancesOffset" type="unsigned long long"/>
       <param name="drawcount" type="GLsizei"/>
     </function>
     <function name="multiDrawElementsInstancedBaseVertexBaseInstanceWEBGL" type="undefined">
       <param name="mode" type="GLenum"/>
       <param name="countsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="countsOffset" type="GLuint"/>
+      <param name="countsOffset" type="unsigned long long"/>
       <param name="type" type="GLenum"/>
       <param name="offsetsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="offsetsOffset" type="GLuint"/>
+      <param name="offsetsOffset" type="unsigned long long"/>
       <param name="instanceCountsList" type="([AllowShared] Int32Array or sequence&lt;GLsizei&gt;)"/>
-      <param name="instanceCountsOffset" type="GLuint"/>
+      <param name="instanceCountsOffset" type="unsigned long long"/>
       <param name="baseVerticesList" type="([AllowShared] Int32Array or sequence&lt;GLint&gt;)"/>
-      <param name="baseVerticesOffset" type="GLuint"/>
+      <param name="baseVerticesOffset" type="unsigned long long"/>
       <param name="baseInstancesList" type="([AllowShared] Uint32Array or sequence&lt;GLuint&gt;)"/>
-      <param name="baseInstancesOffset" type="GLuint"/>
+      <param name="baseInstancesOffset" type="unsigned long long"/>
       <param name="drawcount" type="GLsizei"/>
     </function>
   </newfun>
@@ -215,6 +215,9 @@ void main() {
     </revision>
     <revision date="2021/05/26">
       <change>Removed GLSL extension and builtins.</change>
+    </revision>
+    <revision date="2023/09/08">
+      <change>Changed offset arguments to "unsigned long long" for Wasm.</change>
     </revision>
   </history>
 </draft>

--- a/extensions/WEBGL_shader_pixel_local_storage/extension.xml
+++ b/extensions/WEBGL_shader_pixel_local_storage/extension.xml
@@ -89,13 +89,13 @@ interface WEBGL_shader_pixel_local_storage {
                                                      GLint layer);
   undefined framebufferPixelLocalClearValuefvWEBGL(GLint plane,
                                                    Float32List value,
-                                                   optional GLuint srcOffset = 0);
+                                                   optional unsigned long long srcOffset = 0);
   undefined framebufferPixelLocalClearValueivWEBGL(GLint plane,
                                                    Int32List value,
-                                                   optional GLuint srcOffset = 0);
+                                                   optional unsigned long long srcOffset = 0);
   undefined framebufferPixelLocalClearValueuivWEBGL(GLint plane,
                                                     Uint32List value,
-                                                    optional GLuint srcOffset = 0);
+                                                    optional unsigned long long srcOffset = 0);
   undefined beginPixelLocalStorageWEBGL(sequence&lt;GLenum&gt; loadops);
   undefined endPixelLocalStorageWEBGL(sequence&lt;GLenum&gt; storeops);
   undefined pixelLocalStorageBarrierWEBGL();
@@ -139,7 +139,7 @@ interface WEBGL_shader_pixel_local_storage {
     <function name="framebufferPixelLocalClearValuefvWEBGL" type="undefined">
       <param name="plane" type="GLint"/>
       <param name="value" type="Float32List"/>
-      <param name="srcOffset" type="GLuint" default="0"/>
+      <param name="srcOffset" type="unsigned long long" default="0"/>
       <p>
         Sets the floating point clear value for the given plane.
       </p>
@@ -154,7 +154,7 @@ interface WEBGL_shader_pixel_local_storage {
     <function name="framebufferPixelLocalClearValueivWEBGL" type="undefined">
       <param name="plane" type="GLint"/>
       <param name="value" type="Int32List"/>
-      <param name="srcOffset" type="GLuint" default="0"/>
+      <param name="srcOffset" type="unsigned long long" default="0"/>
       <p>
         Sets the signed integer clear value for the given plane.
       </p>
@@ -169,7 +169,7 @@ interface WEBGL_shader_pixel_local_storage {
     <function name="framebufferPixelLocalClearValueuivWEBGL" type="undefined">
       <param name="plane" type="GLint"/>
       <param name="value" type="Uint32List"/>
-      <param name="srcOffset" type="GLuint" default="0"/>
+      <param name="srcOffset" type="unsigned long long" default="0"/>
       <p>
         Sets the unsigned integer clear value for the given plane.
       </p>
@@ -278,6 +278,9 @@ interface WEBGL_shader_pixel_local_storage {
   <history>
     <revision date="2022/12/06">
       <change>Initial Draft.</change>
+    </revision>
+    <revision date="2023/09/08">
+      <change>Changed srcOffset arguments to "unsigned long long" for Wasm.</change>
     </revision>
   </history>
 </draft>


### PR DESCRIPTION
Updates the ArrayBufferView offset arguments in the following extensions:

  WEBGL_multi_draw
  WEBGL_multi_draw_instanced_base_vertex_base_instance
  WEBGL_shader_pixel_local_storage

to better support large WebAssembly heaps.

Follow-on to #3586.