### PR TITLE
Add readBuffer coverage for invalid enums below COLOR_ATTACHMENT0

### DIFF
--- a/sdk/tests/conformance2/renderbuffers/readbuffer.html
+++ b/sdk/tests/conformance2/renderbuffers/readbuffer.html
@@ -84,6 +84,7 @@ var testReadBufferOnFBO = function() {
   gl.readBuffer(gl.COLOR_ATTACHMENT0 + maxColorAttachments);
   wtu.glErrorShouldBe(gl, gl.INVALID_OPERATION,
       "calling readBuffer with GL_COLOR_ATTACHMENTi that exceeds MAX_COLOR_ATTACHMENT on fbo should generate INVALID_OPERATION.");
+  shouldBe('gl.getParameter(gl.READ_BUFFER)', 'gl.COLOR_ATTACHMENT0');
   gl.readBuffer(gl.COLOR_ATTACHMENT1);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,
       "calling readBuffer with GL_COLOR_ATTACHMENT1 on the fbo should succeed.");

--- a/sdk/tests/conformance2/renderbuffers/readbuffer.html
+++ b/sdk/tests/conformance2/renderbuffers/readbuffer.html
@@ -75,6 +75,10 @@ var testReadBufferOnFBO = function() {
   gl.readBuffer(gl.COLOR_ATTACHMENT0);
   wtu.glErrorShouldBe(gl, gl.NO_ERROR,
       "calling readBuffer with GL_COLOR_ATTACHMENT0 on fbo should succeed.");
+  gl.readBuffer(gl.COLOR_ATTACHMENT0 - 1);
+  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM,
+      "calling readBuffer with an enum below GL_COLOR_ATTACHMENT0 on fbo should generate INVALID_ENUM.");
+  shouldBe('gl.getParameter(gl.READ_BUFFER)', 'gl.COLOR_ATTACHMENT0');
 
   var maxColorAttachments = gl.getParameter(gl.MAX_COLOR_ATTACHMENTS);
   gl.readBuffer(gl.COLOR_ATTACHMENT0 + maxColorAttachments);


### PR DESCRIPTION
This adds WebGL 2 conformance coverage for invalid readBuffer() enums
below GL_COLOR_ATTACHMENT0 on framebuffer objects.

The test verifies that:
- readBuffer(GL_COLOR_ATTACHMENT0 - 1) generates INVALID_ENUM
- READ_BUFFER remains unchanged after the failed call

This covers the Chromium regression where enums below
GL_COLOR_ATTACHMENT0 were not rejected correctly during validation.

chromium issue: https://issues.chromium.org/issues/500066231
chromium bug fix merge request: : https://chromium-review.googlesource.com/c/chromium/src/+/7733122
