### PR TITLE
WEBGL_render_shared_exponent: Update color writemask validation

### DIFF
--- a/extensions/WEBGL_render_shared_exponent/extension.xml
+++ b/extensions/WEBGL_render_shared_exponent/extension.xml
@@ -20,7 +20,7 @@
              name="QCOM_render_shared_exponent">
       <addendum>
         Clearing or drawing to a shared exponent color buffer will generate <code>INVALID_OPERATION</code>
-        if the associated color write mask has different values for red, green, and blue channels.
+        if the associated color write mask has different values for red, green, blue, and alpha channels.
       </addendum>
     </mirrors>
 
@@ -43,6 +43,9 @@ interface WEBGL_render_shared_exponent {
     </revision>
     <revision date="2024/01/25">
       <change>Promoted to Community Approved.</change>
+    </revision>
+    <revision date="2026/06/30">
+      <change>Adjusted color write mask validation to require the same state for all channels.</change>
     </revision>
   </history>
 </extension>

--- a/sdk/tests/conformance2/extensions/webgl-render-shared-exponent.html
+++ b/sdk/tests/conformance2/extensions/webgl-render-shared-exponent.html
@@ -159,8 +159,6 @@ function colorMaskTest() {
     function expectError(enabled, effectiveMask, operation) {
         if (!enabled ||
             effectiveMask == 0x0 /* 0000 */ ||
-            effectiveMask == 0x8 /* 000A */ ||
-            effectiveMask == 0x7 /* RGB0 */ ||
             effectiveMask == 0xF /* RGBA */ ) {
             wtu.glErrorShouldBe(gl, gl.NO_ERROR, operation);
         } else {
@@ -210,9 +208,21 @@ function colorMaskTest() {
                 dbiExt.colorMaskiOES(0, true, false, false, false);
                 runOps(enabled, 1); // overridden
 
-                debug("Setting compatible color mask on RGB9_E5 draw buffer")
+                debug("Setting incompatible color mask on RGB9_E5 draw buffer")
                 dbiExt.colorMaskiOES(0, true, true, true, false);
                 runOps(enabled, 7); // overridden
+
+                debug("Setting incompatible color mask on RGB9_E5 draw buffer")
+                dbiExt.colorMaskiOES(0, false, false, false, true);
+                runOps(enabled, 8); // overridden
+
+                debug("Setting compatible color mask on RGB9_E5 draw buffer")
+                dbiExt.colorMaskiOES(0, false, false, false, false);
+                runOps(enabled, 0); // overridden
+
+                debug("Setting compatible color mask on RGB9_E5 draw buffer")
+                dbiExt.colorMaskiOES(0, true, true, true, true);
+                runOps(enabled, 15); // overridden
             }
         }
     }


### PR DESCRIPTION
Original language was based on the Vulkan spec that required only red, green, and blue color writemask values to be the same.

It turned out that some GPUs apply the alpha writemask to the shared exponent component. As a result of that discovery, the Vulkan spec has been updated (1.4.355, dd June 26, 2026) to require all color writemask values to be the same for color attachments with the shared exponent pixel format.

Since the same requirement exists in Metal and Direct3D, the WebGL extension is updated to match native APIs.

New validation is implemented in Chromium since 152.0.7926.0.