### PR TITLE
Remove default value for interface attributes.

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1773,8 +1773,11 @@ interface mixin <dfn data-dfn-type="interface" id="WebGLRenderingContextBase">We
     readonly attribute GLsizei drawingBufferWidth;
     readonly attribute GLsizei drawingBufferHeight;
     readonly attribute GLenum drawingBufferFormat;
-    attribute PredefinedColorSpace drawingBufferColorSpace = "srgb";
-    attribute PredefinedColorSpace unpackColorSpace = "srgb";
+
+    /* Upon context creation, drawingBufferColorSpace and unpackColorSpace both
+       default to the value "srgb". */
+    attribute PredefinedColorSpace drawingBufferColorSpace;
+    attribute PredefinedColorSpace unpackColorSpace;
 
     [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
     [WebGLHandlesContextLoss] boolean isContextLost();

--- a/specs/latest/1.0/webgl.idl
+++ b/specs/latest/1.0/webgl.idl
@@ -3,7 +3,7 @@
 // WebGL IDL definitions scraped from the Khronos specification:
 // https://www.khronos.org/registry/webgl/specs/latest/
 
-// Copyright (c) 2023 The Khronos Group Inc.
+// Copyright (c) 2024 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the
@@ -540,8 +540,11 @@ interface mixin WebGLRenderingContextBase
     readonly attribute GLsizei drawingBufferWidth;
     readonly attribute GLsizei drawingBufferHeight;
     readonly attribute GLenum drawingBufferFormat;
-    attribute PredefinedColorSpace drawingBufferColorSpace = "srgb";
-    attribute PredefinedColorSpace unpackColorSpace = "srgb";
+
+    /* Upon context creation, drawingBufferColorSpace and unpackColorSpace both
+       default to the value "srgb". */
+    attribute PredefinedColorSpace drawingBufferColorSpace;
+    attribute PredefinedColorSpace unpackColorSpace;
 
     [WebGLHandlesContextLoss] WebGLContextAttributes? getContextAttributes();
     [WebGLHandlesContextLoss] boolean isContextLost();


### PR DESCRIPTION
Per the bug report, Web IDL syntax does not allow default values to be specified for these attributes. Instead, specify the initial values for the drawingBufferColorSpace and unpackColorSpace attributes as comments in the spec.

Fixes #3407.