### PR TITLE
Fix expected error codes for compressed texture updates

### DIFF
--- a/sdk/tests/js/tests/compressed-tex-image.js
+++ b/sdk/tests/js/tests/compressed-tex-image.js
@@ -30,7 +30,7 @@ if (!gl) {
   shouldBe("formats.length", "0");
 
   wtu.shouldGenerateGLError(gl, gl.NO_ERROR, "gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 4, 4, 0, gl.RGBA, gl.UNSIGNED_BYTE, new Uint8Array(4*4*4));");
-  wtu.shouldGenerateGLError(gl, gl.INVALID_ENUM,
+  wtu.shouldGenerateGLError(gl, [gl.INVALID_ENUM, gl.INVALID_OPERATION],
                             "gl.compressedTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 4, 4, COMPRESSED_RGB_PVRTC_4BPPV1_IMG, new Uint8Array(8));");
 
   // Check too-many and too-few args.


### PR DESCRIPTION
Either error code is acceptable because:

> When a command could potentially generate several different errors ..., the GL implementation may choose to generate any of the applicable errors.

Generic rule: 
> If a command that requires an enumerated value is passed a symbolic constant that is not one of those specified as allowable for that command, an `INVALID_ENUM` error is generated.

Command-specific rule:
> An `INVALID_OPERATION` error is generated if format does not match the internal format of the texture image being modified...