### PR TITLE
Use BigInt parameter in 16gb-wasm-memory tests

### DIFF
--- a/sdk/tests/conformance2/wasm/bufferdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/bufferdata-16gb-wasm-memory.html
@@ -29,7 +29,7 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
     testPassed(`Allocating ${SIZE} threw: ${e}`);
     return;

--- a/sdk/tests/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
@@ -29,7 +29,7 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
     testPassed(`Allocating ${SIZE} threw: ${e}`);
     return;

--- a/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
@@ -29,7 +29,7 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
     testPassed(`Allocating ${SIZE} threw: ${e}`);
     return;

--- a/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
@@ -30,7 +30,7 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
     testPassed(`Allocating ${SIZE} threw: ${e}`);
     return;

--- a/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
@@ -29,7 +29,7 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
     testPassed(`Allocating ${SIZE} threw: ${e}`);
     return;

--- a/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
@@ -29,7 +29,7 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: SIZE / PAGE }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
     testPassed(`Allocating ${SIZE} threw: ${e}`);
     return;


### PR DESCRIPTION
The JS API for Memory was updated in https://github.com/WebAssembly/memory64/issues/68 to require BigInt parameters.