### PR TITLE
Add test for tex{Sub}Image2D from HTMLImageElement w/ SVG image w/o natural sizes

### DIFF
--- a/sdk/tests/conformance/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance/textures/misc/00_test_list.txt
@@ -20,7 +20,7 @@ origin-clean-conformance.html
 tex-image-and-sub-image-2d-with-array-buffer-view.html
 tex-image-and-uniform-binding-bugs.html
 --min-version 1.0.3 tex-image-canvas-corruption.html
-tex-image-svg-image-no-natural-width-and-height.html
+--min-version 1.0.4 tex-image-svg-image-no-natural-width-and-height.html
 --min-version 1.0.2 tex-image-webgl.html
 tex-image-with-format-and-type.html
 tex-image-with-invalid-data.html

--- a/sdk/tests/conformance/textures/misc/00_test_list.txt
+++ b/sdk/tests/conformance/textures/misc/00_test_list.txt
@@ -20,6 +20,7 @@ origin-clean-conformance.html
 tex-image-and-sub-image-2d-with-array-buffer-view.html
 tex-image-and-uniform-binding-bugs.html
 --min-version 1.0.3 tex-image-canvas-corruption.html
+tex-image-svg-image-no-natural-width-and-height.html
 --min-version 1.0.2 tex-image-webgl.html
 tex-image-with-format-and-type.html
 tex-image-with-invalid-data.html

--- a/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
+++ b/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
@@ -58,8 +58,10 @@ wtu.loadImageAsync(`data:image/svg+xml,${SVG_IMAGE}`, image => {
 
   test(image, "texImage2D");
   test(image, "texSubImage2D");
+
+  debug('');
+  finishTest();
 });
 
 var successfullyParsed = true;
 </script>
-<script src="../../../js/js-test-post.js"></script>

--- a/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
+++ b/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
@@ -18,10 +18,7 @@ description("Test texImage2D from an img element with an SVG image without natur
 
 const wtu = WebGLTestUtils;
 
-function test(image, variant) {
-  debug('');
-  debug(variant);
-
+function makeTexture(image, variant) {
   const tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
@@ -36,6 +33,13 @@ function test(image, variant) {
   } else {
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
   }
+}
+
+function testWidthHeightSet(image, variant, description) {
+  debug('');
+  debug(`${variant} (HTMLImageElement.width/height set)`);
+
+  makeTexture(image, variant);
   wtu.checkTextureSize(gl, 100, 100);
 
   wtu.clearAndDrawUnitQuad(gl);
@@ -46,6 +50,20 @@ function test(image, variant) {
   wtu.checkCanvasRect(gl, 225, 37, 2, 2, [0, 0, 0, 0], "should be transparent");
 }
 
+function testWidthHeightNotSet(image, variant) {
+  debug('');
+  debug(`${variant} (HTMLImageElement.width/height not set)`);
+
+  makeTexture(image, variant);
+  while (gl.getError()) {}
+
+  // Try to change the texture. This should fail because dimensions should have
+  // been specified as 0x0.
+  const buf = new Uint8Array(4);
+  gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, buf);
+  wtu.glErrorShouldBe(gl, gl.INVALID_VALUE, "texture size should be 0x0");
+}
+
 const SVG_IMAGE = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
                      <rect width='50' height='50' fill='blue'/>
                      <rect x='50' y='50' width='50' height='50' fill='yellow'/>
@@ -54,11 +72,14 @@ const gl = wtu.create3DContext();
 const program = wtu.setupTexturedQuad(gl);
 
 wtu.loadImageAsync(`data:image/svg+xml,${SVG_IMAGE}`, image => {
+  testWidthHeightNotSet(image, "texImage2D");
+  testWidthHeightNotSet(image, "texSubImage2D");
+
   image.width = 100;
   image.height = 100;
 
-  test(image, "texImage2D");
-  test(image, "texSubImage2D");
+  testWidthHeightSet(image, "texImage2D");
+  testWidthHeightSet(image, "texSubImage2D");
 
   debug('');
   finishTest();

--- a/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
+++ b/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
@@ -36,6 +36,7 @@ function test(image, variant) {
   } else {
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
   }
+  wtu.checkTextureSize(gl, 100, 100);
 
   wtu.clearAndDrawUnitQuad(gl);
 

--- a/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
+++ b/sdk/tests/conformance/textures/misc/tex-image-svg-image-no-natural-width-and-height.html
@@ -1,0 +1,65 @@
+<!--
+Copyright (c) 2025 The Khronos Group Inc.
+Use of this source code is governed by an MIT-style license that can be
+found in the LICENSE.txt file.
+-->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>WebGL texImage2D w/ &lt;img> with SVG image without natural width and height</title>
+<link rel="stylesheet" href="../../../resources/js-test-style.css"/>
+<script src="../../../js/js-test-pre.js"></script>
+<script src="../../../js/webgl-test-utils.js"> </script>
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+
+description("Test texImage2D from an img element with an SVG image without natural width and height.");
+
+const wtu = WebGLTestUtils;
+
+function test(image, variant) {
+  debug('');
+  debug(variant);
+
+  const tex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, tex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+
+  if (variant === "texSubImage2D") {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, image.width, image.height, 0, gl.RGBA,
+                  gl.UNSIGNED_BYTE, null);
+    gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, image);
+  } else {
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
+  }
+
+  wtu.clearAndDrawUnitQuad(gl);
+
+  wtu.checkCanvasRect(gl, 75, 37, 2, 2, [0, 0, 255, 255], "should be blue");
+  wtu.checkCanvasRect(gl, 75, 108, 2, 2, [0, 0, 0, 0], "should be transparent");
+  wtu.checkCanvasRect(gl, 225, 108, 2, 2, [255, 255, 0, 255], "should be yellow");
+  wtu.checkCanvasRect(gl, 225, 37, 2, 2, [0, 0, 0, 0], "should be transparent");
+}
+
+const SVG_IMAGE = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+                     <rect width='50' height='50' fill='blue'/>
+                     <rect x='50' y='50' width='50' height='50' fill='yellow'/>
+                   </svg>`;
+const gl = wtu.create3DContext();
+const program = wtu.setupTexturedQuad(gl);
+
+wtu.loadImageAsync(`data:image/svg+xml,${SVG_IMAGE}`, image => {
+  image.width = 100;
+  image.height = 100;
+
+  test(image, "texImage2D");
+  test(image, "texSubImage2D");
+});
+
+var successfullyParsed = true;
+</script>
+<script src="../../../js/js-test-post.js"></script>


### PR DESCRIPTION
The case where an `HTMLImageElement` was referencing an SVG image with no natural width and height wasn't tested.