### PR TITLE
Avoid very long expressions in tests

### DIFF
--- a/sdk/tests/conformance/glsl/bugs/complex-glsl-does-not-crash.html
+++ b/sdk/tests/conformance/glsl/bugs/complex-glsl-does-not-crash.html
@@ -58,7 +58,9 @@ varying vec4 v_varying;
 $(uniforms)
 void main()
 {
-    v_varying = $(code);
+    vec4 t = [0, 0, 0, 0];
+    t += $(code);
+    v_varying = t;
     gl_Position = a_position;
 }
 </script>
@@ -67,7 +69,9 @@ precision mediump float;
 $(uniforms)
 void main()
 {
-    gl_FragColor = $(code);
+    vec4 t = [0, 0, 0, 0];
+    t += $(code);
+    gl_FragColor = t;
 }
 </script>
 <script>
@@ -168,7 +172,7 @@ for (var ss = 0; ss < shaderTypes.length; ++ss) {
       }
       return {
         uniforms: uniforms.join("\n"),
-        code: codes.join(" + \n            "),
+        code: codes.join(";\n    t += "),
       };
     };
 

--- a/sdk/tests/conformance/glsl/misc/shader-uniform-packing-restrictions.html
+++ b/sdk/tests/conformance/glsl/misc/shader-uniform-packing-restrictions.html
@@ -215,9 +215,11 @@ for (var ss = 0; ss < shaderTypes.length; ++ss) {
         uniforms.push("    uniform " + info.type + " u_uniform" + uu + ";");
         sumTerms.push(wtu.replaceParams(info.uniToF, {id: uu, index: ""}));
       }
+      var code = info.fType + " sum = " + sumTerms.shift() + ";\n    sum += ";
+      code += sumTerms.join(";\n    sum += ") + ";"
       return {
         uniforms: uniforms.join("\n"),
-        code: info.fType + " sum = " + sumTerms.join(" + \n            ") + ";",
+        code: code,
         result: wtu.replaceParams(info.fToVec4, {f: 'sum'})
       };
     };


### PR DESCRIPTION
Windows WebKit is observing stack overflow in ANGLE for the following
tests due to very long expressions containing additions of 16384
uniform variables. <https://webkit.org/b/261297>

- glsl/bugs/complex-glsl-does-not-crash.html
- glsl/misc/shader-uniform-packing-restrictions.html

Split the long expressions by using addition assignment operators.
