### PR TITLE
WEBGL_shader_pixel_local_storage: Sync with upstream

### DIFF
--- a/extensions/WEBGL_shader_pixel_local_storage/extension.xml
+++ b/extensions/WEBGL_shader_pixel_local_storage/extension.xml
@@ -56,8 +56,6 @@
           When this extension is enabled, the following WebGL extensions are enabled implicitly:
           <ul>
             <li><a href="../OES_draw_buffers_indexed/">OES_draw_buffers_indexed</a></li>
-            <li><a href="../EXT_color_buffer_float/">EXT_color_buffer_float</a></li>
-            <li><a href="../EXT_color_buffer_half_float/">EXT_color_buffer_half_float</a></li>
           </ul>
         </div>
       </addendum>
@@ -293,6 +291,9 @@ interface WEBGL_shader_pixel_local_storage {
     </revision>
     <revision date="2026/03/02">
       <change>Renamed PIXEL_LOCAL_FORMAT_WEBGL to PIXEL_LOCAL_INTERNAL_FORMAT_WEBGL, tracking ANGLE extension.</change>
+    </revision>
+    <revision date="2026/06/25">
+      <change>Removed implicit enablement of floating-point rendering extensions, tracking ANGLE extension.</change>
     </revision>
   </history>
 </draft>

--- a/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
+++ b/sdk/tests/conformance2/extensions/webgl-shader-pixel-local-storage.html
@@ -82,13 +82,10 @@ function checkExtensionNotSupportedWhenDisabled() {
   shouldBeNull("gl.getParameter(0x96E0 /*MAX_PIXEL_LOCAL_STORAGE_PLANES_WEBGL*/)");
   wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "parameter unknown without enabling the extension");
   shouldBeNull(
-    "gl.getParameter(0x96E1 /*MAX_COLOR_ATTACHMENTS_WITH_ACTIVE_PIXEL_LOCAL_STORAGE_WEBGL*/)");
+    "gl.getParameter(0x96E1 /*MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES_WEBGL*/)");
   wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "parameter unknown without enabling the extension");
   shouldBeNull(
-    "gl.getParameter(0x96E2 /*MAX_COMBINED_DRAW_BUFFERS_AND_PIXEL_LOCAL_STORAGE_PLANES_WEBGL*/)");
-  wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "parameter unknown without enabling the extension");
-  shouldBeNull(
-    "gl.getParameter(0x96E3 /*PIXEL_LOCAL_STORAGE_ACTIVE_PLANES_WEBGL*/)");
+    "gl.getParameter(0x96E2 /*PIXEL_LOCAL_STORAGE_ACTIVE_PLANES_WEBGL*/)");
   wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "parameter unknown without enabling the extension");
   wtu.glErrorShouldBe(gl, gl.NONE);
 }
@@ -101,18 +98,16 @@ function checkDependencyExtensionsEnabled(enabled) {
     wtu.glErrorShouldBe(gl, enabled ? gl.NONE : gl.INVALID_ENUM,
                         "OES_draw_buffers_indexed not enabled or disabled as expected");
   }
-  if (wtu.getSupportedExtensionWithKnownPrefixes(gl, "EXT_color_buffer_float") !== undefined) {
+  {
     gl.bindRenderbuffer(gl.RENDERBUFFER, gl.createRenderbuffer());
     gl.renderbufferStorage(gl.RENDERBUFFER, gl.R32F, 1, 1);
-    wtu.glErrorShouldBe(gl, enabled ? gl.NONE : gl.INVALID_ENUM,
-                        "EXT_color_buffer_float not enabled or disabled as expected");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "EXT_color_buffer_float not disabled as expected");
     gl.bindRenderbuffer(gl.RENDERBUFFER, null);
   }
-  if (wtu.getSupportedExtensionWithKnownPrefixes(gl, "EXT_color_buffer_half_float") !== undefined) {
+  {
     gl.bindRenderbuffer(gl.RENDERBUFFER, gl.createRenderbuffer());
     gl.renderbufferStorage(gl.RENDERBUFFER, gl.RG16F, 1, 1);
-    wtu.glErrorShouldBe(gl, enabled ? gl.NONE : gl.INVALID_ENUM,
-                        "EXT_color_buffer_half_float not enabled or disabled as expected");
+    wtu.glErrorShouldBe(gl, gl.INVALID_ENUM, "EXT_color_buffer_half_float not disabled as expected");
     gl.bindRenderbuffer(gl.RENDERBUFFER, null);
   }
 }


### PR DESCRIPTION
Removed implicit enablement of floating-point rendering extensions to match the ANGLE extension language.

Updated and fixed tests.

---

To pass the updated tests, Chromium would have to stop implicitly enabling floating-point rendering extensions when the PLS extension is being enabled.