### PR TITLE
Add tests for gl.readPixels(), gl.texImage2D() and gl.texSubImage2D() from Wasm Memories of 4GB and 16GB in size.

### DIFF
--- a/sdk/tests/conformance2/00_test_list.txt
+++ b/sdk/tests/conformance2/00_test_list.txt
@@ -18,3 +18,4 @@ textures/00_test_list.txt
 transform_feedback/00_test_list.txt
 uniforms/00_test_list.txt
 vertex_arrays/00_test_list.txt
+--min-version 2.0.1 wasm/00_test_list.txt

--- a/sdk/tests/conformance2/wasm/00_test_list.txt
+++ b/sdk/tests/conformance2/wasm/00_test_list.txt
@@ -1,0 +1,6 @@
+--min-version 2.0.1 readpixels-16gb-wasm-memory.html
+--min-version 2.0.1 readpixels-4gb-wasm-memory.html
+--min-version 2.0.1 teximage2d-16gb-wasm-memory.html
+--min-version 2.0.1 teximage2d-4gb-wasm-memory.html
+--min-version 2.0.1 texsubimage2d-16gb-wasm-memory.html
+--min-version 2.0.1 texsubimage2d-4gb-wasm-memory.html

--- a/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
@@ -1,0 +1,51 @@
+<!--
+Copyright (c) 2023 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gl.readPixels() test to Wasm Memory 16GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("");
+debug("Tests that gl.readPixels() can be called on WebAssembly Memory of 16GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas");
+
+const PAGE = 65536;
+const SIZE = 16*1024*1024*1024; 
+let view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE/PAGE }).buffer);
+
+// Clear the canvas to a specific color
+const expectedColor = [42, 84, 128, 255];
+gl.clearColor(expectedColor[0]/255.0, expectedColor[1]/255.0, expectedColor[2]/255.0, expectedColor[3]/255.0);
+gl.clear(gl.COLOR_BUFFER_BIT);
+
+// Test that gl.readPixels() can be called with a high offset to Memory
+const offset = SIZE - 4;
+view.set([0,0,0,0], offset); // For good measure, clear data at offset before reading
+gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, view, offset);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+let obtainedColor = view.subarray(offset, offset+4);
+shouldBe('obtainedColor[0]', 'expectedColor[0]');
+shouldBe('obtainedColor[1]', 'expectedColor[1]');
+shouldBe('obtainedColor[2]', 'expectedColor[2]');
+shouldBe('obtainedColor[3]', 'expectedColor[3]');
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
@@ -26,7 +26,7 @@ let wtu = WebGLTestUtils;
 let gl = wtu.create3DContext("canvas");
 
 const PAGE = 65536;
-const SIZE = 16*1024*1024*1024; 
+const SIZE = 16*1024*1024*1024;
 let view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE/PAGE }).buffer);
 
 // Clear the canvas to a specific color

