### PR TITLE
Fix quickCheckAPI-A fail when MAX_TEXTURE_IMAGE_UNITS > 32.(KhronosGr…

### DIFF
--- a/sdk/tests/conformance/more/conformance/quickCheckAPI.js
+++ b/sdk/tests/conformance/more/conformance/quickCheckAPI.js
@@ -220,7 +220,7 @@ texParameterParam[GL.TEXTURE_WRAP_T] = texParameterParam[GL.TEXTURE_WRAP_S];
 textureUnit = constCheck.apply(this, (function(){
   var textureUnits = [];
   var texUnits = GL.getParameter(GL.MAX_TEXTURE_IMAGE_UNITS);
-  for (var i=0; i<texUnits; i++) textureUnits.push(GL['TEXTURE'+i]);
+  for (var i=0; i<texUnits; i++) textureUnits.push(GL.TEXTURE0+i);
   return textureUnits;
 })());
 


### PR DESCRIPTION
…oup#3654)

GL['TEXTURE'+i] will report not defined when MAX_TEXTURE_IMAGE_UNITS > 32.

Add more TEXTURE_IMAGE_UNITS support for modern GPU that may support 64 or more.

Fixes #3654 .