### PR TITLE
chore: Add Legal mandated AI block to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 The Khronos Group Inc.
+SPDX-License-Identifier: MIT
+-->
+
 # If you need help with WebGL please use [stackoverflow](http://stackoverflow.com/questions/tagged/webgl).
 
 How to contribute to the WebGL conformance tests.
@@ -8,4 +13,24 @@ How to contribute to the WebGL conformance tests.
 4. Make changes to your clone of the repository.
 5. Submit a pull request.
 
+## Contributing
 
+This project welcomes contributions and suggestions. Contributions require you
+to agree to a
+[Contributor License Agreement (CLA)](https://cla-assistant.io/Khronosgroup/WebGL)
+declaring that you have the right to, and actually do, grant the rights to use
+your contribution.
+
+When you submit a pull request, a CLA bot will determine whether you need to
+sign a CLA. Simply follow the instructions provided.
+
+## AI-Assisted Contributions
+
+By submitting a Contribution to this repository, you additionally represent
+that, to the extent any of Your Contributions were developed with the
+assistance of artificial intelligence tools or AI-generated code, You have
+exercised sufficient review, judgment, and creative direction over such tools
+and resulting material to reasonably consider it Your original creation, and
+You are not aware of any third-party license, intellectual property claim, or
+other restriction arising from such use that is associated with any part of
+Your Contribution or use thereof.


### PR DESCRIPTION
This commit adds two items as mandated by legal:

1. Declaration of the CLA along with a link to the CLA so that contributors may inspect before contributing;
2. An AI-Assisted Contributions block.