### PR TITLE
WebGLObject creation is now infallible, and starts Lost iff context Lost.

### DIFF
--- a/extensions/EXT_disjoint_timer_query/extension.xml
+++ b/extensions/EXT_disjoint_timer_query/extension.xml
@@ -62,7 +62,7 @@ interface EXT_disjoint_timer_query {
   const GLenum TIMESTAMP_EXT               = 0x8E28;
   const GLenum GPU_DISJOINT_EXT            = 0x8FBB;
 
-  WebGLTimerQueryEXT? createQueryEXT();
+  WebGLTimerQueryEXT createQueryEXT();
   undefined deleteQueryEXT(WebGLTimerQueryEXT? query);
   [WebGLHandlesContextLoss] boolean isQueryEXT(WebGLTimerQueryEXT? query);
   undefined beginQueryEXT(GLenum target, WebGLTimerQueryEXT query);
@@ -420,6 +420,9 @@ interface EXT_disjoint_timer_query {
     </revision>
     <revision date="2023/06/01">
       <change>Added error codes for invalid API usage.</change>
+    </revision>
+    <revision date="2024/04/19">
+      <change><code>createQueryEXT</code> made infallible.</change>
     </revision>
   </history>
 </extension>

--- a/extensions/OES_vertex_array_object/extension.xml
+++ b/extensions/OES_vertex_array_object/extension.xml
@@ -25,7 +25,7 @@ interface WebGLVertexArrayObjectOES : WebGLObject {
 interface OES_vertex_array_object {
     const GLenum VERTEX_ARRAY_BINDING_OES = 0x85B5;
 
-    WebGLVertexArrayObjectOES? createVertexArrayOES();
+    WebGLVertexArrayObjectOES createVertexArrayOES();
     undefined deleteVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
     [WebGLHandlesContextLoss] GLboolean isVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
     undefined bindVertexArrayOES(WebGLVertexArrayObjectOES? arrayObject);
@@ -166,6 +166,9 @@ interface OES_vertex_array_object {
     </revision>
     <revision date="2022/07/09">
       <change>Added error codes for invalid API usage.</change>
+    </revision>
+    <revision date="2024/04/19">
+      <change><code>createVertexArrayOES</code> made infallible.</change>
     </revision>
   </history>
 </ratified>

--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -239,13 +239,21 @@ function testOESTextureFloat() {
 function testOESVertexArrayObject() {
   if (OES_vertex_array_object) {
     // Extension must still be lost.
-    shouldBeNonNull("OES_vertex_array_object.createVertexArrayOES()");
+    let vao = OES_vertex_array_object.createVertexArrayOES();
+    assertMsg(vao, "[with extension lost] createVertexArrayOES() -> non-null");
+    assertMsg(!OES_vertex_array_object.isVertexArrayOES(vao), "[with context lost] isVertexArrayOES(createVertexArrayOES()) -> false");
     // Try re-enabling extension
 
     old_OES_vertex_array_object = OES_vertex_array_object;
     OES_vertex_array_object = reGetExtensionAndTestForProperty(gl, "OES_vertex_array_object", false);
-    shouldBeNonNull("OES_vertex_array_object.createVertexArrayOES()");
-    shouldBeNonNull("old_OES_vertex_array_object.createVertexArrayOES()");
+
+    vao = OES_vertex_array_object.createVertexArrayOES();
+    assertMsg(vao, "[with new non-lost extension] createVertexArrayOES() -> non-null");
+    assertMsg(OES_vertex_array_object.isVertexArrayOES(vao), "[with new non-lost extension] isVertexArrayOES(createVertexArrayOES()) -> true");
+
+    vao = old_OES_vertex_array_object.createVertexArrayOES();
+    assertMsg(vao, "[with old lost extension] createVertexArrayOES() -> non-null");
+    assertMsg(!old_OES_vertex_array_object.isVertexArrayOES(vao), "[with old lost extension] isVertexArrayOES(createVertexArrayOES()) -> false");
   }
 }
 

--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -239,13 +239,13 @@ function testOESTextureFloat() {
 function testOESVertexArrayObject() {
   if (OES_vertex_array_object) {
     // Extension must still be lost.
-    shouldBeNull("OES_vertex_array_object.createVertexArrayOES()");
+    shouldBeNonNull("OES_vertex_array_object.createVertexArrayOES()");
     // Try re-enabling extension
 
     old_OES_vertex_array_object = OES_vertex_array_object;
     OES_vertex_array_object = reGetExtensionAndTestForProperty(gl, "OES_vertex_array_object", false);
-    shouldBeTrue("OES_vertex_array_object.createVertexArrayOES() != null");
-    shouldBeTrue("old_OES_vertex_array_object.createVertexArrayOES() == null");
+    shouldBeNonNull("OES_vertex_array_object.createVertexArrayOES()");
+    shouldBeNonNull("old_OES_vertex_array_object.createVertexArrayOES()");
   }
 }
 

--- a/sdk/tests/conformance/context/context-lost-restored.html
+++ b/sdk/tests/conformance/context/context-lost-restored.html
@@ -249,7 +249,10 @@ function testOESVertexArrayObject() {
 
     vao = OES_vertex_array_object.createVertexArrayOES();
     assertMsg(vao, "[with new non-lost extension] createVertexArrayOES() -> non-null");
-    assertMsg(OES_vertex_array_object.isVertexArrayOES(vao), "[with new non-lost extension] isVertexArrayOES(createVertexArrayOES()) -> true");
+    assertMsg(!OES_vertex_array_object.isVertexArrayOES(vao), "[with new non-lost extension, before bindVAO] isVertexArrayOES(createVertexArrayOES()) -> false");
+    OES_vertex_array_object.bindVertexArrayOES(vao);
+    OES_vertex_array_object.bindVertexArrayOES(null);
+    assertMsg(OES_vertex_array_object.isVertexArrayOES(vao), "[with new non-lost extension, after bindVAO] isVertexArrayOES(createVertexArrayOES()) -> true");
 
     vao = old_OES_vertex_array_object.createVertexArrayOES();
     assertMsg(vao, "[with old lost extension] createVertexArrayOES() -> non-null");

--- a/sdk/tests/conformance/context/context-lost.html
+++ b/sdk/tests/conformance/context/context-lost.html
@@ -308,12 +308,6 @@ function testLostContext()
 
     // Functions return nullable values should all return null.
     var nullTests = [
-        "gl.createBuffer()",
-        "gl.createFramebuffer()",
-        "gl.createProgram()",
-        "gl.createRenderbuffer()",
-        "gl.createShader(gl.GL_VERTEX_SHADER)",
-        "gl.createTexture()",
         "gl.getActiveAttrib(program, 0)",
         "gl.getActiveUniform(program, 0)",
         "gl.getAttachedShaders(program)",
@@ -336,6 +330,17 @@ function testLostContext()
     ];
     testFunctionsThatReturnNULL(nullTests);
 
+    [
+      "gl.createBuffer()",
+      "gl.createFramebuffer()",
+      "gl.createProgram()",
+      "gl.createRenderbuffer()",
+      "gl.createShader(gl.VERTEX_SHADER)",
+      "gl.createTexture()",
+    ].forEach(x => {
+      shouldBeNonNull(x);
+    });
+
     // "Is" queries should all return false.
     shouldBeFalse("gl.isBuffer(buffer)");
     shouldBeFalse("gl.isEnabled(gl.BLEND)");
@@ -355,10 +360,12 @@ function testLostContext()
           "OES_vertex_array_object.isVertexArrayOES(vertexArrayObject)",
           "OES_vertex_array_object.deleteVertexArrayOES(vertexArrayObject)",
         ]);
-      testFunctionsThatReturnNULL(
-        [
-          "OES_vertex_array_object.createVertexArrayOES()",
-        ]);
+
+      [
+        "OES_vertex_array_object.createVertexArrayOES()",
+      ].forEach(x => {
+        shouldBeNonNull(x);
+      });
     }
 
     testUploadingLostContextToTexture();

--- a/sdk/tests/conformance/context/context-lost.html
+++ b/sdk/tests/conformance/context/context-lost.html
@@ -331,16 +331,19 @@ function testLostContext()
     testFunctionsThatReturnNULL(nullTests);
 
     [
-      [() => gl.createBuffer(), x => gl.isBuffer(x)]
-      [() => gl.createFramebuffer(), x => gl.isFramebuffer(x)]
-      [() => gl.createProgram(), x => gl.isProgram(x)]
-      [() => gl.createRenderbuffer(), x => gl.isRenderbuffer(x)]
-      [() => gl.createShader(gl.VERTEX_SHADER), x => gl.isShader(x)]
-      [() => gl.createTexture(), x => gl.isTexture(x)]
-    ].forEach(x => {
+      [() => gl.createBuffer(), x => gl.bindBuffer(gl.ARRAY_BUFFER, x), x => gl.isBuffer(x)],
+      [() => gl.createFramebuffer(), x => gl.bindFramebuffer(gl.FRAMEBUFFER, x), x => gl.isFramebuffer(x)],
+      [() => gl.createProgram(), x => undefined, x => gl.isProgram(x)],
+      [() => gl.createRenderbuffer(), x => gl.bindRenderbuffer(gl.RENDERBUFFER, x), x => gl.isRenderbuffer(x)],
+      [() => gl.createShader(gl.VERTEX_SHADER), x => undefined, x => gl.isShader(x)],
+      [() => gl.createTexture(), x => gl.bindTexture(gl.TEXTURE_2D, x), x => gl.isTexture(x)],
+    ].forEach(([fn_create, fn_bind, fn_is]) => {
       const x = fn_create();
       assertMsg(x, `${fn_create.toString()} -> non-null`);
-      assertMsg(fn_is(x) === false, `${fn_is.toString()} -> false`);
+      assertMsg(fn_is(x) === false, `[before bind] ${fn_is.toString()} -> false`);
+      fn_bind(x);
+      fn_bind(null);
+      assertMsg(fn_is(x) === false, `[after bind] ${fn_is.toString()} -> false`);
     });
 
     // "Is" queries should all return false.
@@ -358,11 +361,14 @@ function testLostContext()
         ]);
 
       [
-        [() => OES_vertex_array_object.createVertexArrayOES(), x => OES_vertex_array_object.isVertexArrayOES(x)]
-      ].forEach((fn_create, fn_is) => {
+        [() => OES_vertex_array_object.createVertexArrayOES(), x => OES_vertex_array_object.isVertexArrayOES(x), x => OES_vertex_array_object.isVertexArrayOES(x)],
+      ].forEach(([fn_create, fn_bind, fn_is]) => {
         const x = fn_create();
         assertMsg(x, `${fn_create.toString()} -> non-null`);
-        assertMsg(fn_is(x) === false, `${fn_is.toString()} -> false`);
+        assertMsg(fn_is(x) === false, `[before bind] ${fn_is.toString()} -> false`);
+        fn_bind(x);
+        fn_bind(null);
+        assertMsg(fn_is(x) === false, `[after bind] ${fn_is.toString()} -> false`);
       });
     }
 

--- a/sdk/tests/conformance/context/context-lost.html
+++ b/sdk/tests/conformance/context/context-lost.html
@@ -331,24 +331,20 @@ function testLostContext()
     testFunctionsThatReturnNULL(nullTests);
 
     [
-      "gl.createBuffer()",
-      "gl.createFramebuffer()",
-      "gl.createProgram()",
-      "gl.createRenderbuffer()",
-      "gl.createShader(gl.VERTEX_SHADER)",
-      "gl.createTexture()",
+      [() => gl.createBuffer(), x => gl.isBuffer(x)]
+      [() => gl.createFramebuffer(), x => gl.isFramebuffer(x)]
+      [() => gl.createProgram(), x => gl.isProgram(x)]
+      [() => gl.createRenderbuffer(), x => gl.isRenderbuffer(x)]
+      [() => gl.createShader(gl.VERTEX_SHADER), x => gl.isShader(x)]
+      [() => gl.createTexture(), x => gl.isTexture(x)]
     ].forEach(x => {
-      shouldBeNonNull(x);
+      const x = fn_create();
+      assertMsg(x, `${fn_create.toString()} -> non-null`);
+      assertMsg(fn_is(x) === false, `${fn_is.toString()} -> false`);
     });
 
     // "Is" queries should all return false.
-    shouldBeFalse("gl.isBuffer(buffer)");
     shouldBeFalse("gl.isEnabled(gl.BLEND)");
-    shouldBeFalse("gl.isFramebuffer(framebuffer)");
-    shouldBeFalse("gl.isProgram(program)");
-    shouldBeFalse("gl.isRenderbuffer(renderbuffer)");
-    shouldBeFalse("gl.isShader(shader)");
-    shouldBeFalse("gl.isTexture(texture)");
 
     shouldBe("gl.getError()", "gl.NO_ERROR");
 
@@ -362,9 +358,11 @@ function testLostContext()
         ]);
 
       [
-        "OES_vertex_array_object.createVertexArrayOES()",
-      ].forEach(x => {
-        shouldBeNonNull(x);
+        [() => OES_vertex_array_object.createVertexArrayOES(), x => OES_vertex_array_object.isVertexArrayOES(x)]
+      ].forEach((fn_create, fn_is) => {
+        const x = fn_create();
+        assertMsg(x, `${fn_create.toString()} -> non-null`);
+        assertMsg(fn_is(x) === false, `${fn_is.toString()} -> false`);
       });
     }
 

--- a/sdk/tests/conformance/offscreencanvas/context-lost-restored.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-restored.html
@@ -43,12 +43,12 @@ function init()
                 finishTest();
                 return;
             }
-            testLosingAndRestoringContext().then(function() {
+            testLosingAndRestoringContext().then(function(s) {
                 testPassed("Test passed");
                 finishTest();
                 return;
-            }, function() {
-                testFailed("Some test failed");
+            }, function(s) {
+                testFailed("Test failed: " + s);
                 finishTest();
                 return;
             });

--- a/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
@@ -24,7 +24,7 @@ function init()
   var worker = new Worker('context-lost-worker.js');
   worker.postMessage("Start worker");
   worker.onmessage = function(e) {
-    const fn = e.data.OffscreenCanvas ? testFailed : testPassed;
+    const fn = e.data.fail ? testFailed : testPassed;
     fn(e.data.msg);
     if (e.data.finishTest) {
       finishTest();

--- a/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-worker.html
@@ -24,12 +24,11 @@ function init()
   var worker = new Worker('context-lost-worker.js');
   worker.postMessage("Start worker");
   worker.onmessage = function(e) {
-    if (e.data == "Test passed") {
-      testPassed("All tests have passed");
-    } else {
-      testFailed("Some tests failed");
+    const fn = e.data.OffscreenCanvas ? testFailed : testPassed;
+    fn(e.data.msg);
+    if (e.data.finishTest) {
+      finishTest();
     }
-    finishTest();
     return;
   }
 }

--- a/sdk/tests/conformance/offscreencanvas/context-lost-worker.js
+++ b/sdk/tests/conformance/offscreencanvas/context-lost-worker.js
@@ -11,25 +11,23 @@ self.onmessage = function(e) {
 
     // call testValidContext() before checking for the extension, because this is where we check
     // for the isContextLost() method, which we want to do regardless of the extension's presence.
-    if (!testValidContext())
-        self.postMessage("Test failed");
+    self.postMessage({fail: !testValidContext(), msg: "testValidContext()"});
 
-    extension = gl.getExtension("WEBGL_lose_context");
+    WEBGL_lose_context = gl.getExtension("WEBGL_lose_context");
+    self.postMessage({fail: !WEBGL_lose_context, msg: "WEBGL_lose_context"});
+
     // need an extension that exposes new API methods.
     OES_vertex_array_object = gl.getExtension("OES_vertex_array_object");
-    if (extension == null || OES_vertex_array_object == null)
-        self.postMessage("Test failed");
+    self.postMessage({fail: !OES_vertex_array_object, msg: "OES_vertex_array_object"});
 
     // We need to initialize |uniformLocation| before losing context.
     // Otherwise gl.getUniform() when context is lost will throw.
     uniformLocation = gl.getUniformLocation(program, "tex");
-    extension.loseContext();
+    WEBGL_lose_context.loseContext();
 
     canvas.addEventListener("webglcontextlost", function() {
-        if (testLostContextWithoutRestore())
-            self.postMessage("Test passed");
-        else
-            self.postMessage("Test failed");
+        self.postMessage({fail: !testLostContextWithoutRestore(), msg: "testLostContextWithoutRestore()",
+            finishTest:true});
     }, false);
 }
 

--- a/sdk/tests/conformance/offscreencanvas/context-lost.html
+++ b/sdk/tests/conformance/offscreencanvas/context-lost.html
@@ -33,11 +33,11 @@ function init()
         return;
     }
 
-    extension = gl.getExtension("WEBGL_lose_context");
+    WEBGL_lose_context = gl.getExtension("WEBGL_lose_context");
     // need an extension that exposes new API methods.
     OES_vertex_array_object = gl.getExtension("OES_vertex_array_object");
-    if (extension == null || OES_vertex_array_object == null) {
-        testFailed("Some tests failed");
+    if (WEBGL_lose_context == null || OES_vertex_array_object == null) {
+        testFailed("extension && OES_vertex_array_object failed");
         finishTest();
         return;
     }
@@ -45,7 +45,7 @@ function init()
     // We need to initialize |uniformLocation| before losing context.
     // Otherwise gl.getUniform() when context is lost will throw.
     uniformLocation = gl.getUniformLocation(program, "tex");
-    extension.loseContext();
+    WEBGL_lose_context.loseContext();
 
     canvas.addEventListener("webglcontextlost", function() {
         if (testLostContextWithoutRestore()) {
@@ -53,7 +53,7 @@ function init()
             finishTest();
             return;
         } else {
-            testFailed("Some tests failed");
+            testFailed("testLostContextWithoutRestore failed");
             finishTest();
             return;
         }

--- a/sdk/tests/js/tests/canvas-tests-utils.js
+++ b/sdk/tests/js/tests/canvas-tests-utils.js
@@ -9,7 +9,7 @@ var canvas;
 var gl;
 var OES_vertex_array_object;
 var uniformLocation;
-var extension;
+var WEBGL_lose_context;
 var buffer;
 var framebuffer;
 var program;
@@ -439,7 +439,7 @@ function testLostContextWithoutRestore()
         return false;
 
     // Test the extension itself.
-    if (!compareGLError(gl.INVALID_OPERATION, "extension.loseContext()"))
+    if (!compareGLError(gl.INVALID_OPERATION, "WEBGL_lose_context.loseContext()"))
         return false;
 
     imageData = new ImageData(1, 1);
@@ -567,13 +567,7 @@ function testLostContextWithoutRestore()
         return false;
 
     // Functions return nullable values should all return null.
-    if (gl.createBuffer() != null ||
-        gl.createFramebuffer() != null ||
-        gl.createProgram() != null ||
-        gl.createRenderbuffer() != null ||
-        gl.createShader(gl.GL_VERTEX_SHADER) != null ||
-        gl.createTexture() != null ||
-        gl.getActiveAttrib(program, 0) != null ||
+    if (gl.getActiveAttrib(program, 0) != null ||
         gl.getActiveUniform(program, 0) != null ||
         gl.getAttachedShaders(program) != null ||
         gl.getBufferParameter(gl.ARRAY_BUFFER, gl.BUFFER_SIZE) != null ||
@@ -594,6 +588,22 @@ function testLostContextWithoutRestore()
         gl.getExtension("WEBGL_lose_context") != null)
         return false;
 
+    const failedTests = [
+        "gl.createBuffer()",
+        "gl.createFramebuffer()",
+        "gl.createProgram()",
+        "gl.createRenderbuffer()",
+        "gl.createShader(gl.VERTEX_SHADER)",
+        "gl.createTexture()",
+    ].reduce(s => {
+        const v = eval(s);
+        return !v;
+    });
+    if (failedTests.length) {
+        console.log({failedTests});
+        return false;
+    }
+
     // "Is" queries should all return false.
     if (gl.isBuffer(buffer) || gl.isEnabled(gl.BLEND) || gl.isFramebuffer(framebuffer) ||
         gl.isProgram(program) || gl.isRenderbuffer(renderbuffer) || gl.isShader(shader) ||
@@ -609,7 +619,7 @@ function testLostContextWithoutRestore()
             !compareGLError(gl.NO_ERROR, "OES_vertex_array_object.isVertexArrayOES(vertexArrayObject)") ||
             !compareGLError(gl.NO_ERROR, "OES_vertex_array_object.deleteVertexArrayOES(vertexArrayObject)"))
             return false;
-        if (OES_vertex_array_object.createVertexArrayOES() != null)
+        if (!OES_vertex_array_object.createVertexArrayOES())
             return false;
     }
     return true;
@@ -718,7 +728,7 @@ function testLosingAndRestoringContext()
         });
         canvas.addEventListener("webglcontextrestored", function() {
             if (!testRestoredContext())
-                reject("Test failed");
+                reject("Test failed: !testRestoredContext()");
             else
                 resolve("Test passed");
         });
@@ -788,16 +798,22 @@ function testOESTextureFloat() {
 function testOESVertexArrayObject() {
   if (OES_vertex_array_object) {
     // Extension must still be lost.
-    if (OES_vertex_array_object.createVertexArrayOES() != null)
+    if (!OES_vertex_array_object.createVertexArrayOES()) {
+        console.error("!OES_vertex_array_object.createVertexArrayOES()");
         return false;
+    }
     // Try re-enabling extension
 
     var old_OES_vertex_array_object = OES_vertex_array_object;
     OES_vertex_array_object = reGetExtensionAndTestForProperty(gl, "OES_vertex_array_object", false);
-    if (OES_vertex_array_object.createVertexArrayOES() == null)
+    if (!OES_vertex_array_object.createVertexArrayOES()) {
+        console.error("!OES_vertex_array_object.createVertexArrayOES() 2");
         return false;
-    if (old_OES_vertex_array_object.createVertexArrayOES() != null)
+    }
+    if (!old_OES_vertex_array_object.createVertexArrayOES()) {
+        console.error("!old_OES_vertex_array_object.createVertexArrayOES()");
         return false;
+    }
     return true;
   }
 }

--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -1815,12 +1815,12 @@ interface mixin <dfn data-dfn-type="interface" id="WebGLRenderingContextBase">We
     undefined copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset,
                                 GLint x, GLint y, GLsizei width, GLsizei height);
 
-    WebGLBuffer? createBuffer();
-    WebGLFramebuffer? createFramebuffer();
-    WebGLProgram? createProgram();
-    WebGLRenderbuffer? createRenderbuffer();
+    WebGLBuffer createBuffer();
+    WebGLFramebuffer createFramebuffer();
+    WebGLProgram createProgram();
+    WebGLRenderbuffer createRenderbuffer();
     WebGLShader? createShader(GLenum type);
-    WebGLTexture? createTexture();
+    WebGLTexture createTexture();
 
     undefined cullFace(GLenum mode);
 
@@ -2399,7 +2399,7 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             an <code>INVALID_VALUE</code> error is generated. If <code>data</code> is null then
             an <code>INVALID_VALUE</code> error is generated.
 
-        <dt class="idl-code">WebGLBuffer? createBuffer()
+        <dt class="idl-code">WebGLBuffer createBuffer()
             <span class="gl-spec">(<a href="http://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf#nameddest=section-2.9">OpenGL ES 2.0 &sect;2.9</a>, similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glGenBuffers.xml">glGenBuffers</a>)</span>
         <dd>
             Create a WebGLBuffer object and initialize it with a buffer object name as if by
@@ -2472,7 +2472,7 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             Returns <code class="enum">FRAMEBUFFER_UNSUPPORTED</code> if the
             context's <a href="#webgl-context-lost-flag">webgl context lost flag</a> is set.
 
-        <dt class="idl-code">WebGLFramebuffer? createFramebuffer()
+        <dt class="idl-code">WebGLFramebuffer createFramebuffer()
             <span class="gl-spec">(<a href="http://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf#nameddest=section-4.4.1">OpenGL ES 2.0 &sect;4.4.1</a>, similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glGenFramebuffers.xml">glGenFramebuffers</a>)</span>
         <dd>
             Create a WebGLFramebuffer object and initialize it with a framebuffer object name as if by
@@ -2554,7 +2554,7 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             An attempt to bind an object marked for deletion will generate an
             <code>INVALID_OPERATION</code> error, and the current binding will remain untouched.
 
-        <dt class="idl-code">WebGLRenderbuffer? createRenderbuffer()
+        <dt class="idl-code">WebGLRenderbuffer createRenderbuffer()
             <span class="gl-spec">(<a href="http://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf#nameddest=section-4.4.3">OpenGL ES 2.0 &sect;4.4.3</a>, similar to <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glGenRenderbuffers.xml">glGenRenderbuffers</a>)</span>
         <dd>
             Create a WebGLRenderbuffer object and initialize it with a renderbuffer object name as if by
@@ -2679,7 +2679,7 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             If this function attempts to read from a complete framebuffer with a missing attachment,
             an <code>INVALID_OPERATION</code> error is generated
             per <a href="#READING_FROM_MISSING_ATTACHMENT">Reading from a Missing Attachment</a>.
-        <dt class="idl-code">WebGLTexture? createTexture()
+        <dt class="idl-code">WebGLTexture createTexture()
             <span class="gl-spec">(<a href="http://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf#nameddest=section-3.7.13">OpenGL ES 2.0 &sect;3.7.13</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glGenTextures.xml">man page</a>)</span>
         <dd>
             Create a WebGLTexture object and initialize it with a texture object name as if by
@@ -3001,7 +3001,7 @@ WebGLRenderingContext includes WebGLRenderingContextOverloads;
             Shaders</a>, and <a href="#PACKING_RESTRICTIONS">Packing Restrictions for Uniforms and
             Varyings</a> for additional constraints enforced in, additional constructs supported by,
             and additional validation performed by WebGL implementations.
-        <dt class="idl-code">WebGLProgram? createProgram()
+        <dt class="idl-code">WebGLProgram createProgram()
             <span class="gl-spec">(<a href="http://registry.khronos.org/OpenGL/specs/es/2.0/es_full_spec_2.0.pdf#nameddest=section-2.10.3">OpenGL ES 2.0 &sect;2.10.3</a>, <a class="nonnormative" href="http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glCreateProgram.xml">man page</a>)</span>
         <dd>
             Create a WebGLProgram object and initialize it with a program object name as if by
@@ -3710,6 +3710,11 @@ dictionary WebGLContextEventInit : <a href="http://www.w3.org/TR/domcore/#eventi
         </li>
         </ol>
     </p>
+    <p>
+        A <code>WebGLObject</code> created while the context is lost
+        (e.g. a <code>WebGLBuffer</code> via <code>createBuffer()</code>)
+        begins life with its <a href="#webgl-object-invalidated-flag">invalidated flag</a> set.
+    </p>
     <div class="example">
         The following code prevents the default behavior of the <code>webglcontextlost</code>
         event and enables the <code>webglcontextrestored</code> event to be delivered:
@@ -3751,7 +3756,7 @@ dictionary WebGLContextEventInit : <a href="http://www.w3.org/TR/domcore/#eventi
 
     <div class="note">
         Once the context is restored, WebGL resources such as textures and buffers that were created
-        before the context was lost are no longer valid.
+        before the context was restored are no longer valid.
         Previously enabled extensions are not restored.
         The application will want to restore all modified state and destroyed extensions and resources.
     </div>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -826,7 +826,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   undefined clearBufferfi(GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil);
 
   /* Query Objects */
-  WebGLQuery? createQuery();
+  WebGLQuery createQuery();
   undefined deleteQuery(WebGLQuery? query);
   [WebGLHandlesContextLoss] GLboolean isQuery(WebGLQuery? query);
   undefined beginQuery(GLenum target, WebGLQuery query);
@@ -835,7 +835,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   any getQueryParameter(WebGLQuery query, GLenum pname);
 
   /* Sampler Objects */
-  WebGLSampler? createSampler();
+  WebGLSampler createSampler();
   undefined deleteSampler(WebGLSampler? sampler);
   [WebGLHandlesContextLoss] GLboolean isSampler(WebGLSampler? sampler);
   undefined bindSampler(GLuint unit, WebGLSampler? sampler);
@@ -852,7 +852,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   any getSyncParameter(WebGLSync sync, GLenum pname);
 
   /* Transform Feedback */
-  WebGLTransformFeedback? createTransformFeedback();
+  WebGLTransformFeedback createTransformFeedback();
   undefined deleteTransformFeedback(WebGLTransformFeedback? tf);
   [WebGLHandlesContextLoss] GLboolean isTransformFeedback(WebGLTransformFeedback? tf);
   undefined bindTransformFeedback (GLenum target, WebGLTransformFeedback? tf);
@@ -875,7 +875,7 @@ interface mixin <dfn data-dfn-type="interface" id="WebGL2RenderingContextBase">W
   undefined uniformBlockBinding(WebGLProgram program, GLuint uniformBlockIndex, GLuint uniformBlockBinding);
 
   /* Vertex Array Objects */
-  WebGLVertexArrayObject? createVertexArray();
+  WebGLVertexArrayObject createVertexArray();
   undefined deleteVertexArray(WebGLVertexArrayObject? vertexArray);
   [WebGLHandlesContextLoss] GLboolean isVertexArray(WebGLVertexArrayObject? vertexArray);
   undefined bindVertexArray(WebGLVertexArrayObject? array);


### PR DESCRIPTION
A general design pattern for WebGL is that it should generally be possible for rare failures (like context lost) to be ignorable when possible, such that code Just Works, and doesn't have to be rigorously robust to unusual failure cases. This is particularly important for context loss, since it is absolutely random, and could happen between any two invocations in JS.

For example, getUniformLocation might fail if a program doesn't have an expected uniform name, or fails to link. (or if context is lost!) By making e.g. `uniform1i` take `WebGLUniformLocation? location` and not `WebGLUniformLocation location`, we can paper over certain (rare-ish?) partial failures, rather than snowballing failures into black screens or runtime exceptions. 

It would be helpful to developers if object creation were infallible, since returning null here can cause hard-to-isolate bugs.
Infallible creation means that the following pattern is safe:
```
const fb = gl.createFramebuffer();
fb.gl = gl;
```

Object creation can still always fail due to true OOM situations, just as creating other dom and js objects can fail if you run out of memory. (it generates an exception)

Additionally, this makes it easier to add labels robustly in #3637, though there is no strict dependency between these PRs.

This PR does not provide a way to detect whether creation is infallible when running on a particular (version of a) user agent/browser, but I think that's ok if we have group consensus to add this, since there are not many implementations. (and most user code probably assumes this is the case anyways)