### PR TITLE
Fix memory64 tests

### DIFF
--- a/sdk/tests/conformance2/wasm/bufferdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/bufferdata-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/sdk/tests/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/buffersubdata-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/getbuffersubdata-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16 * 1024 * 1024 * 1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/readpixels-16gb-wasm-memory.html
@@ -30,9 +30,10 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/teximage2d-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 

--- a/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
+++ b/sdk/tests/conformance2/wasm/texsubimage2d-16gb-wasm-memory.html
@@ -29,9 +29,10 @@ const SIZE = 16*1024*1024*1024;
 (() => {
   let view;
   try {
-    view = new Uint8Array(new WebAssembly.Memory({ index: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
+    view = new Uint8Array(new WebAssembly.Memory({ address: 'i64', initial: BigInt(SIZE / PAGE) }).buffer);
   } catch (e) {
-    testPassed(`Allocating ${SIZE} threw: ${e}`);
+    let fn = e instanceof RangeError ? testPassed : testFailed;
+    fn(`Allocating ${SIZE} threw: ${e}`);
     return;
   }
 


### PR DESCRIPTION
1) Use 'address' instead of 'index'; this was a last-minute change, see
   https://github.com/WebAssembly/memory64/pull/90 and
   https://github.com/WebAssembly/memory64/pull/92.
2) Only treat RangeError as passing test.

Note that the tests were passing before because engines threw a TypeError if the memory descriptor used bigints without specifying {address: 'i64'}.