### PR TITLE
Promote four extensions to community approved.

### DIFF
--- a/extensions/EXT_clip_control/extension.xml
+++ b/extensions/EXT_clip_control/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_clip_control/">
+<extension href="EXT_clip_control/">
   <name>EXT_clip_control</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -71,5 +71,8 @@ interface EXT_clip_control {
     <revision date="2023/06/01">
       <change>Initial Draft.</change>
     </revision>
+    <revision date="2023/11/06">
+      <change>WebGL WG promoted to Community Approved on 2023-11-02.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/extensions/EXT_depth_clamp/extension.xml
+++ b/extensions/EXT_depth_clamp/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_depth_clamp/">
+<extension href="EXT_depth_clamp/">
   <name>EXT_depth_clamp</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -63,5 +63,8 @@ interface EXT_depth_clamp {
     <revision date="2023/06/01">
       <change>Initial Draft.</change>
     </revision>
+    <revision date="2023/11/06">
+      <change>WebGL WG promoted to Community Approved on 2023-11-02.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/extensions/EXT_polygon_offset_clamp/extension.xml
+++ b/extensions/EXT_polygon_offset_clamp/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="EXT_polygon_offset_clamp/">
+<extension href="EXT_polygon_offset_clamp/">
   <name>EXT_polygon_offset_clamp</name>
 
   <contact>
@@ -64,5 +64,8 @@ interface EXT_polygon_offset_clamp {
     <revision date="2023/02/09">
       <change>Promoted to Draft.</change>
     </revision>
+    <revision date="2023/11/06">
+      <change>WebGL WG promoted to Community Approved on 2023-11-02.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/extensions/WEBGL_polygon_mode/extension.xml
+++ b/extensions/WEBGL_polygon_mode/extension.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<draft href="WEBGL_polygon_mode/">
+<extension href="WEBGL_polygon_mode/">
   <name>WEBGL_polygon_mode</name>
 
   <contact> <a href="https://www.khronos.org/webgl/public-mailing-list/">WebGL
@@ -19,6 +19,13 @@
     <mirrors href="https://chromium.googlesource.com/angle/angle/+/HEAD/extensions/ANGLE_polygon_mode.txt"
              name="ANGLE_polygon_mode">
     </mirrors>
+
+    <p>
+      <b>Note:</b> Browsers should should discourage use of this extension in non-debug desktop
+      applications due to its non-portability (it is generally only supported on desktop platforms,
+      not on mobile), such as by warning about the use of this extension, and/or disabling it in
+      non-early-access release channel versions of browsers.
+    </p>
   </overview>
 
   <idl xml:space="preserve">
@@ -84,5 +91,8 @@ interface WEBGL_polygon_mode {
     <revision date="2023/06/01">
       <change>Initial Draft.</change>
     </revision>
+    <revision date="2023/11/06">
+      <change>WebGL WG promoted to Community Approved on 2023-11-02, with warning about non-portability.</change>
+    </revision>
   </history>
-</draft>
+</extension>

--- a/extensions/WEBGL_polygon_mode/extension.xml
+++ b/extensions/WEBGL_polygon_mode/extension.xml
@@ -22,8 +22,8 @@
 
     <div class="note">
       Applications should not use this extension to achieve rendering effects, and browsers should
-      should discourage use of this extension in non-debug applications, because it is non-portable.
-      For example, browsers should warn about the use of this extension, and/or disable it in
+      discourage use of this extension in non-debug applications, because it is non-portable. For
+      example, browsers should warn about the use of this extension, and/or disable it in
       non-early-access release channel versions of browsers.
     </div>
   </overview>

--- a/extensions/WEBGL_polygon_mode/extension.xml
+++ b/extensions/WEBGL_polygon_mode/extension.xml
@@ -20,11 +20,12 @@
              name="ANGLE_polygon_mode">
     </mirrors>
 
-    <p>
-      <b>Note:</b> Browsers should should discourage use of this extension in non-debug applications
-      because it is non-portable. For example, browsers should warn about the use of this extension,
-      and/or disable it in non-early-access release channel versions of browsers.
-    </p>
+    <div class="note">
+      Applications should not use this extension to achieve rendering effects, and browsers should
+      should discourage use of this extension in non-debug applications, because it is non-portable.
+      For example, browsers should warn about the use of this extension, and/or disable it in
+      non-early-access release channel versions of browsers.
+    </div>
   </overview>
 
   <idl xml:space="preserve">

--- a/extensions/WEBGL_polygon_mode/extension.xml
+++ b/extensions/WEBGL_polygon_mode/extension.xml
@@ -21,10 +21,9 @@
     </mirrors>
 
     <p>
-      <b>Note:</b> Browsers should should discourage use of this extension in non-debug desktop
-      applications due to its non-portability (it is generally only supported on desktop platforms,
-      not on mobile), such as by warning about the use of this extension, and/or disabling it in
-      non-early-access release channel versions of browsers.
+      <b>Note:</b> Browsers should should discourage use of this extension in non-debug applications
+      because it is non-portable. For example, browsers should warn about the use of this extension,
+      and/or disable it in non-early-access release channel versions of browsers.
     </p>
   </overview>
 


### PR DESCRIPTION
WebGL WG resolved to promote the following to community approved during the meeting of 2023-11-02:

EXT_polygon_offset_clamp
EXT_clip_control
EXT_depth_clamp
WEBGL_polygon_mode

WEBGL_polygon_mode includes a warning about its non-portability which must be implemented in browsers.