### PR TITLE
Canvases should reset their contents when width or height is set

### DIFF
--- a/sdk/tests/conformance/canvas/canvas-test.html
+++ b/sdk/tests/conformance/canvas/canvas-test.html
@@ -182,7 +182,33 @@ if (!gl) {
                   "gl.colorMask should not change after canvas resize");
         shouldBe('getViewport()', '"0,0,300,150"');
         checkCanvasContentIs(0, 0, 0, 0);
-      }
+
+        debug("");
+        debug("change the size of the canvas to the same size it already is and see that it gets cleared");
+        gl.colorMask(true, true, true, true);
+        gl.clearColor(0.25, 0.5, 0.75, 1);
+        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        // Check it's not cleared
+        checkCanvasContentIs(64, 128, 192, 255);
+
+        gl.canvas.width = gl.canvas.width;
+        err = gl.getError();
+        // Some implementations might lost the context when resizing
+        if (err != gl.CONTEXT_LOST_WEBGL) {
+          checkCanvasContentIs(0, 0, 0, 0);
+
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+          // Check it's not cleared
+          checkCanvasContentIs(64, 128, 192, 255);
+
+          gl.canvas.height = gl.canvas.height;
+          err = gl.getError();
+          // Some implementations might lost the context when resizing
+          if (err != gl.CONTEXT_LOST_WEBGL) {
+            checkCanvasContentIs(0, 0, 0, 0);
+          }
+        }
+     }
 
       debug("");
       finishTest();


### PR DESCRIPTION
even if the sizes are the same.

Note: Canvas 2D does this. There are various issues related to requestAnimationFrame and ResizeObserver that this affects. It would probably be best of all the APIs did the same thing so that the workarounds for resizing the canvas are the same across APIs

Safari passes this test, Firefox and Chrome fail