### PR TITLE
In new WebGL 2-only Wasm tests, fetch WebGL 2.0 context directly.

### DIFF
--- a/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
@@ -23,7 +23,7 @@ debug("");
 debug("Tests that gl.readPixels() can be called on WebAssembly Memory of 16GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
-let gl = wtu.create3DContext("canvas");
+let gl = wtu.create3DContext("canvas", undefined, 2);
 
 const PAGE = 65536;
 const SIZE = 16*1024*1024*1024;

--- a/sdk/tests/conformance2/wasm/readpixels-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/readpixels-4gb-wasm-memory.html
@@ -22,7 +22,7 @@ description(document.title);
 debug("Tests that gl.readPixels() can be called on WebAssembly Memory of 4GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
-let gl = wtu.create3DContext("canvas");
+let gl = wtu.create3DContext("canvas", undefined, 2);
 
 const PAGE = 65536;
 const SIZE = 4*1024*1024*1024 - PAGE; // when uint32_t size is max, we can only reach one page short of full 4GB

--- a/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
@@ -22,7 +22,7 @@ description(document.title);
 debug("Tests that gl.texImage2D() can be called on WebAssembly Memory 16GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
+let gl = wtu.create3DContext("canvas", undefined, 2);
 
 const PAGE = 65536;
 const SIZE = 16*1024*1024*1024;

--- a/sdk/tests/conformance2/wasm/teximage2d-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/teximage2d-4gb-wasm-memory.html
@@ -22,7 +22,7 @@ description(document.title);
 debug("Tests that gl.texImage2D() can be called on WebAssembly Memory 4GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
+let gl = wtu.create3DContext("canvas", undefined, 2);
 
 const PAGE = 65536;
 const SIZE = 4*1024*1024*1024 - PAGE; // when uint32_t size is max, we can only reach one page short of full 4GB

--- a/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
@@ -22,7 +22,7 @@ description(document.title);
 debug("Tests that gl.texSubImage2D() can be called on WebAssembly Memory 16GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
+let gl = wtu.create3DContext("canvas", undefined, 2);
 
 const PAGE = 65536;
 const SIZE = 16*1024*1024*1024;

--- a/sdk/tests/conformance2/wasm/texsubimage2d-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/texsubimage2d-4gb-wasm-memory.html
@@ -22,7 +22,7 @@ description(document.title);
 debug("Tests that gl.texSubImage2D() can be called on WebAssembly Memory 4GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
-var gl = wtu.create3DContext("canvas");
+let gl = wtu.create3DContext("canvas", undefined, 2);
 
 const PAGE = 65536;
 const SIZE = 4*1024*1024*1024 - PAGE; // when uint32_t size is max, we can only reach one page short of full 4GB


### PR DESCRIPTION
This makes them runnable by navigating to them outside of the test harness and without URL query parameters.

Follow-on to #3592.