--- a/sdk/tests/conformance2/wasm/readpixels-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/readpixels-4gb-wasm-memory.html
@@ -1,0 +1,50 @@
+<!--
+Copyright (c) 2023 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gl.readPixels() test to Wasm Memory 4GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that gl.readPixels() can be called on WebAssembly Memory of 4GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas");
+
+const PAGE = 65536;
+const SIZE = 4*1024*1024*1024 - PAGE; // when uint32_t size is max, we can only reach one page short of full 4GB
+let view = new Uint8Array(new WebAssembly.Memory({ initial: SIZE/PAGE }).buffer);
+
+// Clear the canvas to a specific color
+const expectedColor = [42, 84, 128, 255];
+gl.clearColor(expectedColor[0]/255.0, expectedColor[1]/255.0, expectedColor[2]/255.0, expectedColor[3]/255.0);
+gl.clear(gl.COLOR_BUFFER_BIT);
+
+// Test that gl.readPixels() can be called with a high offset to Memory
+const offset = SIZE - 4;
+view.set([0,0,0,0], offset); // For good measure, clear data at offset before reading
+gl.readPixels(0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, view, offset);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+let obtainedColor = view.subarray(offset, offset+4);
+shouldBe('obtainedColor[0]', 'expectedColor[0]');
+shouldBe('obtainedColor[1]', 'expectedColor[1]');
+shouldBe('obtainedColor[2]', 'expectedColor[2]');
+shouldBe('obtainedColor[3]', 'expectedColor[3]');
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
@@ -1,0 +1,85 @@
+<!--
+Copyright (c) 2023 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gl.texImage2D() test to Wasm Memory 16GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that gl.texImage2D() can be called on WebAssembly Memory 16GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+
+const PAGE = 65536;
+const SIZE = 16*1024*1024*1024;
+let view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE/PAGE }).buffer);
+
+function compileShader(type, src) {
+  let shader = gl.createShader(type);
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  let log = gl.getShaderInfoLog(shader);
+  if (log) debug(log);
+  return shader;
+}
+
+function createProgram(vs, fs) {
+  let program = gl.createProgram();
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.bindAttribLocation(program, 0, 'pos');
+  gl.linkProgram(program);
+  gl.useProgram(program);
+  return program;
+}
+
+let program = createProgram(
+  compileShader(gl.VERTEX_SHADER, `
+    varying vec2 uv;
+    attribute vec2 pos;
+    void main() { uv = pos; gl_Position = vec4(pos*2.0-vec2(1.0,1.0),0,1); }`),
+  compileShader(gl.FRAGMENT_SHADER, `
+    precision lowp float;
+    uniform sampler2D tex;
+    varying vec2 uv;
+    void main() { gl_FragColor = texture2D(tex,uv); }`));
+
+gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]), gl.STATIC_DRAW);
+gl.vertexAttribPointer(0, 2, gl.FLOAT, gl.FALSE, 0, 0);
+gl.enableVertexAttribArray(0);
+
+let texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+
+// Test uploading an image
+const expectedColor = [42, 84, 128, 255];
+const offset = SIZE - 4;
+view.set(expectedColor, offset);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, view, offset);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+// Test rendering with that image
+gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+// Verify that we rendered what we expected
+wtu.checkCanvasRect(gl, 0, 0, 1, 1, expectedColor, "texImage2D produced expected color");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/teximage2d-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/teximage2d-4gb-wasm-memory.html
@@ -1,0 +1,85 @@
+<!--
+Copyright (c) 2023 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gl.texImage2D() test to Wasm Memory 4GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that gl.texImage2D() can be called on WebAssembly Memory 4GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+
+const PAGE = 65536;
+const SIZE = 4*1024*1024*1024 - PAGE; // when uint32_t size is max, we can only reach one page short of full 4GB
+let view = new Uint8Array(new WebAssembly.Memory({ initial: SIZE/PAGE }).buffer);
+
+function compileShader(type, src) {
+  let shader = gl.createShader(type);
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  let log = gl.getShaderInfoLog(shader);
+  if (log) debug(log);
+  return shader;
+}
+
+function createProgram(vs, fs) {
+  let program = gl.createProgram();
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.bindAttribLocation(program, 0, 'pos');
+  gl.linkProgram(program);
+  gl.useProgram(program);
+  return program;
+}
+
+let program = createProgram(
+  compileShader(gl.VERTEX_SHADER, `
+    varying vec2 uv;
+    attribute vec2 pos;
+    void main() { uv = pos; gl_Position = vec4(pos*2.0-vec2(1.0,1.0),0,1); }`),
+  compileShader(gl.FRAGMENT_SHADER, `
+    precision lowp float;
+    uniform sampler2D tex;
+    varying vec2 uv;
+    void main() { gl_FragColor = texture2D(tex,uv); }`));
+
+gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]), gl.STATIC_DRAW);
+gl.vertexAttribPointer(0, 2, gl.FLOAT, gl.FALSE, 0, 0);
+gl.enableVertexAttribArray(0);
+
+let texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+
+// Test uploading an image
+const expectedColor = [42, 84, 128, 255];
+const offset = SIZE - 4;
+view.set(expectedColor, offset);
+gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, view, offset);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+// Test rendering with that image
+gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+// Verify that we rendered what we expected
+wtu.checkCanvasRect(gl, 0, 0, 1, 1, expectedColor, "texImage2D produced expected color");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
@@ -1,0 +1,86 @@
+<!--
+Copyright (c) 2023 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gl.texSubImage2D() test to Wasm Memory 16GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that gl.texSubImage2D() can be called on WebAssembly Memory 16GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+
+const PAGE = 65536;
+const SIZE = 16*1024*1024*1024;
+let view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE/PAGE }).buffer);
+
+function compileShader(type, src) {
+  let shader = gl.createShader(type);
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  let log = gl.getShaderInfoLog(shader);
+  if (log) debug(log);
+  return shader;
+}
+
+function createProgram(vs, fs) {
+  let program = gl.createProgram();
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.bindAttribLocation(program, 0, 'pos');
+  gl.linkProgram(program);
+  gl.useProgram(program);
+  return program;
+}
+
+let program = createProgram(
+  compileShader(gl.VERTEX_SHADER, `
+    varying vec2 uv;
+    attribute vec2 pos;
+    void main() { uv = pos; gl_Position = vec4(pos*2.0-vec2(1.0,1.0),0,1); }`),
+  compileShader(gl.FRAGMENT_SHADER, `
+    precision lowp float;
+    uniform sampler2D tex;
+    varying vec2 uv;
+    void main() { gl_FragColor = texture2D(tex,uv); }`));
+
+gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]), gl.STATIC_DRAW);
+gl.vertexAttribPointer(0, 2, gl.FLOAT, gl.FALSE, 0, 0);
+gl.enableVertexAttribArray(0);
+
+let texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+
+// Test uploading an image
+const expectedColor = [42, 84, 128, 255];
+const offset = SIZE - 4;
+view.set(expectedColor, offset);
+gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, 1, 1);
+gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, view, offset);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+// Test rendering with that image
+gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+// Verify that we rendered what we expected
+wtu.checkCanvasRect(gl, 0, 0, 1, 1, expectedColor, "texSubImage2D produced expected color");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/texsubimage2d-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/texsubimage2d-4gb-wasm-memory.html
@@ -1,0 +1,86 @@
+<!--
+Copyright (c) 2023 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>gl.texSubImage2D() test to Wasm Memory 4GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that gl.texSubImage2D() can be called on WebAssembly Memory 4GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+var gl = wtu.create3DContext("canvas");
+
+const PAGE = 65536;
+const SIZE = 4*1024*1024*1024 - PAGE; // when uint32_t size is max, we can only reach one page short of full 4GB
+let view = new Uint8Array(new WebAssembly.Memory({ initial: SIZE/PAGE }).buffer);
+
+function compileShader(type, src) {
+  let shader = gl.createShader(type);
+  gl.shaderSource(shader, src);
+  gl.compileShader(shader);
+  let log = gl.getShaderInfoLog(shader);
+  if (log) debug(log);
+  return shader;
+}
+
+function createProgram(vs, fs) {
+  let program = gl.createProgram();
+  gl.attachShader(program, vs);
+  gl.attachShader(program, fs);
+  gl.bindAttribLocation(program, 0, 'pos');
+  gl.linkProgram(program);
+  gl.useProgram(program);
+  return program;
+}
+
+let program = createProgram(
+  compileShader(gl.VERTEX_SHADER, `
+    varying vec2 uv;
+    attribute vec2 pos;
+    void main() { uv = pos; gl_Position = vec4(pos*2.0-vec2(1.0,1.0),0,1); }`),
+  compileShader(gl.FRAGMENT_SHADER, `
+    precision lowp float;
+    uniform sampler2D tex;
+    varying vec2 uv;
+    void main() { gl_FragColor = texture2D(tex,uv); }`));
+
+gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([0, 0, 1, 0, 0, 1, 1, 1]), gl.STATIC_DRAW);
+gl.vertexAttribPointer(0, 2, gl.FLOAT, gl.FALSE, 0, 0);
+gl.enableVertexAttribArray(0);
+
+let texture = gl.createTexture();
+gl.bindTexture(gl.TEXTURE_2D, texture);
+
+// Test uploading an image
+const expectedColor = [42, 84, 128, 255];
+const offset = SIZE - 4;
+view.set(expectedColor, offset);
+gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8, 1, 1);
+gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, view, offset);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+// Test rendering with that image
+gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+
+// Verify that we rendered what we expected
+wtu.checkCanvasRect(gl, 0, 0, 1, 1, expectedColor, "texSubImage2D produced expected color");
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/test-guidelines.md
+++ b/sdk/tests/test-guidelines.md
@@ -18,7 +18,7 @@ the WebGL Working Group when "official" snapshots are taken.
 These lines must appear in a comment at the top of every code file under sdk/tests/conformance
 
 ```
-Copyright (c) 2019 The Khronos Group Inc.
+Copyright (c) 2023 The Khronos Group Inc.
 Use of this source code is governed by an MIT-style license that can be
 found in the LICENSE.txt file.
 ```
@@ -102,7 +102,7 @@ found in the LICENSE.txt file.
 
         *   Tests that are short and run synchronously end with
 
-                <script src="../../resources/js-test-post.js"></script>
+                <script src="../../js/js-test-post.js"></script>
 
         *   Tests that take a long time use setTimeout so as not to freeze the browser.
 
@@ -144,7 +144,7 @@ found in the LICENSE.txt file.
 
         *   Vendors may place test harness specific code in the testing infrastructure.
 
-                resources/js-test-pre.js
+                js/js-test-pre.js
                 conformance/more/unit.js
 
     *   Indent with spaces not tabs. (not everyone uses your tab settings).


### PR DESCRIPTION
Add tests for gl.readPixels(), gl.texImage2D() and gl.texSubImage2D() from Wasm Memories of 4GB and 16GB in size.

CC @kenrussell 