### PR TITLE
Add a test for the creation of `RGBA16UI` textures with `UNPACK_PREMULTIPLY_ALPHA_WEBGL` enabled for chromium issue 40929470

### DIFF
--- a/sdk/tests/conformance2/textures/misc/tex-unpack-params-with-flip-y-and-premultiply-alpha.html
+++ b/sdk/tests/conformance2/textures/misc/tex-unpack-params-with-flip-y-and-premultiply-alpha.html
@@ -482,6 +482,40 @@ function runRegressionTests(gl) {
   gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
 }
 
+function runPremultiplyAlphaForRGBA16UITest() {
+  debug("");
+  debug("Test texImage2D RGBA16UI with premultiply_alpha = true for chromium issue 40929470");
+
+  var width = 16, height = 16;
+
+  // Restore default values except for UNPACK_PREMULTIPLY_ALPHA_WEBGL which is set to true
+  gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
+  gl.pixelStorei(gl.UNPACK_ROW_LENGTH, 0);
+  gl.pixelStorei(gl.UNPACK_IMAGE_HEIGHT, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_ROWS, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_IMAGES, 0);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, true);
+
+  var data = new Uint16Array(width * height * 4);
+
+  var tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA16UI, width, height, 0, gl.RGBA_INTEGER, gl.UNSIGNED_SHORT, data);
+  wtu.glErrorShouldBe(gl, gl.NO_ERROR, "texImage2D RGBA16UI works with PREMULTIPLY_ALPHA = true");
+
+  // Restore default values.
+  gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
+  gl.pixelStorei(gl.UNPACK_ROW_LENGTH, 0);
+  gl.pixelStorei(gl.UNPACK_IMAGE_HEIGHT, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_PIXELS, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_ROWS, 0);
+  gl.pixelStorei(gl.UNPACK_SKIP_IMAGES, 0);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+  gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
+}
+
 var gl = wtu.create3DContext("example", undefined, 2);
 if (!gl) {
   testFailed("Fail to get a WebGL context");
@@ -489,6 +523,7 @@ if (!gl) {
   runTests(gl);
   runNegativeTests(gl);
   runRegressionTests(gl);
+  runPremultiplyAlphaForRGBA16UITest(gl);
 }
 
 debug("");


### PR DESCRIPTION
`RGBA16UI` textures, when created with `UNPACK_PREMULTIPLY_ALPHA_WEBGL` set to `true` result in the `1282` (`GL_INVALID_OPERATION`) error despite that being against standards and the same thing not happening on Firefox.

The issue has been reported and a PR/CL has been requested:
Issue: https://issues.chromium.org/issues/40929470
PR/CL: https://chromium-review.googlesource.com/c/chromium/src/+/5525320

This PR is to add a test confirming that the issue's fix works and for future use.

There's also been an independent test made that this PR is based on:
https://github.com/RandomGamingDev/Chrome-UNPACK_PREMULTIPLY_ALPHA_WEBGL-Failure-Demo