### PR TITLE
Remove MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE enum.

### DIFF
--- a/extensions/WEBGL_shader_pixel_local_storage/extension.xml
+++ b/extensions/WEBGL_shader_pixel_local_storage/extension.xml
@@ -68,20 +68,19 @@
 [Exposed=(Window,Worker), LegacyNoInterfaceObject]
 interface WEBGL_shader_pixel_local_storage {
   const GLenum MAX_PIXEL_LOCAL_STORAGE_PLANES_WEBGL = 0x96E0;
-  const GLenum MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE_WEBGL = 0x96E1;
-  const GLenum MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES_WEBGL = 0x96E2;
-  const GLenum PIXEL_LOCAL_STORAGE_ACTIVE_PLANES_WEBGL = 0x96E3;
-  const GLenum LOAD_OP_ZERO_WEBGL = 0x96E4;
-  const GLenum LOAD_OP_CLEAR_WEBGL = 0x96E5;
-  const GLenum LOAD_OP_LOAD_WEBGL = 0x96E6;
-  const GLenum STORE_OP_STORE_WEBGL = 0x96E7;
-  const GLenum PIXEL_LOCAL_FORMAT_WEBGL = 0x96E8;
-  const GLenum PIXEL_LOCAL_TEXTURE_NAME_WEBGL = 0x96E9;
-  const GLenum PIXEL_LOCAL_TEXTURE_LEVEL_WEBGL = 0x96EA;
-  const GLenum PIXEL_LOCAL_TEXTURE_LAYER_WEBGL = 0x96EB;
-  const GLenum PIXEL_LOCAL_CLEAR_VALUE_FLOAT_WEBGL = 0x96EC;
-  const GLenum PIXEL_LOCAL_CLEAR_VALUE_INT_WEBGL = 0x96ED;
-  const GLenum PIXEL_LOCAL_CLEAR_VALUE_UNSIGNED_INT_WEBGL = 0x96EE;
+  const GLenum MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES_WEBGL = 0x96E1;
+  const GLenum PIXEL_LOCAL_STORAGE_ACTIVE_PLANES_WEBGL = 0x96E2;
+  const GLenum LOAD_OP_ZERO_WEBGL = 0x96E3;
+  const GLenum LOAD_OP_CLEAR_WEBGL = 0x96E4;
+  const GLenum LOAD_OP_LOAD_WEBGL = 0x96E5;
+  const GLenum STORE_OP_STORE_WEBGL = 0x96E6;
+  const GLenum PIXEL_LOCAL_FORMAT_WEBGL = 0x96E7;
+  const GLenum PIXEL_LOCAL_TEXTURE_NAME_WEBGL = 0x96E8;
+  const GLenum PIXEL_LOCAL_TEXTURE_LEVEL_WEBGL = 0x96E9;
+  const GLenum PIXEL_LOCAL_TEXTURE_LAYER_WEBGL = 0x96EA;
+  const GLenum PIXEL_LOCAL_CLEAR_VALUE_FLOAT_WEBGL = 0x96EB;
+  const GLenum PIXEL_LOCAL_CLEAR_VALUE_INT_WEBGL = 0x96EC;
+  const GLenum PIXEL_LOCAL_CLEAR_VALUE_UNSIGNED_INT_WEBGL = 0x96ED;
   GLboolean isCoherent();
   undefined framebufferTexturePixelLocalStorageWEBGL(GLint plane,
                                                      WebGLTexture? texture,
@@ -221,7 +220,6 @@ interface WEBGL_shader_pixel_local_storage {
       <table>
       <tr><th>pname</th><th>returned type</th></tr>
       <tr><td>MAX_PIXEL_LOCAL_STORAGE_PLANES_WEBGL</td><td>GLint</td></tr>
-      <tr><td>MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE_WEBGL</td><td>GLint</td></tr>
       <tr><td>MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES_WEBGL</td><td>GLint</td></tr>
       <tr><td>PIXEL_LOCAL_STORAGE_ACTIVE_PLANES_WEBGL</td><td>GLint</td></tr>
       </table>
@@ -281,6 +279,9 @@ interface WEBGL_shader_pixel_local_storage {
     </revision>
     <revision date="2023/09/08">
       <change>Changed srcOffset arguments to "unsigned long long" for Wasm.</change>
+    </revision>
+    <revision date="2025/03/24">
+      <change>Removed MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE_WEBGL enum, which was removed from the underlying ANGLE extension.</change>
     </revision>
   </history>
 </draft>

--- a/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
+++ b/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
@@ -120,8 +120,6 @@ function checkImplementationDependentLimits() {
   debug("\nVerify conformant implementation-dependent PLS limits.");
   window.MAX_PIXEL_LOCAL_STORAGE_PLANES =
     gl.getParameter(pls.MAX_PIXEL_LOCAL_STORAGE_PLANES_WEBGL);
-  window.MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE =
-    gl.getParameter(pls.MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE_WEBGL);
   window.MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES =
     gl.getParameter(pls.MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES_WEBGL);
   wtu.glErrorShouldBe(gl, gl.NONE, "Pixel local storage queries should be supported.");
@@ -131,14 +129,11 @@ function checkImplementationDependentLimits() {
 
   // Table 6.X: Impementation Dependent Pixel Local Storage Limits.
   shouldBeTrue("MAX_PIXEL_LOCAL_STORAGE_PLANES >= 4");
-  shouldBeTrue("MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE >= 0");
   shouldBeTrue("MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES >= 4");
 
   // Logical deductions based on 6.X.
   shouldBeTrue(`MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES >=
                MAX_PIXEL_LOCAL_STORAGE_PLANES`);
-  shouldBeTrue(`MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES >=
-               MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE`);
   shouldBeTrue(`MAX_COLOR_ATTACHMENTS + MAX_PIXEL_LOCAL_STORAGE_PLANES >=
                MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES`);
   shouldBeTrue(`MAX_DRAW_BUFFERS + MAX_PIXEL_LOCAL_STORAGE_PLANES >=

--- a/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
+++ b/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
@@ -65,6 +65,7 @@ async function runTest() {
   }
   checkDependencyExtensionsEnabled(true);
 
+  checkEnums();
   checkImplementationDependentLimits();
   checkInitialValues();
   checkWebGLNonNormativeBehavior();
@@ -114,6 +115,24 @@ function checkDependencyExtensionsEnabled(enabled) {
                         "EXT_color_buffer_half_float not enabled or disabled as expected");
     gl.bindRenderbuffer(gl.RENDERBUFFER, null);
   }
+}
+
+function checkEnums() {
+  debug("\nVerify the extension's enum values, since they changed during the extension's development.");
+  shouldBe("pls.MAX_PIXEL_LOCAL_STORAGE_PLANES_WEBGL", "0x96E0");
+  shouldBe("pls.MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES_WEBGL", "0x96E1");
+  shouldBe("pls.PIXEL_LOCAL_STORAGE_ACTIVE_PLANES_WEBGL", "0x96E2");
+  shouldBe("pls.LOAD_OP_ZERO_WEBGL", "0x96E3");
+  shouldBe("pls.LOAD_OP_CLEAR_WEBGL", "0x96E4");
+  shouldBe("pls.LOAD_OP_LOAD_WEBGL", "0x96E5");
+  shouldBe("pls.STORE_OP_STORE_WEBGL", "0x96E6");
+  shouldBe("pls.PIXEL_LOCAL_FORMAT_WEBGL", "0x96E7");
+  shouldBe("pls.PIXEL_LOCAL_TEXTURE_NAME_WEBGL", "0x96E8");
+  shouldBe("pls.PIXEL_LOCAL_TEXTURE_LEVEL_WEBGL", "0x96E9");
+  shouldBe("pls.PIXEL_LOCAL_TEXTURE_LAYER_WEBGL", "0x96EA");
+  shouldBe("pls.PIXEL_LOCAL_CLEAR_VALUE_FLOAT_WEBGL", "0x96EB");
+  shouldBe("pls.PIXEL_LOCAL_CLEAR_VALUE_INT_WEBGL", "0x96EC");
+  shouldBe("pls.PIXEL_LOCAL_CLEAR_VALUE_UNSIGNED_INT_WEBGL", "0x96ED");
 }
 
 function checkImplementationDependentLimits() {


### PR DESCRIPTION
Remove this enum from the WEBGL_shader_pixel_local_storage extension, and renumber the remaining enums, both of which have already been done in the underlying ANGLE extension.

Remove the use of this enum from the pixel local storage CTS test as well. The new test passes on Chromium with all of these changes made.

Associated with https://anglebug.com/40096838 .