### PR TITLE
Use ANGLE in Chrome test runner

### DIFF
--- a/other/test-runner/config.json
+++ b/other/test-runner/config.json
@@ -48,7 +48,7 @@
                 "--disable-gpu-driver-bug-workarounds",
                 "--ignore-gpu-blacklist",
                 "--ignore-gpu-blocklist",
-                "--use-gl=desktop"
+                "--use-gl=angle"
             ]
         },
 
@@ -88,7 +88,7 @@
                 "--disable-gpu-driver-bug-workarounds",
                 "--ignore-gpu-blacklist",
                 "--ignore-gpu-blocklist",
-                "--use-gl=desktop"
+                "--use-gl=angle"
             ]
         },
 
@@ -131,7 +131,7 @@
                 "--disable-gpu-driver-bug-workarounds",
                 "--ignore-gpu-blacklist",
                 "--ignore-gpu-blocklist",
-                "--use-gl=desktop"
+                "--use-gl=angle"
             ]
         },
 


### PR DESCRIPTION
Chrome now relies solely on ANGLE, and removes the DesktopGL [1]. This commit update the Chrome flag to "--use-gl=angle" accordingly.

[1] https://issues.chromium.org/issues/40848940