### PR TITLE
Fix image-decoder-to-texture in WebGL 2 mode.

### DIFF
--- a/sdk/tests/conformance/textures/misc/image-decoder-to-texture.html
+++ b/sdk/tests/conformance/textures/misc/image-decoder-to-texture.html
@@ -59,7 +59,7 @@ async function testImage(filename, type)
     }
     let frame = decodeResult.image;
     if (window.WebGL2RenderingContext && gl instanceof window.WebGL2RenderingContext) {
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, frame.width, frame.height, 0, gl.RGBA, gl.UNSIGNED_BYTE, frame);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, frame.codedWidth, frame.codedHeight, 0, gl.RGBA, gl.UNSIGNED_BYTE, frame);
     } else {
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, frame);
     }


### PR DESCRIPTION
The test was fetching nonexistent "width" and "height" properties on the VideoFrame, leading to a (0, 0)-sized texture upload. codedWidth and codedHeight are the best approximation without handling the full visibleRect in the test.

Follow-on to #3641 .

Associated with Chromium bug crbug.com/337904214 .