### PR TITLE
Firefox should not call requestVideoFrameCallback to ensure videos are uploadable.

### DIFF
--- a/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
+++ b/sdk/tests/js/tests/tex-image-and-sub-image-2d-with-video.js
@@ -210,7 +210,7 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
         cases = tiu.crossProductTestCasesWithUnpackColorSpaces(
             cases, tiu.unpackColorSpacesToTest(gl));
 
-        function runTexImageTest(bindingTarget) {
+        async function runTexImageTest(bindingTarget) {
             var program;
             if (bindingTarget == gl.TEXTURE_2D) {
                 program = tiu.setupTexturedQuad(gl, internalFormat);
@@ -218,71 +218,72 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
                 program = tiu.setupTexturedQuadWithCubeMap(gl, internalFormat);
             }
 
-            return new Promise(function(resolve, reject) {
-                var videoNdx = 0;
-                var video;
-                function runNextVideo() {
-                    if (video) {
-                        video.pause();
-                    }
+            for (const info of videos) {
+                debug("");
+                debug("testing: " + JSON.stringify({
+                    type: info.type,
+                    bindingTarget: wtu.glEnumToString(gl, bindingTarget),
+                }));
 
-                    if (videoNdx == videos.length) {
-                        resolve("SUCCESS");
-                        return;
-                    }
+                const video = await loadVideo(info);
+                if (!video) continue;
 
-                    var info = videos[videoNdx++];
-                    debug("");
-                    debug("testing: " + info.type);
-                    video = document.createElement("video");
-                    video.muted = true;
-                    var canPlay = true;
-                    if (!video.canPlayType) {
-                      testFailed("video.canPlayType required method missing");
-                      runNextVideo();
-                      return;
-                    }
-
-                    if(!video.canPlayType(info.type).replace(/no/, '')) {
-                      debug(info.type + " unsupported");
-                      runNextVideo();
-                      return;
-                    };
-
+                try {
                     document.body.appendChild(video);
                     video.type = info.type;
                     video.src = info.src;
-                    wtu.startPlayingAndWaitForVideo(video, runTest);
+
+                    await wtu.waitVideoUploadable(video);
+
+                    await testVideo(video);
+                } finally {
+                    video.pause();
                 }
-                function runTest() {
-                    for (var i in cases) {
-                        if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
-                            // Cube map texture must be square but video is not square.
-                            if (!cases[i].sub) {
-                                break;
-                            }
-                            // Skip sub-rectangle tests for cube map textures for the moment.
-                            if (cases[i].sourceSubRectangle) {
-                                break;
-                            }
+            }
+
+            async function loadVideo(info) {
+                const video = document.createElement("video");
+                video.muted = true;
+                if (!video.canPlayType) {
+                    testFailed("video.canPlayType required method missing");
+                    return null;
+                }
+
+                if(!video.canPlayType(info.type).replace(/no/, '')) {
+                    debug(info.type + " unsupported");
+                    return null;
+                }
+
+                return video;
+            }
+
+            async function testVideo(video) {
+                await wtu.dispatchPromise();
+                for (var i in cases) {
+                    if (bindingTarget == gl.TEXTURE_CUBE_MAP) {
+                        // Cube map texture must be square but video is not square.
+                        if (!cases[i].sub) {
+                            break;
                         }
-                        runOneIteration(video, cases[i].unpackColorSpace, cases[i].sub, cases[i].flipY,
-                                        cases[i].topColor,
-                                        cases[i].bottomColor,
-                                        cases[i].sourceSubRectangle,
-                                        program, bindingTarget);
+                        // Skip sub-rectangle tests for cube map textures for the moment.
+                        if (cases[i].sourceSubRectangle) {
+                            break;
+                        }
                     }
-                    runNextVideo();
+                    runOneIteration(video, cases[i].unpackColorSpace, cases[i].sub, cases[i].flipY,
+                                    cases[i].topColor,
+                                    cases[i].bottomColor,
+                                    cases[i].sourceSubRectangle,
+                                    program, bindingTarget);
                 }
-                runNextVideo();
-            });
+            }
         }
 
-        runTexImageTest(gl.TEXTURE_2D).then(function(val) {
-            runTexImageTest(gl.TEXTURE_CUBE_MAP).then(function(val) {
-                wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
-                finishTest();
-            });
+        call(async () => {
+            await runTexImageTest(gl.TEXTURE_2D);
+            await runTexImageTest(gl.TEXTURE_CUBE_MAP);
+            wtu.glErrorShouldBe(gl, gl.NO_ERROR, "should be no errors");
+            finishTest();
         });
     }
 


### PR DESCRIPTION
It seems to hang sometimes, maybe due to visibility testing. Fortunately, we believe `await video.play()` is enough in Firefox.

In diagnosing and fixing this, did clean-up refactor of tex-image-and-sub-image-*d-with-video.js to use async+await.