### PR TITLE
Fix "previous version" link in WebGL 2.0 spec to point to 2.0.0.

### DIFF
--- a/specs/latest/1.0/index.html
+++ b/specs/latest/1.0/index.html
@@ -65,11 +65,7 @@
             </dd>
         <dt>Editors:
             <dd>
-                <a href="mailto:dino@apple.com">Dean Jackson</a>
-                <a href="http://www.apple.com/">(Apple Inc.)</a>
-            </dd>
-            <dd>
-                <a href="mailto:jgilbert@mozilla.com">Jeff Gilbert</a>
+                <a href="mailto:kelsey.gilbert@mozilla.com">Kelsey Gilbert</a>
                 <a href="https://www.mozilla.org/">(Mozilla Corp.)</a>
             </dd>
     </dl>

--- a/specs/latest/2.0/index.html
+++ b/specs/latest/2.0/index.html
@@ -54,21 +54,17 @@
             </dd>
         <dt>Previous version:
             <dd>
-                <a href="https://www.khronos.org/registry/webgl/specs/1.0.2/">
-                    https://www.khronos.org/registry/webgl/specs/1.0.2/
+                <a href="https://registry.khronos.org/webgl/specs/2.0.0/">
+                    https://registry.khronos.org/webgl/specs/2.0.0/
                 </a>
                 <br>
-                <a href="https://www.khronos.org/registry/webgl/specs/1.0.2/webgl.idl">
-                    <b>WebIDL:</b> https://www.khronos.org/registry/webgl/specs/1.0.2/webgl.idl
+                <a href="https://registry.khronos.org/webgl/specs/2.0.0/webgl2.idl">
+                    <b>WebIDL:</b> https://registry.khronos.org/webgl/specs/2.0.0/webgl2.idl
                 </a>
             </dd>
         <dt>Editors:
             <dd>
-                <a href="mailto:dino@apple.com">Dean Jackson</a>
-                <a href="http://www.apple.com/">(Apple Inc.)</a>
-            </dd>
-            <dd>
-                <a href="mailto:jgilbert@mozilla.com">Jeff Gilbert</a>
+                <a href="mailto:kelsey.gilbert@mozilla.com">Kelsey Gilbert</a>
                 <a href="https://www.mozilla.org/">(Mozilla Corp.)</a>
             </dd>
     </dl>


### PR DESCRIPTION
Drive-by updates to WebGL 2 IDL link and current spec editors' list.

Fixes #3708.
