### PR TITLE
Test framebufferPixelLocalClearValuefv with near-overflow offset.

### DIFF
--- a/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
+++ b/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
@@ -226,6 +226,8 @@ function checkWebGLNonNormativeBehavior() {
   wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
   pls.framebufferPixelLocalClearValuefvWEBGL(2, new Float32Array(5), 2);
   wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
+  pls.framebufferPixelLocalClearValuefvWEBGL(2, new Float32Array(5), 4294967295);
+  wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
   pls.framebufferPixelLocalClearValuefvWEBGL(1, [0, 0, 0, 0, 0], 2);
   wtu.glErrorShouldBe(gl, gl.INVALID_VALUE);
   pls.framebufferPixelLocalClearValueivWEBGL(0, new Int32Array(5), 2);


### PR DESCRIPTION
Associated with crbug.com/332939155.