### PR TITLE
Backport changes to fix quickCheckAPI-A fail

### DIFF
--- a/conformance-suites/1.0.3/conformance/more/conformance/quickCheckAPI.js
+++ b/conformance-suites/1.0.3/conformance/more/conformance/quickCheckAPI.js
@@ -237,7 +237,7 @@ texParameterParam[GL.TEXTURE_WRAP_T] = texParameterParam[GL.TEXTURE_WRAP_S];
 textureUnit = constCheck.apply(this, (function(){
   var textureUnits = [];
   var texUnits = GL.getParameter(GL.MAX_TEXTURE_IMAGE_UNITS);
-  for (var i=0; i<texUnits; i++) textureUnits.push(GL['TEXTURE'+i]);
+  for (var i=0; i<texUnits; i++) textureUnits.push(GL.TEXTURE0+i);
   return textureUnits;
 })());
 

--- a/conformance-suites/2.0.0/conformance/more/conformance/quickCheckAPI.js
+++ b/conformance-suites/2.0.0/conformance/more/conformance/quickCheckAPI.js
@@ -237,7 +237,7 @@ texParameterParam[GL.TEXTURE_WRAP_T] = texParameterParam[GL.TEXTURE_WRAP_S];
 textureUnit = constCheck.apply(this, (function(){
   var textureUnits = [];
   var texUnits = GL.getParameter(GL.MAX_TEXTURE_IMAGE_UNITS);
-  for (var i=0; i<texUnits; i++) textureUnits.push(GL['TEXTURE'+i]);
+  for (var i=0; i<texUnits; i++) textureUnits.push(GL.TEXTURE0+i);
   return textureUnits;
 })());
 


### PR DESCRIPTION
Pick the fixs(#3655) for 2.0.0 and 1.0.3.

Fixes #3654.