### PR TITLE
Add epsilon to float comparison

### DIFF
--- a/sdk/tests/conformance/extensions/webgl-depth-texture.html
+++ b/sdk/tests/conformance/extensions/webgl-depth-texture.html
@@ -323,21 +323,18 @@ function runTestExtension(unpackFlipY) {
                     d01, d01, d11, d11
                 ];
                 expectedMax = expectedMin.slice();
-
-                expectedMin = expectedMin.map(x => x - eps);
-                expectedMax = expectedMax.map(x => x + eps);
             } else {
                 expectedMin = [
-                    d00-eps, d00, d00, d10-eps,
                     d00, d00, d00, d10,
                     d00, d00, d00, d10,
-                    d01-eps, d01, d01, d11-eps,
+                    d00, d00, d00, d10,
+                    d01, d01, d01, d11,
                 ];
                 expectedMax = [
-                    d00+eps, d10, d10, d10+eps,
+                    d00, d10, d10, d10,
                     d01, d11, d11, d11,
                     d01, d11, d11, d11,
-                    d01+eps, d11, d11, d11+eps,
+                    d01, d11, d11, d11,
                 ];
             }
 

--- a/sdk/tests/conformance/extensions/webgl-depth-texture.html
+++ b/sdk/tests/conformance/extensions/webgl-depth-texture.html
@@ -349,7 +349,7 @@ function runTestExtension(unpackFlipY) {
                     const eMax = expectedMax[t];
                     let func = testPassed;
                     const text = `At ${xx},${yy}, expected within [${eMin},${eMax}], was ${was.toFixed(3)}`
-                    if (was <= eMin || was >= eMax) {
+                    if (was <= eMin - eps || was >= eMax + eps) {
                         func = testFailed;
                     }
                     func(text);


### PR DESCRIPTION
Adds an epsilon when comparing float values in
conformance/extensions/webgl-depth-texture.html. As-is, it is possible for tests to fail with output such as:

At 2,0, expected within [0.2,0.6], was 0.600
FAIL At 2,0, expected within [0.2,0.6], was 0.600