### PR TITLE
Add drawingBufferFormat to constants-and-properties tests.

### DIFF
--- a/sdk/tests/conformance/context/constants-and-properties.html
+++ b/sdk/tests/conformance/context/constants-and-properties.html
@@ -445,8 +445,11 @@ var otherProperties = {
 drawingBufferWidth      : "number",
 drawingBufferHeight     : "number",
 drawingBufferColorSpace : "string",
+drawingBufferFormat     : "number",
 unpackColorSpace        : "string",
-canvas                  : "implementation-dependent"
+canvas                  : "implementation-dependent",
+RGB8                    : "number",
+RGBA8                   : "number",
 };
 
 // Properties to be ignored (as a list of strings) because they were

--- a/sdk/tests/conformance2/context/constants-and-properties-2.html
+++ b/sdk/tests/conformance2/context/constants-and-properties-2.html
@@ -711,6 +711,7 @@ var otherProperties = {
 drawingBufferWidth      : "number",
 drawingBufferHeight     : "number",
 drawingBufferColorSpace : "string",
+drawingBufferFormat     : "number",
 unpackColorSpace        : "string",
 canvas                  : "implementation-dependent"
 };


### PR DESCRIPTION
Added:
 drawingBufferFormat to WebGL 1 and 2
 RGB8/RGBA8 to WebGL 1

Tested locally in Chromium.

Fixes #3650.