### PR TITLE
Add tests for bufferData, bufferSubData and getBufferSubData from WASM Memories of 4GB and 16GB in size.

### DIFF
--- a/sdk/tests/conformance2/wasm/00_test_list.txt
+++ b/sdk/tests/conformance2/wasm/00_test_list.txt
@@ -4,3 +4,9 @@
 --min-version 2.0.1 teximage2d-4gb-wasm-memory.html
 --min-version 2.0.1 texsubimage2d-16gb-wasm-memory.html
 --min-version 2.0.1 texsubimage2d-4gb-wasm-memory.html
+--min-version 2.0.1 bufferdata-16gb-wasm-memory.html
+--min-version 2.0.1 bufferdata-4gb-wasm-memory.html
+--min-version 2.0.1 buffersubdata-16gb-wasm-memory.html
+--min-version 2.0.1 buffersubdata-4gb-wasm-memory.html
+--min-version 2.0.1 getbuffersubdata-16gb-wasm-memory.html
+--min-version 2.0.1 getbuffersubdata-4gb-wasm-memory.html

--- a/sdk/tests/conformance2/wasm/bufferdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/bufferdata-16gb-wasm-memory.html
@@ -1,0 +1,51 @@
+<!--
+Copyright (c) 2024 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>bufferData test to Wasm Memory 16GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that bufferData can be called on WebAssembly Memory of 16GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas", undefined, 2);
+
+const PAGE = 65536;
+const SIZE = 16 * 1024 * 1024 * 1024;
+let view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+let expectedData = new Uint8Array([1, 2, 3, 4]);
+const length = expectedData.length;
+const offset = SIZE - length;
+view.set(expectedData, offset);
+
+let buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, view, gl.STATIC_DRAW, offset, length);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+let actualData = new Uint8Array(length);
+gl.getBufferSubData(gl.ARRAY_BUFFER, 0, actualData);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+for (let i = 0; i < length; i++) {
+  shouldBe(`actualData[${i}]`, `expectedData[${i}]`);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/bufferdata-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/bufferdata-4gb-wasm-memory.html
@@ -1,0 +1,51 @@
+<!--
+Copyright (c) 2024 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>bufferData test to Wasm Memory 4GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that bufferData can be called on WebAssembly Memory of 4GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas", undefined, 2);
+
+const PAGE = 65536;
+const SIZE = 4 * 1024 * 1024 * 1024 - PAGE;
+let view = new Uint8Array(new WebAssembly.Memory({ initial: SIZE / PAGE }).buffer);
+let expectedData = new Uint8Array([1, 2, 3, 4]);
+const length = expectedData.length;
+const offset = SIZE - length;
+view.set(expectedData, offset);
+
+let buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, view, gl.STATIC_DRAW, offset, length);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+let actualData = new Uint8Array(length);
+gl.getBufferSubData(gl.ARRAY_BUFFER, 0, actualData);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+for (let i = 0; i < length; i++) {
+  shouldBe(`actualData[${i}]`, `expectedData[${i}]`);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
@@ -1,0 +1,52 @@
+<!--
+Copyright (c) 2024 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>bufferSubData test to Wasm Memory 16GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that bufferSubData can be called on WebAssembly Memory of 16GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas", undefined, 2);
+
+const PAGE = 65536;
+const SIZE = 16 * 1024 * 1024 * 1024;
+let view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+let expectedData = new Uint8Array([1, 2]);
+const length = expectedData.length;
+let srcOffset = SIZE - length;
+view.set(expectedData, srcOffset);
+const dstByteOffset = 4;
+
+let buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, 8, gl.STATIC_DRAW);
+gl.bufferSubData(gl.ARRAY_BUFFER, dstByteOffset, view, srcOffset, length);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+let actualData = new Uint8Array(length);
+gl.getBufferSubData(gl.ARRAY_BUFFER, dstByteOffset, actualData);
+for (let i = 0; i < length; i++) {
+  shouldBe(`actualData[${i}]`, `expectedData[${i}]`);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/buffersubdata-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/buffersubdata-4gb-wasm-memory.html
@@ -1,0 +1,52 @@
+<!--
+Copyright (c) 2024 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>bufferSubData test to Wasm Memory 4GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that bufferSubData can be called on WebAssembly Memory of 4GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas", undefined, 2);
+
+const PAGE = 65536;
+const SIZE = 4 * 1024 * 1024 * 1024 - PAGE;
+let view = new Uint8Array(new WebAssembly.Memory({ initial: SIZE / PAGE }).buffer);
+let expectedData = new Uint8Array([1, 2]);
+const length = expectedData.length;
+let srcOffset = SIZE - length;
+view.set(expectedData, srcOffset);
+const dstByteOffset = 4;
+
+let buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, 8, gl.STATIC_DRAW);
+gl.bufferSubData(gl.ARRAY_BUFFER, dstByteOffset, view, srcOffset, length);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+
+let actualData = new Uint8Array(length);
+gl.getBufferSubData(gl.ARRAY_BUFFER, dstByteOffset, actualData);
+for (let i = 0; i < length; i++) {
+  shouldBe(`actualData[${i}]`, `expectedData[${i}]`);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
@@ -1,0 +1,48 @@
+<!--
+Copyright (c) 2024 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>getBufferSubData test to Wasm Memory 4GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that getBufferSubData can be called on WebAssembly Memory of 4GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas", undefined, 2);
+
+const PAGE = 65536;
+const SIZE = 16 * 1024 * 1024 * 1024;
+let view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+let expectedData = new Uint8Array([1, 2, 3, 4]);
+
+let buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, expectedData, gl.STATIC_DRAW);
+
+const length = expectedData.length;
+const offset = SIZE - length;
+gl.getBufferSubData(gl.ARRAY_BUFFER, 0, view, offset, length);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+for (let i = 0; i < length; i++) {
+  shouldBe(`view[${i + offset}]`, `expectedData[${i}]`);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
@@ -7,7 +7,7 @@ found in the LICENSE.txt file.
 <html>
 <head>
 <meta charset="utf-8">
-<title>getBufferSubData test to Wasm Memory 4GB in size.</title>
+<title>getBufferSubData test to Wasm Memory 16GB in size.</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"> </script>
@@ -19,7 +19,7 @@ found in the LICENSE.txt file.
 <script>
 "use strict";
 description(document.title);
-debug("Tests that getBufferSubData can be called on WebAssembly Memory of 4GB in size.");
+debug("Tests that getBufferSubData can be called on WebAssembly Memory of 16GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
 let gl = wtu.create3DContext("canvas", undefined, 2);

--- a/sdk/tests/conformance2/wasm/getbuffersubdata-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/getbuffersubdata-4gb-wasm-memory.html
@@ -1,0 +1,48 @@
+<!--
+Copyright (c) 2024 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>getBufferSubData test to Wasm Memory 16GB in size.</title>
+<link rel="stylesheet" href="../../resources/js-test-style.css"/>
+<script src="../../js/js-test-pre.js"></script>
+<script src="../../js/webgl-test-utils.js"> </script>
+</head>
+<body>
+<canvas id="canvas" width="2" height="2" style="width: 40px; height: 40px;"></canvas>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description(document.title);
+debug("Tests that getBufferSubData can be called on WebAssembly Memory of 16GB in size.");
+debug("");
+let wtu = WebGLTestUtils;
+let gl = wtu.create3DContext("canvas", undefined, 2);
+
+const PAGE = 65536;
+const SIZE = 4 * 1024 * 1024 * 1024 - PAGE;
+let view = new Uint8Array(new WebAssembly.Memory({ initial: SIZE / PAGE }).buffer);
+let expectedData = new Uint8Array([1, 2, 3, 4]);
+
+let buf = gl.createBuffer();
+gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+gl.bufferData(gl.ARRAY_BUFFER, expectedData, gl.STATIC_DRAW);
+
+const length = expectedData.length;
+const offset = SIZE - length;
+gl.getBufferSubData(gl.ARRAY_BUFFER, 0, view, offset, length);
+wtu.glErrorShouldBe(gl, gl.NO_ERROR);
+for (let i = 0; i < length; i++) {
+  shouldBe(`view[${i + offset}]`, `expectedData[${i}]`);
+}
+
+var successfullyParsed = true;
+</script>
+<script src="../../js/js-test-post.js"></script>
+</body>
+</html>

--- a/sdk/tests/conformance2/wasm/getbuffersubdata-4gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/getbuffersubdata-4gb-wasm-memory.html
@@ -7,7 +7,7 @@ found in the LICENSE.txt file.
 <html>
 <head>
 <meta charset="utf-8">
-<title>getBufferSubData test to Wasm Memory 16GB in size.</title>
+<title>getBufferSubData test to Wasm Memory 4GB in size.</title>
 <link rel="stylesheet" href="../../resources/js-test-style.css"/>
 <script src="../../js/js-test-pre.js"></script>
 <script src="../../js/webgl-test-utils.js"> </script>
@@ -19,7 +19,7 @@ found in the LICENSE.txt file.
 <script>
 "use strict";
 description(document.title);
-debug("Tests that getBufferSubData can be called on WebAssembly Memory of 16GB in size.");
+debug("Tests that getBufferSubData can be called on WebAssembly Memory of 4GB in size.");
 debug("");
 let wtu = WebGLTestUtils;
 let gl = wtu.create3DContext("canvas", undefined, 2);


### PR DESCRIPTION
Add tests for bufferData, bufferSubData and getBufferSubData from WASM Memories of 4GB and 16GB in size.